### PR TITLE
Disciples Necropolis mobs need correct stats 

### DIFF
--- a/data/stats/npcs/21800-21899.xml
+++ b/data/stats/npcs/21800-21899.xml
@@ -6546,11 +6546,11 @@
         </dropLists>		
     </npc>
     <npc id="21895" level="76" type="Monster" name="Mausoleum Prophet">
-        <!-- AUTO GENERATED NPC TODO: FIX IT -->
         <race>DEMONIC</race>
         <sex>FEMALE</sex>
+		<acquire exp="56921" sp="1708"/>
         <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
-            <vitals hp="1339.827876" hpRegen="8.5" mp="1679.73" mpRegen="3"/>
+            <vitals hp="2869.17670907346" hpRegen="8.5" mp="1540.8" mpRegen="3"/>
             <speed>
                 <walk ground="70"/>
                 <run ground="165"/>
@@ -6577,7 +6577,7 @@
                 <item id="6323" min="1" max="1" chance="0.03"/> <!-- Sealed Phoenix Necklace -->
                 <item id="6324" min="1" max="1" chance="0.03"/> <!-- Sealed Phoenix Earring -->
                 <item id="6325" min="1" max="1" chance="0.03"/> <!-- Sealed Phoenix Ring -->
-                <item id="57" min="2710" max="6322" chance="70"/> <!-- Adena -->
+                <item id="57" min="2086" max="4866" chance="70"/> <!-- Adena -->
                 <item id="1869" min="3" max="9" chance="13.72"/> <!-- Iron Ore -->
                 <item id="1880" min="1" max="1" chance="7.86"/> <!-- Steel -->
                 <item id="1873" min="2" max="6" chance="7.842"/> <!-- Silver Nugget -->
@@ -6589,7 +6589,7 @@
                 <item id="4042" min="1" max="1" chance="1.322"/> <!-- Enria -->
             </drop>
             <spoil>
-                <item id="1880" min="1" max="1" chance="48.04"/> <!-- Steel -->
+                <item id="1880" min="1" max="1" chance="72.13"/> <!-- Steel -->
                 <item id="6333" min="1" max="1" chance="5.586"/> <!-- Recipe: Sealed Phoenix Ring (70%) -->
                 <item id="6331" min="1" max="1" chance="3.625"/> <!-- Recipe: Sealed Phoenix Earring (70%) -->
                 <item id="6329" min="1" max="1" chance="2.832"/> <!-- Recipe: Sealed Phoenix Necklace (70%) -->
@@ -6597,11 +6597,11 @@
         </dropLists>
     </npc>
     <npc id="21896" level="77" type="Monster" name="Ancient Holy Ground's Hermit">
-        <!-- AUTO GENERATED NPC TODO: FIX IT -->
         <race>BEAST</race>
         <sex>FEMALE</sex>
+		<acquire exp="58760" sp="1763"/>
         <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
-            <vitals hp="1360.37013" hpRegen="8.5" mp="1716.015" mpRegen="3"/>
+            <vitals hp="2913.59120921392" hpRegen="8.5" mp="1574.0" mpRegen="3"/>
             <speed>
                 <walk ground="50"/>
                 <run ground="180"/>
@@ -6627,8 +6627,8 @@
                 <item id="6328" min="1" max="1" chance="0.03"/> <!-- Sealed Majestic Ring -->
                 <item id="6326" min="1" max="1" chance="0.0075"/> <!-- Sealed Majestic Necklace -->
                 <item id="6327" min="1" max="1" chance="0.0075"/> <!-- Sealed Majestic Earring -->
-                <item id="57" min="2811" max="6564" chance="70"/> <!-- Adena -->
-                <item id="1870" min="3" max="9" chance="19.7"/> <!-- Coal -->
+                <item id="57" min="2168" max="5063" chance="70"/> <!-- Adena -->
+                <item id="1870" min="3" max="9" chance="14.81"/> <!-- Coal -->
                 <item id="1874" min="1" max="1" chance="8.166"/> <!-- Oriharukon Ore -->
                 <item id="1875" min="1" max="1" chance="8.147"/> <!-- Stone of Purity -->
                 <item id="6346" min="1" max="1" chance="3.052"/> <!-- Sealed Majestic Ring Gemstone -->
@@ -6637,7 +6637,7 @@
                 <item id="90012" min="1" max="1" chance="0.3"/> <!-- Common Life Stone -->
             </drop>
             <spoil>
-                <item id="1873" min="1" max="1" chance="81.44"/> <!-- Silver Nugget -->
+                <item id="1873" min="1" max="7" chance="73.96"/> <!-- Silver Nugget -->
                 <item id="6339" min="1" max="1" chance="3.852"/> <!-- Recipe: Sealed Majestic Ring (70%) -->
                 <item id="6337" min="1" max="1" chance="2.514"/> <!-- Recipe: Sealed Majestic Earring (70%) -->
                 <item id="6335" min="1" max="1" chance="1.912"/> <!-- Recipe: Sealed Majestic Necklace (70%) -->
@@ -6645,12 +6645,12 @@
         </dropLists>
     </npc>
     <npc id="21897" level="77" type="Monster" name="Ancient Holy Ground's Totem">
-        <!-- AUTO GENERATED NPC TODO: FIX IT -->
         <race>HUMANOID</race>
         <sex>FEMALE</sex>
         <equipment rhand="135"/>
+		<acquire exp="59258" sp="1778"/>
         <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
-            <vitals hp="1360.37013" hpRegen="8.5" mp="1716.015" mpRegen="3"/>
+            <vitals hp="2913.59120921392" hpRegen="8.5" mp="1574.0" mpRegen="3"/>
             <speed>
                 <walk ground="25"/>
                 <run ground="160"/>
@@ -6680,17 +6680,17 @@
                 <item id="5291" min="1" max="1" chance="0.03"/> <!-- Sealed Dark Crystal Boots -->
                 <item id="5295" min="1" max="1" chance="0.03"/> <!-- Sealed Tallum Gloves -->
                 <item id="5296" min="1" max="1" chance="0.03"/> <!-- Sealed Tallum Boots -->
-                <item id="57" min="2848" max="6651" chance="70"/> <!-- Adena -->
-                <item id="1873" min="2" max="6" chance="17.08"/> <!-- Silver Nugget -->
-                <item id="1880" min="1" max="1" chance="16.99"/> <!-- Steel -->
-                <item id="1869" min="15" max="45" chance="5.548"/> <!-- Iron Ore -->
+                <item id="57" min="2203" max="5145" chance="70"/> <!-- Adena -->
+                <item id="1873" min="2" max="6" chance="13.24"/> <!-- Silver Nugget -->
+                <item id="1880" min="1" max="1" chance="11.10"/> <!-- Steel -->
+                <item id="1869" min="3" max="9" chance="18.30"/> <!-- Iron Ore -->
                 <item id="5497" min="1" max="1" chance="1.726"/> <!-- Sealed Tallum Boot Lining -->
                 <item id="5509" min="1" max="1" chance="1.688"/> <!-- Sealed Tallum Glove Design -->
                 <item id="5508" min="1" max="1" chance="1.678"/> <!-- Sealed Dark Crystal Glove Design -->
                 <item id="5496" min="1" max="1" chance="1.67"/> <!-- Sealed Dark Crystal Boot Lining -->
             </drop>
             <spoil>
-                <item id="1865" min="1" max="1" chance="89.44"/> <!-- Varnish -->
+                <item id="1865" min="1" max="13" chance="82.15"/> <!-- Varnish -->
                 <item id="5370" min="1" max="1" chance="3.562"/> <!-- Recipe: Sealed Tallum Boots (60%) -->
                 <item id="5394" min="1" max="1" chance="3.53"/> <!-- Recipe: Sealed Tallum Gloves (60%) -->
                 <item id="5368" min="1" max="1" chance="3.5"/> <!-- Recipe: Sealed Dark Crystal Boots (60%) -->
@@ -6699,11 +6699,11 @@
         </dropLists>
     </npc>
     <npc id="21898" level="78" type="Monster" name="Ancient Holy Ground's Witch">
-        <!-- AUTO GENERATED NPC TODO: FIX IT -->
         <race>DEMONIC</race>
         <sex>FEMALE</sex>
+		<acquire exp="60297" sp="1809"/>
         <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
-            <vitals hp="1380.469026" hpRegen="8.5" mp="1752.3" mpRegen="3"/>
+            <vitals hp="2956.64545357656" hpRegen="8.5" mp="1607.4" mpRegen="3"/>
             <speed>
                 <walk ground="80"/>
                 <run ground="200"/>
@@ -6729,10 +6729,10 @@
             <drop>
                 <item id="5292" min="1" max="1" chance="0.03"/> <!-- Sealed Dark Crystal Shield -->
                 <item id="5315" min="1" max="1" chance="0.03"/> <!-- Sealed Shield of Nightmare -->
-                <item id="57" min="2892" max="6751" chance="70"/> <!-- Adena -->
-                <item id="1881" min="1" max="1" chance="23.03"/> <!-- Coarse Bone Powder -->
-                <item id="1867" min="7" max="21" chance="15.76"/> <!-- Animal Skin -->
-                <item id="1872" min="24" max="72" chance="4.731"/> <!-- Animal Bone -->
+                <item id="57" min="2231" max="5207" chance="70"/> <!-- Adena -->
+                <item id="1881" min="1" max="1" chance="17.38"/> <!-- Coarse Bone Powder -->
+                <item id="1867" min="7" max="21" chance="12.17"/> <!-- Animal Skin -->
+                <item id="1872" min="24" max="72" chance="3.631"/> <!-- Animal Bone -->
                 <item id="5494" min="1" max="1" chance="3.118"/> <!-- Sealed Dark Crystal Shield Fragment -->
                 <item id="5495" min="1" max="1" chance="2.298"/> <!-- Sealed Shield of Nightmare Fragment -->
             </drop>
@@ -6743,12 +6743,12 @@
         </dropLists>
     </npc>
     <npc id="21899" level="78" type="Monster" name="Ancient Holy Ground's Watchman">
-        <!-- AUTO GENERATED NPC TODO: FIX IT -->
         <race>UNDEAD</race>
         <sex>FEMALE</sex>
         <equipment rhand="78"/>
+		<acquire exp="60893" sp="1827"/>
         <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
-            <vitals hp="1380.469026" hpRegen="8.5" mp="1752.3" mpRegen="3"/>
+            <vitals hp="2956.64545357656" hpRegen="8.5" mp="1607.4" mpRegen="3"/>
             <speed>
                 <walk ground="40"/>
                 <run ground="190"/>
@@ -6778,18 +6778,18 @@
                 <item id="5314" min="1" max="1" chance="0.0075"/> <!-- Sealed Boots of Nightmare -->
                 <item id="5318" min="1" max="1" chance="0.0075"/> <!-- Sealed Majestic Gauntlets -->
                 <item id="5319" min="1" max="1" chance="0.0075"/> <!-- Sealed Majestic Boots -->
-                <item id="57" min="2936" max="6855" chance="70"/> <!-- Adena -->
-                <item id="1878" min="2" max="6" chance="9.94"/> <!-- Durable Braid -->
-                <item id="1865" min="9" max="27" chance="7.153"/> <!-- Varnish -->
-                <item id="1895" min="3" max="9" chance="5.254"/> <!-- Metallic Fiber -->
-                <item id="1864" min="32" max="96" chance="3.995"/> <!-- Stem -->
+                <item id="57" min="2273" max="5306" chance="70"/> <!-- Adena -->
+                <item id="1878" min="2" max="6" chance="8.11"/> <!-- Durable Braid -->
+                <item id="1865" min="9" max="27" chance="5.653"/> <!-- Varnish -->
+                <item id="1895" min="3" max="9" chance="4.254"/> <!-- Metallic Fiber -->
+                <item id="1864" min="4" max="12" chance="26.995"/> <!-- Stem -->
                 <item id="5514" min="1" max="1" chance="1.308"/> <!-- Sealed Gauntlets of Nightmare Design -->
                 <item id="5503" min="1" max="1" chance="1.281"/> <!-- Sealed Majestic Boot Lining -->
                 <item id="5515" min="1" max="1" chance="1.247"/> <!-- Sealed Majestic Gauntlet Design -->
                 <item id="5502" min="1" max="1" chance="1.217"/> <!-- Sealed Boots of Nightmare Lining -->
             </drop>
             <spoil>
-                <item id="1873" min="1" max="1" chance="82.26"/> <!-- Silver Nugget -->
+                <item id="1873" min="1" max="5" chance="86.67"/> <!-- Silver Nugget -->
                 <item id="5380" min="1" max="1" chance="2.434"/> <!-- Recipe: Sealed Boots of Nightmare (60%) -->
                 <item id="5406" min="1" max="1" chance="2.421"/> <!-- Recipe: Sealed Majestic Gauntlets (60%) -->
                 <item id="5404" min="1" max="1" chance="2.414"/> <!-- Recipe: Sealed Gauntlets of Nightmare (60%) -->

--- a/data/stats/npcs/21900-21999.xml
+++ b/data/stats/npcs/21900-21999.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org npcs.xsd">
     <npc id="21900" level="79" type="Monster" name="Ancient Holy Ground's Deadman">
-        <!-- AUTO GENERATED NPC TODO: FIX IT -->
         <race>DEMONIC</race>
         <sex>FEMALE</sex>
-        <acquire exp="56723" sp="3481"/>
-
-     <stats str="40" int="21" dex="30" wit="20" con="43" men="25">
-            <vitals hp="1400.075302" hpRegen="8.5" mp="1789.47" mpRegen="3" />
+		<acquire exp="62726" sp="1882"/>
+		<stats str="40" int="21" dex="30" wit="20" con="43" men="25">
+            <vitals hp="2998.26357950914" hpRegen="8.5" mp="1641.0" mpRegen="3" />
             <speed>
                 <walk ground="48" />
                 <run ground="200" />
@@ -34,10 +32,10 @@
                 <item id="5298" min="1" max="1" chance="0.0075" /> <!-- Sealed Dark Crystal Leggings -->
                 <item id="5297" min="1" max="1" chance="0.003" /> <!-- Sealed Dark Crystal Leather Armor -->
                 <item id="5301" min="1" max="1" chance="0.003" /> <!-- Sealed Tallum Leather Armor -->
-                <item id="57" min="3039" max="7095" chance="70" /> <!-- Adena -->
-                <item id="1881" min="1" max="1" chance="23.01" /> <!-- Coarse Bone Powder -->
-                <item id="1867" min="7" max="21" chance="16.47" /> <!-- Animal Skin -->
-                <item id="1872" min="24" max="72" chance="4.989" /> <!-- Animal Bone -->
+                <item id="57" min="2355" max="5500" chance="70" /> <!-- Adena -->
+                <item id="1881" min="1" max="1" chance="12.01" /> <!-- Coarse Bone Powder -->
+                <item id="1867" min="7" max="21" chance="12.39" /> <!-- Animal Skin -->
+                <item id="1872" min="24" max="72" chance="3.989" /> <!-- Animal Bone -->
                 <item id="5482" min="1" max="1" chance="1.067" /> <!-- Sealed Dark Crystal Legging Design -->
                 <item id="5478" min="1" max="1" chance="0.75" /> <!-- Sealed Dark Crystal Leather Armor Pattern -->
                 <item id="5479" min="1" max="1" chance="0.3" /> <!-- Sealed Tallum Leather Armor Pattern -->
@@ -54,14 +52,12 @@
         </dropLists>
     </npc>
     <npc id="21901" level="79" type="Monster" name="Lillim Slayer">
-        <!-- AUTO GENERATED NPC TODO: FIX IT -->
         <race>DEMONIC</race>
         <sex>FEMALE</sex>
-        <acquire exp="64723" sp="3481"/>
-
         <equipment rhand="236" lhand="236" />
-     <stats str="40" int="21" dex="30" wit="20" con="43" men="25">
-            <vitals hp="1400.075302" hpRegen="8.5" mp="1789.47" mpRegen="3" />
+		<acquire exp="63251" sp="1898"/>
+		<stats str="40" int="21" dex="30" wit="20" con="43" men="25">
+            <vitals hp="2998.26357950914" hpRegen="8.5" mp="1641.0" mpRegen="3" />
             <speed>
                 <walk ground="36" />
                 <run ground="200" />
@@ -88,13 +84,13 @@
                 <item id="5305" min="1" max="1" chance="0.0075" /> <!-- Sealed Tallum Stockings -->
                 <item id="5304" min="1" max="1" chance="0.003" /> <!-- Sealed Tallum Tunic -->
                 <item id="5308" min="1" max="1" chance="0.003" /> <!-- Sealed Dark Crystal Robe -->
-                <item id="57" min="3078" max="7186" chance="70" /> <!-- Adena -->
-                <item id="1869" min="3" max="9" chance="14.5" /> <!-- Iron Ore -->
-                <item id="1873" min="2" max="6" chance="9.025" /> <!-- Silver Nugget -->
-                <item id="1880" min="1" max="1" chance="8.942" /> <!-- Steel -->
-                <item id="1874" min="1" max="1" chance="5.932" /> <!-- Oriharukon Ore -->
+                <item id="57" min="2393" max="5587" chance="70" /> <!-- Adena -->
+                <item id="1869" min="3" max="9" chance="11.51" /> <!-- Iron Ore -->
+                <item id="1873" min="2" max="6" chance="6.616" /> <!-- Silver Nugget -->
+                <item id="1880" min="1" max="1" chance="5.643" /> <!-- Steel -->
+                <item id="1874" min="1" max="1" chance="4.982" /> <!-- Oriharukon Ore -->
                 <item id="4039" min="1" max="1" chance="3.017" /> <!-- Mold Glue -->
-                <item id="4042" min="1" max="1" chance="1.451" /> <!-- Enria -->
+                <item id="4042" min="1" max="1" chance="0.991" /> <!-- Enria -->
                 <item id="5489" min="1" max="1" chance="1.014" /> <!-- Sealed Tallum Stocking Fabric -->
                 <item id="5485" min="1" max="1" chance="0.75" /> <!-- Sealed Tallum Tunic Texture -->
                 <item id="5486" min="1" max="1" chance="0.3" /> <!-- Sealed Dark Crystal Robe Fabric -->
@@ -102,7 +98,7 @@
                 <item id="5488" min="1" max="1" chance="0.3" /> <!-- Sealed Majestic Robe Fabric -->
             </drop>
             <spoil>
-                <item id="1873" min="1" max="1" chance="73.37" /> <!-- Silver Nugget -->
+                <item id="1873" min="1" max="5" chance="73.89" /> <!-- Silver Nugget -->
                 <item id="5354" min="1" max="1" chance="1.679" /> <!-- Recipe: Sealed Tallum Stockings (60%) -->
                 <item id="5346" min="1" max="1" chance="0.995" /> <!-- Recipe: Sealed Tallum Tunic (60%) -->
                 <item id="5348" min="1" max="1" chance="0.75" /> <!-- Recipe: Sealed Dark Crystal Robe (60%) -->
@@ -112,13 +108,11 @@
         </dropLists>
     </npc>
     <npc id="21902" level="80" type="Monster" name="Lillim Shaman">
-        <!-- AUTO GENERATED NPC TODO: FIX IT -->
-        <acquire exp="64723" sp="3481"/>
-
         <race>DEMONIC</race>
         <sex>FEMALE</sex>
-     <stats str="40" int="21" dex="30" wit="20" con="43" men="25">
-            <vitals hp="1418.7456" hpRegen="8.5" mp="1825.755" mpRegen="3" />
+		<acquire exp="66985" sp="2010"/>
+		<stats str="40" int="21" dex="30" wit="20" con="43" men="25">
+            <vitals hp="3038.37159811439" hpRegen="8.5" mp="1674.8" mpRegen="3" />
             <speed>
                 <walk ground="50" />
                 <run ground="180" />
@@ -147,10 +141,10 @@
                 <item id="5293" min="1" max="1" chance="0.003" /> <!-- Sealed Tallum Plate Armor -->
                 <item id="5311" min="1" max="1" chance="0.003" /> <!-- Sealed Armor of Nightmare -->
                 <item id="5316" min="1" max="1" chance="0.003" /> <!-- Sealed Majestic Plate Armor -->
-                <item id="57" min="3326" max="7760" chance="70" /> <!-- Adena -->
-                <item id="1870" min="3" max="9" chance="24.44" /> <!-- Coal -->
-                <item id="1874" min="1" max="1" chance="9.686" /> <!-- Oriharukon Ore -->
-                <item id="1875" min="1" max="1" chance="9.686" /> <!-- Stone of Purity -->
+                <item id="57" min="2614" max="6098" chance="70" /> <!-- Adena -->
+                <item id="1870" min="3" max="9" chance="18.72" /> <!-- Coal -->
+                <item id="1874" min="1" max="1" chance="8.367" /> <!-- Oriharukon Ore -->
+                <item id="1875" min="1" max="1" chance="7.883" /> <!-- Stone of Purity -->
                 <item id="5524" min="1" max="1" chance="0.75" /> <!-- Sealed Dark Crystal Gaiter Pattern -->
                 <item id="5523" min="1" max="1" chance="0.3" /> <!-- Sealed Majestic Plate Armor Pattern -->
                 <item id="5522" min="1" max="1" chance="0.3" /> <!-- Sealed Armor of Nightmare Pattern -->
@@ -159,7 +153,7 @@
                 <item id="90012" min="1" max="1" chance="0.3" /> <!-- Common Life Stone -->
             </drop>
             <spoil>
-                <item id="1873" min="1" max="1" chance="79.83" /> <!-- Silver Nugget -->
+                <item id="1873" min="1" max="5" chance="84.92" /> <!-- Silver Nugget -->
                 <item id="5424" min="1" max="1" chance="1.344" /> <!-- Recipe: Sealed Dark Crystal Gaiters (60%) -->
                 <item id="5416" min="1" max="1" chance="0.75" /> <!-- Recipe: Sealed Dark Crystal Breastplate (60%) -->
                 <item id="5418" min="1" max="1" chance="0.75" /> <!-- Recipe: Sealed Tallum Plate Armor (60%) -->
@@ -169,14 +163,12 @@
         </dropLists>
     </npc>
     <npc id="21903" level="80" type="Monster" name="Lillim Royal Knight">
-        <!-- AUTO GENERATED NPC TODO: FIX IT -->
-        <acquire exp="64723" sp="3481"/>
-
         <race>DEMONIC</race>
         <sex>FEMALE</sex>
         <equipment rhand="5800" lhand="5799" />
-     <stats str="40" int="21" dex="30" wit="20" con="43" men="25">
-            <vitals hp="1418.7456" hpRegen="8.5" mp="1825.755" mpRegen="3" />
+		<acquire exp="66985" sp="2010"/>
+		<stats str="40" int="21" dex="30" wit="20" con="43" men="25">
+            <vitals hp="3038.37159811439" hpRegen="8.5" mp="1674.8" mpRegen="3" />
             <speed>
                 <walk ground="56" />
                 <run ground="200" />
@@ -203,15 +195,15 @@
             <drop>
                 <item id="5289" min="1" max="1" chance="0.03" /> <!-- Sealed Dark Crystal Helmet -->
                 <item id="5294" min="1" max="1" chance="0.03" /> <!-- Sealed Tallum Helmet -->
-                <item id="57" min="3326" max="7760" chance="70" /> <!-- Adena -->
-                <item id="2133" min="1" max="1" chance="1.893" /> <!-- Gemstone (A-grade) -->
+                <item id="57" min="2614" max="6098" chance="70" /> <!-- Adena -->
+                <item id="2133" min="1" max="1" chance="0.750" /> <!-- Gemstone (A-grade) -->
                 <item id="5525" min="1" max="1" chance="1.805" /> <!-- Sealed Dark Crystal Helmet Design -->
                 <item id="5526" min="1" max="1" chance="1.705" /> <!-- Sealed Tallum Helmet Design -->
                 <item id="5527" min="1" max="1" chance="1.388" /> <!-- Sealed Helm of Nightmare Design -->
                 <item id="5528" min="1" max="1" chance="1.321" /> <!-- Sealed Majestic Circlet Design -->
             </drop>
             <spoil>
-                <item id="1875" min="1" max="1" chance="62.77" /> <!-- Stone of Purity -->
+                <item id="1875" min="1" max="1" chance="49.86" /> <!-- Stone of Purity -->
                 <item id="5426" min="1" max="1" chance="2.687" /> <!-- Recipe: Sealed Dark Crystal Helmet (60%) -->
                 <item id="5428" min="1" max="1" chance="2.68" /> <!-- Recipe: Sealed Tallum Helmet (60%) -->
                 <item id="5432" min="1" max="1" chance="1.776" /> <!-- Recipe: Sealed Majestic Circlet (60%) -->
@@ -1232,20 +1224,6 @@
             <skill id="4085" level="1" /> <!-- Critical Damage -->
             <skill id="4086" level="1" /> <!-- Critical Chance -->
         </skillList>
-               <dropLists>
-            <drop>
-                <item id="71438" min="1" max="1" chance="1" /> <!-- Sealed Gauntlets of Nightmare -->
-                <item id="71683" min="1" max="3" chance="1" /> <!-- Sealed Gauntlets of Nightmare -->
-                <item id="70024" min="1" max="10" chance="1.100" /> <!-- Sealed Gauntlets of Nightmare -->
-
-            </drop>
-            <spoil>
-                <item id="71438" min="1" max="1" chance="3" /> <!-- Silver Nugget -->
-                <item id="71683" min="1" max="5" chance="3" /> <!-- Sealed Gauntlets of Nightmare -->
-                <item id="70024" min="1" max="10" chance="5" /> <!-- Sealed Gauntlets of Nightmare -->
-
-            </spoil>
-        </dropLists>
         <ai aggroRange="300" isAggressive="false">
             <clanList>
                 <clan>APT</clan>
@@ -1280,20 +1258,6 @@
             <skill id="4085" level="1" /> <!-- Critical Damage -->
             <skill id="4086" level="1" /> <!-- Critical Chance -->
         </skillList>
-                <dropLists>
-            <drop>
-                <item id="71438" min="1" max="1" chance="1" /> <!-- Sealed Gauntlets of Nightmare -->
-                <item id="71683" min="1" max="3" chance="1" /> <!-- Sealed Gauntlets of Nightmare -->
-                <item id="70024" min="1" max="10" chance="1.100" /> <!-- Sealed Gauntlets of Nightmare -->
-
-            </drop>
-            <spoil>
-                <item id="71438" min="1" max="1" chance="3" /> <!-- Silver Nugget -->
-                <item id="71683" min="1" max="5" chance="3" /> <!-- Sealed Gauntlets of Nightmare -->
-                <item id="70024" min="1" max="10" chance="5" /> <!-- Sealed Gauntlets of Nightmare -->
-
-            </spoil>
-        </dropLists>
         <ai aggroRange="300" isAggressive="false">
             <clanList>
                 <clan>APT</clan>
@@ -1327,20 +1291,6 @@
             <skill id="4085" level="1" /> <!-- Critical Damage -->
             <skill id="4086" level="1" /> <!-- Critical Chance -->
         </skillList>
-                <dropLists>
-            <drop>
-                <item id="71438" min="1" max="1" chance="1" /> <!-- Sealed Gauntlets of Nightmare -->
-                <item id="71683" min="1" max="3" chance="1" /> <!-- Sealed Gauntlets of Nightmare -->
-                <item id="70024" min="1" max="10" chance="1.100" /> <!-- Sealed Gauntlets of Nightmare -->
-
-            </drop>
-            <spoil>
-                <item id="71438" min="1" max="1" chance="3" /> <!-- Silver Nugget -->
-                <item id="71683" min="1" max="5" chance="3" /> <!-- Sealed Gauntlets of Nightmare -->
-                <item id="70024" min="1" max="10" chance="5" /> <!-- Sealed Gauntlets of Nightmare -->
-
-            </spoil>
-        </dropLists>
         <ai aggroRange="300" isAggressive="false">
             <clanList>
                 <clan>APT</clan>
@@ -1375,20 +1325,6 @@
             <skill id="4085" level="1" /> <!-- Critical Damage -->
             <skill id="4086" level="1" /> <!-- Critical Chance -->
         </skillList>
-                <dropLists>
-            <drop>
-                <item id="71438" min="1" max="1" chance="1" /> <!-- Sealed Gauntlets of Nightmare -->
-                <item id="71683" min="1" max="3" chance="1" /> <!-- Sealed Gauntlets of Nightmare -->
-                <item id="70024" min="1" max="10" chance="1.100" /> <!-- Sealed Gauntlets of Nightmare -->
-
-            </drop>
-            <spoil>
-                <item id="71438" min="1" max="1" chance="3" /> <!-- Silver Nugget -->
-                <item id="71683" min="1" max="5" chance="3" /> <!-- Sealed Gauntlets of Nightmare -->
-                <item id="70024" min="1" max="10" chance="5" /> <!-- Sealed Gauntlets of Nightmare -->
-
-            </spoil>
-        </dropLists>
         <ai aggroRange="300" isAggressive="false">
             <clanList>
                 <clan>APT</clan>
@@ -1456,20 +1392,6 @@
             <skill id="4085" level="1" /> <!-- Critical Damage -->
             <skill id="4086" level="1" /> <!-- Critical Chance -->
         </skillList>
-                <dropLists>
-            <drop>
-                <item id="71438" min="1" max="1" chance="1" /> <!-- Sealed Gauntlets of Nightmare -->
-                <item id="71683" min="1" max="3" chance="1" /> <!-- Sealed Gauntlets of Nightmare -->
-                <item id="70024" min="1" max="10" chance="1.100" /> <!-- Sealed Gauntlets of Nightmare -->
-
-            </drop>
-            <spoil>
-                <item id="71438" min="1" max="1" chance="3" /> <!-- Silver Nugget -->
-                <item id="71683" min="1" max="5" chance="3" /> <!-- Sealed Gauntlets of Nightmare -->
-                <item id="70024" min="1" max="10" chance="5" /> <!-- Sealed Gauntlets of Nightmare -->
-
-            </spoil>
-        </dropLists>
         <ai aggroRange="300" isAggressive="false">
             <clanList>
                 <clan>APT</clan>
@@ -1504,20 +1426,6 @@
             <skill id="4085" level="1" /> <!-- Critical Damage -->
             <skill id="4086" level="1" /> <!-- Critical Chance -->
         </skillList>
-                <dropLists>
-            <drop>
-                <item id="71438" min="1" max="1" chance="1" /> <!-- Sealed Gauntlets of Nightmare -->
-                <item id="71683" min="1" max="3" chance="1" /> <!-- Sealed Gauntlets of Nightmare -->
-                <item id="70024" min="1" max="10" chance="1.100" /> <!-- Sealed Gauntlets of Nightmare -->
-
-            </drop>
-            <spoil>
-                <item id="71438" min="1" max="1" chance="3" /> <!-- Silver Nugget -->
-                <item id="71683" min="1" max="5" chance="3" /> <!-- Sealed Gauntlets of Nightmare -->
-                <item id="70024" min="1" max="10" chance="5" /> <!-- Sealed Gauntlets of Nightmare -->
-
-            </spoil>
-        </dropLists>
         <ai aggroRange="300" isAggressive="true">
             <clanList>
                 <clan>APT</clan>
@@ -1542,7 +1450,6 @@
             <radius normal="5" />
             <height normal="12" />
         </collision>
-        
     </npc>
     <npc id="21948" level="85" type="Npc" name="Skaltero">
         <!-- AUTO GENERATED NPC TODO: FIX IT -->

--- a/data/stats/npcs/21900-21999.xml
+++ b/data/stats/npcs/21900-21999.xml
@@ -212,11 +212,11 @@
         </dropLists>
     </npc>
     <npc id="21904" level="76" type="Monster" name="Graveyard Prophet">
-        <!-- AUTO GENERATED NPC TODO: FIX IT -->
         <race>DEMONIC</race>
         <sex>FEMALE</sex>
-      <stats str="40" int="21" dex="30" wit="20" con="43" men="25">
-            <vitals hp="1339.827876" hpRegen="8.5" mp="1679.73" mpRegen="3" />
+		<acquire exp="90738" sp="2723"/>
+		<stats str="40" int="21" dex="30" wit="20" con="43" men="25">
+            <vitals hp="2869.17670907346" hpRegen="8.5" mp="1540.8" mpRegen="3" />
             <speed>
                 <walk ground="70" />
                 <run ground="165" />
@@ -243,10 +243,10 @@
                 <item id="6325" min="1" max="1" chance="0.03" /> <!-- Sealed Phoenix Ring -->
                 <item id="6323" min="1" max="1" chance="0.0075" /> <!-- Sealed Phoenix Necklace -->
                 <item id="6324" min="1" max="1" chance="0.0075" /> <!-- Sealed Phoenix Earring -->
-                <item id="57" min="1810" max="4222" chance="70" /> <!-- Adena -->
-                <item id="1873" min="1" max="1" chance="22.12" /> <!-- Silver Nugget -->
-                <item id="1869" min="3" max="9" chance="8.738" /> <!-- Iron Ore -->
-                <item id="1880" min="1" max="1" chance="5.305" /> <!-- Steel -->
+                <item id="57" min="1433" max="3342" chance="70" /> <!-- Adena -->
+                <item id="1873" min="1" max="1" chance="17.01" /> <!-- Silver Nugget -->
+                <item id="1869" min="1" max="3" chance="20.37" /> <!-- Iron Ore -->
+                <item id="1880" min="1" max="1" chance="2.705" /> <!-- Steel -->
                 <item id="1874" min="1" max="1" chance="3.523" /> <!-- Oriharukon Ore -->
                 <item id="6345" min="1" max="1" chance="2.333" /> <!-- Sealed Phoenix Ring Gemstone -->
                 <item id="6341" min="1" max="1" chance="1.754" /> <!-- Sealed Phoenix Earring Gemstone -->
@@ -255,7 +255,7 @@
                 <item id="4042" min="1" max="1" chance="0.75" /> <!-- Enria -->
             </drop>
             <spoil>
-                <item id="1880" min="1" max="1" chance="64.53" /> <!-- Steel -->
+                <item id="1880" min="1" max="1" chance="51.61" /> <!-- Steel -->
                 <item id="6333" min="1" max="1" chance="3.684" /> <!-- Recipe: Sealed Phoenix Ring (70%) -->
                 <item id="6331" min="1" max="1" chance="2.52" /> <!-- Recipe: Sealed Phoenix Earring (70%) -->
                 <item id="6329" min="1" max="1" chance="1.902" /> <!-- Recipe: Sealed Phoenix Necklace (70%) -->
@@ -263,12 +263,12 @@
         </dropLists>
     </npc>
     <npc id="21905" level="77" type="Monster" name="Netherworld Gatekeeper">
-        <!-- AUTO GENERATED NPC TODO: FIX IT -->
         <race>UNDEAD</race>
         <sex>FEMALE</sex>
         <equipment rhand="78" />
-      <stats str="40" int="21" dex="30" wit="20" con="43" men="25">
-            <vitals hp="1360.37013" hpRegen="8.5" mp="1716.015" mpRegen="3" />
+		<acquire exp="94246" sp="2828"/>
+		<stats str="40" int="21" dex="30" wit="20" con="43" men="25">
+            <vitals hp="2913.59120921392" hpRegen="8.5" mp="1574.0" mpRegen="3" />
             <speed>
                 <walk ground="27" />
                 <run ground="200" />
@@ -294,17 +294,17 @@
                 <item id="6327" min="1" max="1" chance="0.0075" /> <!-- Sealed Majestic Earring -->
                 <item id="6328" min="1" max="1" chance="0.0075" /> <!-- Sealed Majestic Ring -->
                 <item id="6326" min="1" max="1" chance="0.003" /> <!-- Sealed Majestic Necklace -->
-                <item id="57" min="1943" max="4537" chance="70" /> <!-- Adena -->
-                <item id="1870" min="3" max="9" chance="13.88" /> <!-- Coal -->
-                <item id="1875" min="1" max="1" chance="5.668" /> <!-- Stone of Purity -->
-                <item id="1874" min="1" max="1" chance="5.64" /> <!-- Oriharukon Ore -->
+                <item id="57" min="1551" max="3622" chance="70" /> <!-- Adena -->
+                <item id="1870" min="1" max="3" chance="34.33" /> <!-- Coal -->
+                <item id="1875" min="1" max="1" chance="4.318" /> <!-- Stone of Purity -->
+                <item id="1874" min="1" max="1" chance="4.14" /> <!-- Oriharukon Ore -->
                 <item id="6346" min="1" max="1" chance="2.16" /> <!-- Sealed Majestic Ring Gemstone -->
                 <item id="6342" min="1" max="1" chance="1.5" /> <!-- Sealed Majestic Earring Gemstone -->
                 <item id="6344" min="1" max="1" chance="0.75" /> <!-- Sealed Majestic Necklace Beads -->
                 <item id="90012" min="1" max="1" chance="0.075" /> <!-- Common Life Stone -->
             </drop>
             <spoil>
-                <item id="1873" min="1" max="1" chance="92.895" /> <!-- Silver Nugget -->
+                <item id="1873" min="1" max="5" chance="70.54" /> <!-- Silver Nugget -->
                 <item id="6339" min="1" max="1" chance="2.726" /> <!-- Recipe: Sealed Majestic Ring (70%) -->
                 <item id="6337" min="1" max="1" chance="1.814" /> <!-- Recipe: Sealed Majestic Earring (70%) -->
                 <item id="6335" min="1" max="1" chance="1.276" /> <!-- Recipe: Sealed Majestic Necklace (70%) -->
@@ -312,11 +312,11 @@
         </dropLists>
     </npc>
     <npc id="21906" level="77" type="Monster" name="Netherworld Guide">
-        <!-- AUTO GENERATED NPC TODO: FIX IT -->
         <race>UNDEAD</race>
         <sex>FEMALE</sex>
-      <stats str="40" int="21" dex="30" wit="20" con="43" men="25">
-            <vitals hp="1360.37013" hpRegen="8.5" mp="1716.015" mpRegen="3" />
+		<acquire exp="93806" sp="2815"/>
+		<stats str="40" int="21" dex="30" wit="20" con="43" men="25">
+            <vitals hp="2913.59120921392" hpRegen="8.5" mp="1574.0" mpRegen="3" />
             <speed>
                 <walk ground="80" />
                 <run ground="165" />
@@ -345,17 +345,17 @@
                 <item id="5291" min="1" max="1" chance="0.0075" /> <!-- Sealed Dark Crystal Boots -->
                 <item id="5295" min="1" max="1" chance="0.0075" /> <!-- Sealed Tallum Gloves -->
                 <item id="5296" min="1" max="1" chance="0.0075" /> <!-- Sealed Tallum Boots -->
-                <item id="57" min="1910" max="4461" chance="70" /> <!-- Adena -->
-                <item id="1869" min="3" max="9" chance="17.98" /> <!-- Iron Ore -->
-                <item id="1873" min="2" max="6" chance="11.39" /> <!-- Silver Nugget -->
-                <item id="1880" min="1" max="1" chance="10.93" /> <!-- Steel -->
+                <item id="57" min="1520" max="3550" chance="70" /> <!-- Adena -->
+                <item id="1869" min="3" max="9" chance="15.86" /> <!-- Iron Ore -->
+                <item id="1873" min="2" max="6" chance="8.057" /> <!-- Silver Nugget -->
+                <item id="1880" min="1" max="1" chance="9.015" /> <!-- Steel -->
                 <item id="5509" min="1" max="1" chance="1.168" /> <!-- Sealed Tallum Glove Design -->
                 <item id="5497" min="1" max="1" chance="1.139" /> <!-- Sealed Tallum Boot Lining -->
                 <item id="5496" min="1" max="1" chance="1.134" /> <!-- Sealed Dark Crystal Boot Lining -->
                 <item id="5508" min="1" max="1" chance="1.099" /> <!-- Sealed Dark Crystal Glove Design -->
             </drop>
             <spoil>
-                <item id="1865" min="1" max="1" chance="91.785" /> <!-- Varnish -->
+                <item id="1865" min="1" max="9" chance="86.07" /> <!-- Varnish -->
                 <item id="5370" min="1" max="1" chance="2.388" /> <!-- Recipe: Sealed Tallum Boots (60%) -->
                 <item id="5394" min="1" max="1" chance="2.387" /> <!-- Recipe: Sealed Tallum Gloves (60%) -->
                 <item id="5392" min="1" max="1" chance="2.357" /> <!-- Recipe: Sealed Dark Crystal Gloves (60%) -->
@@ -364,11 +364,11 @@
         </dropLists>
     </npc>
     <npc id="21907" level="78" type="Monster" name="Sepulcher Royal Guard">
-        <!-- AUTO GENERATED NPC TODO: FIX IT -->
         <race>UNDEAD</race>
         <sex>FEMALE</sex>
-      <stats str="40" int="21" dex="30" wit="20" con="43" men="25">
-            <vitals hp="1380.469026" hpRegen="8.5" mp="1752.3" mpRegen="3" />
+		<acquire exp="97016" sp="2911"/>
+		<stats str="40" int="21" dex="30" wit="20" con="43" men="25">
+            <vitals hp="2956.64545357656" hpRegen="8.5" mp="1607.4" mpRegen="3" />
             <speed>
                 <walk ground="27" />
                 <run ground="200" />
@@ -393,10 +393,10 @@
             <drop>
                 <item id="5292" min="1" max="1" chance="0.03" /> <!-- Sealed Dark Crystal Shield -->
                 <item id="5315" min="1" max="1" chance="0.03" /> <!-- Sealed Shield of Nightmare -->
-                <item id="57" min="2022" max="4720" chance="70" /> <!-- Adena -->
-                <item id="1872" min="4" max="12" chance="20.1" /> <!-- Animal Bone -->
-                <item id="1881" min="1" max="1" chance="15.02" /> <!-- Coarse Bone Powder -->
-                <item id="1867" min="7" max="21" chance="10.16" /> <!-- Animal Skin -->
+                <item id="57" min="1618" max="3776" chance="70" /> <!-- Adena -->
+                <item id="1872" min="4" max="12" chance="15.92" /> <!-- Animal Bone -->
+                <item id="1881" min="1" max="1" chance="11.07" /> <!-- Coarse Bone Powder -->
+                <item id="1867" min="7" max="21" chance="8.213" /> <!-- Animal Skin -->
                 <item id="5494" min="1" max="1" chance="2.143" /> <!-- Sealed Dark Crystal Shield Fragment -->
                 <item id="5495" min="1" max="1" chance="1.52" /> <!-- Sealed Shield of Nightmare Fragment -->
             </drop>
@@ -407,11 +407,11 @@
         </dropLists>
     </npc>
     <npc id="21908" level="78" type="Monster" name="Sepulcher Prophet">
-        <!-- AUTO GENERATED NPC TODO: FIX IT -->
         <race>UNDEAD</race>
         <sex>FEMALE</sex>
-      <stats str="40" int="21" dex="30" wit="20" con="43" men="25">
-            <vitals hp="1380.469026" hpRegen="8.5" mp="1752.3" mpRegen="3" />
+		<acquire exp="97416" sp="2923"/>
+		<stats str="40" int="21" dex="30" wit="20" con="43" men="25">
+            <vitals hp="2956.64545357656" hpRegen="8.5" mp="1607.4" mpRegen="3" />
             <speed>
                 <walk ground="80" />
                 <run ground="165" />
@@ -440,18 +440,18 @@
                 <item id="5314" min="1" max="1" chance="0.0075" /> <!-- Sealed Boots of Nightmare -->
                 <item id="5318" min="1" max="1" chance="0.0075" /> <!-- Sealed Majestic Gauntlets -->
                 <item id="5319" min="1" max="1" chance="0.0075" /> <!-- Sealed Majestic Boots -->
-                <item id="57" min="2052" max="4789" chance="70" /> <!-- Adena -->
-                <item id="1864" min="4" max="12" chance="22.78" /> <!-- Stem -->
-                <item id="1878" min="2" max="6" chance="7.14" /> <!-- Durable Braid -->
-                <item id="1865" min="9" max="27" chance="4.968" /> <!-- Varnish -->
-                <item id="1895" min="3" max="9" chance="3.682" /> <!-- Metallic Fiber -->
+                <item id="57" min="1646" max="3842" chance="70" /> <!-- Adena -->
+                <item id="1864" min="4" max="12" chance="18.40" /> <!-- Stem -->
+                <item id="1878" min="2" max="6" chance="5.213" /> <!-- Durable Braid -->
+                <item id="1865" min="9" max="27" chance="3.923" /> <!-- Varnish -->
+                <item id="1895" min="1" max="1" chance="18.89" /> <!-- Metallic Fiber -->
                 <item id="5502" min="1" max="1" chance="0.75" /> <!-- Sealed Boots of Nightmare Lining -->
                 <item id="5503" min="1" max="1" chance="0.75" /> <!-- Sealed Majestic Boot Lining -->
                 <item id="5514" min="1" max="1" chance="0.75" /> <!-- Sealed Gauntlets of Nightmare Design -->
                 <item id="5515" min="1" max="1" chance="0.75" /> <!-- Sealed Majestic Gauntlet Design -->
             </drop>
             <spoil>
-                <item id="1873" min="1" max="1" chance="79.32" /> <!-- Silver Nugget -->
+                <item id="1873" min="1" max="3" chance="89.68" /> <!-- Silver Nugget -->
                 <item id="5380" min="1" max="1" chance="1.721" /> <!-- Recipe: Sealed Boots of Nightmare (60%) -->
                 <item id="5406" min="1" max="1" chance="1.71" /> <!-- Recipe: Sealed Majestic Gauntlets (60%) -->
                 <item id="5404" min="1" max="1" chance="1.676" /> <!-- Recipe: Sealed Gauntlets of Nightmare (60%) -->
@@ -460,11 +460,11 @@
         </dropLists>
     </npc>
     <npc id="21909" level="79" type="Monster" name="Sepulcher Hermit">
-        <!-- AUTO GENERATED NPC TODO: FIX IT -->
         <race>DEMONIC</race>
         <sex>FEMALE</sex>
-      <stats str="40" int="21" dex="30" wit="20" con="43" men="25">
-            <vitals hp="1400.075302" hpRegen="8.5" mp="1789.47" mpRegen="3" />
+		<acquire exp="98497" sp="2955"/>
+		<stats str="40" int="21" dex="30" wit="20" con="43" men="25">
+            <vitals hp="2998.26357950914" hpRegen="8.5" mp="1641.0" mpRegen="3" />
             <speed>
                 <walk ground="70" />
                 <run ground="165" />
@@ -491,10 +491,10 @@
                 <item id="5297" min="1" max="1" chance="0.003" /> <!-- Sealed Dark Crystal Leather Armor -->
                 <item id="5298" min="1" max="1" chance="0.003" /> <!-- Sealed Dark Crystal Leggings -->
                 <item id="5301" min="1" max="1" chance="0.003" /> <!-- Sealed Tallum Leather Armor -->
-                <item id="57" min="2002" max="4676" chance="70" /> <!-- Adena -->
-                <item id="1872" min="4" max="12" chance="20.4" /> <!-- Animal Bone -->
-                <item id="1881" min="1" max="1" chance="15.05" /> <!-- Coarse Bone Powder -->
-                <item id="1867" min="7" max="21" chance="10.82" /> <!-- Animal Skin -->
+                <item id="57" min="1590" max="3713" chance="70" /> <!-- Adena -->
+                <item id="1872" min="4" max="12" chance="15.42" /> <!-- Animal Bone -->
+                <item id="1881" min="1" max="1" chance="12.80" /> <!-- Coarse Bone Powder -->
+                <item id="1867" min="7" max="21" chance="8.026" /> <!-- Animal Skin -->
                 <item id="5482" min="1" max="1" chance="0.75" /> <!-- Sealed Dark Crystal Legging Design -->
                 <item id="5478" min="1" max="1" chance="0.3" /> <!-- Sealed Dark Crystal Leather Armor Pattern -->
                 <item id="5479" min="1" max="1" chance="0.3" /> <!-- Sealed Tallum Leather Armor Pattern -->
@@ -511,11 +511,11 @@
         </dropLists>
     </npc>
     <npc id="21910" level="79" type="Monster" name="Nephilim Royal Guard">
-        <!-- AUTO GENERATED NPC TODO: FIX IT -->
         <race>DIVINE</race>
         <sex>FEMALE</sex>
-      <stats str="40" int="21" dex="30" wit="20" con="43" men="25">
-            <vitals hp="1400.075302" hpRegen="8.5" mp="1789.47" mpRegen="3" />
+		<acquire exp="98917" sp="2968"/>
+		<stats str="40" int="21" dex="30" wit="20" con="43" men="25">
+            <vitals hp="2998.26357950914" hpRegen="8.5" mp="1641.0" mpRegen="3" />
             <speed>
                 <walk ground="65" />
                 <run ground="200" />
@@ -542,11 +542,11 @@
                 <item id="5304" min="1" max="1" chance="0.003" /> <!-- Sealed Tallum Tunic -->
                 <item id="5305" min="1" max="1" chance="0.003" /> <!-- Sealed Tallum Stockings -->
                 <item id="5308" min="1" max="1" chance="0.003" /> <!-- Sealed Dark Crystal Robe -->
-                <item id="57" min="2034" max="4749" chance="70" /> <!-- Adena -->
-                <item id="1873" min="1" max="1" chance="23.2" /> <!-- Silver Nugget -->
-                <item id="1869" min="3" max="9" chance="9.918" /> <!-- Iron Ore -->
-                <item id="1880" min="1" max="1" chance="5.879" /> <!-- Steel -->
-                <item id="1874" min="1" max="1" chance="3.946" /> <!-- Oriharukon Ore -->
+                <item id="57" min="1620" max="3783" chance="70" /> <!-- Adena -->
+                <item id="1873" min="1" max="1" chance="18.21" /> <!-- Silver Nugget -->
+                <item id="1869" min="3" max="9" chance="8.159" /> <!-- Iron Ore -->
+                <item id="1880" min="1" max="1" chance="4.951" /> <!-- Steel -->
+                <item id="1874" min="1" max="1" chance="3.521" /> <!-- Oriharukon Ore -->
                 <item id="4039" min="1" max="1" chance="2.049" /> <!-- Mold Glue -->
                 <item id="4042" min="1" max="1" chance="0.75" /> <!-- Enria -->
                 <item id="5489" min="1" max="1" chance="0.75" /> <!-- Sealed Tallum Stocking Fabric -->
@@ -556,7 +556,7 @@
                 <item id="5488" min="1" max="1" chance="0.3" /> <!-- Sealed Majestic Robe Fabric -->
             </drop>
             <spoil>
-                <item id="1873" min="1" max="1" chance="64.36" /> <!-- Silver Nugget -->
+                <item id="1873" min="1" max="3" chance="80.52" /> <!-- Silver Nugget -->
                 <item id="5354" min="1" max="1" chance="1.179" /> <!-- Recipe: Sealed Tallum Stockings (60%) -->
                 <item id="5346" min="1" max="1" chance="0.75" /> <!-- Recipe: Sealed Tallum Tunic (60%) -->
                 <item id="5348" min="1" max="1" chance="0.3" /> <!-- Recipe: Sealed Dark Crystal Robe (60%) -->
@@ -566,9 +566,9 @@
         </dropLists>
     </npc>
     <npc id="21911" level="80" type="Monster" name="Nephilim High Priest">
-        <!-- AUTO GENERATED NPC TODO: FIX IT -->
         <race>DIVINE</race>
         <sex>FEMALE</sex>
+		<acquire exp="110612" sp="3319"/>
         <stats str="40" int="21" dex="30" wit="20" con="43" men="25">
             <vitals hp="1418.7456" hpRegen="8.5" mp="1825.755" mpRegen="3" />
             <speed>
@@ -599,10 +599,10 @@
                 <item id="5293" min="1" max="1" chance="0.003" /> <!-- Sealed Tallum Plate Armor -->
                 <item id="5311" min="1" max="1" chance="0.0009" /> <!-- Sealed Armor of Nightmare -->
                 <item id="5316" min="1" max="1" chance="0.0009" /> <!-- Sealed Majestic Plate Armor -->
-                <item id="57" min="2780" max="6486" chance="70" /> <!-- Adena -->
-                <item id="1870" min="3" max="9" chance="20.28" /> <!-- Coal -->
-                <item id="1875" min="1" max="1" chance="8.134" /> <!-- Stone of Purity -->
-                <item id="1874" min="1" max="1" chance="8.076" /> <!-- Oriharukon Ore -->
+                <item id="57" min="2321" max="5417" chance="70" /> <!-- Adena -->
+                <item id="1870" min="3" max="9" chance="17.37" /> <!-- Coal -->
+                <item id="1875" min="1" max="1" chance="6.518" /> <!-- Stone of Purity -->
+                <item id="1874" min="1" max="1" chance="6.654" /> <!-- Oriharukon Ore -->
                 <item id="5524" min="1" max="1" chance="0.75" /> <!-- Sealed Dark Crystal Gaiter Pattern -->
                 <item id="5523" min="1" max="1" chance="0.3" /> <!-- Sealed Majestic Plate Armor Pattern -->
                 <item id="5522" min="1" max="1" chance="0.3" /> <!-- Sealed Armor of Nightmare Pattern -->
@@ -611,7 +611,7 @@
                 <item id="90012" min="1" max="1" chance="0.3" /> <!-- Common Life Stone -->
             </drop>
             <spoil>
-                <item id="1873" min="1" max="1" chance="86.78" /> <!-- Silver Nugget -->
+                <item id="1873" min="1" max="5" chance="71.29" /> <!-- Silver Nugget -->
                 <item id="5424" min="1" max="1" chance="1.155" /> <!-- Recipe: Sealed Dark Crystal Gaiters (60%) -->
                 <item id="5416" min="1" max="1" chance="0.75" /> <!-- Recipe: Sealed Dark Crystal Breastplate (60%) -->
                 <item id="5418" min="1" max="1" chance="0.3" /> <!-- Recipe: Sealed Tallum Plate Armor (60%) -->
@@ -621,11 +621,11 @@
         </dropLists>
     </npc>
     <npc id="21912" level="80" type="Monster" name="Nephilim Escort">
-        <!-- AUTO GENERATED NPC TODO: FIX IT -->
         <race>DIVINE</race>
-        <sex>FEMALE</sex>
+        <sex>FEMALE</sex>		
+		<acquire exp="110612" sp="3319"/>
         <stats str="40" int="21" dex="30" wit="20" con="43" men="25">
-            <vitals hp="1418.7456" hpRegen="8.5" mp="1825.755" mpRegen="3" />
+            <vitals hp="3038.37159811439" hpRegen="8.5" mp="1674.8" mpRegen="3" />
             <speed>
                 <walk ground="65" />
                 <run ground="200" />
@@ -652,10 +652,10 @@
             <drop>
                 <item id="5289" min="1" max="1" chance="0.03" /> <!-- Sealed Dark Crystal Helmet -->
                 <item id="5294" min="1" max="1" chance="0.03" /> <!-- Sealed Tallum Helmet -->
-                <item id="57" min="2780" max="6486" chance="70" /> <!-- Adena -->
-                <item id="1878" min="2" max="6" chance="9.671" /> <!-- Durable Braid -->
-                <item id="1865" min="9" max="27" chance="6.709" /> <!-- Varnish -->
-                <item id="1895" min="3" max="9" chance="4.916" /> <!-- Metallic Fiber -->
+                <item id="57" min="2321" max="5417" chance="70" /> <!-- Adena -->
+                <item id="1878" min="2" max="6" chance="8.334" /> <!-- Durable Braid -->
+                <item id="1865" min="9" max="27" chance="6.140" /> <!-- Varnish -->
+                <item id="1895" min="3" max="9" chance="4.693" /> <!-- Metallic Fiber -->
                 <item id="1864" min="32" max="96" chance="3.819" /> <!-- Stem -->
                 <item id="5525" min="1" max="1" chance="1.424" /> <!-- Sealed Dark Crystal Helmet Design -->
                 <item id="5526" min="1" max="1" chance="1.393" /> <!-- Sealed Tallum Helmet Design -->
@@ -663,7 +663,7 @@
                 <item id="5528" min="1" max="1" chance="1.129" /> <!-- Sealed Majestic Circlet Design -->
             </drop>
             <spoil>
-                <item id="1875" min="1" max="1" chance="53.56" /> <!-- Stone of Purity -->
+                <item id="1875" min="1" max="1" chance="42.89" /> <!-- Stone of Purity -->
                 <item id="5428" min="1" max="1" chance="2.231" /> <!-- Recipe: Sealed Tallum Helmet (60%) -->
                 <item id="5426" min="1" max="1" chance="2.221" /> <!-- Recipe: Sealed Dark Crystal Helmet (60%) -->
                 <item id="5432" min="1" max="1" chance="1.491" /> <!-- Recipe: Sealed Majestic Circlet (60%) -->


### PR DESCRIPTION
Location: The Disciple's Necropolis
npc id="21895" level="76" name="Mausoleum Prophet"
npc id="21896" level="77" name="Ancient Holy Ground's Hermit"
npc id="21897" level="77" name="Ancient Holy Ground's Totem"
npc id="21898" level="78" name="Ancient Holy Ground's Witch"
npc id="21899" level="78" name="Ancient Holy Ground's Watchman"
npc id="21900" level="79" name="Ancient Holy Ground's Deadman"
npc id="21901" level="79" name="Lillim Slayer"
npc id="21902" level="80" name="Lillim Shaman"
npc id="21903" level="80" name="Lillim Royal Knight"

Location: Catacomb of Dark Omens
npc id="21904" level="76" name="Graveyard Prophet"
npc id="21905" level="77" name="Netherworld Gatekeeper"
npc id="21906" level="77" name="Netherworld Guide"
npc id="21907" level="78" name="Sepulcher Royal Guard"
npc id="21908" level="78" name="Sepulcher Prophet"
npc id="21909" level="79" name="Sepulcher Hermit"
npc id="21910" level="79" name="Nephilim Royal Guard"
npc id="21911" level="80" name="Nephilim High Priest"
npc id="21912" level="80" name="Nephilim Escort"