### PR TITLE
Update AbysWalker skillTrees

### DIFF
--- a/data/skillTrees/2ndClass/AbyssWalker.xml
+++ b/data/skillTrees/2ndClass/AbyssWalker.xml
@@ -1,191 +1,228 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="36" parentClassId="35">
-		<skill skillName="Pirate" skillId="1800" skillLvl="1" getLevel="45" autoGet="true" />
-		<skill skillName="Dark Assassin" skillId="1801" skillLvl="1" getLevel="60" autoGet="true" />
-		<skill skillName="White Assassin" skillId="1802" skillLvl="1" getLevel="70" autoGet="true" />
+
+		<!-- Skills Lv40 -->
 		<skill skillName="Silent Move" skillId="221" skillLvl="1" getLevel="40" levelUpSp="65000" />
 		<skill skillName="Vicious Stance" skillId="312" skillLvl="6" getLevel="40" levelUpSp="65000" />
+		<skill skillName="Potion Mastery" skillId="45184" skillLvl="1" getLevel="40">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
 		<skill skillName="Dagger Mastery" skillId="209" skillLvl="9" getLevel="40" levelUpSp="65000" />
 		<skill skillName="Dagger Mastery" skillId="209" skillLvl="10" getLevel="40" levelUpSp="65000" />
 		<skill skillName="Dagger Mastery" skillId="209" skillLvl="11" getLevel="40" levelUpSp="65000" />
 		<skill skillName="Light Armor Mastery" skillId="233" skillLvl="11" getLevel="40" levelUpSp="65000" />
 		<skill skillName="Light Armor Mastery" skillId="233" skillLvl="12" getLevel="40" levelUpSp="65000" />
 		<skill skillName="Light Armor Mastery" skillId="233" skillLvl="13" getLevel="40" levelUpSp="65000" />
-		<skill skillName="Sting" skillId="223" skillLvl="13" getLevel="40" levelUpSp="65000" />
-		<skill skillName="Sting" skillId="223" skillLvl="14" getLevel="40" levelUpSp="65000" />
-		<skill skillName="Sting" skillId="223" skillLvl="15" getLevel="40" levelUpSp="65000" />
+		<skill skillName="Weapon Mastery" skillId="141" skillLvl="4" getLevel="40" levelUpSp="65000" />
+		<skill skillName="Empower" skillId="45105" skillLvl="3" getLevel="40" levelUpSp="80000" />
+		<skill skillName="Wild Magic" skillId="45106" skillLvl="2" getLevel="40" levelUpSp="80000" />
+		<skill skillName="Berserker Spirit" skillId="45112" skillLvl="2" getLevel="40" levelUpSp="80000" />
 		<skill skillName="Confusion" skillId="2" skillLvl="5" getLevel="40" levelUpSp="65000" />
-		<skill skillName="Freezing Strike" skillId="105" skillLvl="3" getLevel="40" levelUpSp="65000" />
-		<skill skillName="Freezing Strike" skillId="105" skillLvl="4" getLevel="40" levelUpSp="65000" />
-		<skill skillName="Drain Energy" skillId="70" skillLvl="17" getLevel="40" levelUpSp="65000" />
-		<skill skillName="Drain Energy" skillId="70" skillLvl="18" getLevel="40" levelUpSp="65000" />
-		<skill skillName="Drain Energy" skillId="70" skillLvl="19" getLevel="40" levelUpSp="65000" />
+		<skill skillName="Freezing Weapon" skillId="105" skillLvl="5" getLevel="40" levelUpSp="65000" />
+		<skill skillName="Drain Energy" skillId="45250" skillLvl="6" getLevel="40" levelUpSp="65000" />
 		<skill skillName="Critical Damage" skillId="193" skillLvl="3" getLevel="40" levelUpSp="65000" />
+		<skill skillName="Blood Attack" skillId="223" skillLvl="15" getLevel="40" levelUpSp="65000" />
+		<skill skillName="Magic Barrier" skillId="45108" skillLvl="2" getLevel="40" levelUpSp="80000" />
+		<skill skillName="Might" skillId="1068" skillLvl="3" getLevel="40" levelUpSp="80000" />
+		<skill skillName="Sharpness" skillId="53009" skillLvl="1" getLevel="40" levelUpSp="65000" />
 		<skill skillName="Unlock" skillId="27" skillLvl="6" getLevel="40" levelUpSp="65000" />
+		<skill skillName="Acumen" skillId="45104" skillLvl="3" getLevel="40" levelUpSp="80000" />
+		<skill skillName="Hex" skillId="122" skillLvl="1" getLevel="40" levelUpSp="65000" />
+		<skill skillName="Power Break" skillId="115" skillLvl="3" getLevel="40" levelUpSp="65000" />
 		<skill skillName="Deadly Blow" skillId="263" skillLvl="1" getLevel="40" levelUpSp="65000" />
 		<skill skillName="Deadly Blow" skillId="263" skillLvl="2" getLevel="40" levelUpSp="65000" />
 		<skill skillName="Deadly Blow" skillId="263" skillLvl="3" getLevel="40" levelUpSp="65000" />
-		<skill skillName="Power Break" skillId="115" skillLvl="3" getLevel="40" levelUpSp="65000" />
+		<skill skillName="Deadly Blow" skillId="263" skillLvl="4" getLevel="40" levelUpSp="65000" />
+		<skill skillName="Deadly Blow" skillId="263" skillLvl="5" getLevel="40" levelUpSp="65000" />
+		<skill skillName="Accuracy" skillId="256" skillLvl="2" getLevel="40" levelUpSp="110000" />
 		<skill skillName="Backstab" skillId="30" skillLvl="1" getLevel="40" levelUpSp="65000" />
 		<skill skillName="Backstab" skillId="30" skillLvl="2" getLevel="40" levelUpSp="65000" />
 		<skill skillName="Backstab" skillId="30" skillLvl="3" getLevel="40" levelUpSp="65000" />
-		<skill skillName="Potion Mastery" skillId="45184" skillLvl="1" getLevel="40">
-			<item id="57" count="1000000"/> <!-- Adena -->
-		</skill>
-		<skill skillName="Hex" skillId="122" skillLvl="1" getLevel="40" levelUpSp="65000">
-			<item id="3050" count="1" />
-		</skill>
+		<skill skillName="Haste" skillId="45111" skillLvl="2" getLevel="40" levelUpSp="80000" />
+		<skill skillName="Focus" skillId="45109" skillLvl="3" getLevel="40" levelUpSp="80000" />
+		<skill skillName="Clarity" skillId="45113" skillLvl="3" getLevel="40" levelUpSp="80000" />
+		<skill skillName="Death Whisper" skillId="45110" skillLvl="3" getLevel="40" levelUpSp="80000" />
+		<skill skillName="Shield" skillId="1040" skillLvl="3" getLevel="40" levelUpSp="80000" />
+		<skill skillName="Emergency Rescue" skillId="70" skillLvl="10" getLevel="40" levelUpSp="65000" />
 
+		<!-- Skills Lv41 -->
 		<skill skillName="Dagger Mastery" skillId="209" skillLvl="12" getLevel="41" levelUpSp="76000" />
 		<skill skillName="Light Armor Mastery" skillId="233" skillLvl="14" getLevel="41" levelUpSp="76000" />
-		<skill skillName="Sting" skillId="223" skillLvl="16" getLevel="41" levelUpSp="76000" />
-		<skill skillName="Drain Energy" skillId="70" skillLvl="20" getLevel="41" levelUpSp="76000" />
-		<skill skillName="Deadly Blow" skillId="263" skillLvl="4" getLevel="41" levelUpSp="76000" />
+		<skill skillName="Blood Attack" skillId="223" skillLvl="16" getLevel="41" levelUpSp="76000" />
+		<skill skillName="Deadly Blow" skillId="263" skillLvl="6" getLevel="41" levelUpSp="76000" />
 		<skill skillName="Backstab" skillId="30" skillLvl="4" getLevel="41" levelUpSp="76000" />
-		
+		<skill skillName="Emergency Rescue" skillId="70" skillLvl="11" getLevel="41" levelUpSp="76000" />
+
+		<!-- Skills Lv42 -->
 		<skill skillName="Dagger Mastery" skillId="209" skillLvl="13" getLevel="42" levelUpSp="76000" />
 		<skill skillName="Light Armor Mastery" skillId="233" skillLvl="15" getLevel="42" levelUpSp="76000" />
-		<skill skillName="Sting" skillId="223" skillLvl="17" getLevel="42" levelUpSp="76000" />
-		<skill skillName="Freezing Strike" skillId="105" skillLvl="5" getLevel="42" levelUpSp="76000" />
-		<skill skillName="Drain Energy" skillId="70" skillLvl="21" getLevel="42" levelUpSp="76000" />
-		<skill skillName="Deadly Blow" skillId="263" skillLvl="5" getLevel="42" levelUpSp="76000" />
+		<skill skillName="Freezing Weapon" skillId="105" skillLvl="6" getLevel="42" levelUpSp="76000" />
+		<skill skillName="Drain Energy" skillId="45250" skillLvl="7" getLevel="42" levelUpSp="76000" />
+		<skill skillName="Blood Attack" skillId="223" skillLvl="17" getLevel="42" levelUpSp="76000" />
+		<skill skillName="Deadly Blow" skillId="263" skillLvl="7" getLevel="42" levelUpSp="76000" />
 		<skill skillName="Backstab" skillId="30" skillLvl="5" getLevel="42" levelUpSp="76000" />
-		
+		<skill skillName="Emergency Rescue" skillId="70" skillLvl="12" getLevel="42" levelUpSp="76000" />
+
+		<!-- Skills Lv43 -->
 		<skill skillName="Acrobatic Move" skillId="225" skillLvl="2" getLevel="43" levelUpSp="76000" />
 		<skill skillName="Vicious Stance" skillId="312" skillLvl="7" getLevel="43" levelUpSp="76000" />
 		<skill skillName="Esprit" skillId="171" skillLvl="2" getLevel="43" levelUpSp="76000" />
 		<skill skillName="Quick Step" skillId="169" skillLvl="2" getLevel="43" levelUpSp="76000" />
 		<skill skillName="Dagger Mastery" skillId="209" skillLvl="14" getLevel="43" levelUpSp="76000" />
 		<skill skillName="Light Armor Mastery" skillId="233" skillLvl="16" getLevel="43" levelUpSp="76000" />
-		<skill skillName="Sting" skillId="223" skillLvl="18" getLevel="43" levelUpSp="76000" />
 		<skill skillName="Confusion" skillId="2" skillLvl="6" getLevel="43" levelUpSp="76000" />
-		<skill skillName="Freezing Strike" skillId="105" skillLvl="6" getLevel="43" levelUpSp="76000" />
-		<skill skillName="Drain Energy" skillId="70" skillLvl="22" getLevel="43" levelUpSp="76000" />
+		<skill skillName="Blood Attack" skillId="223" skillLvl="18" getLevel="43" levelUpSp="76000" />
 		<skill skillName="Unlock" skillId="27" skillLvl="7" getLevel="43" levelUpSp="76000" />
 		<skill skillName="Hex" skillId="122" skillLvl="2" getLevel="43" levelUpSp="76000" />
-		<skill skillName="Deadly Blow" skillId="263" skillLvl="6" getLevel="43" levelUpSp="76000" />
 		<skill skillName="Power Break" skillId="115" skillLvl="4" getLevel="43" levelUpSp="76000" />
+		<skill skillName="Deadly Blow" skillId="263" skillLvl="8" getLevel="43" levelUpSp="76000" />
 		<skill skillName="Backstab" skillId="30" skillLvl="6" getLevel="43" levelUpSp="76000" />
+		<skill skillName="Emergency Rescue" skillId="70" skillLvl="13" getLevel="43" levelUpSp="76000" />
 
+		<!-- Skills Lv44 -->
 		<skill skillName="Dagger Mastery" skillId="209" skillLvl="15" getLevel="44" levelUpSp="110000" />
 		<skill skillName="Light Armor Mastery" skillId="233" skillLvl="17" getLevel="44" levelUpSp="110000" />
-		<skill skillName="Sting" skillId="223" skillLvl="19" getLevel="44" levelUpSp="110000" />
-		<skill skillName="Drain Energy" skillId="70" skillLvl="23" getLevel="44" levelUpSp="110000" />
-		<skill skillName="Deadly Blow" skillId="263" skillLvl="7" getLevel="44" levelUpSp="110000" />
+		<skill skillName="Freezing Weapon" skillId="105" skillLvl="7" getLevel="44" levelUpSp="110000" />
+		<skill skillName="Drain Energy" skillId="45250" skillLvl="8" getLevel="44" levelUpSp="110000" />
+		<skill skillName="Blood Attack" skillId="223" skillLvl="19" getLevel="44" levelUpSp="110000" />
+		<skill skillName="Deadly Blow" skillId="263" skillLvl="9" getLevel="44" levelUpSp="110000" />
 		<skill skillName="Backstab" skillId="30" skillLvl="7" getLevel="44" levelUpSp="110000" />
-		
+		<skill skillName="Emergency Rescue" skillId="70" skillLvl="14" getLevel="44" levelUpSp="110000" />
+
+		<!-- Skills Lv45 -->
 		<skill skillName="Dagger Mastery" skillId="209" skillLvl="16" getLevel="45" levelUpSp="110000" />
 		<skill skillName="Light Armor Mastery" skillId="233" skillLvl="18" getLevel="45" levelUpSp="110000" />
-		<skill skillName="Sting" skillId="223" skillLvl="20" getLevel="45" levelUpSp="110000" />
-		<skill skillName="Freezing Strike" skillId="105" skillLvl="7" getLevel="45" levelUpSp="110000" />
-		<skill skillName="Drain Energy" skillId="70" skillLvl="24" getLevel="45" levelUpSp="110000" />
-		<skill skillName="Deadly Blow" skillId="263" skillLvl="8" getLevel="45" levelUpSp="110000" />
+		<skill skillName="Blood Attack" skillId="223" skillLvl="20" getLevel="45" levelUpSp="110000" />
+		<skill skillName="Deadly Blow" skillId="263" skillLvl="10" getLevel="45" levelUpSp="110000" />
+		<skill skillName="Pirate Transformation" skillId="1800" skillLvl="1" getLevel="45" autoGet="true" />
 		<skill skillName="Backstab" skillId="30" skillLvl="8" getLevel="45" levelUpSp="110000" />
-		
+		<skill skillName="Emergency Rescue" skillId="70" skillLvl="15" getLevel="45" levelUpSp="110000" />
+
+		<!-- Skills Lv46 -->
 		<skill skillName="Vicious Stance" skillId="312" skillLvl="8" getLevel="46" levelUpSp="110000" />
 		<skill skillName="Esprit" skillId="171" skillLvl="3" getLevel="46" levelUpSp="110000" />
+		<skill skillName="Fast Run" skillId="4" skillLvl="2" getLevel="46" levelUpSp="110000" />
 		<skill skillName="Dagger Mastery" skillId="209" skillLvl="17" getLevel="46" levelUpSp="110000" />
 		<skill skillName="Light Armor Mastery" skillId="233" skillLvl="19" getLevel="46" levelUpSp="110000" />
-		<skill skillName="Sting" skillId="223" skillLvl="21" getLevel="46" levelUpSp="110000" />
 		<skill skillName="Confusion" skillId="2" skillLvl="7" getLevel="46" levelUpSp="110000" />
-		<skill skillName="Freezing Strike" skillId="105" skillLvl="8" getLevel="46" levelUpSp="110000" />
-		<skill skillName="Drain Energy" skillId="70" skillLvl="25" getLevel="46" levelUpSp="110000" />
+		<skill skillName="Freezing Weapon" skillId="105" skillLvl="8" getLevel="46" levelUpSp="110000" />
+		<skill skillName="Drain Energy" skillId="45250" skillLvl="9" getLevel="46" levelUpSp="110000" />
+		<skill skillName="Blood Attack" skillId="223" skillLvl="21" getLevel="46" levelUpSp="110000" />
 		<skill skillName="Unlock" skillId="27" skillLvl="8" getLevel="46" levelUpSp="110000" />
 		<skill skillName="Hex" skillId="122" skillLvl="3" getLevel="46" levelUpSp="110000" />
-		<skill skillName="Deadly Blow" skillId="263" skillLvl="9" getLevel="46" levelUpSp="110000" />
 		<skill skillName="Power Break" skillId="115" skillLvl="5" getLevel="46" levelUpSp="110000" />
+		<skill skillName="Deadly Blow" skillId="263" skillLvl="11" getLevel="46" levelUpSp="110000" />
 		<skill skillName="Boost Evasion" skillId="198" skillLvl="2" getLevel="46" levelUpSp="110000" />
 		<skill skillName="Backstab" skillId="30" skillLvl="9" getLevel="46" levelUpSp="110000" />
+		<skill skillName="Emergency Rescue" skillId="70" skillLvl="16" getLevel="46" levelUpSp="110000" />
 
+		<!-- Skills Lv47 -->
 		<skill skillName="Dagger Mastery" skillId="209" skillLvl="18" getLevel="47" levelUpSp="160000" />
 		<skill skillName="Light Armor Mastery" skillId="233" skillLvl="20" getLevel="47" levelUpSp="160000" />
-		<skill skillName="Sting" skillId="223" skillLvl="22" getLevel="47" levelUpSp="160000" />
-		<skill skillName="Drain Energy" skillId="70" skillLvl="26" getLevel="47" levelUpSp="160000" />
-		<skill skillName="Deadly Blow" skillId="263" skillLvl="10" getLevel="47" levelUpSp="160000" />
+		<skill skillName="Blood Attack" skillId="223" skillLvl="22" getLevel="47" levelUpSp="160000" />
+		<skill skillName="Deadly Blow" skillId="263" skillLvl="12" getLevel="47" levelUpSp="160000" />
 		<skill skillName="Backstab" skillId="30" skillLvl="10" getLevel="47" levelUpSp="160000" />
-		
+		<skill skillName="Emergency Rescue" skillId="70" skillLvl="17" getLevel="47" levelUpSp="160000" />
+
+		<!-- Skills Lv48 -->
 		<skill skillName="Dagger Mastery" skillId="209" skillLvl="19" getLevel="48" levelUpSp="160000" />
 		<skill skillName="Light Armor Mastery" skillId="233" skillLvl="21" getLevel="48" levelUpSp="160000" />
-		<skill skillName="Sting" skillId="223" skillLvl="23" getLevel="48" levelUpSp="160000" />
-		<skill skillName="Freezing Strike" skillId="105" skillLvl="9" getLevel="48" levelUpSp="160000" />
-		<skill skillName="Drain Energy" skillId="70" skillLvl="27" getLevel="48" levelUpSp="160000" />
-		<skill skillName="Deadly Blow" skillId="263" skillLvl="11" getLevel="48" levelUpSp="160000" />
+		<skill skillName="Freezing Weapon" skillId="105" skillLvl="9" getLevel="48" levelUpSp="160000" />
+		<skill skillName="Drain Energy" skillId="45250" skillLvl="10" getLevel="48" levelUpSp="160000" />
+		<skill skillName="Blood Attack" skillId="223" skillLvl="23" getLevel="48" levelUpSp="160000" />
+		<skill skillName="Deadly Blow" skillId="263" skillLvl="13" getLevel="48" levelUpSp="160000" />
 		<skill skillName="Backstab" skillId="30" skillLvl="11" getLevel="48" levelUpSp="160000" />
-		
+		<skill skillName="Emergency Rescue" skillId="70" skillLvl="18" getLevel="48" levelUpSp="160000" />
+
+		<!-- Skills Lv49 -->
 		<skill skillName="Vicious Stance" skillId="312" skillLvl="9" getLevel="49" levelUpSp="160000" />
 		<skill skillName="Esprit" skillId="171" skillLvl="4" getLevel="49" levelUpSp="160000" />
 		<skill skillName="Dagger Mastery" skillId="209" skillLvl="20" getLevel="49" levelUpSp="160000" />
 		<skill skillName="Light Armor Mastery" skillId="233" skillLvl="22" getLevel="49" levelUpSp="160000" />
-		<skill skillName="Sting" skillId="223" skillLvl="24" getLevel="49" levelUpSp="160000" />
 		<skill skillName="Confusion" skillId="2" skillLvl="8" getLevel="49" levelUpSp="160000" />
-		<skill skillName="Freezing Strike" skillId="105" skillLvl="10" getLevel="49" levelUpSp="160000" />
-		<skill skillName="Drain Energy" skillId="70" skillLvl="28" getLevel="49" levelUpSp="160000" />
+		<skill skillName="Blood Attack" skillId="223" skillLvl="24" getLevel="49" levelUpSp="160000" />
 		<skill skillName="Bleed" skillId="96" skillLvl="3" getLevel="49" levelUpSp="160000" />
-		<skill skillName="Poison" skillId="129" skillLvl="2" getLevel="49" levelUpSp="160000" />
 		<skill skillName="Hex" skillId="122" skillLvl="4" getLevel="49" levelUpSp="160000" />
-		<skill skillName="Deadly Blow" skillId="263" skillLvl="12" getLevel="49" levelUpSp="160000" />
 		<skill skillName="Power Break" skillId="115" skillLvl="6" getLevel="49" levelUpSp="160000" />
+		<skill skillName="Deadly Blow" skillId="263" skillLvl="14" getLevel="49" levelUpSp="160000" />
 		<skill skillName="Trick" skillId="11" skillLvl="1" getLevel="49" levelUpSp="160000" />
 		<skill skillName="Backstab" skillId="30" skillLvl="12" getLevel="49" levelUpSp="160000" />
+		<skill skillName="Emergency Rescue" skillId="70" skillLvl="19" getLevel="49" levelUpSp="160000" />
 
+		<!-- Skills Lv50 -->
+		<skill skillName="Potion Mastery" skillId="45184" skillLvl="2" getLevel="50">
+			<item id="57" count="3000000" /> <!-- Adena -->
+		</skill>
 		<skill skillName="Dagger Mastery" skillId="209" skillLvl="21" getLevel="50" levelUpSp="230000" />
 		<skill skillName="Light Armor Mastery" skillId="233" skillLvl="23" getLevel="50" levelUpSp="230000" />
-		<skill skillName="Sting" skillId="223" skillLvl="25" getLevel="50" levelUpSp="230000" />
-		<skill skillName="Drain Energy" skillId="70" skillLvl="29" getLevel="50" levelUpSp="230000" />
-		<skill skillName="Deadly Blow" skillId="263" skillLvl="13" getLevel="50" levelUpSp="230000" />
+		<skill skillName="Recover HP" skillId="45176" skillLvl="2" getLevel="50" levelUpSp="300000" >
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill skillName="Recover MP" skillId="45177" skillLvl="2" getLevel="50" levelUpSp="300000" >
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill skillName="Dark Elven Spirit" skillId="129" skillLvl="3" getLevel="50" levelUpSp="230000" />
+		<skill skillName="Freezing Weapon" skillId="105" skillLvl="10" getLevel="50" levelUpSp="230000" />
+		<skill skillName="Drain Energy" skillId="45250" skillLvl="11" getLevel="50" levelUpSp="230000" />
+		<skill skillName="Blood Attack" skillId="223" skillLvl="25" getLevel="50" levelUpSp="230000" />
+		<skill skillName="Deadly Blow" skillId="263" skillLvl="15" getLevel="50" levelUpSp="230000" />
 		<skill skillName="Backstab" skillId="30" skillLvl="13" getLevel="50" levelUpSp="230000" />
 		<skill skillName="Shadow Step" skillId="821" skillLvl="1" getLevel="50" levelUpSp="230000" />
-		<skill skillName="Potion Mastery" skillId="45184" skillLvl="2" getLevel="50">
-			<item id="57" count="3000000"/> <!-- Adena -->
-		</skill>
-		
+		<skill skillName="Emergency Rescue" skillId="70" skillLvl="20" getLevel="50" levelUpSp="230000" />
+
+		<!-- Skills Lv51 -->
 		<skill skillName="Dagger Mastery" skillId="209" skillLvl="22" getLevel="51" levelUpSp="230000" />
 		<skill skillName="Light Armor Mastery" skillId="233" skillLvl="24" getLevel="51" levelUpSp="230000" />
-		<skill skillName="Sting" skillId="223" skillLvl="26" getLevel="51" levelUpSp="230000" />
-		<skill skillName="Freezing Strike" skillId="105" skillLvl="11" getLevel="51" levelUpSp="230000" />
-		<skill skillName="Drain Energy" skillId="70" skillLvl="30" getLevel="51" levelUpSp="230000" />
-		<skill skillName="Deadly Blow" skillId="263" skillLvl="14" getLevel="51" levelUpSp="230000" />
+		<skill skillName="Freezing Weapon" skillId="105" skillLvl="11" getLevel="51" levelUpSp="230000" />
+		<skill skillName="Blood Attack" skillId="223" skillLvl="26" getLevel="51" levelUpSp="230000" />
+		<skill skillName="Deadly Blow" skillId="263" skillLvl="16" getLevel="51" levelUpSp="230000" />
+		<skill skillName="Hide" skillId="922" skillLvl="1" getLevel="51" levelUpSp="230000" />
 		<skill skillName="Backstab" skillId="30" skillLvl="14" getLevel="51" levelUpSp="230000" />
-		<skill skillName="Hide" skillId="922" skillLvl="1" getLevel="51" levelUpSp="230000" >
-			<item id="49429" count="1" />
-		</skill>
+		<skill skillName="Emergency Rescue" skillId="70" skillLvl="21" getLevel="51" levelUpSp="230000" />
 
+		<!-- Skills Lv52 -->
 		<skill skillName="Vicious Stance" skillId="312" skillLvl="10" getLevel="52" levelUpSp="230000" />
 		<skill skillName="Esprit" skillId="171" skillLvl="5" getLevel="52" levelUpSp="230000" />
+		<skill skillName="Divine Inspiration" skillId="1405" skillLvl="1" getLevel="52" levelUpSp="230000" >
+			<item id="8618" count="1" /> <!-- Ancient Book: Divine Inspiration (Modern Language Version) Lv 1 -->
+		</skill>
 		<skill skillName="Dagger Mastery" skillId="209" skillLvl="23" getLevel="52" levelUpSp="230000" />
 		<skill skillName="Light Armor Mastery" skillId="233" skillLvl="25" getLevel="52" levelUpSp="230000" />
-		<skill skillName="Sting" skillId="223" skillLvl="27" getLevel="52" levelUpSp="230000" />
 		<skill skillName="Confusion" skillId="2" skillLvl="9" getLevel="52" levelUpSp="230000" />
-		<skill skillName="Freezing Strike" skillId="105" skillLvl="12" getLevel="52" levelUpSp="230000" />
-		<skill skillName="Drain Energy" skillId="70" skillLvl="31" getLevel="52" levelUpSp="230000" />
+		<skill skillName="Freezing Weapon" skillId="105" skillLvl="12" getLevel="52" levelUpSp="230000" />
+		<skill skillName="Drain Energy" skillId="45250" skillLvl="12" getLevel="52" levelUpSp="230000" />
 		<skill skillName="Critical Damage" skillId="193" skillLvl="4" getLevel="52" levelUpSp="230000" />
+		<skill skillName="Blood Attack" skillId="223" skillLvl="27" getLevel="52" levelUpSp="230000" />
 		<skill skillName="Unlock" skillId="27" skillLvl="9" getLevel="52" levelUpSp="230000" />
 		<skill skillName="Hex" skillId="122" skillLvl="5" getLevel="52" levelUpSp="230000" />
-		<skill skillName="Deadly Blow" skillId="263" skillLvl="15" getLevel="52" levelUpSp="230000" />
 		<skill skillName="Power Break" skillId="115" skillLvl="7" getLevel="52" levelUpSp="230000" />
+		<skill skillName="Deadly Blow" skillId="263" skillLvl="17" getLevel="52" levelUpSp="230000" />
 		<skill skillName="Trick" skillId="11" skillLvl="2" getLevel="52" levelUpSp="230000" />
 		<skill skillName="Backstab" skillId="30" skillLvl="15" getLevel="52" levelUpSp="230000" />
-		<skill skillName="Divine Inspiration" skillId="1405" skillLvl="1" getLevel="52" levelUpSp="230000" >
-			<item id="8618" count="1" /> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
-		</skill>
-		
+		<skill skillName="Emergency Rescue" skillId="70" skillLvl="22" getLevel="52" levelUpSp="230000" />
+
+		<!-- Skills Lv53 -->
 		<skill skillName="Dagger Mastery" skillId="209" skillLvl="24" getLevel="53" levelUpSp="320000" />
 		<skill skillName="Light Armor Mastery" skillId="233" skillLvl="26" getLevel="53" levelUpSp="320000" />
-		<skill skillName="Sting" skillId="223" skillLvl="28" getLevel="53" levelUpSp="320000" />
-		<skill skillName="Drain Energy" skillId="70" skillLvl="32" getLevel="53" levelUpSp="320000" />
-		<skill skillName="Deadly Blow" skillId="263" skillLvl="16" getLevel="53" levelUpSp="320000" />
+		<skill skillName="Freezing Weapon" skillId="105" skillLvl="13" getLevel="53" levelUpSp="320000" />
+		<skill skillName="Blood Attack" skillId="223" skillLvl="28" getLevel="53" levelUpSp="320000" />
+		<skill skillName="Deadly Blow" skillId="263" skillLvl="18" getLevel="53" levelUpSp="320000" />
 		<skill skillName="Backstab" skillId="30" skillLvl="16" getLevel="53" levelUpSp="320000" />
-		
+		<skill skillName="Emergency Rescue" skillId="70" skillLvl="23" getLevel="53" levelUpSp="320000" />
+
+		<!-- Skills Lv54 -->
 		<skill skillName="Dagger Mastery" skillId="209" skillLvl="25" getLevel="54" levelUpSp="320000" />
 		<skill skillName="Light Armor Mastery" skillId="233" skillLvl="27" getLevel="54" levelUpSp="320000" />
-		<skill skillName="Sting" skillId="223" skillLvl="29" getLevel="54" levelUpSp="320000" />
-		<skill skillName="Freezing Strike" skillId="105" skillLvl="13" getLevel="54" levelUpSp="320000" />
-		<skill skillName="Drain Energy" skillId="70" skillLvl="33" getLevel="54" levelUpSp="320000" />
-		<skill skillName="Deadly Blow" skillId="263" skillLvl="17" getLevel="54" levelUpSp="320000" />
+		<skill skillName="Freezing Weapon" skillId="105" skillLvl="14" getLevel="54" levelUpSp="320000" />
+		<skill skillName="Drain Energy" skillId="45250" skillLvl="13" getLevel="54" levelUpSp="320000" />
+		<skill skillName="Blood Attack" skillId="223" skillLvl="29" getLevel="54" levelUpSp="320000" />
+		<skill skillName="Deadly Blow" skillId="263" skillLvl="19" getLevel="54" levelUpSp="320000" />
 		<skill skillName="Backstab" skillId="30" skillLvl="17" getLevel="54" levelUpSp="320000" />
 		<skill skillName="Shadow Step" skillId="821" skillLvl="2" getLevel="54" levelUpSp="320000" />
-		
+		<skill skillName="Emergency Rescue" skillId="70" skillLvl="24" getLevel="54" levelUpSp="320000" />
+
+		<!-- Skills Lv55 -->
 		<skill skillName="Ultimate Evasion" skillId="111" skillLvl="2" getLevel="55" levelUpSp="320000" />
 		<skill skillName="Acrobatics" skillId="173" skillLvl="2" getLevel="55" levelUpSp="320000" />
 		<skill skillName="Acrobatic Move" skillId="225" skillLvl="3" getLevel="55" levelUpSp="320000" />
@@ -193,242 +230,287 @@
 		<skill skillName="Dagger Mastery" skillId="209" skillLvl="26" getLevel="55" levelUpSp="320000" />
 		<skill skillName="Light Armor Mastery" skillId="233" skillLvl="28" getLevel="55" levelUpSp="320000" />
 		<skill skillName="Boost Breath" skillId="195" skillLvl="2" getLevel="55" levelUpSp="320000" />
-		<skill skillName="Sting" skillId="223" skillLvl="30" getLevel="55" levelUpSp="320000" />
 		<skill skillName="Confusion" skillId="2" skillLvl="10" getLevel="55" levelUpSp="320000" />
-		<skill skillName="Freezing Strike" skillId="105" skillLvl="14" getLevel="55" levelUpSp="320000" />
-		<skill skillName="Drain Energy" skillId="70" skillLvl="34" getLevel="55" levelUpSp="320000" />
+		<skill skillName="Freezing Weapon" skillId="105" skillLvl="15" getLevel="55" levelUpSp="320000" />
+		<skill skillName="Blood Attack" skillId="223" skillLvl="30" getLevel="55" levelUpSp="320000" />
+		<skill skillName="Sharpness" skillId="53009" skillLvl="2" getLevel="55" levelUpSp="320000" />
 		<skill skillName="Unlock" skillId="27" skillLvl="10" getLevel="55" levelUpSp="320000" />
+		<skill skillName="Sand Bomb" skillId="412" skillLvl="1" getLevel="55" levelUpSp="320000" />
 		<skill skillName="Hex" skillId="122" skillLvl="6" getLevel="55" levelUpSp="320000" />
-		<skill skillName="Deadly Blow" skillId="263" skillLvl="18" getLevel="55" levelUpSp="320000" />
 		<skill skillName="Power Break" skillId="115" skillLvl="8" getLevel="55" levelUpSp="320000" />
+		<skill skillName="Deadly Blow" skillId="263" skillLvl="20" getLevel="55" levelUpSp="320000" />
 		<skill skillName="Trick" skillId="11" skillLvl="3" getLevel="55" levelUpSp="320000" />
 		<skill skillName="Backstab" skillId="30" skillLvl="18" getLevel="55" levelUpSp="320000" />
-		<skill skillName="Sand Bomb" skillId="412" skillLvl="1" getLevel="55" levelUpSp="320000" >
-			<item id="49569" count="1" />
-		</skill>
+		<skill skillName="Emergency Rescue" skillId="70" skillLvl="25" getLevel="55" levelUpSp="320000" />
 
+		<!-- Skills Lv56 -->
 		<skill skillName="Dagger Mastery" skillId="209" skillLvl="27" getLevel="56" levelUpSp="440000" />
 		<skill skillName="Light Armor Mastery" skillId="233" skillLvl="29" getLevel="56" levelUpSp="440000" />
-		<skill skillName="Sting" skillId="223" skillLvl="31" getLevel="56" levelUpSp="440000" />
-		<skill skillName="Drain Energy" skillId="70" skillLvl="35" getLevel="56" levelUpSp="440000" />
-		<skill skillName="Deadly Blow" skillId="263" skillLvl="19" getLevel="56" levelUpSp="440000" />
+		<skill skillName="Freezing Weapon" skillId="105" skillLvl="16" getLevel="56" levelUpSp="440000" />
+		<skill skillName="Drain Energy" skillId="45250" skillLvl="14" getLevel="56" levelUpSp="440000" />
+		<skill skillName="Blood Attack" skillId="223" skillLvl="31" getLevel="56" levelUpSp="440000" />
+		<skill skillName="Deadly Blow" skillId="263" skillLvl="21" getLevel="56" levelUpSp="440000" />
 		<skill skillName="Backstab" skillId="30" skillLvl="19" getLevel="56" levelUpSp="440000" />
-		
+		<skill skillName="Emergency Rescue" skillId="70" skillLvl="26" getLevel="56" levelUpSp="440000" />
+
+		<!-- Skills Lv57 -->
 		<skill skillName="Dagger Mastery" skillId="209" skillLvl="28" getLevel="57" levelUpSp="440000" />
 		<skill skillName="Light Armor Mastery" skillId="233" skillLvl="30" getLevel="57" levelUpSp="440000" />
-		<skill skillName="Sting" skillId="223" skillLvl="32" getLevel="57" levelUpSp="440000" />
-		<skill skillName="Freezing Strike" skillId="105" skillLvl="15" getLevel="57" levelUpSp="440000" />
-		<skill skillName="Drain Energy" skillId="70" skillLvl="36" getLevel="57" levelUpSp="440000" />
-		<skill skillName="Deadly Blow" skillId="263" skillLvl="20" getLevel="57" levelUpSp="440000" />
+		<skill skillName="Freezing Weapon" skillId="105" skillLvl="17" getLevel="57" levelUpSp="440000" />
+		<skill skillName="Blood Attack" skillId="223" skillLvl="32" getLevel="57" levelUpSp="440000" />
+		<skill skillName="Deadly Blow" skillId="263" skillLvl="22" getLevel="57" levelUpSp="440000" />
 		<skill skillName="Backstab" skillId="30" skillLvl="20" getLevel="57" levelUpSp="440000" />
-		
+		<skill skillName="Emergency Rescue" skillId="70" skillLvl="27" getLevel="57" levelUpSp="440000" />
+
+		<!-- Skills Lv58 -->
 		<skill skillName="Vicious Stance" skillId="312" skillLvl="12" getLevel="58" levelUpSp="440000" />
 		<skill skillName="Dagger Mastery" skillId="209" skillLvl="29" getLevel="58" levelUpSp="440000" />
 		<skill skillName="Light Armor Mastery" skillId="233" skillLvl="31" getLevel="58" levelUpSp="440000" />
-		<skill skillName="Sting" skillId="223" skillLvl="33" getLevel="58" levelUpSp="440000" />
 		<skill skillName="Confusion" skillId="2" skillLvl="11" getLevel="58" levelUpSp="440000" />
-		<skill skillName="Freezing Strike" skillId="105" skillLvl="16" getLevel="58" levelUpSp="440000" />
-		<skill skillName="Drain Energy" skillId="70" skillLvl="37" getLevel="58" levelUpSp="440000" />
+		<skill skillName="Freezing Weapon" skillId="105" skillLvl="18" getLevel="58" levelUpSp="440000" />
+		<skill skillName="Drain Energy" skillId="45250" skillLvl="15" getLevel="58" levelUpSp="440000" />
+		<skill skillName="Blood Attack" skillId="223" skillLvl="33" getLevel="58" levelUpSp="440000" />
 		<skill skillName="Bleed" skillId="96" skillLvl="4" getLevel="58" levelUpSp="440000" />
-		<skill skillName="Poison" skillId="129" skillLvl="3" getLevel="58" levelUpSp="440000" />
 		<skill skillName="Sand Bomb" skillId="412" skillLvl="2" getLevel="58" levelUpSp="440000" />
 		<skill skillName="Hex" skillId="122" skillLvl="7" getLevel="58" levelUpSp="440000" />
-		<skill skillName="Deadly Blow" skillId="263" skillLvl="21" getLevel="58" levelUpSp="440000" />
 		<skill skillName="Power Break" skillId="115" skillLvl="9" getLevel="58" levelUpSp="440000" />
+		<skill skillName="Deadly Blow" skillId="263" skillLvl="23" getLevel="58" levelUpSp="440000" />
 		<skill skillName="Trick" skillId="11" skillLvl="4" getLevel="58" levelUpSp="440000" />
 		<skill skillName="Boost Evasion" skillId="198" skillLvl="3" getLevel="58" levelUpSp="440000" />
 		<skill skillName="Backstab" skillId="30" skillLvl="21" getLevel="58" levelUpSp="440000" />
 		<skill skillName="Shadow Step" skillId="821" skillLvl="3" getLevel="58" levelUpSp="440000" />
+		<skill skillName="Emergency Rescue" skillId="70" skillLvl="28" getLevel="58" levelUpSp="440000" />
 
+		<!-- Skills Lv59 -->
 		<skill skillName="Dagger Mastery" skillId="209" skillLvl="30" getLevel="59" levelUpSp="640000" />
 		<skill skillName="Light Armor Mastery" skillId="233" skillLvl="32" getLevel="59" levelUpSp="640000" />
-		<skill skillName="Sting" skillId="223" skillLvl="34" getLevel="59" levelUpSp="640000" />
-		<skill skillName="Drain Energy" skillId="70" skillLvl="38" getLevel="59" levelUpSp="640000" />
-		<skill skillName="Deadly Blow" skillId="263" skillLvl="22" getLevel="59" levelUpSp="640000" />
+		<skill skillName="Freezing Weapon" skillId="105" skillLvl="19" getLevel="59" levelUpSp="640000" />
+		<skill skillName="Blood Attack" skillId="223" skillLvl="34" getLevel="59" levelUpSp="640000" />
+		<skill skillName="Deadly Blow" skillId="263" skillLvl="24" getLevel="59" levelUpSp="640000" />
 		<skill skillName="Backstab" skillId="30" skillLvl="22" getLevel="59" levelUpSp="640000" />
-		
+		<skill skillName="Emergency Rescue" skillId="70" skillLvl="29" getLevel="59" levelUpSp="640000" />
+
+		<!-- Skills Lv60 -->
 		<skill skillName="Vicious Stance" skillId="312" skillLvl="13" getLevel="60" levelUpSp="640000" />
+		<skill skillName="Potion Mastery" skillId="45184" skillLvl="3" getLevel="60">
+			<item id="57" count="6000000" /> <!-- Adena -->
+		</skill>
 		<skill skillName="Dagger Mastery" skillId="209" skillLvl="31" getLevel="60" levelUpSp="640000" />
 		<skill skillName="Light Armor Mastery" skillId="233" skillLvl="33" getLevel="60" levelUpSp="640000" />
-		<skill skillName="Sting" skillId="223" skillLvl="35" getLevel="60" levelUpSp="640000" />
+		<skill skillName="Dark Elven Spirit" skillId="129" skillLvl="4" getLevel="60" levelUpSp="640000" />
 		<skill skillName="Confusion" skillId="2" skillLvl="12" getLevel="60" levelUpSp="640000" />
-		<skill skillName="Freezing Strike" skillId="105" skillLvl="17" getLevel="60" levelUpSp="640000" />
-		<skill skillName="Drain Energy" skillId="70" skillLvl="39" getLevel="60" levelUpSp="640000" />
+		<skill skillName="Freezing Weapon" skillId="105" skillLvl="20" getLevel="60" levelUpSp="640000" />
+		<skill skillName="Drain Energy" skillId="45250" skillLvl="16" getLevel="60" levelUpSp="640000" />
+		<skill skillName="Blood Attack" skillId="223" skillLvl="35" getLevel="60" levelUpSp="640000" />
 		<skill skillName="Unlock" skillId="27" skillLvl="11" getLevel="60" levelUpSp="640000" />
 		<skill skillName="Sand Bomb" skillId="412" skillLvl="3" getLevel="60" levelUpSp="640000" />
 		<skill skillName="Hex" skillId="122" skillLvl="8" getLevel="60" levelUpSp="640000" />
-		<skill skillName="Deadly Blow" skillId="263" skillLvl="23" getLevel="60" levelUpSp="640000" />
 		<skill skillName="Power Break" skillId="115" skillLvl="10" getLevel="60" levelUpSp="640000" />
+		<skill skillName="Deadly Blow" skillId="263" skillLvl="25" getLevel="60" levelUpSp="640000" />
+		<skill skillName="Ability to Attack" skillId="77" skillLvl="3" getLevel="60" levelUpSp="640000" />
+		<skill skillName="Dark Assassin Transformation" skillId="1801" skillLvl="1" getLevel="60" autoGet="true" />
 		<skill skillName="Trick" skillId="11" skillLvl="5" getLevel="60" levelUpSp="640000" />
 		<skill skillName="Backstab" skillId="30" skillLvl="23" getLevel="60" levelUpSp="640000" />
+		<skill skillName="Emergency Rescue" skillId="70" skillLvl="30" getLevel="60" levelUpSp="640000" />
 
+		<!-- Skills Lv61 -->
+		<skill skillName="Divine Inspiration" skillId="1405" skillLvl="2" getLevel="61" levelUpSp="640000" >
+			<item id="8619" count="1" /> <!-- Ancient Book: Divine Inspiration (Modern Language Version) Lv 2 -->
+		</skill>
 		<skill skillName="Dagger Mastery" skillId="209" skillLvl="32" getLevel="61" levelUpSp="640000" />
 		<skill skillName="Light Armor Mastery" skillId="233" skillLvl="34" getLevel="61" levelUpSp="640000" />
-		<skill skillName="Sting" skillId="223" skillLvl="36" getLevel="61" levelUpSp="640000" />
-		<skill skillName="Drain Energy" skillId="70" skillLvl="40" getLevel="61" levelUpSp="640000" />
-		<skill skillName="Deadly Blow" skillId="263" skillLvl="24" getLevel="61" levelUpSp="640000" />
+		<skill skillName="Blood Attack" skillId="223" skillLvl="36" getLevel="61" levelUpSp="640000" />
+		<skill skillName="Deadly Blow" skillId="263" skillLvl="26" getLevel="61" levelUpSp="640000" />
 		<skill skillName="Hide" skillId="922" skillLvl="2" getLevel="61" levelUpSp="640000" />
 		<skill skillName="Backstab" skillId="30" skillLvl="24" getLevel="61" levelUpSp="640000" />
-		<skill skillName="Divine Inspiration" skillId="1405" skillLvl="2" getLevel="61" levelUpSp="640000" >
-			<item id="8619" count="1" /> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
-		</skill>
-		
+		<skill skillName="Emergency Rescue" skillId="70" skillLvl="31" getLevel="61" levelUpSp="640000" />
+
+		<!-- Skills Lv62 -->
 		<skill skillName="Vicious Stance" skillId="312" skillLvl="14" getLevel="62" levelUpSp="790000" />
 		<skill skillName="Esprit" skillId="171" skillLvl="6" getLevel="62" levelUpSp="790000" />
 		<skill skillName="Dagger Mastery" skillId="209" skillLvl="33" getLevel="62" levelUpSp="790000" />
 		<skill skillName="Light Armor Mastery" skillId="233" skillLvl="35" getLevel="62" levelUpSp="790000" />
-		<skill skillName="Sting" skillId="223" skillLvl="37" getLevel="62" levelUpSp="790000" />
 		<skill skillName="Confusion" skillId="2" skillLvl="13" getLevel="62" levelUpSp="790000" />
-		<skill skillName="Freezing Strike" skillId="105" skillLvl="18" getLevel="62" levelUpSp="790000" />
-		<skill skillName="Drain Energy" skillId="70" skillLvl="41" getLevel="62" levelUpSp="790000" />
+		<skill skillName="Freezing Weapon" skillId="105" skillLvl="21" getLevel="62" levelUpSp="790000" />
+		<skill skillName="Drain Energy" skillId="45250" skillLvl="17" getLevel="62" levelUpSp="790000" />
+		<skill skillName="Blood Attack" skillId="223" skillLvl="37" getLevel="62" levelUpSp="790000" />
 		<skill skillName="Sand Bomb" skillId="412" skillLvl="4" getLevel="62" levelUpSp="790000" />
 		<skill skillName="Hex" skillId="122" skillLvl="9" getLevel="62" levelUpSp="790000" />
-		<skill skillName="Deadly Blow" skillId="263" skillLvl="25" getLevel="62" levelUpSp="790000" />
 		<skill skillName="Power Break" skillId="115" skillLvl="11" getLevel="62" levelUpSp="790000" />
+		<skill skillName="Deadly Blow" skillId="263" skillLvl="27" getLevel="62" levelUpSp="790000" />
 		<skill skillName="Trick" skillId="11" skillLvl="6" getLevel="62" levelUpSp="790000" />
 		<skill skillName="Backstab" skillId="30" skillLvl="25" getLevel="62" levelUpSp="790000" />
 		<skill skillName="Shadow Step" skillId="821" skillLvl="4" getLevel="62" levelUpSp="790000" />
+		<skill skillName="Emergency Rescue" skillId="70" skillLvl="32" getLevel="62" levelUpSp="790000" />
 
+		<!-- Skills Lv63 -->
 		<skill skillName="Dagger Mastery" skillId="209" skillLvl="34" getLevel="63" levelUpSp="790000" />
 		<skill skillName="Light Armor Mastery" skillId="233" skillLvl="36" getLevel="63" levelUpSp="790000" />
-		<skill skillName="Sting" skillId="223" skillLvl="38" getLevel="63" levelUpSp="790000" />
-		<skill skillName="Drain Energy" skillId="70" skillLvl="42" getLevel="63" levelUpSp="790000" />
-		<skill skillName="Deadly Blow" skillId="263" skillLvl="26" getLevel="63" levelUpSp="790000" />
+		<skill skillName="Blood Attack" skillId="223" skillLvl="38" getLevel="63" levelUpSp="790000" />
+		<skill skillName="Deadly Blow" skillId="263" skillLvl="28" getLevel="63" levelUpSp="790000" />
 		<skill skillName="Backstab" skillId="30" skillLvl="26" getLevel="63" levelUpSp="790000" />
-			
+		<skill skillName="Emergency Rescue" skillId="70" skillLvl="33" getLevel="63" levelUpSp="790000" />
+
+		<!-- Skills Lv64 -->
 		<skill skillName="Vicious Stance" skillId="312" skillLvl="15" getLevel="64" levelUpSp="990000" />
 		<skill skillName="Dagger Mastery" skillId="209" skillLvl="35" getLevel="64" levelUpSp="990000" />
 		<skill skillName="Light Armor Mastery" skillId="233" skillLvl="37" getLevel="64" levelUpSp="990000" />
-		<skill skillName="Sting" skillId="223" skillLvl="39" getLevel="64" levelUpSp="990000" />
 		<skill skillName="Confusion" skillId="2" skillLvl="14" getLevel="64" levelUpSp="990000" />
-		<skill skillName="Freezing Strike" skillId="105" skillLvl="19" getLevel="64" levelUpSp="990000" />
-		<skill skillName="Drain Energy" skillId="70" skillLvl="43" getLevel="64" levelUpSp="990000" />
+		<skill skillName="Freezing Weapon" skillId="105" skillLvl="22" getLevel="64" levelUpSp="990000" />
+		<skill skillName="Drain Energy" skillId="45250" skillLvl="18" getLevel="64" levelUpSp="990000" />
 		<skill skillName="Critical Damage" skillId="193" skillLvl="5" getLevel="64" levelUpSp="990000" />
+		<skill skillName="Blood Attack" skillId="223" skillLvl="39" getLevel="64" levelUpSp="990000" />
 		<skill skillName="Unlock" skillId="27" skillLvl="12" getLevel="64" levelUpSp="990000" />
 		<skill skillName="Sand Bomb" skillId="412" skillLvl="5" getLevel="64" levelUpSp="990000" />
 		<skill skillName="Hex" skillId="122" skillLvl="10" getLevel="64" levelUpSp="990000" />
-		<skill skillName="Deadly Blow" skillId="263" skillLvl="27" getLevel="64" levelUpSp="990000" />
 		<skill skillName="Power Break" skillId="115" skillLvl="12" getLevel="64" levelUpSp="990000" />
+		<skill skillName="Deadly Blow" skillId="263" skillLvl="29" getLevel="64" levelUpSp="990000" />
 		<skill skillName="Trick" skillId="11" skillLvl="7" getLevel="64" levelUpSp="990000" />
 		<skill skillName="Backstab" skillId="30" skillLvl="27" getLevel="64" levelUpSp="990000" />
+		<skill skillName="Emergency Rescue" skillId="70" skillLvl="34" getLevel="64" levelUpSp="990000" />
 
+		<!-- Skills Lv65 -->
 		<skill skillName="Dagger Mastery" skillId="209" skillLvl="36" getLevel="65" levelUpSp="990000" />
 		<skill skillName="Light Armor Mastery" skillId="233" skillLvl="38" getLevel="65" levelUpSp="990000" />
-		<skill skillName="Sting" skillId="223" skillLvl="40" getLevel="65" levelUpSp="990000" />
-		<skill skillName="Drain Energy" skillId="70" skillLvl="44" getLevel="65" levelUpSp="990000" />
-		<skill skillName="Deadly Blow" skillId="263" skillLvl="28" getLevel="65" levelUpSp="990000" />
+		<skill skillName="Blood Attack" skillId="223" skillLvl="40" getLevel="65" levelUpSp="990000" />
+		<skill skillName="Deadly Blow" skillId="263" skillLvl="30" getLevel="65" levelUpSp="990000" />
 		<skill skillName="Backstab" skillId="30" skillLvl="28" getLevel="65" levelUpSp="990000" />
-		
+		<skill skillName="Emergency Rescue" skillId="70" skillLvl="35" getLevel="65" levelUpSp="990000" />
+
+		<!-- Skills Lv66 -->
 		<skill skillName="Vicious Stance" skillId="312" skillLvl="16" getLevel="66" levelUpSp="1100000" />
 		<skill skillName="Dagger Mastery" skillId="209" skillLvl="37" getLevel="66" levelUpSp="1100000" />
 		<skill skillName="Light Armor Mastery" skillId="233" skillLvl="39" getLevel="66" levelUpSp="1100000" />
-		<skill skillName="Sting" skillId="223" skillLvl="41" getLevel="66" levelUpSp="1100000" />
 		<skill skillName="Confusion" skillId="2" skillLvl="15" getLevel="66" levelUpSp="1100000" />
-		<skill skillName="Freezing Strike" skillId="105" skillLvl="20" getLevel="66" levelUpSp="1100000" />
-		<skill skillName="Drain Energy" skillId="70" skillLvl="45" getLevel="66" levelUpSp="1100000" />
+		<skill skillName="Freezing Weapon" skillId="105" skillLvl="23" getLevel="66" levelUpSp="1100000" />
+		<skill skillName="Drain Energy" skillId="45250" skillLvl="19" getLevel="66" levelUpSp="1100000" />
+		<skill skillName="Blood Attack" skillId="223" skillLvl="41" getLevel="66" levelUpSp="1100000" />
 		<skill skillName="Bleed" skillId="96" skillLvl="5" getLevel="66" levelUpSp="1100000" />
-		<skill skillName="Poison" skillId="129" skillLvl="4" getLevel="66" levelUpSp="1100000" />
 		<skill skillName="Sand Bomb" skillId="412" skillLvl="6" getLevel="66" levelUpSp="1100000" />
 		<skill skillName="Hex" skillId="122" skillLvl="11" getLevel="66" levelUpSp="1100000" />
-		<skill skillName="Deadly Blow" skillId="263" skillLvl="29" getLevel="66" levelUpSp="1100000" />
 		<skill skillName="Power Break" skillId="115" skillLvl="13" getLevel="66" levelUpSp="1100000" />
+		<skill skillName="Deadly Blow" skillId="263" skillLvl="31" getLevel="66" levelUpSp="1100000" />
 		<skill skillName="Trick" skillId="11" skillLvl="8" getLevel="66" levelUpSp="1100000" />
 		<skill skillName="Backstab" skillId="30" skillLvl="29" getLevel="66" levelUpSp="1100000" />
 		<skill skillName="Shadow Step" skillId="821" skillLvl="5" getLevel="66" levelUpSp="1100000" />
+		<skill skillName="Emergency Rescue" skillId="70" skillLvl="36" getLevel="66" levelUpSp="1100000" />
 
+		<!-- Skills Lv67 -->
 		<skill skillName="Dagger Mastery" skillId="209" skillLvl="38" getLevel="67" levelUpSp="1100000" />
 		<skill skillName="Light Armor Mastery" skillId="233" skillLvl="40" getLevel="67" levelUpSp="1100000" />
-		<skill skillName="Sting" skillId="223" skillLvl="42" getLevel="67" levelUpSp="1100000" />
-		<skill skillName="Drain Energy" skillId="70" skillLvl="46" getLevel="67" levelUpSp="1100000" />
-		<skill skillName="Deadly Blow" skillId="263" skillLvl="30" getLevel="67" levelUpSp="1100000" />
+		<skill skillName="Blood Attack" skillId="223" skillLvl="42" getLevel="67" levelUpSp="1100000" />
+		<skill skillName="Deadly Blow" skillId="263" skillLvl="32" getLevel="67" levelUpSp="1100000" />
 		<skill skillName="Backstab" skillId="30" skillLvl="30" getLevel="67" levelUpSp="1100000" />
-		
+		<skill skillName="Emergency Rescue" skillId="70" skillLvl="37" getLevel="67" levelUpSp="1100000" />
+
+		<!-- Skills Lv68 -->
 		<skill skillName="Vicious Stance" skillId="312" skillLvl="17" getLevel="68" levelUpSp="1500000" />
 		<skill skillName="Esprit" skillId="171" skillLvl="7" getLevel="68" levelUpSp="1500000" />
 		<skill skillName="Dagger Mastery" skillId="209" skillLvl="39" getLevel="68" levelUpSp="1500000" />
 		<skill skillName="Light Armor Mastery" skillId="233" skillLvl="41" getLevel="68" levelUpSp="1500000" />
-		<skill skillName="Sting" skillId="223" skillLvl="43" getLevel="68" levelUpSp="1500000" />
 		<skill skillName="Confusion" skillId="2" skillLvl="16" getLevel="68" levelUpSp="1500000" />
-		<skill skillName="Freezing Strike" skillId="105" skillLvl="21" getLevel="68" levelUpSp="1500000" />
-		<skill skillName="Drain Energy" skillId="70" skillLvl="47" getLevel="68" levelUpSp="1500000" />
+		<skill skillName="Freezing Weapon" skillId="105" skillLvl="24" getLevel="68" levelUpSp="1500000" />
+		<skill skillName="Drain Energy" skillId="45250" skillLvl="20" getLevel="68" levelUpSp="1500000" />
+		<skill skillName="Blood Attack" skillId="223" skillLvl="43" getLevel="68" levelUpSp="1500000" />
 		<skill skillName="Unlock" skillId="27" skillLvl="13" getLevel="68" levelUpSp="1500000" />
 		<skill skillName="Sand Bomb" skillId="412" skillLvl="7" getLevel="68" levelUpSp="1500000" />
 		<skill skillName="Hex" skillId="122" skillLvl="12" getLevel="68" levelUpSp="1500000" />
-		<skill skillName="Deadly Blow" skillId="263" skillLvl="31" getLevel="68" levelUpSp="1500000" />
 		<skill skillName="Power Break" skillId="115" skillLvl="14" getLevel="68" levelUpSp="1500000" />
+		<skill skillName="Deadly Blow" skillId="263" skillLvl="33" getLevel="68" levelUpSp="1500000" />
 		<skill skillName="Trick" skillId="11" skillLvl="9" getLevel="68" levelUpSp="1500000" />
 		<skill skillName="Backstab" skillId="30" skillLvl="31" getLevel="68" levelUpSp="1500000" />
+		<skill skillName="Emergency Rescue" skillId="70" skillLvl="38" getLevel="68" levelUpSp="1500000" />
 
+		<!-- Skills Lv69 -->
 		<skill skillName="Dagger Mastery" skillId="209" skillLvl="40" getLevel="69" levelUpSp="1500000" />
 		<skill skillName="Light Armor Mastery" skillId="233" skillLvl="42" getLevel="69" levelUpSp="1500000" />
-		<skill skillName="Sting" skillId="223" skillLvl="44" getLevel="69" levelUpSp="1500000" />
-		<skill skillName="Drain Energy" skillId="70" skillLvl="48" getLevel="69" levelUpSp="1500000" />
-		<skill skillName="Deadly Blow" skillId="263" skillLvl="32" getLevel="69" levelUpSp="1500000" />
+		<skill skillName="Blood Attack" skillId="223" skillLvl="44" getLevel="69" levelUpSp="1500000" />
+		<skill skillName="Deadly Blow" skillId="263" skillLvl="34" getLevel="69" levelUpSp="1500000" />
 		<skill skillName="Backstab" skillId="30" skillLvl="32" getLevel="69" levelUpSp="1500000" />
-		
+		<skill skillName="Emergency Rescue" skillId="70" skillLvl="39" getLevel="69" levelUpSp="1500000" />
+
+		<!-- Skills Lv70 -->
 		<skill skillName="Vicious Stance" skillId="312" skillLvl="18" getLevel="70" levelUpSp="1900000" />
 		<skill skillName="Dagger Mastery" skillId="209" skillLvl="41" getLevel="70" levelUpSp="1900000" />
 		<skill skillName="Light Armor Mastery" skillId="233" skillLvl="43" getLevel="70" levelUpSp="1900000" />
-		<skill skillName="Sting" skillId="223" skillLvl="45" getLevel="70" levelUpSp="1900000" />
+		<skill skillName="Dark Elven Spirit" skillId="129" skillLvl="5" getLevel="70" levelUpSp="1900000" />
 		<skill skillName="Confusion" skillId="2" skillLvl="17" getLevel="70" levelUpSp="1900000" />
-		<skill skillName="Freezing Strike" skillId="105" skillLvl="22" getLevel="70" levelUpSp="1900000" />
-		<skill skillName="Drain Energy" skillId="70" skillLvl="49" getLevel="70" levelUpSp="1900000" />
+		<skill skillName="Freezing Weapon" skillId="105" skillLvl="25" getLevel="70" levelUpSp="1900000" />
+		<skill skillName="Drain Energy" skillId="45250" skillLvl="21" getLevel="70" levelUpSp="1900000" />
+		<skill skillName="Blood Attack" skillId="223" skillLvl="45" getLevel="70" levelUpSp="1900000" />
 		<skill skillName="Bleed" skillId="96" skillLvl="6" getLevel="70" levelUpSp="1900000" />
+		<skill skillName="Sharpness" skillId="53009" skillLvl="3" getLevel="70" levelUpSp="1900000" />
 		<skill skillName="Sand Bomb" skillId="412" skillLvl="8" getLevel="70" levelUpSp="1900000" />
 		<skill skillName="Hex" skillId="122" skillLvl="13" getLevel="70" levelUpSp="1900000" />
-		<skill skillName="Deadly Blow" skillId="263" skillLvl="33" getLevel="70" levelUpSp="1900000" />
 		<skill skillName="Power Break" skillId="115" skillLvl="15" getLevel="70" levelUpSp="1900000" />
+		<skill skillName="Deadly Blow" skillId="263" skillLvl="35" getLevel="70" levelUpSp="1900000" />
+		<skill skillName="White Assassin Transformation" skillId="1802" skillLvl="1" getLevel="70" autoGet="true" />
 		<skill skillName="Trick" skillId="11" skillLvl="10" getLevel="70" levelUpSp="1900000" />
 		<skill skillName="Backstab" skillId="30" skillLvl="33" getLevel="70" levelUpSp="1900000" />
 		<skill skillName="Shadow Step" skillId="821" skillLvl="6" getLevel="70" levelUpSp="1900000" />
-		
+		<skill skillName="Emergency Rescue" skillId="70" skillLvl="40" getLevel="70" levelUpSp="1900000" />
+
+		<!-- Skills Lv71 -->
 		<skill skillName="Dagger Mastery" skillId="209" skillLvl="42" getLevel="71" levelUpSp="1900000" />
 		<skill skillName="Light Armor Mastery" skillId="233" skillLvl="44" getLevel="71" levelUpSp="1900000" />
-		<skill skillName="Sting" skillId="223" skillLvl="46" getLevel="71" levelUpSp="1900000" />
-		<skill skillName="Drain Energy" skillId="70" skillLvl="50" getLevel="71" levelUpSp="1900000" />
-		<skill skillName="Deadly Blow" skillId="263" skillLvl="34" getLevel="71" levelUpSp="1900000" />
+		<skill skillName="Blood Attack" skillId="223" skillLvl="46" getLevel="71" levelUpSp="1900000" />
+		<skill skillName="Deadly Blow" skillId="263" skillLvl="36" getLevel="71" levelUpSp="1900000" />
 		<skill skillName="Hide" skillId="922" skillLvl="3" getLevel="71" levelUpSp="1900000" />
 		<skill skillName="Backstab" skillId="30" skillLvl="34" getLevel="71" levelUpSp="1900000" />
+		<skill skillName="Emergency Rescue" skillId="70" skillLvl="41" getLevel="71" levelUpSp="1900000" />
 
+		<!-- Skills Lv72 -->
 		<skill skillName="Vicious Stance" skillId="312" skillLvl="19" getLevel="72" levelUpSp="2100000" />
 		<skill skillName="Dagger Mastery" skillId="209" skillLvl="43" getLevel="72" levelUpSp="2100000" />
 		<skill skillName="Light Armor Mastery" skillId="233" skillLvl="45" getLevel="72" levelUpSp="2100000" />
-		<skill skillName="Sting" skillId="223" skillLvl="47" getLevel="72" levelUpSp="2100000" />
 		<skill skillName="Confusion" skillId="2" skillLvl="18" getLevel="72" levelUpSp="2100000" />
-		<skill skillName="Freezing Strike" skillId="105" skillLvl="23" getLevel="72" levelUpSp="2100000" />
-		<skill skillName="Drain Energy" skillId="70" skillLvl="51" getLevel="72" levelUpSp="2100000" />
+		<skill skillName="Freezing Weapon" skillId="105" skillLvl="26" getLevel="72" levelUpSp="2100000" />
+		<skill skillName="Drain Energy" skillId="45250" skillLvl="22" getLevel="72" levelUpSp="2100000" />
 		<skill skillName="Critical Damage" skillId="193" skillLvl="6" getLevel="72" levelUpSp="2100000" />
+		<skill skillName="Blood Attack" skillId="223" skillLvl="47" getLevel="72" levelUpSp="2100000" />
 		<skill skillName="Unlock" skillId="27" skillLvl="14" getLevel="72" levelUpSp="2100000" />
 		<skill skillName="Sand Bomb" skillId="412" skillLvl="9" getLevel="72" levelUpSp="2100000" />
 		<skill skillName="Hex" skillId="122" skillLvl="14" getLevel="72" levelUpSp="2100000" />
-		<skill skillName="Deadly Blow" skillId="263" skillLvl="35" getLevel="72" levelUpSp="2100000" />
 		<skill skillName="Power Break" skillId="115" skillLvl="16" getLevel="72" levelUpSp="2100000" />
+		<skill skillName="Deadly Blow" skillId="263" skillLvl="37" getLevel="72" levelUpSp="2100000" />
 		<skill skillName="Trick" skillId="11" skillLvl="11" getLevel="72" levelUpSp="2100000" />
 		<skill skillName="Backstab" skillId="30" skillLvl="35" getLevel="72" levelUpSp="2100000" />
+		<skill skillName="Emergency Rescue" skillId="70" skillLvl="42" getLevel="72" levelUpSp="2100000" />
 
+		<!-- Skills Lv73 -->
 		<skill skillName="Dagger Mastery" skillId="209" skillLvl="44" getLevel="73" levelUpSp="2100000" />
 		<skill skillName="Light Armor Mastery" skillId="233" skillLvl="46" getLevel="73" levelUpSp="2100000" />
-		<skill skillName="Sting" skillId="223" skillLvl="48" getLevel="73" levelUpSp="2100000" />
-		<skill skillName="Drain Energy" skillId="70" skillLvl="52" getLevel="73" levelUpSp="2100000" />
-		<skill skillName="Deadly Blow" skillId="263" skillLvl="36" getLevel="73" levelUpSp="2100000" />
+		<skill skillName="Drain Energy" skillId="45250" skillLvl="23" getLevel="73" levelUpSp="2100000" />
+		<skill skillName="Blood Attack" skillId="223" skillLvl="48" getLevel="73" levelUpSp="2100000" />
+		<skill skillName="Deadly Blow" skillId="263" skillLvl="38" getLevel="73" levelUpSp="2100000" />
 		<skill skillName="Backstab" skillId="30" skillLvl="36" getLevel="73" levelUpSp="2100000" />
-		
+		<skill skillName="Emergency Rescue" skillId="70" skillLvl="43" getLevel="73" levelUpSp="2100000" />
+
+		<!-- Skills Lv74 -->
 		<skill skillName="Vicious Stance" skillId="312" skillLvl="20" getLevel="74" levelUpSp="2100000" />
 		<skill skillName="Esprit" skillId="171" skillLvl="8" getLevel="74" levelUpSp="2100000" />
 		<skill skillName="Dagger Mastery" skillId="209" skillLvl="45" getLevel="74" levelUpSp="2100000" />
 		<skill skillName="Light Armor Mastery" skillId="233" skillLvl="47" getLevel="74" levelUpSp="2100000" />
-		<skill skillName="Sting" skillId="223" skillLvl="49" getLevel="74" levelUpSp="2100000" />
 		<skill skillName="Confusion" skillId="2" skillLvl="19" getLevel="74" levelUpSp="2100000" />
-		<skill skillName="Freezing Strike" skillId="105" skillLvl="24" getLevel="74" levelUpSp="2100000" />
-		<skill skillName="Drain Energy" skillId="70" skillLvl="53" getLevel="74" levelUpSp="2100000" />
+		<skill skillName="Freezing Weapon" skillId="105" skillLvl="27" getLevel="74" levelUpSp="2100000" />
+		<skill skillName="Drain Energy" skillId="45250" skillLvl="24" getLevel="74" levelUpSp="2100000" />
 		<skill skillName="Critical Damage" skillId="193" skillLvl="7" getLevel="74" levelUpSp="2100000" />
-		<skill skillName="Poison" skillId="129" skillLvl="5" getLevel="74" levelUpSp="2100000" />
+		<skill skillName="Blood Attack" skillId="223" skillLvl="49" getLevel="74" levelUpSp="2100000" />
 		<skill skillName="Sand Bomb" skillId="412" skillLvl="10" getLevel="74" levelUpSp="2100000" />
 		<skill skillName="Hex" skillId="122" skillLvl="15" getLevel="74" levelUpSp="2100000" />
-		<skill skillName="Deadly Blow" skillId="263" skillLvl="37" getLevel="74" levelUpSp="2100000" />
 		<skill skillName="Power Break" skillId="115" skillLvl="17" getLevel="74" levelUpSp="2100000" />
+		<skill skillName="Deadly Blow" skillId="263" skillLvl="39" getLevel="74" levelUpSp="2100000" />
 		<skill skillName="Trick" skillId="11" skillLvl="12" getLevel="74" levelUpSp="2100000" />
 		<skill skillName="Backstab" skillId="30" skillLvl="37" getLevel="74" levelUpSp="2100000" />
 		<skill skillName="Shadow Step" skillId="821" skillLvl="7" getLevel="74" levelUpSp="2100000" />
+		<skill skillName="Emergency Rescue" skillId="70" skillLvl="44" getLevel="74" levelUpSp="2100000" />
+
+		<!-- Skills Lv75 -->
+		<skill skillName="Confusion" skillId="2" skillLvl="20" getLevel="75" levelUpSp="2100000" />
+		<skill skillName="Drain Energy" skillId="45250" skillLvl="25" getLevel="75" levelUpSp="2100000" />
+		<skill skillName="Blood Attack" skillId="223" skillLvl="50" getLevel="75" levelUpSp="2100000" />
+		<skill skillName="Deadly Blow" skillId="263" skillLvl="40" getLevel="75" levelUpSp="2100000" />
+		<skill skillName="Emergency Rescue" skillId="70" skillLvl="45" getLevel="75" levelUpSp="2100000" />
+
 	</skillTree>
 </list>


### PR DESCRIPTION
Update for current 306 ver. No 2nd job books, new lvls to Potion Mastery