### PR TITLE
Update to Datapack

### DIFF
--- a/data/EnchantItemOptions.xml
+++ b/data/EnchantItemOptions.xml
@@ -12,7 +12,7 @@
 		<options level="7" option1="33455" />
 		<options level="8" option1="33456" />
 		<options level="9" option1="33457" />
-		<options level="10" option1="33458" />		
+		<options level="10" option1="33458" />
 	</item>
 	<item id="92405"> <!-- Core's_Plasmic_Bow-->
 		<options level="0" option1="33470" />
@@ -25,7 +25,7 @@
 		<options level="7" option1="33477" />
 		<options level="8" option1="33478" />
 		<options level="9" option1="33479" />
-		<options level="10" option1="33480" />		
+		<options level="10" option1="33480" />
 	</item>
 	<item id="92406"> <!-- Queen_Ant's_Stone_Spear-->
 		<options level="0" option1="33437" />
@@ -38,7 +38,7 @@
 		<options level="7" option1="33444" />
 		<options level="8" option1="33445" />
 		<options level="9" option1="33446" />
-		<options level="10" option1="33447" />		
+		<options level="10" option1="33447" />
 	</item>
 	<item id="92407"> <!-- Orfen's_Venomed_Sword-->
 		<options level="0" option1="33459" />
@@ -51,7 +51,7 @@
 		<options level="7" option1="33466" />
 		<options level="8" option1="33467" />
 		<options level="9" option1="33468" />
-		<options level="10" option1="33469" />		
+		<options level="10" option1="33469" />
 	</item>
 	<item id="92408"> <!-- Baium's_Thunder_Breaker-->
 		<options level="0" option1="33426" />
@@ -64,7 +64,7 @@
 		<options level="7" option1="33433" />
 		<options level="8" option1="33434" />
 		<options level="9" option1="33435" />
-		<options level="10" option1="33436" />		
+		<options level="10" option1="33436" />
 	</item>
 	<item id="92421"> <!-- Queen_Ant's_Stone_Breaker-->
 		<options level="0" option1="33437" />
@@ -77,9 +77,9 @@
 		<options level="7" option1="33444" />
 		<options level="8" option1="33445" />
 		<options level="9" option1="33446" />
-		<options level="10" option1="33447" />		
+		<options level="10" option1="33447" />
 	</item>
-	
+
 	<!-- Armor -->
 	<item id="93075"> <!-- Gloves_of_Silence -->
 		<options level="0" option1="33483" />
@@ -92,7 +92,7 @@
 		<options level="7" option1="33490" />
 		<options level="8" option1="33491" />
 		<options level="9" option1="33492" />
-		<options level="10" option1="33493" />		
+		<options level="10" option1="33493" />
 	</item>
 	<item id="93076"> <!-- Gloves_of_Silence -->
 		<options level="0" option1="33483" />
@@ -105,9 +105,9 @@
 		<options level="7" option1="33490" />
 		<options level="8" option1="33491" />
 		<options level="9" option1="33492" />
-		<options level="10" option1="33493" />		
+		<options level="10" option1="33493" />
 	</item>
-	
+
 	<!-- Hat -->
 	<item id="70728"> <!-- White Uniform Hat -->
 		<options level="1" option1="30190" />
@@ -323,7 +323,7 @@
 		<options level="7" option1="30202" option2="50202" />
 		<options level="8" option1="30204" option2="50203" />
 		<options level="9" option1="30206" option2="50204" />
-		<options level="10" option1="30208" option2="50205" />		
+		<options level="10" option1="30208" option2="50205" />
 	</item>
 	<item id="70737"> <!-- Refined Romantic Chapeau: Blue -->
 		<options level="1" option1="30190" />
@@ -335,7 +335,7 @@
 		<options level="7" option1="30202" option2="50202" />
 		<options level="8" option1="30204" option2="50203" />
 		<options level="9" option1="30206" option2="50204" />
-		<options level="10" option1="30208" option2="50205" />		
+		<options level="10" option1="30208" option2="50205" />
 	</item>
 	<item id="70736"> <!-- Refined Romantic Chapeau: Blue -->
 		<options level="1" option1="30190" />
@@ -347,7 +347,7 @@
 		<options level="7" option1="30202" option2="50202" />
 		<options level="8" option1="30204" option2="50203" />
 		<options level="9" option1="30206" option2="50204" />
-		<options level="10" option1="30208" option2="50205" />		
+		<options level="10" option1="30208" option2="50205" />
 	</item>
 	<item id="70735"> <!-- Refined Romantic Chapeau: Blue -->
 		<options level="1" option1="30190" />
@@ -359,7 +359,7 @@
 		<options level="7" option1="30202" option2="50202" />
 		<options level="8" option1="30204" option2="50203" />
 		<options level="9" option1="30206" option2="50204" />
-		<options level="10" option1="30208" option2="50205" />		
+		<options level="10" option1="30208" option2="50205" />
 	</item>
 	<item id="70749"> <!-- Chic Silver Chapeau -->
 		<options level="1" option1="30190" />
@@ -371,7 +371,7 @@
 		<options level="7" option1="30202" option2="50202" />
 		<options level="8" option1="30204" option2="50203" />
 		<options level="9" option1="30206" option2="50204" />
-		<options level="10" option1="30208" option2="50205" />		
+		<options level="10" option1="30208" option2="50205" />
 	</item>
 	<item id="70748"> <!-- Chic Silver Chapeau -->
 		<options level="1" option1="30190" />
@@ -383,7 +383,7 @@
 		<options level="7" option1="30202" option2="50202" />
 		<options level="8" option1="30204" option2="50203" />
 		<options level="9" option1="30206" option2="50204" />
-		<options level="10" option1="30208" option2="50205" />		
+		<options level="10" option1="30208" option2="50205" />
 	</item>
 	<item id="70747"> <!-- Chic Silver Chapeau -->
 		<options level="1" option1="30190" />
@@ -395,9 +395,9 @@
 		<options level="7" option1="30202" option2="50202" />
 		<options level="8" option1="30204" option2="50203" />
 		<options level="9" option1="30206" option2="50204" />
-		<options level="10" option1="30208" option2="50205" />		
+		<options level="10" option1="30208" option2="50205" />
 	</item>
-	
+
 	<item id="94213"> <!-- Hero's Circlet -->
 		<options level="0" option1="34125" />
 		<options level="1" option1="34126" />
@@ -409,37 +409,37 @@
 		<options level="7" option1="34132" />
 		<options level="8" option1="34133" />
 		<options level="9" option1="34134" />
-		<options level="10" option1="34135" />		
+		<options level="10" option1="34135" />
 	</item>
-	
+
 	<!-- Belt -->
 	<item id="91788"> <!-- Dragon_Belt-->
-		<options level="0" option1="33359" />
-		<options level="1" option1="33360" />
-		<options level="2" option1="33361" />
-		<options level="3" option1="33362" />
-		<options level="4" option1="33363" />
-		<options level="5" option1="33364" />
-		<options level="6" option1="33365" />
-		<options level="7" option1="33366" />
-		<options level="8" option1="33367" />
-		<options level="9" option1="33368" />
-		<options level="10" option1="33369" />		
+		<options level="1" option1="33359" />
+		<options level="2" option1="33360" />
+		<options level="3" option1="33361" />
+		<options level="4" option1="33362" />
+		<options level="5" option1="33363" />
+		<options level="6" option1="33364" />
+		<options level="7" option1="33365" />
+		<options level="8" option1="33366" />
+		<options level="9" option1="33367" />
+		<options level="10" option1="33368" />
+		<options level="11" option1="33369" />
 	</item>
-	<item id="91862"> <!-- Dragon_Belt-->
-		<options level="0" option1="33359" />
-		<options level="1" option1="33360" />
-		<options level="2" option1="33361" />
-		<options level="3" option1="33362" />
-		<options level="4" option1="33363" />
-		<options level="5" option1="33364" />
-		<options level="6" option1="33365" />
-		<options level="7" option1="33366" />
-		<options level="8" option1="33367" />
-		<options level="9" option1="33368" />
-		<options level="10" option1="33369" />		
+	<item id="91862"> <!-- Dragon_Belt (Imprint) -->
+		<options level="1" option1="33359" />
+		<options level="2" option1="33360" />
+		<options level="3" option1="33361" />
+		<options level="4" option1="33362" />
+		<options level="5" option1="33363" />
+		<options level="6" option1="33364" />
+		<options level="7" option1="33365" />
+		<options level="8" option1="33366" />
+		<options level="9" option1="33367" />
+		<options level="10" option1="33368" />
+		<options level="11" option1="33369" />
 	</item>
-	
+
 	<item id="91952"> <!-- Ring_of_Insolence-->
 		<options level="0" option1="33376" />
 		<options level="1" option1="33377" />
@@ -451,9 +451,9 @@
 		<options level="7" option1="33383" />
 		<options level="8" option1="33384" />
 		<options level="9" option1="33385" />
-		<options level="10" option1="33386" />		
+		<options level="10" option1="33386" />
 	</item>
-	
+
 	<!-- Cloak -->
 	<item id="93041"> <!-- Adventurer's_Cloak -->
 		<options level="0" option1="33481" />
@@ -470,7 +470,7 @@
 		<options level="7" option1="80008" />
 		<options level="8" option1="80009" />
 		<options level="9" option1="80010" />
-		<options level="10" option1="80011" />		
+		<options level="10" option1="80011" />
 	</item>
 	<item id="70878"> <!-- Aden Cloak -->
 		<options level="0" option1="80023" />
@@ -497,7 +497,7 @@
 		<options level="8" option1="80053" />
 		<options level="9" option1="80054" />
 		<options level="10" option1="80055" />
-	</item>	
+	</item>
 	<item id="70880"> <!-- Ferios Cloak -->
 		<options level="0" option1="80067" />
 		<options level="1" option1="80068" />
@@ -510,7 +510,7 @@
 		<options level="8" option1="80075" />
 		<options level="9" option1="80076" />
 		<options level="10" option1="80077" />
-	</item>	
+	</item>
 	<item id="70881"> <!-- Elmoreden Cloak - Legendary -->
 		<options level="0" option1="80001" />
 		<options level="1" option1="80002" />
@@ -579,7 +579,7 @@
 		<options level="18" option1="80063" />
 		<options level="19" option1="80064" />
 		<options level="20" option1="80065" option2="80066" />
-	</item>	
+	</item>
 	<item id="70884"> <!-- Ferios Cloak - Legendary -->
 		<options level="0" option1="80067" />
 		<options level="1" option1="80068" />
@@ -602,7 +602,7 @@
 		<options level="18" option1="80085" />
 		<options level="19" option1="80086" />
 		<options level="20" option1="80087" option2="80088" />
-	</item>	
+	</item>
 	<item id="93301"> <!-- Cloak_of_Protection -->
 		<options level="0" option1="33494" />
 		<options level="1" option1="33495" />
@@ -655,7 +655,7 @@
 		<options level="9" option1="33334" />
 		<options level="10" option1="33335" option2="33336" />
 	</item>
-	
+
 	<item id="91210"> <!-- Black Sayha's Cloak -->
 		<options level="0" option1="50377" />
 		<options level="1" option1="50378" />
@@ -695,27 +695,27 @@
 		<options level="9" option1="50386" />
 		<options level="10" option1="50387" option2="50388" />
 	</item>
-	
-	<!-- Dandy Pendant -->	
+
+	<!-- Dandy Pendant -->
 	<item id="49801"> <!-- Dandy_Pendant_1d -->
-		<options level="0" option1="50009" />		
+		<options level="0" option1="50009" />
 	</item>
 	<item id="49802"> <!-- Dandy_S_Pendant_1d -->
-		<options level="0" option1="50010" />		
+		<options level="0" option1="50010" />
 	</item>
 	<item id="90190"> <!-- Dandy_Pendant_1d -->
-		<options level="0" option1="50009" />		
+		<options level="0" option1="50009" />
 	</item>
 	<item id="90191"> <!-- Dandy_S_Pendant_1d -->
-		<options level="0" option1="50010" />		
+		<options level="0" option1="50010" />
 	</item>
 	<item id="90196"> <!-- Dandy_Pendant_1d -->
-		<options level="0" option1="50009" />		
+		<options level="0" option1="50009" />
 	</item>
 	<item id="90197"> <!-- Dandy_S_Pendant_1d -->
-		<options level="0" option1="50010" />		
+		<options level="0" option1="50010" />
 	</item>
-	<!-- Pendant -->	
+	<!-- Pendant -->
 	<item id="91244"> <!-- Dragon Pendant Lv. 1 -->
 		<options level="0" option1="50389" />
 		<options level="1" option1="50390" />
@@ -1008,7 +1008,7 @@
 		<options level="9" option1="60218" />
 		<options level="10" option1="60219" />
 	</item>
-	
+
 	<!-- Talisman -->
 	<item id="49683"> <!-- Talisman_of_Baium -->
 		<options level="1" option1="33399" />
@@ -1018,30 +1018,30 @@
 		<options level="5" option1="33403" />
 	</item>
 	<item id="91745"> <!-- Talisman of Aden -->
-		<options level="0" option1="33338"  />
-		<options level="1" option1="33339" />
-		<options level="2" option1="33340" />
-		<options level="3" option1="33341" />
-		<options level="4" option1="33342" />
-		<options level="5" option1="33343" />
-		<options level="6" option1="33344" />
-		<options level="7" option1="33345" />
-		<options level="8" option1="33346" />
-		<options level="9" option1="33347" />
-		<options level="10" option1="33348" />
+		<options level="1" option1="33338"  />
+		<options level="2" option1="33339" />
+		<options level="3" option1="33340" />
+		<options level="4" option1="33341" />
+		<options level="5" option1="33342" />
+		<options level="6" option1="33343" />
+		<options level="7" option1="33344" />
+		<options level="8" option1="33345" />
+		<options level="9" option1="33346" />
+		<options level="10" option1="33347" />
+		<options level="11" option1="33348" />
 	</item>
 	<item id="92018"> <!-- Talisman of Eva -->
-		<options level="0" option1="33404" />
-		<options level="1" option1="33405" />
-		<options level="2" option1="33406" />
-		<options level="3" option1="33407" />
-		<options level="4" option1="33408" />
-		<options level="5" option1="33409" />
-		<options level="6" option1="33410" />
-		<options level="7" option1="33411" />
-		<options level="8" option1="33412" />
-		<options level="9" option1="33413" />
-		<options level="10" option1="33414" />
+		<options level="1" option1="33404" />
+		<options level="2" option1="33405" />
+		<options level="3" option1="33406" />
+		<options level="4" option1="33407" />
+		<options level="5" option1="33408" />
+		<options level="6" option1="33409" />
+		<options level="7" option1="33410" />
+		<options level="8" option1="33411" />
+		<options level="9" option1="33412" />
+		<options level="10" option1="33413" />
+		<options level="11" option1="33414" />
 	</item>
 	<item id="92403"> <!-- Talisman_of_Speed -->
 		<options level="0" option1="33415" />
@@ -1056,7 +1056,7 @@
 		<options level="9" option1="33424" />
 		<options level="10" option1="33425" />
 	</item>
-	
+
 	<!-- Damaged RB accessory -->
 	<item id="90993"> <!-- Damaged_Antharas'_Earring -->
 		<options level="0" option1="50300" />
@@ -1069,7 +1069,7 @@
 		<options level="7" option1="50307" />
 		<options level="8" option1="50308" />
 		<options level="9" option1="50309" />
-		<options level="10" option1="50310" />		
+		<options level="10" option1="50310" />
 	</item>
 	<item id="90994"> <!-- Damaged_Baium's_Ring -->
 		<options level="0" option1="50311" />
@@ -1082,7 +1082,7 @@
 		<options level="7" option1="50318" />
 		<options level="8" option1="50319" />
 		<options level="9" option1="50320" />
-		<options level="10" option1="50321" />		
+		<options level="10" option1="50321" />
 	</item>
 	<item id="91006"> <!-- Damaged_Zaken's_Earring -->
 		<options level="0" option1="50322" />
@@ -1095,10 +1095,10 @@
 		<options level="7" option1="50329" />
 		<options level="8" option1="50330" />
 		<options level="9" option1="50331" />
-		<options level="10" option1="50332" />		
+		<options level="10" option1="50332" />
 	</item>
-		
-	<!-- Elemental RB Necklace	 -->	
+
+	<!-- Elemental RB Necklace	 -->
 	<item id="91119"> <!-- Ignis'_Necklace -->
 		<options level="0" option1="50333" />
 		<options level="1" option1="50334" />
@@ -1151,7 +1151,7 @@
 		<options level="9" option1="50375" />
 		<options level="10" option1="50376" />
 	</item>
-	
+
 	<item id="91953"> <!-- Dragon valley earing -->
 		<options level="0" option1="33387" />
 		<options level="1" option1="33388" />
@@ -1165,7 +1165,7 @@
 		<options level="9" option1="33396" />
 		<options level="10" option1="33397" />
 	</item>
-	
+
 	<item id="71691"> <!-- Dragon Pedant - Attack Type Lv. 1 -->
 		<options level="0" option1="81023" />
 		<options level="1" option1="81024" />
@@ -1514,7 +1514,7 @@
 		<options level="8" option1="80690" />
 		<options level="9" option1="80691" />
 		<options level="10" option1="80692" />
-	</item>	
+	</item>
 	<item id="71304"> <!-- Agathion - Capricorn -->
 		<options level="0" option1="80693"  />
 		<options level="1" option1="80694" />
@@ -1527,7 +1527,7 @@
 		<options level="8" option1="80701" />
 		<options level="9" option1="80702" />
 		<options level="10" option1="80703" />
-	</item>	
+	</item>
 	<item id="71305"> <!-- Agathion - Libra -->
 		<options level="0" option1="80704"  />
 		<options level="1" option1="80705" />

--- a/data/combination-items.xml
+++ b/data/combination-items.xml
@@ -1,2442 +1,1827 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org xsd/combination-items.xsd" >
 
-<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	  xmlns="http://l2j.org"
-	  xsi:schemaLocation="http://l2j.org xsd/combination-items.xsd" >
-	  <!-- POWER TALISMAN -->
-	<item one="70080" two="71078" chance="30">
-		<reward id="70081" type="ON_SUCCESS" /> <!-- Brooch Lv. 2 -->
-		<reward id="70080" type="ON_FAILURE" /> <!-- Brooch Lv. 1 -->
+	<!-- Topaz (Imprint) -->
+	<item one="90313" two="90313" chance="65"> <!-- Topaz Lv. 1/ Topaz Lv. 1 -->
+		<reward id="90314" type="ON_SUCCESS" /> <!-- Topaz Lv. 2 -->
+		<reward id="90313" type="ON_FAILURE" /> <!-- Topaz Lv. 1 -->
 	</item>
-
-	<item one="70081" two="71078" chance="30">
-		<reward id="70082" type="ON_SUCCESS" /> <!-- Brooch Lv. 2 -->
-		<reward id="70081" type="ON_FAILURE" /> <!-- Brooch Lv. 1 -->
+	<item one="90314" two="90314" chance="40"> <!-- Topaz Lv. 2/ Topaz Lv. 2 -->
+		<reward id="90315" type="ON_SUCCESS" /> <!-- Topaz Lv. 3 -->
+		<reward id="90314" type="ON_FAILURE" /> <!-- Topaz Lv. 2 -->
 	</item>
-
-	<item one="70082" two="71078" chance="30">
-		<reward id="70083" type="ON_SUCCESS" /> <!-- Brooch Lv. 2 -->
-		<reward id="70082" type="ON_FAILURE" /> <!-- Brooch Lv. 1 -->
+	<item one="90315" two="90315" chance="20"> <!-- Topaz Lv. 3/ Topaz Lv. 3 -->
+		<reward id="90316" type="ON_SUCCESS" /> <!-- Topaz Lv. 4 -->
+		<reward id="90315" type="ON_FAILURE" /> <!-- Topaz Lv. 3 -->
 	</item>
-
-	<item one="70083" two="71078" chance="30">
-		<reward id="70084" type="ON_SUCCESS" /> <!-- Brooch Lv. 2 -->
-		<reward id="70083" type="ON_FAILURE" /> <!-- Brooch Lv. 1 -->
+	<item one="90316" two="90316" chance="10"> <!-- Topaz Lv. 4/ Topaz Lv. 4 -->
+		<reward id="90317" type="ON_SUCCESS" /> <!-- Topaz Lv. 5 -->
+		<reward id="90316" type="ON_FAILURE" /> <!-- Topaz Lv. 4 -->
 	</item>
 
+	<!-- Garnet (Imprint) -->
+	<item one="90318" two="90318" chance="65"> <!-- Garnet Lv. 1/ Garnet Lv. 1 -->
+		<reward id="90319" type="ON_SUCCESS" /> <!-- Garnet Lv. 2 -->
+		<reward id="90318" type="ON_FAILURE" /> <!-- Garnet Lv. 1 -->
+	</item>
+	<item one="90319" two="90319" chance="40"> <!-- Garnet Lv. 2/ Garnet Lv. 2 -->
+		<reward id="90320" type="ON_SUCCESS" /> <!-- Garnet Lv. 3 -->
+		<reward id="90319" type="ON_FAILURE" /> <!-- Garnet Lv. 2 -->
+	</item>
+	<item one="90320" two="90320" chance="20"> <!-- Garnet Lv. 3/ Garnet Lv. 3 -->
+		<reward id="90321" type="ON_SUCCESS" /> <!-- Garnet Lv. 4 -->
+		<reward id="90320" type="ON_FAILURE" /> <!-- Garnet Lv. 3 -->
+	</item>
+	<item one="90321" two="90321" chance="10"> <!-- Garnet Lv. 4/ Garnet Lv. 4 -->
+		<reward id="90322" type="ON_SUCCESS" /> <!-- Garnet Lv. 5 -->
+		<reward id="90321" type="ON_FAILURE" /> <!-- Garnet Lv. 4 -->
+	</item>
+
+	<!-- Jade (imrpint) -->
+	<item one="90323" two="90323" chance="65"> <!-- Jade Lv. 1/ Jade Lv. 1 -->
+		<reward id="90324" type="ON_SUCCESS" /> <!-- Jade Lv. 2 -->
+		<reward id="90323" type="ON_FAILURE" /> <!-- Jade Lv. 1 -->
+	</item>
+	<item one="90324" two="90324" chance="40"> <!-- Jade Lv. 2/ Jade Lv. 2 -->
+		<reward id="90325" type="ON_SUCCESS" /> <!-- Jade Lv. 3 -->
+		<reward id="90324" type="ON_FAILURE" /> <!-- Jade Lv. 2 -->
+	</item>
+	<item one="90325" two="90325" chance="20"> <!-- Jade Lv. 3/ Jade Lv. 3 -->
+		<reward id="90326" type="ON_SUCCESS" /> <!-- Jade Lv. 4 -->
+		<reward id="90325" type="ON_FAILURE" /> <!-- Jade Lv. 3 -->
+	</item>
+	<item one="90326" two="90326" chance="10"> <!-- Jade Lv. 4/ Jade Lv. 4 -->
+		<reward id="90327" type="ON_SUCCESS" /> <!-- Jade Lv. 5 -->
+		<reward id="90326" type="ON_FAILURE" /> <!-- Jade Lv. 4 -->
+	</item>
+
+	<!-- Ruby (Imprint) -->
+	<item one="90328" two="90328" chance="65"> <!-- Ruby Lv. 1/ Ruby Lv. 1 -->
+		<reward id="90329" type="ON_SUCCESS" /> <!-- Ruby Lv. 2 -->
+		<reward id="90328" type="ON_FAILURE" /> <!-- Ruby Lv. 1 -->
+	</item>
+	<item one="90329" two="90329" chance="40"> <!-- Ruby Lv. 2/ Ruby Lv. 2 -->
+		<reward id="90330" type="ON_SUCCESS" /> <!-- Ruby Lv. 3 -->
+		<reward id="90329" type="ON_FAILURE" /> <!-- Ruby Lv. 2 -->
+	</item>
+	<item one="90330" two="90330" chance="20"> <!-- Ruby Lv. 3/ Ruby Lv. 3 -->
+		<reward id="90331" type="ON_SUCCESS" /> <!-- Ruby Lv. 4 -->
+		<reward id="90330" type="ON_FAILURE" /> <!-- Ruby Lv. 3 -->
+	</item>
+	<item one="90331" two="90331" chance="10"> <!-- Ruby Lv. 4/ Ruby Lv. 4 -->
+		<reward id="90332" type="ON_SUCCESS" /> <!-- Ruby Lv. 5 -->
+		<reward id="90331" type="ON_FAILURE" /> <!-- Ruby Lv. 4 -->
+	</item>
+
+	<!-- Sapphire (Imprint) -->
+	<item one="90333" two="90333" chance="65"> <!-- Sapphire Lv. 1/ Sapphire Lv. 1 -->
+		<reward id="90334" type="ON_SUCCESS" /> <!-- Sapphire Lv. 2 -->
+		<reward id="90333" type="ON_FAILURE" /> <!-- Sapphire Lv. 1 -->
+	</item>
+	<item one="90334" two="90334" chance="40"> <!-- Sapphire Lv. 2/ Sapphire Lv. 2 -->
+		<reward id="90335" type="ON_SUCCESS" /> <!-- Sapphire Lv. 3 -->
+		<reward id="90334" type="ON_FAILURE" /> <!-- Sapphire Lv. 2 -->
+	</item>
+	<item one="90335" two="90335" chance="20"> <!-- Sapphire Lv. 4/ Sapphire Lv. 3 -->
+		<reward id="90336" type="ON_SUCCESS" /> <!-- Sapphire Lv. 4 -->
+		<reward id="90335" type="ON_FAILURE" /> <!-- Sapphire Lv. 3 -->
+	</item>
+	<item one="90336" two="90336" chance="10"> <!-- Sapphire Lv. 4/ Sapphire Lv. 4 -->
+		<reward id="90337" type="ON_SUCCESS" /> <!-- Sapphire Lv. 5 -->
+		<reward id="90336" type="ON_FAILURE" /> <!-- Sapphire Lv. 4 -->
+	</item>
+
+	<!-- Cat's Eye (Imprint) -->
+	<item one="90929" two="90929" chance="65"> <!-- Cat's Eye Lv. 1/ Cat's Eye Lv. 1 -->
+		<reward id="90930" type="ON_SUCCESS" /> <!-- Cat's Eye Lv. 2 -->
+		<reward id="90929" type="ON_FAILURE" /> <!-- Cat's Eye Lv. 1 -->
+	</item>
+	<item one="90930" two="90930" chance="40"> <!-- Cat's Eye Lv. 2/ Cat's Eye Lv. 2 -->
+		<reward id="90931" type="ON_SUCCESS" /> <!-- Cat's Eye Lv. 3 -->
+		<reward id="90930" type="ON_FAILURE" /> <!-- Cat's Eye Lv. 2 -->
+	</item>
+	<item one="90931" two="90931" chance="20"> <!-- Cat's Eye Lv. 3/ Cat's Eye Lv. 3 -->
+		<reward id="90932" type="ON_SUCCESS" /> <!-- Cat's Eye Lv. 4 -->
+		<reward id="90931" type="ON_FAILURE" /> <!-- Cat's Eye Lv. 3 -->
+	</item>
+	<item one="90932" two="90932" chance="10"> <!-- Cat's Eye Lv. 4/ Cat's Eye Lv. 4 -->
+		<reward id="90933" type="ON_SUCCESS" /> <!-- Cat's Eye Lv. 5 -->
+		<reward id="90932" type="ON_FAILURE" /> <!-- Cat's Eye Lv. 4 -->
+	</item>
+
+	<!-- Diamond (Imprint) -->
+	<item one="90338" two="90338" chance="65"> <!-- Diamond Lv. 1/ Diamond Lv. 1 -->
+		<reward id="90339" type="ON_SUCCESS" /> <!-- Diamond Lv. 2 -->
+		<reward id="90338" type="ON_FAILURE" /> <!-- Diamond Lv. 1 -->
+	</item>
+	<item one="90339" two="90339" chance="40"> <!-- Diamond Lv. 2/ Diamond Lv. 2 -->
+		<reward id="90340" type="ON_SUCCESS" /> <!-- Diamond Lv. 3 -->
+		<reward id="90339" type="ON_FAILURE" /> <!-- Diamond Lv. 2 -->
+	</item>
+	<item one="90340" two="90340" chance="20"> <!-- Diamond Lv. 3/ Diamond Lv. 3 -->
+		<reward id="90341" type="ON_SUCCESS" /> <!-- Diamond Lv. 4 -->
+		<reward id="90340" type="ON_FAILURE" /> <!-- Diamond Lv. 3 -->
+	</item>
+	<item one="90341" two="90341" chance="10"> <!-- Diamond Lv. 4/ Diamond Lv. 4 -->
+		<reward id="90342" type="ON_SUCCESS" /> <!-- Diamond Lv. 5 -->
+		<reward id="90341" type="ON_FAILURE" /> <!-- Diamond Lv. 4 -->
+	</item>
+
+	<!-- Pearl (Imprint) -->
+	<item one="90343" two="90343" chance="65"> <!-- Pearl Lv. 1/ Pearl Lv. 1 -->
+		<reward id="90344" type="ON_SUCCESS" /> <!-- Pearl Lv. 2 -->
+		<reward id="90343" type="ON_FAILURE" /> <!-- Pearl Lv. 1 -->
+	</item>
+	<item one="90344" two="90344" chance="40"> <!-- Pearl Lv. 2/ Pearl Lv. 2 -->
+		<reward id="90345" type="ON_SUCCESS" /> <!-- Pearl Lv. 3 -->
+		<reward id="90344" type="ON_FAILURE" /> <!-- Pearl Lv. 2 -->
+	</item>
+	<item one="90345" two="90345" chance="20"> <!-- Pearl Lv. 3/ Pearl Lv. 3 -->
+		<reward id="90346" type="ON_SUCCESS" /> <!-- Pearl Lv. 4 -->
+		<reward id="90345" type="ON_FAILURE" /> <!-- Pearl Lv. 3 -->
+	</item>
+	<item one="90346" two="90346" chance="10"> <!-- Pearl Lv. 4/ Pearl Lv. 4 -->
+		<reward id="90347" type="ON_SUCCESS" /> <!-- Pearl Lv. 5 -->
+		<reward id="90346" type="ON_FAILURE" /> <!-- Pearl Lv. 4 -->
+	</item>
+
+	<!-- Vital Stone (Imprint) -->
+	<item one="90353" two="90353" chance="65"> <!-- Vital Stone Lv. 1/ Vital Stone Lv. 1 -->
+		<reward id="90354" type="ON_SUCCESS" /> <!-- Vital Stone Lv. 2 -->
+		<reward id="90353" type="ON_FAILURE" /> <!-- Vital Stone Lv. 1 -->
+	</item>
+	<item one="90354" two="90354" chance="40"> <!-- Vital Stone Lv. 2/ Vital Stone Lv. 2 -->
+		<reward id="90355" type="ON_SUCCESS" /> <!-- Vital Stone Lv. 3 -->
+		<reward id="90354" type="ON_FAILURE" /> <!-- Vital Stone Lv. 2 -->
+	</item>
+	<item one="90355" two="90355" chance="20"> <!-- Vital Stone Lv. 3/ Vital Stone Lv. 3 -->
+		<reward id="90356" type="ON_SUCCESS" /> <!-- Vital Stone Lv. 4 -->
+		<reward id="90355" type="ON_FAILURE" /> <!-- Vital Stone Lv. 3 -->
+	</item>
+	<item one="90356" two="90356" chance="10"> <!-- Vital Stone Lv. 4/ Vital Stone Lv. 4 -->
+		<reward id="90357" type="ON_SUCCESS" /> <!-- Vital Stone Lv. 5 -->
+		<reward id="90356" type="ON_FAILURE" /> <!-- Vital Stone Lv. 4 -->
+	</item>
+
+	<!-- Emerald (Imprint) -->
+	<item one="91357" two="91357" chance="65"> <!-- Emerald Lv. 1/ Emerald Lv. 1 -->
+		<reward id="91358" type="ON_SUCCESS" /> <!-- Emerald Lv. 2 -->
+		<reward id="91357" type="ON_FAILURE" /> <!-- Emerald Lv. 1 -->
+	</item>
+	<item one="91358" two="91358" chance="40"> <!-- Emerald Lv. 2/ Emerald Lv. 2 -->
+		<reward id="91359" type="ON_SUCCESS" /> <!-- Emerald Lv. 3 -->
+		<reward id="91358" type="ON_FAILURE" /> <!-- Emerald Lv. 2 -->
+	</item>
+	<item one="91359" two="91359" chance="20"> <!-- Emerald Lv. 3/ Emerald Lv. 3 -->
+		<reward id="91360" type="ON_SUCCESS" /> <!-- Emerald Lv. 4 -->
+		<reward id="91359" type="ON_FAILURE" /> <!-- Emerald Lv. 2 -->
+	</item>
+	<item one="91360" two="91360" chance="10"> <!-- Emerald Lv. 4/ Emerald Lv. 4 -->
+		<reward id="91361" type="ON_SUCCESS" /> <!-- Emerald Lv. 5 -->
+		<reward id="91360" type="ON_FAILURE" /> <!-- Emerald Lv. 4 -->
+	</item>
+
+	<!-- Aquamarine (Imprint) -->
+	<item one="90924" two="90924" chance="70"> <!-- Aquamarine Lv. 1/ Aquamarine Lv. 1 -->
+		<reward id="90925" type="ON_SUCCESS" /> <!-- Aquamarine LV. 2 -->
+		<reward id="90924" type="ON_FAILURE" /> <!-- Aquamarine Lv. 1 -->
+	</item>
+	<item one="90925" two="90925" chance="70"> <!-- Aquamarine Lv. 2/ Aquamarine Lv. 2 -->
+		<reward id="90926" type="ON_SUCCESS" /> <!-- Aquamarine LV. 3 -->
+		<reward id="90925" type="ON_FAILURE" /> <!-- Aquamarine LV. 2 -->
+	</item>
+	<item one="90926" two="90926" chance="70"> <!-- Aquamarine Lv. 3/ Aquamarine Lv. 3 -->
+		<reward id="90927" type="ON_SUCCESS" /> <!-- Aquamarine LV. 4 -->
+		<reward id="90926" type="ON_FAILURE" /> <!-- Aquamarine LV. 3 -->
+	</item>
+	<item one="90927" two="90927" chance="70"> <!-- Aquamarine Lv. 4/ Aquamarine Lv. 4 -->
+		<reward id="90928" type="ON_SUCCESS" /> <!-- Aquamarine LV. 5 -->
+		<reward id="90927" type="ON_FAILURE" /> <!-- Aquamarine LV. 4 -->
+	</item>
+
+	<!-- Sigel Soul Crystal -->
+	<item one="90534" two="90534" chance="33"> <!-- Sigel Soul Crystal Lv. 1 / Sigel Soul Crystal Lv. 1 -->
+		<reward id="90535" count="1" type="ON_SUCCESS" /> <!-- Sigel Soul Crystal Lv. 2 -->
+		<reward id="90534" count="1" type="ON_FAILURE" /> <!-- Sigel Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90535" two="90534" chance="33"> <!-- Sigel Soul Crystal Lv. 2 / Sigel Soul Crystal Lv. 1 -->
+		<reward id="90536" count="1" type="ON_SUCCESS" /> <!-- Sigel Soul Crystal Lv. 3 -->
+		<reward id="90534" count="1" type="ON_FAILURE" /> <!-- Sigel Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90536" two="90534" chance="33"> <!-- Sigel Soul Crystal Lv. 3 / Sigel Soul Crystal Lv. 1 -->
+		<reward id="90537" count="1" type="ON_SUCCESS" /> <!-- Sigel Soul Crystal Lv. 4 -->
+		<reward id="90534" count="1" type="ON_FAILURE" /> <!-- Sigel Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90537" two="90534" chance="33"> <!-- Sigel Soul Crystal Lv. 4 / Sigel Soul Crystal Lv. 1 -->
+		<reward id="90538" count="1" type="ON_SUCCESS" /> <!-- Sigel Soul Crystal Lv. 5 -->
+		<reward id="90534" count="1" type="ON_FAILURE" /> <!-- Sigel Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90538" two="90534" chance="33"> <!-- Sigel Soul Crystal Lv. 5 / Sigel Soul Crystal Lv. 1 -->
+		<reward id="90539" count="1" type="ON_SUCCESS" /> <!-- Sigel Soul Crystal Lv. 6 -->
+		<reward id="90534" count="1" type="ON_FAILURE" /> <!-- Sigel Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90539" two="90534" chance="33"> <!-- Sigel Soul Crystal Lv. 6 / Sigel Soul Crystal Lv. 1 -->
+		<reward id="90540" count="1" type="ON_SUCCESS" /> <!-- Sigel Soul Crystal Lv. 7 -->
+		<reward id="90539" count="1" type="ON_FAILURE" /> <!-- Sigel Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90540" two="90534" chance="33"> <!-- Sigel Soul Crystal Lv. 7 / Sigel Soul Crystal Lv. 1 -->
+		<reward id="90541" count="1" type="ON_SUCCESS" /> <!-- Sigel Soul Crystal Lv. 8 -->
+		<reward id="90539" count="1" type="ON_FAILURE" /> <!-- Sigel Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90541" two="90534" chance="33"> <!-- Sigel Soul Crystal Lv. 8 / Sigel Soul Crystal Lv. 1 -->
+		<reward id="90542" count="1" type="ON_SUCCESS" /> <!-- Sigel Soul Crystal Lv. 9 -->
+		<reward id="90539" count="1" type="ON_FAILURE" /> <!-- Sigel Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90542" two="90534" chance="33"> <!-- Sigel Soul Crystal Lv. 9 / Sigel Soul Crystal Lv. 1 -->
+		<reward id="90543" count="1" type="ON_SUCCESS" /> <!-- Sigel Soul Crystal Lv. 10 -->
+		<reward id="90539" count="1" type="ON_FAILURE" /> <!-- Sigel Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90543" two="90534" chance="33"> <!-- Sigel Soul Crystal Lv. 10 / Sigel Soul Crystal Lv. 1 -->
+		<reward id="90544" count="1" type="ON_SUCCESS" /> <!-- Sigel Soul Crystal Lv. 11 -->
+		<reward id="90539" count="1" type="ON_FAILURE" /> <!-- Sigel Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90544" two="90534" chance="33"> <!-- Sigel Soul Crystal Lv. 11 / Sigel Soul Crystal Lv. 1 -->
+		<reward id="90545" count="1" type="ON_SUCCESS" /> <!-- Sigel Soul Crystal Lv. 12 -->
+		<reward id="90544" count="1" type="ON_FAILURE" /> <!-- Sigel Soul Crystal Lv. 11 -->
+	</item>
+	<item one="90545" two="90534" chance="33"> <!-- Sigel Soul Crystal Lv. 12 / Sigel Soul Crystal Lv. 1 -->
+		<reward id="90546" count="1" type="ON_SUCCESS" /> <!-- Sigel Soul Crystal Lv. 13 -->
+		<reward id="90544" count="1" type="ON_FAILURE" /> <!-- Sigel Soul Crystal Lv. 11 -->
+	</item>
+	<item one="90546" two="90534" chance="33"> <!-- Sigel Soul Crystal Lv. 13 / Sigel Soul Crystal Lv. 1 -->
+		<reward id="90547" count="1" type="ON_SUCCESS" /> <!-- Sigel Soul Crystal Lv. 14 -->
+		<reward id="90544" count="1" type="ON_FAILURE" /> <!-- Sigel Soul Crystal Lv. 11 -->
+	</item>
+	<item one="90547" two="90534" chance="33"> <!-- Sigel Soul Crystal Lv. 14 / Sigel Soul Crystal Lv. 1 -->
+		<reward id="90548" count="1" type="ON_SUCCESS" /> <!-- Sigel Soul Crystal Lv. 15 -->
+		<reward id="90544" count="1" type="ON_FAILURE" /> <!-- Sigel Soul Crystal Lv. 11 -->
+	</item>
+
+	<!-- Tyrr Soul Crystal -->
+	<item one="90554" two="90554" chance="33"> <!-- Tyrr Soul Crystal Lv. 1 / Tyrr Soul Crystal Lv. 1 -->
+		<reward id="90555" count="1" type="ON_SUCCESS" /> <!-- Tyrr Soul Crystal Lv. 2 -->
+		<reward id="90554" count="1" type="ON_FAILURE" /> <!-- Tyrr Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90555" two="90554" chance="33"> <!-- Tyrr Soul Crystal Lv. 2 / Tyrr Soul Crystal Lv. 1 -->
+		<reward id="90556" count="1" type="ON_SUCCESS" /> <!-- Tyrr Soul Crystal Lv. 3 -->
+		<reward id="90554" count="1" type="ON_FAILURE" /> <!-- Tyrr Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90556" two="90554" chance="33"> <!-- Tyrr Soul Crystal Lv. 3 / Tyrr Soul Crystal Lv. 1 -->
+		<reward id="90557" count="1" type="ON_SUCCESS" /> <!-- Tyrr Soul Crystal Lv. 4 -->
+		<reward id="90554" count="1" type="ON_FAILURE" /> <!-- Tyrr Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90557" two="90554" chance="33"> <!-- Tyrr Soul Crystal Lv. 4 / Tyrr Soul Crystal Lv. 1 -->
+		<reward id="90558" count="1" type="ON_SUCCESS" /> <!-- Tyrr Soul Crystal Lv. 5 -->
+		<reward id="90554" count="1" type="ON_FAILURE" /> <!-- Tyrr Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90558" two="90554" chance="33"> <!-- Tyrr Soul Crystal Lv. 5 / Tyrr Soul Crystal Lv. 1 -->
+		<reward id="90559" count="1" type="ON_SUCCESS" /> <!-- Tyrr Soul Crystal Lv. 6 -->
+		<reward id="90554" count="1" type="ON_FAILURE" /> <!-- Tyrr Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90559" two="90554" chance="33"> <!-- Tyrr Soul Crystal Lv. 6 / Tyrr Soul Crystal Lv. 1 -->
+		<reward id="90560" count="1" type="ON_SUCCESS" /> <!-- Tyrr Soul Crystal Lv. 7 -->
+		<reward id="90559" count="1" type="ON_FAILURE" /> <!-- Tyrr Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90560" two="90554" chance="33"> <!-- Tyrr Soul Crystal Lv. 7 / Tyrr Soul Crystal Lv. 1 -->
+		<reward id="90561" count="1" type="ON_SUCCESS" /> <!-- Tyrr Soul Crystal Lv. 8 -->
+		<reward id="90559" count="1" type="ON_FAILURE" /> <!-- Tyrr Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90561" two="90554" chance="33"> <!-- Tyrr Soul Crystal Lv. 8 / Tyrr Soul Crystal Lv. 1 -->
+		<reward id="90562" count="1" type="ON_SUCCESS" /> <!-- Tyrr Soul Crystal Lv. 9 -->
+		<reward id="90559" count="1" type="ON_FAILURE" /> <!-- Tyrr Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90562" two="90554" chance="33"> <!-- Tyrr Soul Crystal Lv. 9 / Tyrr Soul Crystal Lv. 1 -->
+		<reward id="90563" count="1" type="ON_SUCCESS" /> <!-- Tyrr Soul Crystal Lv. 10 -->
+		<reward id="90559" count="1" type="ON_FAILURE" /> <!-- Tyrr Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90563" two="90554" chance="33"> <!-- Tyrr Soul Crystal Lv. 10 / Tyrr Soul Crystal Lv. 1 -->
+		<reward id="90564" count="1" type="ON_SUCCESS" /> <!-- Tyrr Soul Crystal Lv. 11 -->
+		<reward id="90559" count="1" type="ON_FAILURE" /> <!-- Tyrr Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90564" two="90554" chance="33"> <!-- Tyrr Soul Crystal Lv. 11 / Tyrr Soul Crystal Lv. 1 -->
+		<reward id="90565" count="1" type="ON_SUCCESS" /> <!-- Tyrr Soul Crystal Lv. 12 -->
+		<reward id="90564" count="1" type="ON_FAILURE" /> <!-- Tyrr Soul Crystal Lv. 11 -->
+	</item>
+	<item one="90565" two="90554" chance="33"> <!-- Tyrr Soul Crystal Lv. 12 / Tyrr Soul Crystal Lv. 1 -->
+		<reward id="90566" count="1" type="ON_SUCCESS" /> <!-- Tyrr Soul Crystal Lv. 13 -->
+		<reward id="90564" count="1" type="ON_FAILURE" /> <!-- Tyrr Soul Crystal Lv. 11 -->
+	</item>
+	<item one="90566" two="90554" chance="33"> <!-- Tyrr Soul Crystal Lv. 13 / Tyrr Soul Crystal Lv. 1 -->
+		<reward id="90567" count="1" type="ON_SUCCESS" /> <!-- Tyrr Soul Crystal Lv. 14 -->
+		<reward id="90564" count="1" type="ON_FAILURE" /> <!-- Tyrr Soul Crystal Lv. 11 -->
+	</item>
+	<item one="90567" two="90554" chance="33"> <!-- Tyrr Soul Crystal Lv. 14 / Tyrr Soul Crystal Lv. 1 -->
+		<reward id="90568" count="1" type="ON_SUCCESS" /> <!-- Tyrr Soul Crystal Lv. 15 -->
+		<reward id="90564" count="1" type="ON_FAILURE" /> <!-- Tyrr Soul Crystal Lv. 11 -->
+	</item>
+
+	<!-- Othell Soul Crystal -->
+	<item one="90574" two="90574" chance="33"> <!-- Othell Soul Crystal Lv. 1 / Othell Soul Crystal Lv. 1 -->
+		<reward id="90575" count="1" type="ON_SUCCESS" /> <!-- Othell Soul Crystal Lv. 2 -->
+		<reward id="90574" count="1" type="ON_FAILURE" /> <!-- Othell Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90575" two="90574" chance="33"> <!-- Othell Soul Crystal Lv. 2 / Othell Soul Crystal Lv. 1 -->
+		<reward id="90576" count="1" type="ON_SUCCESS" /> <!-- Othell Soul Crystal Lv. 3 -->
+		<reward id="90574" count="1" type="ON_FAILURE" /> <!-- Othell Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90576" two="90574" chance="33"> <!-- Othell Soul Crystal Lv. 3 / Othell Soul Crystal Lv. 1 -->
+		<reward id="90577" count="1" type="ON_SUCCESS" /> <!-- Othell Soul Crystal Lv. 4 -->
+		<reward id="90574" count="1" type="ON_FAILURE" /> <!-- Othell Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90577" two="90574" chance="33"> <!-- Othell Soul Crystal Lv. 4 / Othell Soul Crystal Lv. 1 -->
+		<reward id="90578" count="1" type="ON_SUCCESS" /> <!-- Othell Soul Crystal Lv. 5 -->
+		<reward id="90574" count="1" type="ON_FAILURE" /> <!-- Othell Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90578" two="90574" chance="33"> <!-- Othell Soul Crystal Lv. 5 / Othell Soul Crystal Lv. 1 -->
+		<reward id="90579" count="1" type="ON_SUCCESS" /> <!-- Othell Soul Crystal Lv. 6 -->
+		<reward id="90574" count="1" type="ON_FAILURE" /> <!-- Othell Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90579" two="90574" chance="33"> <!-- Othell Soul Crystal Lv. 6 / Othell Soul Crystal Lv. 1 -->
+		<reward id="90580" count="1" type="ON_SUCCESS" /> <!-- Othell Soul Crystal Lv. 7 -->
+		<reward id="90579" count="1" type="ON_FAILURE" /> <!-- Othell Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90580" two="90574" chance="33"> <!-- Othell Soul Crystal Lv. 7 / Othell Soul Crystal Lv. 1 -->
+		<reward id="90581" count="1" type="ON_SUCCESS" /> <!-- Othell Soul Crystal Lv. 8 -->
+		<reward id="90579" count="1" type="ON_FAILURE" /> <!-- Othell Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90581" two="90574" chance="33"> <!-- Othell Soul Crystal Lv. 8 / Othell Soul Crystal Lv. 1 -->
+		<reward id="90582" count="1" type="ON_SUCCESS" /> <!-- Othell Soul Crystal Lv. 9 -->
+		<reward id="90579" count="1" type="ON_FAILURE" /> <!-- Othell Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90582" two="90574" chance="33"> <!-- Othell Soul Crystal Lv. 9 / Othell Soul Crystal Lv. 1 -->
+		<reward id="90583" count="1" type="ON_SUCCESS" /> <!-- Othell Soul Crystal Lv. 10 -->
+		<reward id="90579" count="1" type="ON_FAILURE" /> <!-- Othell Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90583" two="90574" chance="33"> <!-- Othell Soul Crystal Lv. 10 / Othell Soul Crystal Lv. 1 -->
+		<reward id="90584" count="1" type="ON_SUCCESS" /> <!-- Othell Soul Crystal Lv. 11 -->
+		<reward id="90579" count="1" type="ON_FAILURE" /> <!-- Othell Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90584" two="90574" chance="33"> <!-- Othell Soul Crystal Lv. 11 / Othell Soul Crystal Lv. 1 -->
+		<reward id="90585" count="1" type="ON_SUCCESS" /> <!-- Othell Soul Crystal Lv. 12 -->
+		<reward id="90584" count="1" type="ON_FAILURE" /> <!-- Othell Soul Crystal Lv. 11 -->
+	</item>
+	<item one="90585" two="90574" chance="33"> <!-- Othell Soul Crystal Lv. 12 / Othell Soul Crystal Lv. 1 -->
+		<reward id="90586" count="1" type="ON_SUCCESS" /> <!-- Othell Soul Crystal Lv. 13 -->
+		<reward id="90584" count="1" type="ON_FAILURE" /> <!-- Othell Soul Crystal Lv. 11 -->
+	</item>
+	<item one="90586" two="90574" chance="33"> <!-- Othell Soul Crystal Lv. 13 / Othell Soul Crystal Lv. 1 -->
+		<reward id="90587" count="1" type="ON_SUCCESS" /> <!-- Othell Soul Crystal Lv. 14 -->
+		<reward id="90584" count="1" type="ON_FAILURE" /> <!-- Othell Soul Crystal Lv. 11 -->
+	</item>
+	<item one="90587" two="90574" chance="33"> <!-- Othell Soul Crystal Lv. 14 / Othell Soul Crystal Lv. 1 -->
+		<reward id="90588" count="1" type="ON_SUCCESS" /> <!-- Othell Soul Crystal Lv. 15 -->
+		<reward id="90584" count="1" type="ON_FAILURE" /> <!-- Othell Soul Crystal Lv. 11 -->
+	</item>
+
+	<!-- Yul Soul Crystal -->
+	<item one="90594" two="90594" chance="33"> <!-- Yul Soul Crystal Lv. 1 / Yul Soul Crystal Lv. 1 -->
+		<reward id="90595" count="1" type="ON_SUCCESS" /> <!-- Yul Soul Crystal Lv. 2 -->
+		<reward id="90594" count="1" type="ON_FAILURE" /> <!-- Yul Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90595" two="90594" chance="33"> <!-- Yul Soul Crystal Lv. 2 / Yul Soul Crystal Lv. 1 -->
+		<reward id="90596" count="1" type="ON_SUCCESS" /> <!-- Yul Soul Crystal Lv. 3 -->
+		<reward id="90594" count="1" type="ON_FAILURE" /> <!-- Yul Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90596" two="90594" chance="33"> <!-- Yul Soul Crystal Lv. 3 / Yul Soul Crystal Lv. 1 -->
+		<reward id="90597" count="1" type="ON_SUCCESS" /> <!-- Yul Soul Crystal Lv. 4 -->
+		<reward id="90594" count="1" type="ON_FAILURE" /> <!-- Yul Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90597" two="90594" chance="33"> <!-- Yul Soul Crystal Lv. 4 / Yul Soul Crystal Lv. 1 -->
+		<reward id="90598" count="1" type="ON_SUCCESS" /> <!-- Yul Soul Crystal Lv. 5 -->
+		<reward id="90594" count="1" type="ON_FAILURE" /> <!-- Yul Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90598" two="90594" chance="33"> <!-- Yul Soul Crystal Lv. 5 / Yul Soul Crystal Lv. 1 -->
+		<reward id="90599" count="1" type="ON_SUCCESS" /> <!-- Yul Soul Crystal Lv. 6 -->
+		<reward id="90594" count="1" type="ON_FAILURE" /> <!-- Yul Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90599" two="90594" chance="33"> <!-- Yul Soul Crystal Lv. 6 / Yul Soul Crystal Lv. 1 -->
+		<reward id="90600" count="1" type="ON_SUCCESS" /> <!-- Yul Soul Crystal Lv. 7 -->
+		<reward id="90599" count="1" type="ON_FAILURE" /> <!-- Yul Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90600" two="90594" chance="33"> <!-- Yul Soul Crystal Lv. 7 / Yul Soul Crystal Lv. 1 -->
+		<reward id="90601" count="1" type="ON_SUCCESS" /> <!-- Yul Soul Crystal Lv. 8 -->
+		<reward id="90599" count="1" type="ON_FAILURE" /> <!-- Yul Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90601" two="90594" chance="33"> <!-- Yul Soul Crystal Lv. 8 / Yul Soul Crystal Lv. 1 -->
+		<reward id="90602" count="1" type="ON_SUCCESS" /> <!-- Yul Soul Crystal Lv. 9 -->
+		<reward id="90599" count="1" type="ON_FAILURE" /> <!-- Yul Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90602" two="90594" chance="33"> <!-- Yul Soul Crystal Lv. 9 / Yul Soul Crystal Lv. 1 -->
+		<reward id="90603" count="1" type="ON_SUCCESS" /> <!-- Yul Soul Crystal Lv. 10 -->
+		<reward id="90599" count="1" type="ON_FAILURE" /> <!-- Yul Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90603" two="90594" chance="33"> <!-- Yul Soul Crystal Lv. 10 / Yul Soul Crystal Lv. 1 -->
+		<reward id="90604" count="1" type="ON_SUCCESS" /> <!-- Yul Soul Crystal Lv. 11 -->
+		<reward id="90599" count="1" type="ON_FAILURE" /> <!-- Yul Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90604" two="90594" chance="33"> <!-- Yul Soul Crystal Lv. 11 / Yul Soul Crystal Lv. 1 -->
+		<reward id="90605" count="1" type="ON_SUCCESS" /> <!-- Yul Soul Crystal Lv. 12 -->
+		<reward id="90604" count="1" type="ON_FAILURE" /> <!-- Yul Soul Crystal Lv. 11 -->
+	</item>
+	<item one="90605" two="90594" chance="33"> <!-- Yul Soul Crystal Lv. 12 / Yul Soul Crystal Lv. 1 -->
+		<reward id="90606" count="1" type="ON_SUCCESS" /> <!-- Yul Soul Crystal Lv. 13 -->
+		<reward id="90604" count="1" type="ON_FAILURE" /> <!-- Yul Soul Crystal Lv. 11 -->
+	</item>
+	<item one="90606" two="90594" chance="33"> <!-- Yul Soul Crystal Lv. 13 / Yul Soul Crystal Lv. 1 -->
+		<reward id="90607" count="1" type="ON_SUCCESS" /> <!-- Yul Soul Crystal Lv. 14 -->
+		<reward id="90604" count="1" type="ON_FAILURE" /> <!-- Yul Soul Crystal Lv. 11 -->
+	</item>
+	<item one="90607" two="90594" chance="33"> <!-- Yul Soul Crystal Lv. 14 / Yul Soul Crystal Lv. 1 -->
+		<reward id="90608" count="1" type="ON_SUCCESS" /> <!-- Yul Soul Crystal Lv. 15 -->
+		<reward id="90604" count="1" type="ON_FAILURE" /> <!-- Yul Soul Crystal Lv. 11 -->
+	</item>
+
+	<!-- Feoh Soul Crystal -->
+	<item one="90614" two="90614" chance="33"> <!-- Feoh Soul Crystal Lv. 1 / Feoh Soul Crystal Lv. 1 -->
+		<reward id="90615" count="1" type="ON_SUCCESS" /> <!-- Feoh Soul Crystal Lv. 2 -->
+		<reward id="90614" count="1" type="ON_FAILURE" /> <!-- Feoh Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90615" two="90614" chance="33"> <!-- Feoh Soul Crystal Lv. 2 / Feoh Soul Crystal Lv. 1 -->
+		<reward id="90616" count="1" type="ON_SUCCESS" /> <!-- Feoh Soul Crystal Lv. 3 -->
+		<reward id="90614" count="1" type="ON_FAILURE" /> <!-- Feoh Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90616" two="90614" chance="33"> <!-- Feoh Soul Crystal Lv. 3 / Feoh Soul Crystal Lv. 1 -->
+		<reward id="90617" count="1" type="ON_SUCCESS" /> <!-- Feoh Soul Crystal Lv. 4 -->
+		<reward id="90614" count="1" type="ON_FAILURE" /> <!-- Feoh Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90617" two="90614" chance="33"> <!-- Feoh Soul Crystal Lv. 4 / Feoh Soul Crystal Lv. 1 -->
+		<reward id="90618" count="1" type="ON_SUCCESS" /> <!-- Feoh Soul Crystal Lv. 5 -->
+		<reward id="90614" count="1" type="ON_FAILURE" /> <!-- Feoh Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90618" two="90614" chance="33"> <!-- Feoh Soul Crystal Lv. 5 / Feoh Soul Crystal Lv. 1 -->
+		<reward id="90619" count="1" type="ON_SUCCESS" /> <!-- Feoh Soul Crystal Lv. 6 -->
+		<reward id="90614" count="1" type="ON_FAILURE" /> <!-- Feoh Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90619" two="90614" chance="33"> <!-- Feoh Soul Crystal Lv. 6 / Feoh Soul Crystal Lv. 1 -->
+		<reward id="90620" count="1" type="ON_SUCCESS" /> <!-- Feoh Soul Crystal Lv. 7 -->
+		<reward id="90619" count="1" type="ON_FAILURE" /> <!-- Feoh Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90620" two="90614" chance="33"> <!-- Feoh Soul Crystal Lv. 7 / Feoh Soul Crystal Lv. 1 -->
+		<reward id="90621" count="1" type="ON_SUCCESS" /> <!-- Feoh Soul Crystal Lv. 8 -->
+		<reward id="90619" count="1" type="ON_FAILURE" /> <!-- Feoh Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90621" two="90614" chance="33"> <!-- Feoh Soul Crystal Lv. 8 / Feoh Soul Crystal Lv. 1 -->
+		<reward id="90622" count="1" type="ON_SUCCESS" /> <!-- Feoh Soul Crystal Lv. 9 -->
+		<reward id="90619" count="1" type="ON_FAILURE" /> <!-- Feoh Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90622" two="90614" chance="33"> <!-- Feoh Soul Crystal Lv. 9 / Feoh Soul Crystal Lv. 1 -->
+		<reward id="90623" count="1" type="ON_SUCCESS" /> <!-- Feoh Soul Crystal Lv. 10 -->
+		<reward id="90619" count="1" type="ON_FAILURE" /> <!-- Feoh Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90623" two="90614" chance="33"> <!-- Feoh Soul Crystal Lv. 10 / Feoh Soul Crystal Lv. 1 -->
+		<reward id="90624" count="1" type="ON_SUCCESS" /> <!-- Feoh Soul Crystal Lv. 11 -->
+		<reward id="90619" count="1" type="ON_FAILURE" /> <!-- Feoh Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90624" two="90614" chance="33"> <!-- Feoh Soul Crystal Lv. 11 / Feoh Soul Crystal Lv. 1 -->
+		<reward id="90625" count="1" type="ON_SUCCESS" /> <!-- Feoh Soul Crystal Lv. 12 -->
+		<reward id="90624" count="1" type="ON_FAILURE" /> <!-- Feoh Soul Crystal Lv. 11 -->
+	</item>
+	<item one="90625" two="90614" chance="33"> <!-- Feoh Soul Crystal Lv. 12 / Feoh Soul Crystal Lv. 1 -->
+		<reward id="90626" count="1" type="ON_SUCCESS" /> <!-- Feoh Soul Crystal Lv. 13 -->
+		<reward id="90624" count="1" type="ON_FAILURE" /> <!-- Feoh Soul Crystal Lv. 11 -->
+	</item>
+	<item one="90626" two="90614" chance="33"> <!-- Feoh Soul Crystal Lv. 13 / Feoh Soul Crystal Lv. 1 -->
+		<reward id="90627" count="1" type="ON_SUCCESS" /> <!-- Feoh Soul Crystal Lv. 14 -->
+		<reward id="90624" count="1" type="ON_FAILURE" /> <!-- Feoh Soul Crystal Lv. 11 -->
+	</item>
+	<item one="90627" two="90614" chance="33"> <!-- Feoh Soul Crystal Lv. 14 / Feoh Soul Crystal Lv. 1 -->
+		<reward id="90628" count="1" type="ON_SUCCESS" /> <!-- Feoh Soul Crystal Lv. 15 -->
+		<reward id="90624" count="1" type="ON_FAILURE" /> <!-- Feoh Soul Crystal Lv. 11 -->
+	</item>
+
+	<!-- Iss Soul Crystal -->
+	<item one="90634" two="90634" chance="33"> <!-- Iss Soul Crystal Lv. 1 / Iss Soul Crystal Lv. 1 -->
+		<reward id="90635" count="1" type="ON_SUCCESS" /> <!-- Iss Soul Crystal Lv. 2 -->
+		<reward id="90634" count="1" type="ON_FAILURE" /> <!-- Iss Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90635" two="90634" chance="33"> <!-- Iss Soul Crystal Lv. 2 / Iss Soul Crystal Lv. 1 -->
+		<reward id="90636" count="1" type="ON_SUCCESS" /> <!-- Iss Soul Crystal Lv. 3 -->
+		<reward id="90634" count="1" type="ON_FAILURE" /> <!-- Iss Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90636" two="90634" chance="33"> <!-- Iss Soul Crystal Lv. 3 / Iss Soul Crystal Lv. 1 -->
+		<reward id="90637" count="1" type="ON_SUCCESS" /> <!-- Iss Soul Crystal Lv. 4 -->
+		<reward id="90634" count="1" type="ON_FAILURE" /> <!-- Iss Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90637" two="90634" chance="33"> <!-- Iss Soul Crystal Lv. 4 / Iss Soul Crystal Lv. 1 -->
+		<reward id="90638" count="1" type="ON_SUCCESS" /> <!-- Iss Soul Crystal Lv. 5 -->
+		<reward id="90634" count="1" type="ON_FAILURE" /> <!-- Iss Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90638" two="90634" chance="33"> <!-- Iss Soul Crystal Lv. 5 / Iss Soul Crystal Lv. 1 -->
+		<reward id="90639" count="1" type="ON_SUCCESS" /> <!-- Iss Soul Crystal Lv. 6 -->
+		<reward id="90634" count="1" type="ON_FAILURE" /> <!-- Iss Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90639" two="90634" chance="33"> <!-- Iss Soul Crystal Lv. 6 / Iss Soul Crystal Lv. 1 -->
+		<reward id="90640" count="1" type="ON_SUCCESS" /> <!-- Iss Soul Crystal Lv. 7 -->
+		<reward id="90639" count="1" type="ON_FAILURE" /> <!-- Iss Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90640" two="90634" chance="33"> <!-- Iss Soul Crystal Lv. 7 / Iss Soul Crystal Lv. 1 -->
+		<reward id="90641" count="1" type="ON_SUCCESS" /> <!-- Iss Soul Crystal Lv. 8 -->
+		<reward id="90639" count="1" type="ON_FAILURE" /> <!-- Iss Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90641" two="90634" chance="33"> <!-- Iss Soul Crystal Lv. 8 / Iss Soul Crystal Lv. 1 -->
+		<reward id="90642" count="1" type="ON_SUCCESS" /> <!-- Iss Soul Crystal Lv. 9 -->
+		<reward id="90639" count="1" type="ON_FAILURE" /> <!-- Iss Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90642" two="90634" chance="33"> <!-- Iss Soul Crystal Lv. 9 / Iss Soul Crystal Lv. 1 -->
+		<reward id="90643" count="1" type="ON_SUCCESS" /> <!-- Iss Soul Crystal Lv. 10 -->
+		<reward id="90639" count="1" type="ON_FAILURE" /> <!-- Iss Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90643" two="90634" chance="33"> <!-- Iss Soul Crystal Lv. 10 / Iss Soul Crystal Lv. 1 -->
+		<reward id="90644" count="1" type="ON_SUCCESS" /> <!-- Iss Soul Crystal Lv. 11 -->
+		<reward id="90639" count="1" type="ON_FAILURE" /> <!-- Iss Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90644" two="90634" chance="33"> <!-- Iss Soul Crystal Lv. 11 / Iss Soul Crystal Lv. 1 -->
+		<reward id="90645" count="1" type="ON_SUCCESS" /> <!-- Iss Soul Crystal Lv. 12 -->
+		<reward id="90644" count="1" type="ON_FAILURE" /> <!-- Iss Soul Crystal Lv. 11 -->
+	</item>
+	<item one="90645" two="90634" chance="33"> <!-- Iss Soul Crystal Lv. 12 / Iss Soul Crystal Lv. 1 -->
+		<reward id="90646" count="1" type="ON_SUCCESS" /> <!-- Iss Soul Crystal Lv. 13 -->
+		<reward id="90644" count="1" type="ON_FAILURE" /> <!-- Iss Soul Crystal Lv. 11 -->
+	</item>
+	<item one="90646" two="90634" chance="33"> <!-- Iss Soul Crystal Lv. 13 / Iss Soul Crystal Lv. 1 -->
+		<reward id="90647" count="1" type="ON_SUCCESS" /> <!-- Iss Soul Crystal Lv. 14 -->
+		<reward id="90644" count="1" type="ON_FAILURE" /> <!-- Iss Soul Crystal Lv. 11 -->
+	</item>
+	<item one="90647" two="90634" chance="33"> <!-- Iss Soul Crystal Lv. 14 / Iss Soul Crystal Lv. 1 -->
+		<reward id="90648" count="1" type="ON_SUCCESS" /> <!-- Iss Soul Crystal Lv. 15 -->
+		<reward id="90644" count="1" type="ON_FAILURE" /> <!-- Iss Soul Crystal Lv. 11 -->
+	</item>
+
+	<!-- Wynn Soul Crystal -->
+	<item one="90654" two="90654" chance="33"> <!-- Wynn Soul Crystal Lv. 1 / Wynn Soul Crystal Lv. 1 -->
+		<reward id="90655" count="1" type="ON_SUCCESS" /> <!-- Wynn Soul Crystal Lv. 2 -->
+		<reward id="90654" count="1" type="ON_FAILURE" /> <!-- Wynn Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90655" two="90654" chance="33"> <!-- Wynn Soul Crystal Lv. 2 / Wynn Soul Crystal Lv. 1 -->
+		<reward id="90656" count="1" type="ON_SUCCESS" /> <!-- Wynn Soul Crystal Lv. 3 -->
+		<reward id="90654" count="1" type="ON_FAILURE" /> <!-- Wynn Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90656" two="90654" chance="33"> <!-- Wynn Soul Crystal Lv. 3 / Wynn Soul Crystal Lv. 1 -->
+		<reward id="90657" count="1" type="ON_SUCCESS" /> <!-- Wynn Soul Crystal Lv. 4 -->
+		<reward id="90654" count="1" type="ON_FAILURE" /> <!-- Wynn Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90657" two="90654" chance="33"> <!-- Wynn Soul Crystal Lv. 4 / Wynn Soul Crystal Lv. 1 -->
+		<reward id="90658" count="1" type="ON_SUCCESS" /> <!-- Wynn Soul Crystal Lv. 5 -->
+		<reward id="90654" count="1" type="ON_FAILURE" /> <!-- Wynn Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90658" two="90654" chance="33"> <!-- Wynn Soul Crystal Lv. 5 / Wynn Soul Crystal Lv. 1 -->
+		<reward id="90659" count="1" type="ON_SUCCESS" /> <!-- Wynn Soul Crystal Lv. 6 -->
+		<reward id="90654" count="1" type="ON_FAILURE" /> <!-- Wynn Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90659" two="90654" chance="33"> <!-- Wynn Soul Crystal Lv. 6 / Wynn Soul Crystal Lv. 1 -->
+		<reward id="90660" count="1" type="ON_SUCCESS" /> <!-- Wynn Soul Crystal Lv. 7 -->
+		<reward id="90659" count="1" type="ON_FAILURE" /> <!-- Wynn Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90660" two="90654" chance="33"> <!-- Wynn Soul Crystal Lv. 7 / Wynn Soul Crystal Lv. 1 -->
+		<reward id="90661" count="1" type="ON_SUCCESS" /> <!-- Wynn Soul Crystal Lv. 8 -->
+		<reward id="90659" count="1" type="ON_FAILURE" /> <!-- Wynn Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90661" two="90654" chance="33"> <!-- Wynn Soul Crystal Lv. 8 / Wynn Soul Crystal Lv. 1 -->
+		<reward id="90662" count="1" type="ON_SUCCESS" /> <!-- Wynn Soul Crystal Lv. 9 -->
+		<reward id="90659" count="1" type="ON_FAILURE" /> <!-- Wynn Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90662" two="90654" chance="33"> <!-- Wynn Soul Crystal Lv. 9 / Wynn Soul Crystal Lv. 1 -->
+		<reward id="90663" count="1" type="ON_SUCCESS" /> <!-- Wynn Soul Crystal Lv. 10 -->
+		<reward id="90659" count="1" type="ON_FAILURE" /> <!-- Wynn Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90663" two="90654" chance="33"> <!-- Wynn Soul Crystal Lv. 10 / Wynn Soul Crystal Lv. 1 -->
+		<reward id="90664" count="1" type="ON_SUCCESS" /> <!-- Wynn Soul Crystal Lv. 11 -->
+		<reward id="90659" count="1" type="ON_FAILURE" /> <!-- Wynn Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90664" two="90654" chance="33"> <!-- Wynn Soul Crystal Lv. 11 / Wynn Soul Crystal Lv. 1 -->
+		<reward id="90665" count="1" type="ON_SUCCESS" /> <!-- Wynn Soul Crystal Lv. 12 -->
+		<reward id="90664" count="1" type="ON_FAILURE" /> <!-- Wynn Soul Crystal Lv. 11 -->
+	</item>
+	<item one="90665" two="90654" chance="33"> <!-- Wynn Soul Crystal Lv. 12 / Wynn Soul Crystal Lv. 1 -->
+		<reward id="90666" count="1" type="ON_SUCCESS" /> <!-- Wynn Soul Crystal Lv. 13 -->
+		<reward id="90664" count="1" type="ON_FAILURE" /> <!-- Wynn Soul Crystal Lv. 11 -->
+	</item>
+	<item one="90666" two="90654" chance="33"> <!-- Wynn Soul Crystal Lv. 13 / Wynn Soul Crystal Lv. 1 -->
+		<reward id="90667" count="1" type="ON_SUCCESS" /> <!-- Wynn Soul Crystal Lv. 14 -->
+		<reward id="90664" count="1" type="ON_FAILURE" /> <!-- Wynn Soul Crystal Lv. 11 -->
+	</item>
+	<item one="90667" two="90654" chance="33"> <!-- Wynn Soul Crystal Lv. 14 / Wynn Soul Crystal Lv. 1 -->
+		<reward id="90668" count="1" type="ON_SUCCESS" /> <!-- Wynn Soul Crystal Lv. 15 -->
+		<reward id="90664" count="1" type="ON_FAILURE" /> <!-- Wynn Soul Crystal Lv. 11 -->
+	</item>
+
+	<!-- Aeore Soul Crystal -->
+	<item one="90674" two="90674" chance="33"> <!-- Aeore Soul Crystal Lv. 1 / Aeore Soul Crystal Lv. 1 -->
+		<reward id="90675" count="1" type="ON_SUCCESS" /> <!-- Aeore Soul Crystal Lv. 2 -->
+		<reward id="90674" count="1" type="ON_FAILURE" /> <!-- Aeore Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90675" two="90674" chance="33"> <!-- Aeore Soul Crystal Lv. 2 / Aeore Soul Crystal Lv. 1 -->
+		<reward id="90676" count="1" type="ON_SUCCESS" /> <!-- Aeore Soul Crystal Lv. 3 -->
+		<reward id="90674" count="1" type="ON_FAILURE" /> <!-- Aeore Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90676" two="90674" chance="33"> <!-- Aeore Soul Crystal Lv. 3 / Aeore Soul Crystal Lv. 1 -->
+		<reward id="90677" count="1" type="ON_SUCCESS" /> <!-- Aeore Soul Crystal Lv. 4 -->
+		<reward id="90674" count="1" type="ON_FAILURE" /> <!-- Aeore Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90677" two="90674" chance="33"> <!-- Aeore Soul Crystal Lv. 4 / Aeore Soul Crystal Lv. 1 -->
+		<reward id="90678" count="1" type="ON_SUCCESS" /> <!-- Aeore Soul Crystal Lv. 5 -->
+		<reward id="90674" count="1" type="ON_FAILURE" /> <!-- Aeore Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90678" two="90674" chance="33"> <!-- Aeore Soul Crystal Lv. 5 / Aeore Soul Crystal Lv. 1 -->
+		<reward id="90679" count="1" type="ON_SUCCESS" /> <!-- Aeore Soul Crystal Lv. 6 -->
+		<reward id="90674" count="1" type="ON_FAILURE" /> <!-- Aeore Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90679" two="90674" chance="33"> <!-- Aeore Soul Crystal Lv. 6 / Aeore Soul Crystal Lv. 1 -->
+		<reward id="90680" count="1" type="ON_SUCCESS" /> <!-- Aeore Soul Crystal Lv. 7 -->
+		<reward id="90679" count="1" type="ON_FAILURE" /> <!-- Aeore Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90680" two="90674" chance="33"> <!-- Aeore Soul Crystal Lv. 7 / Aeore Soul Crystal Lv. 1 -->
+		<reward id="90681" count="1" type="ON_SUCCESS" /> <!-- Aeore Soul Crystal Lv. 8 -->
+		<reward id="90679" count="1" type="ON_FAILURE" /> <!-- Aeore Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90681" two="90674" chance="33"> <!-- Aeore Soul Crystal Lv. 8 / Aeore Soul Crystal Lv. 1 -->
+		<reward id="90682" count="1" type="ON_SUCCESS" /> <!-- Aeore Soul Crystal Lv. 9 -->
+		<reward id="90679" count="1" type="ON_FAILURE" /> <!-- Aeore Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90682" two="90674" chance="33"> <!-- Aeore Soul Crystal Lv. 9 / Aeore Soul Crystal Lv. 1 -->
+		<reward id="90683" count="1" type="ON_SUCCESS" /> <!-- Aeore Soul Crystal Lv. 10 -->
+		<reward id="90679" count="1" type="ON_FAILURE" /> <!-- Aeore Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90683" two="90674" chance="33"> <!-- Aeore Soul Crystal Lv. 10 / Aeore Soul Crystal Lv. 1 -->
+		<reward id="90684" count="1" type="ON_SUCCESS" /> <!-- Aeore Soul Crystal Lv. 11 -->
+		<reward id="90679" count="1" type="ON_FAILURE" /> <!-- Aeore Soul Crystal Lv. 6 -->
+	</item>
+	<item one="90684" two="90674" chance="33"> <!-- Aeore Soul Crystal Lv. 11 / Aeore Soul Crystal Lv. 1 -->
+		<reward id="90685" count="1" type="ON_SUCCESS" /> <!-- Aeore Soul Crystal Lv. 12 -->
+		<reward id="90684" count="1" type="ON_FAILURE" /> <!-- Aeore Soul Crystal Lv. 11 -->
+	</item>
+	<item one="90685" two="90674" chance="33"> <!-- Aeore Soul Crystal Lv. 12 / Aeore Soul Crystal Lv. 1 -->
+		<reward id="90686" count="1" type="ON_SUCCESS" /> <!-- Aeore Soul Crystal Lv. 13 -->
+		<reward id="90684" count="1" type="ON_FAILURE" /> <!-- Aeore Soul Crystal Lv. 11 -->
+	</item>
+	<item one="90686" two="90674" chance="33"> <!-- Aeore Soul Crystal Lv. 13 / Aeore Soul Crystal Lv. 1 -->
+		<reward id="90687" count="1" type="ON_SUCCESS" /> <!-- Aeore Soul Crystal Lv. 14 -->
+		<reward id="90684" count="1" type="ON_FAILURE" /> <!-- Aeore Soul Crystal Lv. 11 -->
+	</item>
+	<item one="90687" two="90674" chance="33"> <!-- Aeore Soul Crystal Lv. 14 / Aeore Soul Crystal Lv. 1 -->
+		<reward id="90688" count="1" type="ON_SUCCESS" /> <!-- Aeore Soul Crystal Lv. 15 -->
+		<reward id="90684" count="1" type="ON_FAILURE" /> <!-- Aeore Soul Crystal Lv. 11 -->
+	</item>
+
+	<!-- Venir Talisman -->
+	<item one="91077" two="91076" chance="33"> <!-- Venir's Talisman Lv. 1 / Venir's Talisman Fragment -->
+		<reward id="91078" count="1" type="ON_SUCCESS" /> <!-- Venir's Talisman Lv. 2 -->
+		<reward id="91077" count="1" type="ON_FAILURE" /> <!-- Venir's Talisman Lv. 1 -->
+	</item>
+	<item one="91078" two="91076" chance="33"> <!-- Venir's Talisman Lv. 2 / Venir's Talisman Fragment -->
+		<reward id="91079" count="1" type="ON_SUCCESS" /> <!-- Venir's Talisman Lv. 3 -->
+		<reward id="91077" count="1" type="ON_FAILURE" /> <!-- Venir's Talisman Lv. 1 -->
+	</item>
+	<item one="91079" two="91076" chance="33"> <!-- Venir's Talisman Lv. 3 / Venir's Talisman Fragment -->
+		<reward id="91080" count="1" type="ON_SUCCESS" /> <!-- Venir's Talisman Lv. 4 -->
+		<reward id="91077" count="1" type="ON_FAILURE" /> <!-- Venir's Talisman Lv. 1 -->
+	</item>
+	<item one="91080" two="91076" chance="33"> <!-- Venir's Talisman Lv. 4 / Venir's Talisman Fragment -->
+		<reward id="91081" count="1" type="ON_SUCCESS" /> <!-- Venir's Talisman Lv. 5 -->
+		<reward id="91077" count="1" type="ON_FAILURE" /> <!-- Venir's Talisman Lv. 1 -->
+	</item>
+	<item one="91081" two="91076" chance="33"> <!-- Venir's Talisman Lv. 5 / Venir's Talisman Fragment -->
+		<reward id="91082" count="1" type="ON_SUCCESS" /> <!-- Venir's Talisman Lv. 6 -->
+		<reward id="91077" count="1" type="ON_FAILURE" /> <!-- Venir's Talisman Lv. 1 -->
+	</item>
+	<item one="91082" two="91076" chance="33"> <!-- Venir's Talisman Lv. 6 / Venir's Talisman Fragment -->
+		<reward id="91083" count="1" type="ON_SUCCESS" /> <!-- Venir's Talisman Lv. 7 -->
+		<reward id="91082" count="1" type="ON_FAILURE" /> <!-- Venir's Talisman Lv. 6 -->
+	</item>
+	<item one="91083" two="91076" chance="33"> <!-- Venir's Talisman Lv. 7 / Venir's Talisman Fragment -->
+		<reward id="91084" count="1" type="ON_SUCCESS" /> <!-- Venir's Talisman Lv. 8 -->
+		<reward id="91082" count="1" type="ON_FAILURE" /> <!-- Venir's Talisman Lv. 6 -->
+	</item>
+	<item one="91084" two="91076" chance="33"> <!-- Venir's Talisman Lv. 8 / Venir's Talisman Fragment -->
+		<reward id="91085" count="1" type="ON_SUCCESS" /> <!-- Venir's Talisman Lv. 9 -->
+		<reward id="91082" count="1" type="ON_FAILURE" /> <!-- Venir's Talisman Lv. 6 -->
+	</item>
+	<item one="91085" two="91076" chance="33"> <!-- Venir's Talisman Lv. 9 / Venir's Talisman Fragment -->
+		<reward id="91086" count="1" type="ON_SUCCESS" /> <!-- Venir's Talisman Lv. 10 -->
+		<reward id="91082" count="1" type="ON_FAILURE" /> <!-- Venir's Talisman Lv. 6 -->
+	</item>
+	<item one="91086" two="91076" chance="33"> <!-- Venir's Talisman Lv. 10 / Venir's Talisman Fragment -->
+		<reward id="91087" count="1" type="ON_SUCCESS" /> <!-- Venir's Talisman Lv. 11 -->
+		<reward id="91082" count="1" type="ON_FAILURE" /> <!-- Venir's Talisman Lv. 6 -->
+	</item>
+	<item one="91087" two="91076" chance="33"> <!-- Venir's Talisman Lv. 11 / Venir's Talisman Fragment -->
+		<reward id="91088" count="1" type="ON_SUCCESS" /> <!-- Venir's Talisman Lv. 12 -->
+		<reward id="91082" count="1" type="ON_FAILURE" /> <!-- Venir's Talisman Lv. 6 -->
+	</item>
+	<item one="91088" two="91076" chance="33"> <!-- Venir's Talisman Lv. 12 / Venir's Talisman Fragment -->
+		<reward id="91089" count="1" type="ON_SUCCESS" /> <!-- Venir's Talisman Lv. 13 -->
+		<reward id="91088" count="1" type="ON_FAILURE" /> <!-- Venir's Talisman Lv. 12 -->
+	</item>
+	<item one="91089" two="91076" chance="33"> <!-- Venir's Talisman Lv. 13 / Venir's Talisman Fragment -->
+		<reward id="91090" count="1" type="ON_SUCCESS" /> <!-- Venir's Talisman Lv. 14 -->
+		<reward id="91088" count="1" type="ON_FAILURE" /> <!-- Venir's Talisman Lv. 12 -->
+	</item>
+	<item one="91090" two="91076" chance="33"> <!-- Venir's Talisman Lv. 14 / Venir's Talisman Fragment -->
+		<reward id="91091" count="1" type="ON_SUCCESS" /> <!-- Venir's Talisman Lv. 15 -->
+		<reward id="91088" count="1" type="ON_FAILURE" /> <!-- Venir's Talisman Lv. 12 -->
+	</item>
+	<item one="91091" two="91076" chance="33"> <!-- Venir's Talisman Lv. 15 / Venir's Talisman Fragment -->
+		<reward id="94174" count="1" type="ON_SUCCESS" /> <!-- Venir's Talisman Lv. 16 -->
+		<reward id="91088" count="1" type="ON_FAILURE" /> <!-- Venir's Talisman Lv. 12 -->
+	</item>
+	<item one="94174" two="91076" chance="33"> <!-- Venir's Talisman Lv. 16 / Venir's Talisman Fragment -->
+		<reward id="94175" count="1" type="ON_SUCCESS" /> <!-- Venir's Talisman Lv. 17 -->
+		<reward id="91088" count="1" type="ON_FAILURE" /> <!-- Venir's Talisman Lv. 12 -->
+	</item>
+	<item one="94175" two="91076" chance="33"> <!-- Venir's Talisman Lv. 17 / Venir's Talisman Fragment -->
+		<reward id="94176" count="1" type="ON_SUCCESS" /> <!-- Venir's Talisman Lv. 18 -->
+		<reward id="91088" count="1" type="ON_FAILURE" /> <!-- Venir's Talisman Lv. 12 -->
+	</item>
+	<item one="94176" two="91076" chance="33"> <!-- Venir's Talisman Lv. 18 / Venir's Talisman Fragment -->
+		<reward id="94177" count="1" type="ON_SUCCESS" /> <!-- Venir's Talisman Lv. 19 -->
+		<reward id="94176" count="1" type="ON_FAILURE" /> <!-- Venir's Talisman Lv. 18 -->
+	</item>
+	<item one="94177" two="91076" chance="33"> <!-- Venir's Talisman Lv. 19 / Venir's Talisman Fragment -->
+		<reward id="94178" count="1" type="ON_SUCCESS" /> <!-- Venir's Talisman Lv. 20 -->
+		<reward id="94176" count="1" type="ON_FAILURE" /> <!-- Venir's Talisman Lv. 18 -->
+	</item>
+	<item one="94178" two="91076" chance="33"> <!-- Venir's Talisman Lv. 20 / Venir's Talisman Fragment -->
+		<reward id="94179" count="1" type="ON_SUCCESS" /> <!-- Venir's Talisman Lv. 21 -->
+		<reward id="94176" count="1" type="ON_FAILURE" /> <!-- Venir's Talisman Lv. 18 -->
+	</item>
+	<item one="94179" two="91076" chance="33"> <!-- Venir's Talisman Lv. 21 / Venir's Talisman Fragment -->
+		<reward id="94180" count="1" type="ON_SUCCESS" /> <!-- Venir's Talisman Lv. 22 -->
+		<reward id="94176" count="1" type="ON_FAILURE" /> <!-- Venir's Talisman Lv. 18 -->
+	</item>
+	<item one="94180" two="91076" chance="33"> <!-- Venir's Talisman Lv. 22 / Venir's Talisman Fragment -->
+		<reward id="94181" count="1" type="ON_SUCCESS" /> <!-- Venir's Talisman Lv. 23 -->
+		<reward id="94176" count="1" type="ON_FAILURE" /> <!-- Venir's Talisman Lv. 18 -->
+	</item>
+	<item one="94181" two="91076" chance="33"> <!-- Venir's Talisman Lv. 23 / Venir's Talisman Fragment -->
+		<reward id="94182" count="1" type="ON_SUCCESS" /> <!-- Venir's Talisman Lv. 24 -->
+		<reward id="94176" count="1" type="ON_FAILURE" /> <!-- Venir's Talisman Lv. 18 -->
+	</item>
+	<item one="94182" two="91076" chance="33"> <!-- Venir's Talisman Lv. 24 / Venir's Talisman Fragment -->
+		<reward id="94183" count="1" type="ON_SUCCESS" /> <!-- Venir's Talisman Lv. 25 -->
+		<reward id="94182" count="1" type="ON_FAILURE" /> <!-- Venir's Talisman Lv. 24 -->
+	</item>
+	<item one="94183" two="91076" chance="33"> <!-- Venir's Talisman Lv. 25 / Venir's Talisman Fragment -->
+		<reward id="95883" count="1" type="ON_SUCCESS" /> <!-- Venir's Talisman Lv. 26 -->
+		<reward id="94182" count="1" type="ON_FAILURE" /> <!-- Venir's Talisman Lv. 24 -->
+	</item>
+	<item one="95883" two="91076" chance="33"> <!-- Venir's Talisman Lv. 26 / Venir's Talisman Fragment -->
+		<reward id="95884" count="1" type="ON_SUCCESS" /> <!-- Venir's Talisman Lv. 27 -->
+		<reward id="94182" count="1" type="ON_FAILURE" /> <!-- Venir's Talisman Lv. 24 -->
+	</item>
+	<item one="95884" two="91076" chance="33"> <!-- Venir's Talisman Lv. 27 / Venir's Talisman Fragment -->
+		<reward id="95885" count="1" type="ON_SUCCESS" /> <!-- Venir's Talisman Lv. 28 -->
+		<reward id="94182" count="1" type="ON_FAILURE" /> <!-- Venir's Talisman Lv. 24 -->
+	</item>
+	<item one="95885" two="91076" chance="33"> <!-- Venir's Talisman Lv. 28 / Venir's Talisman Fragment -->
+		<reward id="95886" count="1" type="ON_SUCCESS" /> <!-- Venir's Talisman Lv. 29 -->
+		<reward id="94182" count="1" type="ON_FAILURE" /> <!-- Venir's Talisman Lv. 24 -->
+	</item>
+	<item one="95886" two="91076" chance="33"> <!-- Venir's Talisman Lv. 29/ Venir's Talisman Fragment -->
+		<reward id="95887" count="1" type="ON_SUCCESS" /> <!-- Venir's Talisman Lv. 30 -->
+		<reward id="94182" count="1" type="ON_FAILURE" /> <!-- Venir's Talisman Lv. 24 -->
+	</item>
 
 
+	<!-- Emerald Lv. 5 (Imprint) to Greater Emerald Lv. 1 -->
+	<item one="91361" two="91356" chance="50"> <!-- Emerald Lv. 5 (Imprint)/ Gem Energy -->
+		<reward id="91362" type="ON_SUCCESS" /> <!-- Greater Emerald Lv. 1 -->
+		<reward id="91361" type="ON_FAILURE" /> <!-- Emerald Lv. 5 (Imprint) -->
+	</item>
 
-	<!-- Brooch Lv. 2 -->
-	<item one="90311" two="90311" chance="25">
-		<reward id="90312" type="ON_SUCCESS" /> <!-- Brooch Lv. 2 -->
-		<reward id="90311" type="ON_FAILURE" /> <!-- Brooch Lv. 1 -->
-	</item>
-	<!-- Topaz -->
-	<item one="90313" two="90313" chance="65">
-		<reward id="90314" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90313" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90314" two="90314" chance="40">
-		<reward id="90315" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90314" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90315" two="90315" chance="20">
-		<reward id="90316" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90315" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90316" two="90316" chance="10">
-		<reward id="90317" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90316" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Garnet -->
-	<item one="90318" two="90318" chance="65">
-		<reward id="90319" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90318" type="ON_FAILURE" /> <!-- info -->
-	</item>                                
-	<item one="90319" two="90319" chance="40">
-		<reward id="90320" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90319" type="ON_FAILURE" /> <!-- info -->
-	</item>                                
-	<item one="90320" two="90320" chance="20">
-		<reward id="90321" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90320" type="ON_FAILURE" /> <!-- info -->
-	</item>                                
-	<item one="90321" two="90321" chance="10">
-		<reward id="90322" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90321" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Jade -->
-	<item one="90323" two="90323" chance="65">
-		<reward id="90324" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90323" type="ON_FAILURE" /> <!-- info -->
-	</item>                                
-	<item one="90324" two="90324" chance="40">
-		<reward id="90325" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90324" type="ON_FAILURE" /> <!-- info -->
-	</item>                                
-	<item one="90325" two="90325" chance="20">
-		<reward id="90326" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90325" type="ON_FAILURE" /> <!-- info -->
-	</item>                                
-	<item one="90326" two="90326" chance="10">
-		<reward id="90327" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90326" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Ruby -->
-	<item one="90328" two="90328" chance="65">
-		<reward id="90329" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90328" type="ON_FAILURE" /> <!-- info -->
-	</item>                                
-	<item one="90329" two="90329" chance="40">
-		<reward id="90330" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90329" type="ON_FAILURE" /> <!-- info -->
-	</item>                                
-	<item one="90330" two="90330" chance="20">
-		<reward id="90331" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90330" type="ON_FAILURE" /> <!-- info -->
-	</item>                                
-	<item one="90331" two="90331" chance="10">
-		<reward id="90332" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90331" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Sapphire -->
-	<item one="90333" two="90333" chance="65">
-		<reward id="90334" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90333" type="ON_FAILURE" /> <!-- info -->
-	</item>                                
-	<item one="90334" two="90334" chance="40">
-		<reward id="90335" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90334" type="ON_FAILURE" /> <!-- info -->
-	</item>                                
-	<item one="90335" two="90335" chance="20">
-		<reward id="90336" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90335" type="ON_FAILURE" /> <!-- info -->
-	</item>                                
-	<item one="90336" two="90336" chance="10">
-		<reward id="90337" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90336" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Diamond -->
-	<item one="90338" two="90338" chance="65">
-		<reward id="90339" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90338" type="ON_FAILURE" /> <!-- info -->
-	</item>                                
-	<item one="90339" two="90339" chance="40">
-		<reward id="90340" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90339" type="ON_FAILURE" /> <!-- info -->
-	</item>                                
-	<item one="90340" two="90340" chance="20">
-		<reward id="90341" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90340" type="ON_FAILURE" /> <!-- info -->
-	</item>                                
-	<item one="90341" two="90341" chance="10">
-		<reward id="90342" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90341" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Pearl -->
-	<item one="90343" two="90343" chance="65">
-		<reward id="90344" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90343" type="ON_FAILURE" /> <!-- info -->
-	</item>                                
-	<item one="90344" two="90344" chance="40">
-		<reward id="90345" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90344" type="ON_FAILURE" /> <!-- info -->
-	</item>                                
-	<item one="90345" two="90345" chance="20">
-		<reward id="90346" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90345" type="ON_FAILURE" /> <!-- info -->
-	</item>                                
-	<item one="90346" two="90346" chance="10">
-		<reward id="90347" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90346" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Vital Stone -->
-	<item one="90353" two="90353" chance="65">
-		<reward id="90354" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90353" type="ON_FAILURE" /> <!-- info -->
-	</item>                                
-	<item one="90354" two="90354" chance="40">
-		<reward id="90355" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90354" type="ON_FAILURE" /> <!-- info -->
-	</item>                                
-	<item one="90355" two="90355" chance="20">
-		<reward id="90356" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90355" type="ON_FAILURE" /> <!-- info -->
-	</item>                                
-	<item one="90356" two="90356" chance="10">
-		<reward id="90357" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90356" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	
-	<!-- Sigel's Rune -->
-	<item one="90534" two="90534" chance="70">
-		<reward id="90535" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90534" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90535" two="90534" chance="70">
-		<reward id="90536" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90534" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90536" two="90534" chance="70">
-		<reward id="90537" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90534" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90537" two="90534" chance="70">
-		<reward id="90538" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90534" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90538" two="90534" chance="70">
-		<reward id="90539" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90537" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90539" two="90534" chance="70">
-		<reward id="90540" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90537" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90540" two="90534" chance="70">
-		<reward id="90541" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90537" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90541" two="90534" chance="70">
-		<reward id="90542" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90537" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90542" two="90534" chance="70">
-		<reward id="90543" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90537" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90543" two="90534" chance="70">
-		<reward id="90544" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90542" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90544" two="90534" chance="70">
-		<reward id="90545" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90542" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90545" two="90534" chance="70">
-		<reward id="90546" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90542" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90546" two="90534" chance="70">
-		<reward id="90547" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90542" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90547" two="90534" chance="70">
-		<reward id="90548" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90542" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90548" two="90534" chance="70">
-		<reward id="90549" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90534" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90549" two="90534" chance="70">
-		<reward id="90550" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90534" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90550" two="90534" chance="70">
-		<reward id="90551" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90534" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90551" two="90534" chance="70">
-		<reward id="90552" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90534" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90552" two="90534" chance="70">
-		<reward id="90553" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90534" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90554" two="90554" chance="70">
-		<reward id="90555" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90554" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90555" two="90554" chance="70">
-		<reward id="90556" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90554" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90556" two="90554" chance="70">
-		<reward id="90557" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90554" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90557" two="90554" chance="70">
-		<reward id="90558" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90554" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90558" two="90554" chance="70">
-		<reward id="90559" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90557" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90559" two="90554" chance="70">
-		<reward id="90560" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90557" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90560" two="90554" chance="70">
-		<reward id="90561" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90557" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90561" two="90554" chance="70">
-		<reward id="90562" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90557" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90562" two="90554" chance="70">
-		<reward id="90563" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90557" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90563" two="90554" chance="70">
-		<reward id="90564" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90562" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90564" two="90554" chance="70">
-		<reward id="90565" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90562" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90565" two="90554" chance="70">
-		<reward id="90566" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90562" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90566" two="90554" chance="70">
-		<reward id="90567" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90562" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90567" two="90554" chance="70">
-		<reward id="90568" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90562" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90568" two="90554" chance="70">
-		<reward id="90569" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90554" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90569" two="90554" chance="70">
-		<reward id="90570" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90554" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90570" two="90554" chance="70">
-		<reward id="90571" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90554" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90571" two="90554" chance="70">
-		<reward id="90572" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90554" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90572" two="90554" chance="70">
-		<reward id="90573" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90554" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90574" two="90574" chance="70">
-		<reward id="90575" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90574" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90575" two="90574" chance="70">
-		<reward id="90576" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90574" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90576" two="90574" chance="70">
-		<reward id="90577" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90574" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90577" two="90574" chance="70">
-		<reward id="90578" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90574" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90578" two="90574" chance="70">
-		<reward id="90579" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90577" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90579" two="90574" chance="70">
-		<reward id="90580" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90577" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90580" two="90574" chance="70">
-		<reward id="90581" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90577" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90581" two="90574" chance="70">
-		<reward id="90582" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90577" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90582" two="90574" chance="70">
-		<reward id="90583" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90577" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90583" two="90574" chance="70">
-		<reward id="90584" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90582" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90584" two="90574" chance="70">
-		<reward id="90585" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90582" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90585" two="90574" chance="70">
-		<reward id="90586" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90582" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90586" two="90574" chance="70">
-		<reward id="90587" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90582" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90587" two="90574" chance="70">
-		<reward id="90588" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90582" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90588" two="90574" chance="70">
-		<reward id="90589" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90574" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90589" two="90574" chance="70">
-		<reward id="90590" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90574" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90590" two="90574" chance="70">
-		<reward id="90591" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90574" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90591" two="90574" chance="70">
-		<reward id="90592" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90574" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90592" two="90574" chance="70">
-		<reward id="90593" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90574" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90594" two="90594" chance="70">
-		<reward id="90595" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90594" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90595" two="90594" chance="70">
-		<reward id="90596" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90594" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90596" two="90594" chance="70">
-		<reward id="90597" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90594" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90597" two="90594" chance="70">
-		<reward id="90598" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90594" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90598" two="90594" chance="70">
-		<reward id="90599" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90597" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90599" two="90594" chance="70">
-		<reward id="90600" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90597" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90600" two="90594" chance="70">
-		<reward id="90601" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90597" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90601" two="90594" chance="70">
-		<reward id="90602" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90597" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90602" two="90594" chance="70">
-		<reward id="90603" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90597" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90603" two="90594" chance="70">
-		<reward id="90604" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90602" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90604" two="90594" chance="70">
-		<reward id="90605" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90602" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90605" two="90594" chance="70">
-		<reward id="90606" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90602" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90606" two="90594" chance="70">
-		<reward id="90607" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90602" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90607" two="90594" chance="70">
-		<reward id="90608" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90602" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90608" two="90594" chance="70">
-		<reward id="90609" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90594" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90609" two="90594" chance="70">
-		<reward id="90610" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90594" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90610" two="90594" chance="70">
-		<reward id="90611" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90594" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90611" two="90594" chance="70">
-		<reward id="90612" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90594" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90612" two="90594" chance="70">
-		<reward id="90613" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90594" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90614" two="90614" chance="70">
-		<reward id="90615" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90614" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90615" two="90614" chance="70">
-		<reward id="90616" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90614" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90616" two="90614" chance="70">
-		<reward id="90617" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90614" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90617" two="90614" chance="70">
-		<reward id="90618" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90614" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90618" two="90614" chance="70">
-		<reward id="90619" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90617" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90619" two="90614" chance="70">
-		<reward id="90620" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90617" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90620" two="90614" chance="70">
-		<reward id="90621" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90617" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90621" two="90614" chance="70">
-		<reward id="90622" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90617" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90622" two="90614" chance="70">
-		<reward id="90623" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90617" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90623" two="90614" chance="70">
-		<reward id="90624" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90622" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90624" two="90614" chance="70">
-		<reward id="90625" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90622" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90625" two="90614" chance="70">
-		<reward id="90626" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90622" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90626" two="90614" chance="70">
-		<reward id="90627" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90622" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90627" two="90614" chance="70">
-		<reward id="90628" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90622" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90628" two="90614" chance="70">
-		<reward id="90629" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90614" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90629" two="90614" chance="70">
-		<reward id="90630" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90614" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90630" two="90614" chance="70">
-		<reward id="90631" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90614" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90631" two="90614" chance="70">
-		<reward id="90632" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90614" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90632" two="90614" chance="70">
-		<reward id="90633" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90614" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90634" two="90634" chance="70">
-		<reward id="90635" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90634" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90635" two="90634" chance="70">
-		<reward id="90636" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90634" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90636" two="90634" chance="70">
-		<reward id="90637" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90634" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90637" two="90634" chance="70">
-		<reward id="90638" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90634" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90638" two="90634" chance="70">
-		<reward id="90639" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90637" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90639" two="90634" chance="70">
-		<reward id="90640" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90637" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90640" two="90634" chance="70">
-		<reward id="90641" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90637" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90641" two="90634" chance="70">
-		<reward id="90642" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90637" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90642" two="90634" chance="70">
-		<reward id="90643" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90637" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90643" two="90634" chance="70">
-		<reward id="90644" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90642" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90644" two="90634" chance="70">
-		<reward id="90645" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90642" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90645" two="90634" chance="70">
-		<reward id="90646" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90642" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90646" two="90634" chance="70">
-		<reward id="90647" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90642" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90647" two="90634" chance="70">
-		<reward id="90648" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90642" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90648" two="90634" chance="70">
-		<reward id="90649" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90634" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90649" two="90634" chance="70">
-		<reward id="90650" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90634" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90650" two="90634" chance="70">
-		<reward id="90651" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90634" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90651" two="90634" chance="70">
-		<reward id="90652" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90634" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90652" two="90634" chance="70">
-		<reward id="90653" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90634" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90654" two="90654" chance="70">
-		<reward id="90655" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90654" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90655" two="90654" chance="70">
-		<reward id="90656" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90654" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90656" two="90654" chance="70">
-		<reward id="90657" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90654" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90657" two="90654" chance="70">
-		<reward id="90658" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90654" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90658" two="90654" chance="70">
-		<reward id="90659" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90657" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90659" two="90654" chance="70">
-		<reward id="90660" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90657" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90660" two="90654" chance="70">
-		<reward id="90661" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90657" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90661" two="90654" chance="70">
-		<reward id="90662" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90657" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90662" two="90654" chance="70">
-		<reward id="90663" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90657" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90663" two="90654" chance="70">
-		<reward id="90664" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90662" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90664" two="90654" chance="70">
-		<reward id="90665" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90662" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90665" two="90654" chance="70">
-		<reward id="90666" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90662" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90666" two="90654" chance="70">
-		<reward id="90667" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90662" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90667" two="90654" chance="70">
-		<reward id="90668" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90662" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90668" two="90654" chance="70">
-		<reward id="90669" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90654" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90669" two="90654" chance="70">
-		<reward id="90670" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90654" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90670" two="90654" chance="70">
-		<reward id="90671" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90654" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90671" two="90654" chance="70">
-		<reward id="90672" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90654" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90672" two="90654" chance="70">
-		<reward id="90673" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90654" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90674" two="90674" chance="70">
-		<reward id="90675" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90674" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90675" two="90674" chance="70">
-		<reward id="90676" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90674" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90676" two="90674" chance="70">
-		<reward id="90677" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90674" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90677" two="90674" chance="70">
-		<reward id="90678" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90674" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90678" two="90674" chance="70">
-		<reward id="90679" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90677" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90679" two="90674" chance="70">
-		<reward id="90680" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90677" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90680" two="90674" chance="70">
-		<reward id="90681" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90677" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90681" two="90674" chance="70">
-		<reward id="90682" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90677" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90682" two="90674" chance="70">
-		<reward id="90683" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90677" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90683" two="90674" chance="70">
-		<reward id="90684" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90682" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90684" two="90674" chance="70">
-		<reward id="90685" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90682" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90685" two="90674" chance="70">
-		<reward id="90686" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90682" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90686" two="90674" chance="70">
-		<reward id="90687" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90682" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90687" two="90674" chance="70">
-		<reward id="90688" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90682" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90688" two="90674" chance="70">
-		<reward id="90689" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90674" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90689" two="90674" chance="70">
-		<reward id="90690" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90674" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90690" two="90674" chance="70">
-		<reward id="90691" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90674" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90691" two="90674" chance="70">
-		<reward id="90692" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90674" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90692" two="90674" chance="70">
-		<reward id="90693" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90674" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Brooch Lv. 3 -->
-	<item one="90312" two="90312" chance="25">
-		<reward id="90934" type="ON_SUCCESS" /> <!-- Brooch Lv. 3 -->
-		<reward id="90312" type="ON_FAILURE" /> <!-- Brooch Lv. 2 -->
-	</item>
-	<item one="90924" two="90924" chance="70">
-		<reward id="90925" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90924" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90925" two="90925" chance="70">
-		<reward id="90926" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90925" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90926" two="90926" chance="70">
-		<reward id="90927" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90926" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90927" two="90927" chance="70">
-		<reward id="90928" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90927" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90929" two="90929" chance="70">
-		<reward id="90930" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90929" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90930" two="90930" chance="70">
-		<reward id="90931" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90930" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90931" two="90931" chance="70">
-		<reward id="90932" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90931" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90932" two="90932" chance="70">
-		<reward id="90933" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90932" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91061" two="91059" chance="70">
-		<reward id="91062" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91061" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91062" two="91059" chance="70">
-		<reward id="91063" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91061" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91063" two="91059" chance="70">
-		<reward id="91064" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91061" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91064" two="91059" chance="70">
-		<reward id="91065" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91061" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91066" two="91059" chance="70">
-		<reward id="91067" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91066" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91067" two="91059" chance="70">
-		<reward id="91068" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91066" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91068" two="91059" chance="70">
-		<reward id="91069" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91066" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91069" two="91059" chance="70">
-		<reward id="91070" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91066" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91071" two="91059" chance="70">
-		<reward id="91072" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91071" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91072" two="91059" chance="70">
-		<reward id="91073" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91071" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91073" two="91059" chance="70">
-		<reward id="91074" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91071" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91074" two="91059" chance="70">
-		<reward id="91075" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91071" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91077" two="91076" chance="70">
-		<reward id="91078" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91077" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91078" two="91076" chance="70">
-		<reward id="91079" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91077" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91079" two="91076" chance="70">
-		<reward id="91080" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91077" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91080" two="91076" chance="70">
-		<reward id="91081" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91077" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91081" two="91076" chance="70">
-		<reward id="91082" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91077" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91082" two="91076" chance="70">
-		<reward id="91083" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91082" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91083" two="91076" chance="70">
-		<reward id="91084" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91082" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91084" two="91076" chance="70">
-		<reward id="91085" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91082" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91085" two="91076" chance="70">
-		<reward id="91086" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91082" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91086" two="91076" chance="70">
-		<reward id="91087" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91082" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91087" two="91076" chance="70">
-		<reward id="91088" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91082" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91088" two="91076" chance="70">
-		<reward id="91089" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91088" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91089" two="91076" chance="70">
-		<reward id="91090" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91088" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91090" two="91076" chance="70">
-		<reward id="91091" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91088" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91091" two="91076" chance="70">
-		<reward id="91092" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91088" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91092" two="91076" chance="70">
-		<reward id="91093" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91088" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91093" two="91076" chance="70">
-		<reward id="91094" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91088" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91094" two="91076" chance="70">
-		<reward id="91140" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91094" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91140" two="91076" chance="70">
-		<reward id="91141" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91094" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91141" two="91076" chance="70">
-		<reward id="91142" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91094" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91142" two="91076" chance="70">
-		<reward id="91143" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91094" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91143" two="91076" chance="70">
-		<reward id="91144" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91094" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91144" two="91076" chance="70">
-		<reward id="91145" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91094" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	
-	<!-- Anakim's Rune -->
-	<item one="91163" two="91163" chance="95">
-		<reward id="91164" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91163" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91164" two="91164" chance="95">
-		<reward id="91165" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91164" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91165" two="91165" chance="95">
-		<reward id="91166" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91165" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91166" two="91166" chance="95">
-		<reward id="91167" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91166" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91167" two="91167" chance="50">
-		<reward id="91168" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91167" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91168" two="91168" chance="50">
-		<reward id="91169" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91168" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91169" two="91169" chance="50">
-		<reward id="91170" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91169" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91170" two="91170" chance="30">
-		<reward id="91171" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91170" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91171" two="91171" chance="30">
-		<reward id="91172" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91171" type="ON_FAILURE" /> <!-- info -->
-	</item>	
-	<!-- Lilith's Rune -->
-	<item one="91173" two="91173" chance="95">
-		<reward id="91174" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91173" type="ON_FAILURE" /> <!-- info -->
-	</item>                                
-	<item one="91174" two="91174" chance="95">
-		<reward id="91175" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91174" type="ON_FAILURE" /> <!-- info -->
-	</item>                                
-	<item one="91175" two="91175" chance="95">
-		<reward id="91176" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91175" type="ON_FAILURE" /> <!-- info -->
-	</item>                                
-	<item one="91176" two="91176" chance="95">
-		<reward id="91177" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91176" type="ON_FAILURE" /> <!-- info -->
-	</item>                                
-	<item one="91177" two="91177" chance="50">
-		<reward id="91178" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91177" type="ON_FAILURE" /> <!-- info -->
-	</item>                                
-	<item one="91178" two="91178" chance="50">
-		<reward id="91179" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91178" type="ON_FAILURE" /> <!-- info -->
-	</item>                                
-	<item one="91179" two="91179" chance="50">
-		<reward id="91180" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91179" type="ON_FAILURE" /> <!-- info -->
-	</item>                                
-	<item one="91180" two="91180" chance="30">
-		<reward id="91181" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91180" type="ON_FAILURE" /> <!-- info -->
-	</item>                                
-	<item one="91181" two="91181" chance="30">
-		<reward id="91182" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91181" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Emerald -->
-	<item one="91357" two="91357" chance="65">
-		<reward id="91358" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91357" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91358" two="91358" chance="40">
-		<reward id="91359" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91358" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91359" two="91359" chance="20">
-		<reward id="91360" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91359" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91360" two="91360" chance="10">
-		<reward id="91361" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91360" type="ON_FAILURE" /> <!-- info -->
-	</item>
 	<!-- Greater Emerald -->
-	<item one="91361" two="91356" chance="50">
-		<reward id="91362" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91361" type="ON_FAILURE" /> <!-- info -->
+	<item one="91362" two="91356" chance="70"> <!-- Greater Emerald Lv. 1/ Gem Energy -->
+		<reward id="91363" type="ON_SUCCESS" /> <!-- Greater Emerald Lv. 2-->
+		<reward id="91362" type="ON_FAILURE" /> <!-- Greater Emerald Lv. 1 -->
 	</item>
-	<item one="91362" two="91356" chance="70">
-		<reward id="91363" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91362" type="ON_FAILURE" /> <!-- info -->
+	<item one="91363" two="91356" chance="70"> <!-- Greater Emerald Lv. 2/ Gem Energy -->
+		<reward id="91364" type="ON_SUCCESS" />  <!-- Greater Emerald Lv. 3 -->
+		<reward id="91362" type="ON_FAILURE" />  <!-- Greater Emerald Lv. 2 -->
 	</item>
-	<item one="91363" two="91356" chance="70">
-		<reward id="91364" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91362" type="ON_FAILURE" /> <!-- info -->
+	<item one="91364" two="91356" chance="70"> <!-- Greater Emerald Lv. 3/ Gem Energy -->
+		<reward id="91365" type="ON_SUCCESS" />  <!-- Greater Emerald Lv. 4 -->
+		<reward id="91362" type="ON_FAILURE" />  <!-- Greater Emerald Lv. 3 -->
 	</item>
-	<item one="91364" two="91356" chance="70">
-		<reward id="91365" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91362" type="ON_FAILURE" /> <!-- info -->
+	<item one="91365" two="91356" chance="70"> <!-- Greater Emerald Lv. 4/ Gem Energy -->
+		<reward id="91366" type="ON_SUCCESS" />  <!-- Greater Emerald Lv. 5 -->
+		<reward id="91362" type="ON_FAILURE" />  <!-- Greater Emerald Lv. 4 -->
 	</item>
-	<item one="91365" two="91356" chance="70">
-		<reward id="91366" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91362" type="ON_FAILURE" /> <!-- info -->
+
+	<!-- Topaz  Lv. 5 (Imprint) to Greater Topaz Lv. 1-->
+	<item one="90317" two="91356" chance="70"> <!-- Topaz Lv. 5 (Imprint)/ Gem Energy -->
+		<reward id="91305" type="ON_SUCCESS" />  <!-- Greater Topaz Lv. 1 -->
+		<reward id="90317" type="ON_FAILURE" />  <!-- Topaz Lv. 5 (Imprint) -->
 	</item>
-	<item one="90317" two="91356" chance="70">
-		<reward id="91305" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90317" type="ON_FAILURE" /> <!-- info -->
+
+	<!-- Greater Topaz -->
+	<item one="91305" two="91356" chance="70"> <!-- Greater Topaz Lv. 1/ Gem Energy -->
+		<reward id="91306" type="ON_SUCCESS" />  <!-- Greater Topaz Lv. 2 -->
+		<reward id="91305" type="ON_FAILURE" />  <!-- Greater Topaz Lv. 1 -->
 	</item>
-	<item one="91305" two="91356" chance="70">
-		<reward id="91306" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91305" type="ON_FAILURE" /> <!-- info -->
+	<item one="91306" two="91356" chance="70"> <!-- Greater Topaz Lv. 2/ Gem Energy -->
+		<reward id="91307" type="ON_SUCCESS" />  <!-- Greater Topaz Lv. 3 -->
+		<reward id="91305" type="ON_FAILURE" />  <!-- Greater Topaz Lv. 2 -->
 	</item>
-	<item one="91306" two="91356" chance="70">
-		<reward id="91307" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91305" type="ON_FAILURE" /> <!-- info -->
+	<item one="91307" two="91356" chance="70"> <!-- Greater Topaz Lv. 3/ Gem Energy -->
+		<reward id="91308" type="ON_SUCCESS" />  <!-- Greater Topaz Lv. 4 -->
+		<reward id="91305" type="ON_FAILURE" />  <!-- Greater Topaz Lv. 3 -->
 	</item>
-	<item one="91307" two="91356" chance="70">
-		<reward id="91308" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91305" type="ON_FAILURE" /> <!-- info -->
+	<item one="91308" two="91356" chance="70"> <!-- Greater Topaz Lv. 4/ Gem Energy -->
+		<reward id="91309" type="ON_SUCCESS" />  <!-- Greater Topaz Lv. 5 -->
+		<reward id="91305" type="ON_FAILURE" />  <!-- Greater Topaz Lv. 4 -->
 	</item>
-	<item one="91308" two="91356" chance="70">
-		<reward id="91309" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91305" type="ON_FAILURE" /> <!-- info -->
+
+	<!-- Garnet  Lv. 5 (Imprint) to Greater Garnet Lv. 1-->
+	<item one="90322" two="91356" chance="70"> <!-- Garnet Lv. 5 (Imprint)/ Gem Energy -->
+		<reward id="91310" type="ON_SUCCESS" />  <!-- Greater Garnet Lv. 1 -->
+		<reward id="90322" type="ON_FAILURE" />  <!-- Garnet Lv. 5 (Imprint) -->
 	</item>
-	<item one="90322" two="91356" chance="70">
-		<reward id="91310" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90322" type="ON_FAILURE" /> <!-- info -->
+
+	<!-- Greater Garnet -->
+	<item one="91310" two="91356" chance="70"> <!--  Greater Garnet Lv. 1/ Gem Energy -->
+		<reward id="91311" type="ON_SUCCESS" />  <!-- Greater Garnet Lv. 2 -->
+		<reward id="91310" type="ON_FAILURE" />  <!-- Greater Garnet Lv. 1 -->
 	</item>
-	<item one="91310" two="91356" chance="70">
-		<reward id="91311" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91310" type="ON_FAILURE" /> <!-- info -->
+	<item one="91311" two="91356" chance="70"> <!--  Greater Garnet Lv. 2/ Gem Energy -->
+		<reward id="91312" type="ON_SUCCESS" />  <!-- Greater Garnet Lv. 3 -->
+		<reward id="91310" type="ON_FAILURE" />  <!-- Greater Garnet Lv. 2 -->
 	</item>
-	<item one="91311" two="91356" chance="70">
-		<reward id="91312" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91310" type="ON_FAILURE" /> <!-- info -->
+	<item one="91312" two="91356" chance="70"> <!--  Greater Garnet Lv. 3/ Gem Energy -->
+		<reward id="91313" type="ON_SUCCESS" />  <!-- Greater Garnet Lv. 4 -->
+		<reward id="91310" type="ON_FAILURE" />  <!-- Greater Garnet Lv. 3 -->
 	</item>
-	<item one="91312" two="91356" chance="70">
-		<reward id="91313" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91310" type="ON_FAILURE" /> <!-- info -->
+	<item one="91313" two="91356" chance="70"> <!--  Greater Garnet Lv. 4/ Gem Energy -->
+		<reward id="91314" type="ON_SUCCESS" />  <!-- Greater Garnet Lv. 5 -->
+		<reward id="91310" type="ON_FAILURE" />  <!-- Greater Garnet Lv. 4 -->
 	</item>
-	<item one="91313" two="91356" chance="70">
-		<reward id="91314" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91310" type="ON_FAILURE" /> <!-- info -->
+
+	<!-- Jade  Lv. 5 (Imprint) to Greater Jade Lv. 1-->
+	<item one="90327" two="91356" chance="70"> <!-- Jade Lv. 5 (Imprint)/ Gem Energy -->
+		<reward id="91315" type="ON_SUCCESS" />  <!-- Greater Jade Lv. 2 -->
+		<reward id="90327" type="ON_FAILURE" />  <!-- Jade Lv. 5 (Imprint) -->
 	</item>
-	<item one="90327" two="91356" chance="70">
-		<reward id="91315" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90327" type="ON_FAILURE" /> <!-- info -->
+
+	<!-- Greater Jade -->
+	<item one="91315" two="91356" chance="70">  <!--  Greater Jade Lv. 1/ Gem Energy -->
+		<reward id="91316" type="ON_SUCCESS" />  <!-- Greater Jade Lv. 2 -->
+		<reward id="91315" type="ON_FAILURE" />  <!-- Greater Jade Lv. 1 -->
 	</item>
-	<item one="91315" two="91356" chance="70">
-		<reward id="91316" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91315" type="ON_FAILURE" /> <!-- info -->
+	<item one="91316" two="91356" chance="70">  <!--  Greater Jade Lv. 2/ Gem Energy -->
+		<reward id="91317" type="ON_SUCCESS" />  <!-- Greater Jade Lv. 3 -->
+		<reward id="91315" type="ON_FAILURE" />  <!-- Greater Jade Lv. 2-->
 	</item>
-	<item one="91316" two="91356" chance="70">
-		<reward id="91317" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91315" type="ON_FAILURE" /> <!-- info -->
+	<item one="91317" two="91356" chance="70">  <!--  Greater Jade Lv. 3/ Gem Energy -->
+		<reward id="91318" type="ON_SUCCESS" />  <!-- Greater Jade Lv. 4 -->
+		<reward id="91315" type="ON_FAILURE" />  <!-- Greater Jade Lv. 3 -->
 	</item>
-	<item one="91317" two="91356" chance="70">
-		<reward id="91318" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91315" type="ON_FAILURE" /> <!-- info -->
+	<item one="91318" two="91356" chance="70">  <!--  Greater Jade Lv. 4/ Gem Energy -->
+		<reward id="91319" type="ON_SUCCESS" />  <!-- Greater Jade Lv. 5 -->
+		<reward id="91315" type="ON_FAILURE" />  <!-- Greater Jade Lv. 4 -->
 	</item>
-	<item one="91318" two="91356" chance="70">
-		<reward id="91319" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91315" type="ON_FAILURE" /> <!-- info -->
+
+	<!-- Ruby  Lv. 5 (Imprint) to Greater Ruby Lv. 1-->
+	<item one="90332" two="91356" chance="70"> <!-- Ruby Lv. 5 (Imprint)/ Gem Energy -->
+		<reward id="91320" type="ON_SUCCESS" />  <!-- Greater Ruby Lv. 1 -->
+		<reward id="90332" type="ON_FAILURE" />  <!-- Ruby Lv. 5 (Imprint) -->
 	</item>
-	<item one="90332" two="91356" chance="70">
-		<reward id="91320" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90332" type="ON_FAILURE" /> <!-- info -->
+
+	<!-- Greater Ruby -->
+	<item one="91320" two="91356" chance="70"> <!-- Greater Ruby Lv. 1/ Gem Energy -->
+		<reward id="91321" type="ON_SUCCESS" />  <!-- Greater Ruby Lv. 2 -->
+		<reward id="91320" type="ON_FAILURE" />  <!-- Greater Ruby Lv. 1 -->
 	</item>
-	<item one="91320" two="91356" chance="70">
-		<reward id="91321" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91320" type="ON_FAILURE" /> <!-- info -->
+	<item one="91321" two="91356" chance="70"> <!-- Greater Ruby Lv. 2/ Gem Energy -->
+		<reward id="91322" type="ON_SUCCESS" />  <!-- Greater Ruby Lv. 3 -->
+		<reward id="91320" type="ON_FAILURE" />  <!-- Greater Ruby Lv. 2 -->
 	</item>
-	<item one="91321" two="91356" chance="70">
-		<reward id="91322" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91320" type="ON_FAILURE" /> <!-- info -->
+	<item one="91322" two="91356" chance="70"> <!-- Greater Ruby Lv. 3/ Gem Energy -->
+		<reward id="91323" type="ON_SUCCESS" />  <!-- Greater Ruby Lv. 4 -->
+		<reward id="91320" type="ON_FAILURE" />  <!-- Greater Ruby Lv. 3 -->
 	</item>
-	<item one="91322" two="91356" chance="70">
-		<reward id="91323" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91320" type="ON_FAILURE" /> <!-- info -->
+	<item one="91323" two="91356" chance="70"> <!-- Greater Ruby Lv. 4/ Gem Energy -->
+		<reward id="91324" type="ON_SUCCESS" />  <!-- Greater Ruby Lv. 3 -->
+		<reward id="91320" type="ON_FAILURE" />  <!-- Greater Ruby Lv. 4 -->
 	</item>
-	<item one="91323" two="91356" chance="70">
-		<reward id="91324" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91320" type="ON_FAILURE" /> <!-- info -->
+
+	<!-- Sapphire  Lv. 5 (Imprint) to Greater Sapphire Lv. 1-->
+	<item one="90337" two="91356" chance="70"> <!-- Sapphire Lv. 5 (Imprint)/ Gem Energy -->
+		<reward id="91325" type="ON_SUCCESS" />  <!-- Greater Sapphire Lv. 1 -->
+		<reward id="90337" type="ON_FAILURE" />  <!-- Sapphire Lv. 5 (Imprint) -->
 	</item>
-	<item one="90337" two="91356" chance="70">
-		<reward id="91325" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90337" type="ON_FAILURE" /> <!-- info -->
+
+	<!-- Greater Sapphire -->
+	<item one="91325" two="91356" chance="70"> <!-- Greater Sapphire Lv. 1/ Gem Energy -->
+		<reward id="91326" type="ON_SUCCESS" />  <!-- Greater Sapphire Lv. 2 -->
+		<reward id="91325" type="ON_FAILURE" />  <!-- Greater Sapphire Lv. 1 -->
 	</item>
-	<item one="91325" two="91356" chance="70">
-		<reward id="91326" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91325" type="ON_FAILURE" /> <!-- info -->
+	<item one="91326" two="91356" chance="70"> <!-- Greater Sapphire Lv. 2/ Gem Energy -->
+		<reward id="91327" type="ON_SUCCESS" />  <!-- Greater Sapphire Lv. 3 -->
+		<reward id="91325" type="ON_FAILURE" />  <!-- Greater Sapphire Lv. 2 -->
 	</item>
-	<item one="91326" two="91356" chance="70">
-		<reward id="91327" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91325" type="ON_FAILURE" /> <!-- info -->
+	<item one="91327" two="91356" chance="70"> <!-- Greater Sapphire Lv. 3/ Gem Energy -->
+		<reward id="91328" type="ON_SUCCESS" />  <!-- Greater Sapphire Lv. 4 -->
+		<reward id="91325" type="ON_FAILURE" />  <!-- Greater Sapphire Lv. 3 -->
 	</item>
-	<item one="91327" two="91356" chance="70">
-		<reward id="91328" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91325" type="ON_FAILURE" /> <!-- info -->
+	<item one="91328" two="91356" chance="70"> <!-- Greater Sapphire Lv. 4/ Gem Energy -->
+		<reward id="91329" type="ON_SUCCESS" />  <!-- Greater Sapphire Lv. 5 -->
+		<reward id="91325" type="ON_FAILURE" />  <!-- Greater Sapphire Lv. 4 -->
 	</item>
-	<item one="91328" two="91356" chance="70">
-		<reward id="91329" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91325" type="ON_FAILURE" /> <!-- info -->
+
+	<!-- Diamond  Lv. 5 (Imprint) to Greater Diamond Lv. 1-->
+	<item one="90342" two="91356" chance="70"> <!-- Diamond Lv. 5 (Imprint)/ Gem Energy -->
+		<reward id="91330" type="ON_SUCCESS" />  <!-- Greater Diamond Lv. 1 -->
+		<reward id="90342" type="ON_FAILURE" />  <!-- Greater Emerald Lv. 1 -->
 	</item>
-	<item one="90342" two="91356" chance="70">
-		<reward id="91330" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90342" type="ON_FAILURE" /> <!-- info -->
-	</item>
+
+	<!-- Grater Diamond -->
 	<item one="91330" two="91356" chance="70">
-		<reward id="91331" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91330" type="ON_FAILURE" /> <!-- info -->
+		<reward id="91331" type="ON_SUCCESS" />  <!-- Greater Diamond Lv. 1 -->
+		<reward id="91330" type="ON_FAILURE" />  <!-- Greater Diamond Lv. 1 -->
 	</item>
 	<item one="91331" two="91356" chance="70">
-		<reward id="91332" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91330" type="ON_FAILURE" /> <!-- info -->
+		<reward id="91332" type="ON_SUCCESS" /> <!-- Greater Diamond Lv. 1 -->
+		<reward id="91330" type="ON_FAILURE" /> <!-- Greater Diamond Lv. 1 -->
 	</item>
 	<item one="91332" two="91356" chance="70">
-		<reward id="91333" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91330" type="ON_FAILURE" /> <!-- info -->
+		<reward id="91333" type="ON_SUCCESS" /> <!-- Greater Diamond Lv. 1 -->
+		<reward id="91330" type="ON_FAILURE" /> <!-- Greater Diamond Lv. 1 -->
 	</item>
 	<item one="91333" two="91356" chance="70">
-		<reward id="91334" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91330" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90347" two="91356" chance="70">
-		<reward id="91335" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90347" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91335" two="91356" chance="70">
-		<reward id="91336" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91335" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91336" two="91356" chance="70">
-		<reward id="91337" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91335" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91337" two="91356" chance="70">
-		<reward id="91338" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91335" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91338" two="91356" chance="70">
-		<reward id="91339" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91335" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90357" two="91356" chance="70">
-		<reward id="91340" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90357" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91340" two="91356" chance="70">
-		<reward id="91341" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91340" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91341" two="91356" chance="70">
-		<reward id="91342" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91340" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91342" two="91356" chance="70">
-		<reward id="91343" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91340" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91343" two="91356" chance="70">
-		<reward id="91344" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91340" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90928" two="91356" chance="70">
-		<reward id="91345" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90928" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91345" two="91356" chance="70">
-		<reward id="91346" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91345" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91346" two="91356" chance="70">
-		<reward id="91347" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91345" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91347" two="91356" chance="70">
-		<reward id="91348" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91345" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91348" two="91356" chance="70">
-		<reward id="91349" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91345" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="90933" two="91356" chance="70">
-		<reward id="91350" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90933" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91350" two="91356" chance="70">
-		<reward id="91351" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91350" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91351" two="91356" chance="70">
-		<reward id="91352" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91350" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91352" two="91356" chance="70">
-		<reward id="91353" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91350" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91353" two="91356" chance="70">
-		<reward id="91354" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91350" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Brooch Lv. 4 -->
-	<item one="90934" two="90934" chance="25">
-		<reward id="91303" type="ON_SUCCESS" /> <!-- Brooch Lv. 4 -->
-		<reward id="90934" type="ON_FAILURE" /> <!-- Brooch Lv. 3 -->
-	</item>
-	<!-- Brooch Lv. 5 -->
-	<item one="91303" two="91303" chance="25">
-		<reward id="91304" type="ON_SUCCESS" /> <!-- Brooch Lv. 5 -->
-		<reward id="91303" type="ON_FAILURE" /> <!-- Brooch Lv. 4 -->
-	</item>
-	<item one="91398" two="90045" chance="70">
-		<reward id="91394" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91399" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91145" two="91145" chance="70">
-		<reward id="91791" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91791" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91791" two="91791" chance="70">
-		<reward id="91792" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91792" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Talisman Bracelet Lv. 2 -->
-	<item one="9589" two="9589" chance="25">
-		<reward id="9590" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="9589" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Talisman Bracelet Lv. 3 -->
-	<item one="9590" two="9590" chance="25">
-		<reward id="9591" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="9590" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Talisman Bracelet Lv. 4 -->
-	<item one="9591" two="9591" chance="25">
-		<reward id="49703" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="9591" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Talisman Bracelet Lv. 5 -->
-	<item one="49703" two="49703" chance="25">
-		<reward id="92031" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="49703" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Talisman Bracelet Lv. 6 -->
-	<item one="92031" two="92031" chance="25">
-		<reward id="92032" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="92031" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Lilith's Rune Lv. 10 -->
-	<item one="91182" two="91173" chance="70">
-		<reward id="92920" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91181" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Lilith' Soul Crystal Lv. 12 -->
-	<item one="92920" two="91173" chance="70">
-		<reward id="92921" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91181" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Lilith' Soul Crystal Lv. 13 -->
-	<item one="92921" two="91173" chance="70">
-		<reward id="92922" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91181" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Lilith' Soul Crystal Lv. 14 -->
-	<item one="92922" two="91173" chance="70">
-		<reward id="92923" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91181" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Lilith' Soul Crystal Lv. 15 -->
-	<item one="92923" two="91173" chance="70">
-		<reward id="92924" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91181" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Anakim's Rune Lv. 10 -->
-	<item one="91172" two="91163" chance="70">
-		<reward id="92925" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91171" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Anakim's Soul Crystal Lv. 11 -->
-	<item one="92925" two="91163" chance="70">
-		<reward id="92926" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91171" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Anakim's Soul Crystal Lv. 12 -->
-	<item one="92926" two="91163" chance="70">
-		<reward id="92927" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91171" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Anakim's Soul Crystal Lv. 13 -->
-	<item one="92927" two="91163" chance="70">
-		<reward id="92928" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91171" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Anakim's Soul Crystal Lv. 14 -->
-	<item one="92928" two="91163" chance="70">
-		<reward id="92929" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91171" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Jewel of Adventurer Fragment - Q 25+ all player -->
-	<item one="91936" two="91936" chance="70">
-		<reward id="93065" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="93065" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Agathion Bracelet Lv. 5 -->
-	<item one="90891" two="90891" chance="70">
-		<reward id="91161" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="90891" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Baium's Doll -->
-	<item one="91256" two="91256" chance="7">
-		<reward id="91423" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91256" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91423" two="91423" chance="70">
-		<reward id="99024" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91423" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Queen Ant's Doll -->
-	<item one="91257" two="91257" chance="7">
-		<reward id="91422" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91257" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91422" two="91422" chance="70">
-		<reward id="99023" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91422" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Orfen's Doll -->
-	<item one="91258" two="91258" chance="7">
-		<reward id="91424" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91258" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91424" two="91424" chance="70">
-		<reward id="99022" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91424" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Frintezza's Doll -->
-	<item one="91604" two="91604" chance="7">
-		<reward id="91605" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91604" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="91605" two="91605" chance="70">
-		<reward id="99025" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="91605" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	
-	<!-- Sigel's Rune -->
-	<item one="29818" two="29818" chance="70">
-		<reward id="29819" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29818" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="29819" two="29818" chance="70">
-		<reward id="29820" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29818" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="29820" two="29818" chance="70">
-		<reward id="29821" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29818" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="29821" two="29818" chance="70">
-		<reward id="29822" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29818" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="29822" two="29818" chance="70">
-		<reward id="29823" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29818" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="29823" two="29818" chance="40">
-		<reward id="29824" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29818" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="29824" two="29818" chance="40">
-		<reward id="29825" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29818" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="29825" two="29818" chance="40">
-		<reward id="29826" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29818" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="29826" two="29818" chance="40">
-		<reward id="29827" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29818" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="29827" two="29818" chance="40">
-		<reward id="29828" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29818" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="29828" two="29818" chance="40">
-		<reward id="29829" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29818" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="29829" two="29818" chance="40">
-		<reward id="29830" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29818" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Tyrr's Rune -->
-	<item one="29838" two="29838" chance="70">
-		<reward id="29839" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29838" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29839" two="29838" chance="70">
-		<reward id="29840" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29838" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29840" two="29838" chance="70">
-		<reward id="29841" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29838" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29841" two="29838" chance="70">
-		<reward id="29842" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29838" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29842" two="29838" chance="70">
-		<reward id="29843" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29838" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29843" two="29838" chance="40">
-		<reward id="29844" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29838" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29844" two="29838" chance="40">
-		<reward id="29845" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29838" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29845" two="29838" chance="40">
-		<reward id="29846" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29838" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29846" two="29838" chance="40">
-		<reward id="29847" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29838" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29847" two="29838" chance="40">
-		<reward id="29848" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29838" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29848" two="29838" chance="40">
-		<reward id="29849" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29838" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29849" two="29838" chance="40">
-		<reward id="29850" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29838" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<!-- Othell's Rune -->
-	<item one="29858" two="29858" chance="70">
-		<reward id="29859" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29858" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29859" two="29858" chance="70">
-		<reward id="29860" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29858" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29860" two="29858" chance="70">
-		<reward id="29861" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29858" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29861" two="29858" chance="70">
-		<reward id="29862" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29858" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29862" two="29858" chance="70">
-		<reward id="29863" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29858" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29863" two="29858" chance="40">
-		<reward id="29864" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29858" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29864" two="29858" chance="40">
-		<reward id="29865" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29858" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29865" two="29858" chance="40">
-		<reward id="29866" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29858" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29866" two="29858" chance="40">
-		<reward id="29867" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29858" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29867" two="29858" chance="40">
-		<reward id="29868" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29858" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29868" two="29858" chance="40">
-		<reward id="29869" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29858" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29869" two="29858" chance="40">
-		<reward id="29870" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29858" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Yul's Rune -->
-	<item one="29878" two="29878" chance="70">
-		<reward id="29879" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29878" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29879" two="29878" chance="70">
-		<reward id="29880" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29878" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29880" two="29878" chance="70">
-		<reward id="29881" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29878" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29881" two="29878" chance="70">
-		<reward id="29882" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29878" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29882" two="29878" chance="70">
-		<reward id="29883" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29878" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29883" two="29878" chance="40">
-		<reward id="29884" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29878" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29884" two="29878" chance="40">
-		<reward id="29885" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29878" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29885" two="29878" chance="40">
-		<reward id="29886" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29878" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29886" two="29878" chance="40">
-		<reward id="29887" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29878" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29887" two="29878" chance="40">
-		<reward id="29888" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29878" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29888" two="29878" chance="40">
-		<reward id="29889" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29878" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29889" two="29878" chance="40">
-		<reward id="29890" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29878" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Feoh's Rune -->
-	<item one="29898" two="29898" chance="70">
-		<reward id="29899" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29898" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29899" two="29898" chance="70">
-		<reward id="29900" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29898" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29900" two="29898" chance="70">
-		<reward id="29901" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29898" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29901" two="29898" chance="70">
-		<reward id="29902" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29898" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29902" two="29898" chance="70">
-		<reward id="29903" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29898" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29903" two="29898" chance="40">
-		<reward id="29904" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29898" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29904" two="29898" chance="40">
-		<reward id="29905" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29898" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29905" two="29898" chance="40">
-		<reward id="29906" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29898" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29906" two="29898" chance="40">
-		<reward id="29907" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29898" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29907" two="29898" chance="40">
-		<reward id="29908" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29898" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29908" two="29898" chance="40">
-		<reward id="29909" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29898" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29909" two="29898" chance="40">
-		<reward id="29910" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29898" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Iss' Rune -->
-	<item one="29918" two="29918" chance="70">
-		<reward id="29919" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29918" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29919" two="29918" chance="70">
-		<reward id="29920" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29918" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29920" two="29918" chance="70">
-		<reward id="29921" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29918" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29921" two="29918" chance="70">
-		<reward id="29922" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29918" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29922" two="29918" chance="70">
-		<reward id="29923" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29918" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29923" two="29918" chance="40">
-		<reward id="29924" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29918" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29924" two="29918" chance="40">
-		<reward id="29925" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29918" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29925" two="29918" chance="40">
-		<reward id="29926" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29918" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29926" two="29918" chance="40">
-		<reward id="29927" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29918" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29927" two="29918" chance="40">
-		<reward id="29928" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29918" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29928" two="29918" chance="40">
-		<reward id="29929" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29918" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29929" two="29918" chance="40">
-		<reward id="29930" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29918" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Wynn's Rune -->
-	<item one="29938" two="29938" chance="70">
-		<reward id="29939" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29938" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29939" two="29938" chance="70">
-		<reward id="29940" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29938" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29940" two="29938" chance="70">
-		<reward id="29941" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29938" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29941" two="29938" chance="70">
-		<reward id="29942" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29938" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29942" two="29938" chance="70">
-		<reward id="29943" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29938" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29943" two="29938" chance="40">
-		<reward id="29944" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29938" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29944" two="29938" chance="40">
-		<reward id="29945" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29938" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29945" two="29938" chance="40">
-		<reward id="29946" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29938" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29946" two="29938" chance="40">
-		<reward id="29947" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29938" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29947" two="29938" chance="40">
-		<reward id="29948" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29938" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29948" two="29938" chance="40">
-		<reward id="29949" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29938" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29949" two="29938" chance="40">
-		<reward id="29950" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29938" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Aeore's Rune -->
-	<item one="29958" two="29958" chance="70">
-		<reward id="29959" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29958" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29959" two="29958" chance="70">
-		<reward id="29960" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29958" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29960" two="29958" chance="70">
-		<reward id="29961" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29958" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29961" two="29958" chance="70">
-		<reward id="29962" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29958" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29962" two="29958" chance="70">
-		<reward id="29963" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29958" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29963" two="29958" chance="40">
-		<reward id="29964" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29958" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29964" two="29958" chance="40">
-		<reward id="29965" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29958" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29965" two="29958" chance="40">
-		<reward id="29966" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29958" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29966" two="29958" chance="40">
-		<reward id="29967" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29958" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29967" two="29958" chance="40">
-		<reward id="29968" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29958" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29968" two="29958" chance="40">
-		<reward id="29969" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29958" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="29969" two="29958" chance="40">
-		<reward id="29970" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="29958" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Brooch -->
-	<item one="70434" two="70434" chance="25">
-		<reward id="70435" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70434" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Topaz -->
-	<item one="70436" two="70436" chance="65">
-		<reward id="70437" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70436" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="70437" two="70437" chance="40">
-		<reward id="70438" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70437" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="70438" two="70438" chance="20">
-		<reward id="70439" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70438" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="70439" two="70439" chance="10">
-		<reward id="70440" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70439" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Garnet -->
-	<item one="70441" two="70441" chance="65">
-		<reward id="70442" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70441" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="70442" two="70442" chance="40">
-		<reward id="70443" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70442" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="70443" two="70443" chance="20">
-		<reward id="70444" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70443" type="ON_FAILURE" /> <!-- info -->
-	</item>	
-	<item one="70444" two="70444" chance="10">
-		<reward id="70445" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70444" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	
-	<item one="70446" two="70446" chance="65">
-		<reward id="70447" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70446" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="70447" two="70447" chance="40">
-		<reward id="70448" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70447" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="70448" two="70448" chance="20">
-		<reward id="70449" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70448" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="70449" two="70449" chance="10">
-		<reward id="70450" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70449" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Ruby -->
-	<item one="70451" two="70451" chance="65">
-		<reward id="70452" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70451" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="70452" two="70452" chance="40">
-		<reward id="70453" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70452" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="70453" two="70453" chance="20">
-		<reward id="70454" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70453" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="70454" two="70454" chance="10">
-		<reward id="70455" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70454" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Sapphire -->
-	<item one="70456" two="70456" chance="65">
-		<reward id="70457" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70456" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="70457" two="70457" chance="40">
-		<reward id="70458" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70457" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="70458" two="70458" chance="20">
-		<reward id="70459" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70458" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="70459" two="70459" chance="10">
-		<reward id="70460" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70459" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Diamond -->
-	<item one="70461" two="70461" chance="65">
-		<reward id="70462" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70461" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="70462" two="70462" chance="40">
-		<reward id="70463" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70462" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="70463" two="70463" chance="20">
-		<reward id="70464" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70463" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="70464" two="70464" chance="10">
-		<reward id="70465" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70464" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Pearl -->
-	<item one="70466" two="70466" chance="65">
-		<reward id="70467" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70466" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="70467" two="70467" chance="40">
-		<reward id="70468" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70467" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="70468" two="70468" chance="20">
-		<reward id="70469" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70468" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="70469" two="70469" chance="10">
-		<reward id="70470" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70469" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Vital Stone -->
-	<item one="70471" two="70471" chance="65">
-		<reward id="70472" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70471" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="70472" two="70472" chance="40">
-		<reward id="70473" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70472" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="70473" two="70473" chance="20">
-		<reward id="70474" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70473" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="70474" two="70474" chance="10">
-		<reward id="70475" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70474" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Aquamarine -->
-	<item one="70520" two="70520" chance="65">
-		<reward id="70521" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70520" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="70521" two="70521" chance="40">
-		<reward id="70522" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70521" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="70522" two="70522" chance="20">
-		<reward id="70523" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70522" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="70523" two="70523" chance="10">
-		<reward id="70524" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70523" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Red Cat's Eye -->
-	<item one="70811" two="70811" chance="65">
-		<reward id="70812" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70811" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="70812" two="70812" chance="40">
-		<reward id="70813" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70812" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="70813" two="70813" chance="20">
-		<reward id="70814" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70813" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="70814" two="70814" chance="10">
-		<reward id="70815" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70814" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Blue Cat's Eye -->
-	<item one="70816" two="70816" chance="65">
-		<reward id="70817" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70816" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="70817" two="70817" chance="40">
-		<reward id="70818" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70817" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="70818" two="70818" chance="20">
-		<reward id="70819" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70818" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="70819" two="70819" chance="10">
-		<reward id="70820" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="70819" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	
-	<!-- Matchstick -->
-	<item one="71026" two="71027" chance="70">
-		<reward id="71028" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71029" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Match Head -->
-	<item one="71027" two="71026" chance="70">
-		<reward id="71028" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71029" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	
-	<!-- Talisman of Authority -->
-	<item one="71080" two="71078" chance="70">
-		<reward id="71081" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71080" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="71081" two="71078" chance="60">
-		<reward id="71082" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71080" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="71082" two="71078" chance="50">
-		<reward id="71083" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71080" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="71083" two="71078" chance="40">
-		<reward id="71084" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71080" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Noble Talisman of Authority -->
-	<item one="71085" two="71078" chance="45">
-		<reward id="71086" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71085" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="71086" two="71078" chance="35">
-		<reward id="71087" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71085" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="71087" two="71078" chance="25">
-		<reward id="71088" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71085" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="71088" two="71078" chance="20">
-		<reward id="71089" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71085" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Radiant Talisman of Authority -->
-	<item one="71090" two="71078" chance="30">
-		<reward id="71091" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71090" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="71091" two="71078" chance="25">
-		<reward id="71092" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71090" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="71092" two="71078" chance="20">
-		<reward id="71093" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71090" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="71093" two="71078" chance="10">
-		<reward id="71094" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71090" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Stable Talisman of Power Fragment -->
-	<item one="71085" two="71095" chance="45">
-		<reward id="71086" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71085" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="71086" two="71095" chance="35">
-		<reward id="71087" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71086" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="71087" two="71095" chance="25">
-		<reward id="71088" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71087" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="71088" two="71095" chance="20">
-		<reward id="71089" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71088" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Venir's Talisman -->
-	<item one="71271" two="71270" chance="50">
-		<reward id="71272" type="ON_SUCCESS" /> <!-- 2 level -->
-		<reward id="71271" type="ON_FAILURE" /> <!-- 1 level -->
-	</item>
-	<item one="71272" two="71270" chance="45">
-		<reward id="71273" type="ON_SUCCESS" /> <!-- 3 level -->
-		<reward id="71271" type="ON_FAILURE" /> <!-- 1 level -->
-	</item>
-	<item one="71273" two="71270" chance="40">
-		<reward id="71274" type="ON_SUCCESS" /> <!-- 4 level -->
-		<reward id="71271" type="ON_FAILURE" /> <!-- 1 level -->
-	</item>
-	<item one="71274" two="71270" chance="35">
-		<reward id="71275" type="ON_SUCCESS" /> <!-- 5 level -->
-		<reward id="71271" type="ON_FAILURE" /> <!-- 1 level -->
-	</item>
-	<item one="71275" two="71270" chance="50">
-		<reward id="71276" type="ON_SUCCESS" /> <!-- 6 level -->
-		<reward id="71271" type="ON_FAILURE" /> <!-- 1 level -->
-	</item>
-	<item one="71276" two="71270" chance="45">
-		<reward id="71277" type="ON_SUCCESS" /> <!-- 7 level -->
-		<reward id="71276" type="ON_FAILURE" /> <!-- 6 level -->
-	</item>
-	<item one="71277" two="71270" chance="40">
-		<reward id="71278" type="ON_SUCCESS" /> <!-- 8 level -->
-		<reward id="71276" type="ON_FAILURE" /> <!-- 6 level -->
-	</item>
-	<item one="71278" two="71270" chance="35">
-		<reward id="71279" type="ON_SUCCESS" /> <!-- 9 level -->
-		<reward id="71276" type="ON_FAILURE" /> <!-- 6 level -->
-	</item>
-	<item one="71279" two="71270" chance="30">
-		<reward id="71280" type="ON_SUCCESS" /> <!-- 10 level -->
-		<reward id="71276" type="ON_FAILURE" /> <!-- 6 level -->
-	</item>
-	<item one="71280" two="71270" chance="25">
-		<reward id="71281" type="ON_SUCCESS" /> <!-- 11 level -->
-		<reward id="71276" type="ON_FAILURE" /> <!-- 6 level -->
-	</item>
-	<item one="71281" two="71270" chance="50">
-		<reward id="71282" type="ON_SUCCESS" /> <!-- 12 level -->
-		<reward id="71276" type="ON_FAILURE" /> <!-- 6 level -->
-	</item>
-	<item one="71282" two="71270" chance="35">
-		<reward id="71283" type="ON_SUCCESS" /> <!-- 13 level -->
-		<reward id="71282" type="ON_FAILURE" /> <!-- 12 level -->
-	</item>
-	<item one="71283" two="71270" chance="30">
-		<reward id="71284" type="ON_SUCCESS" /> <!-- 14 level -->
-		<reward id="71282" type="ON_FAILURE" /> <!-- 12 level -->
-	</item>
-	<item one="71284" two="71270" chance="25">
-		<reward id="71285" type="ON_SUCCESS" /> <!-- 15 level -->
-		<reward id="71282" type="ON_FAILURE" /> <!-- 12 level -->
-	</item>
-	<item one="71285" two="71270" chance="20">
-		<reward id="71286" type="ON_SUCCESS" /> <!-- 16 level -->
-		<reward id="71282" type="ON_FAILURE" /> <!-- 12 level -->
-	</item>
-	<item one="71286" two="71270" chance="15">
-		<reward id="71287" type="ON_SUCCESS" /> <!-- 17 level -->
-		<reward id="71282" type="ON_FAILURE" /> <!-- 12 level -->
-	</item>
-	<item one="71287" two="71270" chance="50">
-		<reward id="71288" type="ON_SUCCESS" /> <!-- 18 level -->
-		<reward id="71282" type="ON_FAILURE" /> <!-- 12 level -->
-	</item>
-	<item one="71288" two="71270" chance="35">
-		<reward id="71289" type="ON_SUCCESS" /> <!-- 19 level -->
-		<reward id="71288" type="ON_FAILURE" /> <!-- 18 level -->
-	</item>
-	<item one="71289" two="71270" chance="30">
-		<reward id="71290" type="ON_SUCCESS" /> <!-- 20 level -->
-		<reward id="71288" type="ON_FAILURE" /> <!-- 18 level -->
-	</item>
-	<item one="71290" two="71270" chance="25">
-		<reward id="71291" type="ON_SUCCESS" /> <!-- 21 level -->
-		<reward id="71288" type="ON_FAILURE" /> <!-- 18 level -->
-	</item>
-	<item one="71291" two="71270" chance="20">
-		<reward id="71292" type="ON_SUCCESS" /> <!-- 22 level -->
-		<reward id="71288" type="ON_FAILURE" /> <!-- 18 level -->
-	</item>
-	<item one="71292" two="71270" chance="15">
-		<reward id="71293" type="ON_SUCCESS" /> <!-- 23 level -->
-		<reward id="71288" type="ON_FAILURE" /> <!-- 18 level -->
-	</item>
-	<item one="71293" two="71270" chance="50">
-		<reward id="71294" type="ON_SUCCESS" /> <!-- 24 level -->
-		<reward id="71288" type="ON_FAILURE" /> <!-- 18 level -->
-	</item>
-	<!-- Emerald EU klient -->
-	<item one="71348" two="71348" chance="70">
-		<reward id="71349" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71348" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="71349" two="71349" chance="70">
-		<reward id="71350" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71349" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="71350" two="71350" chance="70">
-		<reward id="71351" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71350" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="71351" two="71351" chance="70">
-		<reward id="71352" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71351" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	
-	<item one="70440" two="70440" chance="100">
-		<reward id="71353" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71353" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="70445" two="70445" chance="100">
-		<reward id="71358" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71358" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="70450" two="70450" chance="100">
-		<reward id="71363" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71363" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="70455" two="70455" chance="100">
-		<reward id="71368" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71368" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="70460" two="70460" chance="100">
-		<reward id="71373" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71373" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="70465" two="70465" chance="100">
-		<reward id="71378" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71378" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="70470" two="70470" chance="100">
-		<reward id="71383" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71383" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="70475" two="70475" chance="100">
-		<reward id="71388" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71388" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="70524" two="70524" chance="100">
-		<reward id="71393" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71393" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="70815" two="70815" chance="100">
-		<reward id="71398" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71398" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="70820" two="70820" chance="100">
-		<reward id="71403" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71403" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="71352" two="71352" chance="100">
-		<reward id="71408" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71408" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Greater Topaz -->
-	<item one="71353" two="71414" chance="35">
-		<reward id="71354" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71353" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="71354" two="71414" chance="25">
-		<reward id="71355" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71353" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="71355" two="71414" chance="15">
-		<reward id="71356" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71353" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<item one="71356" two="71414" chance="10">
-		<reward id="71357" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71353" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Greater Garnet -->
-	<item one="71358" two="71414" chance="35">
-		<reward id="71359" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71358" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="71359" two="71414" chance="25">
-		<reward id="71360" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71358" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="71360" two="71414" chance="15">
-		<reward id="71361" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71358" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="71361" two="71414" chance="10">
-		<reward id="71362" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71358" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Greater Jade -->
-	<item one="71363" two="71414" chance="35">
-		<reward id="71364" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71363" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="71364" two="71414" chance="25">
-		<reward id="71365" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71363" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="71365" two="71414" chance="15">
-		<reward id="71366" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71363" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="71366" two="71414" chance="10">
-		<reward id="71367" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71363" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Greater Ruby -->
-	<item one="71368" two="71414" chance="35">
-		<reward id="71369" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71368" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="71369" two="71414" chance="25">
-		<reward id="71370" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71368" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="71370" two="71414" chance="15">
-		<reward id="71371" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71368" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="71371" two="71414" chance="10">
-		<reward id="71372" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71368" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Greater Sapphire -->
-	<item one="71373" two="71414" chance="35">
-		<reward id="71374" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71373" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="71374" two="71414" chance="25">
-		<reward id="71375" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71373" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="71375" two="71414" chance="15">
-		<reward id="71376" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71373" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="71376" two="71414" chance="10">
-		<reward id="71377" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71373" type="ON_FAILURE" /> <!-- info -->
-	</item>
-	<!-- Greater Diamond -->
-	<item one="71378" two="71414" chance="35">
-		<reward id="71379" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71378" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="71379" two="71414" chance="25">
-		<reward id="71380" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71378" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="71380" two="71414" chance="15">
-		<reward id="71381" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71378" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="71381" two="71414" chance="10">
-		<reward id="71382" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71378" type="ON_FAILURE" /> <!-- info -->
-	</item>
+		<reward id="91334" type="ON_SUCCESS" /> <!-- Greater Diamond Lv. 1 -->
+		<reward id="91330" type="ON_FAILURE" /> <!-- Greater Diamond Lv. 1 -->
+	</item>
+
+	<!-- Pearl  Lv. 5 (Imprint) to Greater Pearl Lv. 1-->
+	<item one="90347" two="91356" chance="70"> <!-- Pearl Lv. 5 (Imprint)/ Gem Energy -->
+		<reward id="91335" type="ON_SUCCESS" /> <!-- Greater Pearl Lv. 1 -->
+		<reward id="90347" type="ON_FAILURE" /> <!-- Pearl Lv. 5 (Imprint) -->
+	</item>
+
 	<!-- Greater Pearl -->
-	<item one="71383" two="71414" chance="35">
-		<reward id="71384" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71383" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="71384" two="71414" chance="25">
-		<reward id="71385" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71383" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="71385" two="71414" chance="15">
-		<reward id="71386" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71383" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="71386" two="71414" chance="10">
-		<reward id="71387" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71383" type="ON_FAILURE" /> <!-- info -->
+	<item one="91335" two="91356" chance="70"> <!-- Greater Pearl Lv.1/ Gem Energy -->
+		<reward id="91336" type="ON_SUCCESS" /> <!-- Greater Pearl Lv. 2 -->
+		<reward id="91335" type="ON_FAILURE" /> <!-- Greater Pearl Lv. 1 -->
 	</item>
+	<item one="91336" two="91356" chance="70"> <!-- Greater Pearl Lv.2/ Gem Energy -->
+		<reward id="91337" type="ON_SUCCESS" /> <!-- Greater Pearl Lv. 3 -->
+		<reward id="91335" type="ON_FAILURE" /> <!-- Greater Pearl Lv. 2 -->
+	</item>
+	<item one="91337" two="91356" chance="70"> <!-- Greater Pearl Lv.3/ Gem Energy -->
+		<reward id="91338" type="ON_SUCCESS" /> <!-- Greater Pearl Lv. 4 -->
+		<reward id="91335" type="ON_FAILURE" /> <!-- Greater Pearl Lv. 3 -->
+	</item>
+	<item one="91338" two="91356" chance="70"> <!-- Greater Pearl Lv.4/ Gem Energy -->
+		<reward id="91339" type="ON_SUCCESS" /> <!-- Greater Pearl Lv. 5 -->
+		<reward id="91335" type="ON_FAILURE" /> <!-- Greater Pearl Lv. 4 -->
+	</item>
+
+	<!-- Vital Stone Lv. 5 (imprint)  to Greater Vital Stone Lv. 1 -->
+	<item one="90357" two="91356" chance="70"> <!-- Vital Stone Lv. 5 (Imprint)/ Gem Energy -->
+		<reward id="91340" type="ON_SUCCESS" />  <!-- Greater Vital Stone Lv. 1 -->
+		<reward id="90357" type="ON_FAILURE" />  <!-- Vital Stone Lv. 5 (Imprint) -->
+	</item>
+
 	<!-- Greater Vital Stone -->
-	<item one="71388" two="71414" chance="35">
-		<reward id="71389" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71388" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="71389" two="71414" chance="25">
-		<reward id="71390" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71388" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="71390" two="71414" chance="15">
-		<reward id="71391" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71388" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="71391" two="71414" chance="10">
-		<reward id="71392" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71388" type="ON_FAILURE" /> <!-- info -->
+	<item one="91340" two="91356" chance="70"> <!-- Greater Vital Stone Lv. 1/ Gem Energy -->
+		<reward id="91341" type="ON_SUCCESS" />  <!-- Greater Vital Stone Lv. 2 -->
+		<reward id="91340" type="ON_FAILURE" />  <!-- Greater Vital Stone Lv. 1 -->
 	</item>
+	<item one="91341" two="91356" chance="70"> <!-- Greater Vital Stone Lv. 2/ Gem Energy -->
+		<reward id="91342" type="ON_SUCCESS" />  <!-- Greater Vital Stone Lv. 3 -->
+		<reward id="91340" type="ON_FAILURE" />  <!-- Greater Vital Stone Lv. 2 -->
+	</item>
+	<item one="91342" two="91356" chance="70"> <!-- Greater Vital Stone Lv. 3/ Gem Energy -->
+		<reward id="91343" type="ON_SUCCESS" />  <!-- Greater Vital Stone Lv. 4 -->
+		<reward id="91340" type="ON_FAILURE" />  <!-- Greater Vital Stone Lv. 3 -->
+	</item>
+	<item one="91343" two="91356" chance="70"> <!-- Greater Vital Stone Lv. 4/ Gem Energy -->
+		<reward id="91344" type="ON_SUCCESS" />  <!-- Greater Vital Stone Lv. 5 -->
+		<reward id="91340" type="ON_FAILURE" />  <!-- Greater Vital Stone Lv. 4 -->
+	</item>
+
+	<!-- Aquamarine Lv. 5 (imprint) to Greater Aquamarine Lv. 1 -->
+	<item one="90928" two="91356" chance="70"> <!-- Aquamarine Lv. 5 (Imprint)/ Gem Energy -->
+		<reward id="91345" type="ON_SUCCESS" />  <!-- Greater Aquamarine Lv. 1 -->
+		<reward id="90928" type="ON_FAILURE" />  <!-- Aquamarine Lv. 5 (Imprint) -->
+	</item>
+
 	<!-- Greater Aquamarine -->
-	<item one="71393" two="71414" chance="35">
-		<reward id="71394" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71393" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="71394" two="71414" chance="25">
-		<reward id="71395" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71393" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="71395" two="71414" chance="15">
-		<reward id="71396" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71393" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="71396" two="71414" chance="10">
-		<reward id="71397" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71393" type="ON_FAILURE" /> <!-- info -->
+	<item one="91345" two="91356" chance="70"> <!-- Greater Aquamarine Lv. 1/ Gem Energy -->
+		<reward id="91346" type="ON_SUCCESS" />  <!-- Greater Aquamarine Lv. 2 -->
+		<reward id="91345" type="ON_FAILURE" />  <!-- Greater Aquamarine Lv. 1 -->
 	</item>
-	<!-- Greater Red Cat's Eye -->
-	<item one="71398" two="71414" chance="35">
-		<reward id="71399" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71398" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="71399" two="71414" chance="25">
-		<reward id="71400" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71398" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="71400" two="71414" chance="15">
-		<reward id="71401" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71398" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="71401" two="71414" chance="10">
-		<reward id="71402" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71398" type="ON_FAILURE" /> <!-- info -->
+	<item one="91346" two="91356" chance="70"> <!-- Greater Aquamarine Lv. 2/ Gem Energy -->
+		<reward id="91347" type="ON_SUCCESS" />  <!-- Greater Aquamarine Lv. 3 -->
+		<reward id="91345" type="ON_FAILURE" />  <!-- Greater Aquamarine Lv. 2 -->
 	</item>
-	<!-- Greater Blue Cat's Eye -->
-	<item one="71403" two="71414" chance="35">
-		<reward id="71404" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71403" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="71404" two="71414" chance="25">
-		<reward id="71405" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71403" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="71405" two="71414" chance="15">
-		<reward id="71406" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71403" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="71406" two="71414" chance="10">
-		<reward id="71407" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71403" type="ON_FAILURE" /> <!-- info -->
+	<item one="91347" two="91356" chance="70"> <!-- Greater Aquamarine Lv. 3/ Gem Energy -->
+		<reward id="91348" type="ON_SUCCESS" />  <!-- Greater Aquamarine Lv. 4 -->
+		<reward id="91345" type="ON_FAILURE" />  <!-- Greater Aquamarine Lv. 3 -->
 	</item>
-	<!-- Greater Emerald -->
-	<item one="71408" two="71414" chance="35">
-		<reward id="71409" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71408" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="71409" two="71414" chance="25">
-		<reward id="71410" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71408" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="71410" two="71414" chance="15">
-		<reward id="71411" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71408" type="ON_FAILURE" /> <!-- info -->
-	</item>                               
-	<item one="71411" two="71414" chance="10">
-		<reward id="71412" type="ON_SUCCESS" /> <!-- info -->
-		<reward id="71408" type="ON_FAILURE" /> <!-- info -->
+	<item one="91348" two="91356" chance="70"> <!-- Greater Aquamarine Lv. 4/ Gem Energy -->
+		<reward id="91349" type="ON_SUCCESS" />  <!-- Greater Aquamarine Lv. 5 -->
+		<reward id="91345" type="ON_FAILURE" />  <!-- Greater Aquamarine Lv. 4 -->
 	</item>
+
+	<!-- Cat's Eye  Lv. 5 (Imprint) to Greater Cat's Eye Lv. 1-->
+	<item one="90933" two="91356" chance="70"> <!-- Cat's Eye Lv. 5 (Imprint)/ Gem Energy -->
+		<reward id="91350" type="ON_SUCCESS" />  <!-- Greater Cat's Eye Lv. 1 -->
+		<reward id="90933" type="ON_FAILURE" />  <!-- Cat's Eye Lv. 5 (Imprint) -->
+	</item>
+
+	<!-- Greater Cat's Eye -->
+	<item one="91350" two="91356" chance="70"> <!-- Greater Cat's Eye Lv. 1/ Gem Energy -->
+		<reward id="91351" type="ON_SUCCESS" />  <!-- Greater Cat's Eye Lv. 2 -->
+		<reward id="91350" type="ON_FAILURE" />  <!-- Greater Cat's Eye Lv. 1 -->
+	</item>
+	<item one="91351" two="91356" chance="70"> <!-- Greater Cat's Eye Lv. 2/ Gem Energy -->
+		<reward id="91352" type="ON_SUCCESS" />  <!-- Greater Cat's Eye Lv. 3 -->
+		<reward id="91350" type="ON_FAILURE" />  <!-- Greater Cat's Eye Lv. 2 -->
+	</item>
+	<item one="91352" two="91356" chance="70"> <!-- Greater Cat's Eye Lv. 3/ Gem Energy -->
+		<reward id="91353" type="ON_SUCCESS" />  <!-- Greater Cat's Eye Lv. 4 -->
+		<reward id="91350" type="ON_FAILURE" />  <!-- Greater Cat's Eye Lv. 3 -->
+	</item>
+	<item one="91353" two="91356" chance="70"> <!-- Greater Cat's Eye Lv. 4/ Gem Energy -->
+		<reward id="91354" type="ON_SUCCESS" />  <!-- Greater Cat's Eye Lv. 5 -->
+		<reward id="91350" type="ON_FAILURE" />  <!-- Greater Cat's Eye Lv. 4 -->
+	</item>
+
+	<!-- Brooch -->
+	<item one="90311" two="90311" chance="25"> <!-- Brooch Lv. 1 / Brooch Lv. 1 -->
+		<reward id="90312" count="1" type="ON_SUCCESS" /> <!-- Brooch Lv. 2 -->
+		<reward id="90311" count="1" type="ON_FAILURE" /> <!-- Brooch Lv. 1 -->
+	</item>
+	<item one="90312" two="90312" chance="25"> <!-- Brooch Lv. 2 / Brooch Lv. 2 -->
+		<reward id="90934" count="1" type="ON_SUCCESS" /> <!-- Brooch Lv. 3 -->
+		<reward id="90312" count="1" type="ON_FAILURE" /> <!-- Brooch Lv. 2 -->
+	</item>
+	<item one="90934" two="90934" chance="25"> <!-- Brooch Lv. 3 / Brooch Lv. 3 -->
+		<reward id="91303" count="1" type="ON_SUCCESS" /> <!-- Brooch Lv. 4 -->
+		<reward id="90934" count="1" type="ON_FAILURE" /> <!-- Brooch Lv. 3 -->
+	</item>
+	<item one="91303" two="91303" chance="25"> <!-- Brooch Lv. 4 / Brooch Lv. 4 -->
+		<reward id="91304" count="1" type="ON_SUCCESS" /> <!-- Brooch Lv. 5 -->
+		<reward id="91303" count="1" type="ON_FAILURE" /> <!-- Brooch Lv. 4 -->
+	</item>
+
+	<!-- Talisman Bracelet -->
+	<item one="9589" two="9589" chance="33"> <!-- Talisman Bracelet Lv. 1 / Talisman Bracelet Lv. 1 -->
+		<reward id="9590" count="1" type="ON_SUCCESS" /> <!-- Talisman Bracelet Lv. 2 -->
+		<reward id="9589" count="1" type="ON_FAILURE" /> <!-- Talisman Bracelet Lv. 1 -->
+	</item>
+	<item one="9590" two="9590" chance="33"> <!-- Talisman Bracelet Lv. 2 / Talisman Bracelet Lv. 2 -->
+		<reward id="9591" count="1" type="ON_SUCCESS" /> <!-- Talisman Bracelet Lv. 3 -->
+		<reward id="9590" count="1" type="ON_FAILURE" /> <!-- Talisman Bracelet Lv. 2 -->
+	</item>
+	<item one="9591" two="9591" chance="33"> <!-- Talisman Bracelet Lv. 3 / Talisman Bracelet Lv. 3 -->
+		<reward id="49703" count="1" type="ON_SUCCESS" /> <!-- Talisman Bracelet Lv. 4 -->
+		<reward id="9591" count="1" type="ON_FAILURE" /> <!-- Talisman Bracelet Lv. 3 -->
+	</item>
+	<item one="49703" two="49703" chance="33"> <!-- Talisman Bracelet Lv. 4 / Talisman Bracelet Lv. 4 -->
+		<reward id="92031" count="1" type="ON_SUCCESS" /> <!-- Talisman Bracelet Lv. 5 -->
+		<reward id="49703" count="1" type="ON_FAILURE" /> <!-- Talisman Bracelet Lv. 4 -->
+	</item>
+	<item one="92031" two="92031" chance="25"> <!-- Talisman Bracelet Lv. 5 / Talisman Bracelet Lv. 5 -->
+		<reward id="92032" type="ON_SUCCESS" /> <!-- Talisman Bracelet Lv. 6 -->
+		<reward id="92031" type="ON_FAILURE" /> <!-- Talisman Bracelet Lv. 5 -->
+	</item>
+
+	<!-- Lilith's Soul Crystal -->
+	<item one="91173" two="91173" chance="33"> <!-- Lilith' Soul Crystal Lv. 1 (Rare) / Lilith' Soul Crystal Lv. 1 (Rare) -->
+		<reward id="91174" count="1" type="ON_SUCCESS" /> <!-- Lilith' Soul Crystal Lv. 2 (Rare) -->
+		<reward id="91173" count="1" type="ON_FAILURE" /> <!-- Lilith' Soul Crystal Lv. 1 (Rare) -->
+	</item>
+	<item one="91174" two="91173" chance="33"> <!-- Lilith' Soul Crystal Lv. 2 (Rare) / Lilith' Soul Crystal Lv. 1 (Rare) -->
+		<reward id="91175" count="1" type="ON_SUCCESS" /> <!-- Lilith' Soul Crystal Lv. 3 (Rare) -->
+		<reward id="91173" count="1" type="ON_FAILURE" /> <!-- Lilith' Soul Crystal Lv. 1 (Rare) -->
+	</item>
+	<item one="91175" two="91173" chance="33"> <!-- Lilith' Soul Crystal Lv. 3 (Rare) / Lilith' Soul Crystal Lv. 1 (Rare) -->
+		<reward id="91176" count="1" type="ON_SUCCESS" /> <!-- Lilith' Soul Crystal Lv. 4 (Rare) -->
+		<reward id="91173" count="1" type="ON_FAILURE" /> <!-- Lilith' Soul Crystal Lv. 1 (Rare) -->
+	</item>
+	<item one="91176" two="91173" chance="33"> <!-- Lilith' Soul Crystal Lv. 4 (Rare) / Lilith' Soul Crystal Lv. 1 (Rare) -->
+		<reward id="91177" count="1" type="ON_SUCCESS" /> <!-- Lilith' Soul Crystal Lv. 5 (Rare) -->
+		<reward id="91173" count="1" type="ON_FAILURE" /> <!-- Lilith' Soul Crystal Lv. 1 (Rare) -->
+	</item>
+	<item one="91177" two="91173" chance="33"> <!-- Lilith' Soul Crystal Lv. 5 (Rare) / Lilith' Soul Crystal Lv. 1 (Rare) -->
+		<reward id="91178" count="1" type="ON_SUCCESS" /> <!-- Lilith' Soul Crystal Lv. 6 (Rare) -->
+		<reward id="91173" count="1" type="ON_FAILURE" /> <!-- Lilith' Soul Crystal Lv. 1 (Rare) -->
+	</item>
+	<item one="91178" two="91173" chance="33"> <!-- Lilith' Soul Crystal Lv. 6 (Rare) / Lilith' Soul Crystal Lv. 1 (Rare) -->
+		<reward id="91179" count="1" type="ON_SUCCESS" /> <!-- Lilith' Soul Crystal Lv. 7 (Rare) -->
+		<reward id="91178" count="1" type="ON_FAILURE" /> <!-- Lilith' Soul Crystal Lv. 6 (Rare) -->
+	</item>
+	<item one="91179" two="91173" chance="33"> <!-- Lilith' Soul Crystal Lv. 7 (Rare) / Lilith' Soul Crystal Lv. 1 (Rare) -->
+		<reward id="91180" count="1" type="ON_SUCCESS" /> <!-- Lilith' Soul Crystal Lv. 8 (Rare) -->
+		<reward id="91178" count="1" type="ON_FAILURE" /> <!-- Lilith' Soul Crystal Lv. 6 (Rare) -->
+	</item>
+	<item one="91180" two="91173" chance="33"> <!-- Lilith' Soul Crystal Lv. 8 (Rare) / Lilith' Soul Crystal Lv. 1 (Rare) -->
+		<reward id="91181" count="1" type="ON_SUCCESS" /> <!-- Lilith' Soul Crystal Lv. 9 (Rare) -->
+		<reward id="91178" count="1" type="ON_FAILURE" /> <!-- Lilith' Soul Crystal Lv. 6 (Rare) -->
+	</item>
+	<item one="91181" two="91173" chance="33"> <!-- Lilith' Soul Crystal Lv. 9 (Rare) / Lilith' Soul Crystal Lv. 1 (Rare) -->
+		<reward id="91182" count="1" type="ON_SUCCESS" /> <!-- Lilith' Soul Crystal Lv. 10 (Rare) -->
+		<reward id="91178" count="1" type="ON_FAILURE" /> <!-- Lilith' Soul Crystal Lv. 6 (Rare) -->
+	</item>
+	<item one="91182" two="91173" chance="33"> <!-- Lilith' Soul Crystal Lv. 10 (Rare) / Lilith' Soul Crystal Lv. 1 (Rare) -->
+		<reward id="92920" count="1" type="ON_SUCCESS" /> <!-- Lilith' Soul Crystal Lv. 11 (Rare) -->
+		<reward id="91178" count="1" type="ON_FAILURE" /> <!-- Lilith' Soul Crystal Lv. 6 (Rare) -->
+	</item>
+	<item one="92920" two="91173" chance="33"> <!-- Lilith' Soul Crystal Lv. 11 (Rare) / Lilith' Soul Crystal Lv. 1 (Rare) -->
+		<reward id="92921" count="1" type="ON_SUCCESS" /> <!-- Lilith' Soul Crystal Lv. 12 (Rare) -->
+		<reward id="92920" count="1" type="ON_FAILURE" /> <!-- Lilith' Soul Crystal Lv. 11 (Rare) -->
+	</item>
+	<item one="92921" two="91173" chance="33"> <!-- Lilith' Soul Crystal Lv. 12 (Rare) / Lilith' Soul Crystal Lv. 1 (Rare) -->
+		<reward id="92922" count="1" type="ON_SUCCESS" /> <!-- Lilith' Soul Crystal Lv. 13 (Rare) -->
+		<reward id="92920" count="1" type="ON_FAILURE" /> <!-- Lilith' Soul Crystal Lv. 11 (Rare) -->
+	</item>
+	<item one="92922" two="91173" chance="33"> <!-- Lilith' Soul Crystal Lv. 13 (Rare) / Lilith' Soul Crystal Lv. 1 (Rare) -->
+		<reward id="92923" count="1" type="ON_SUCCESS" /> <!-- Lilith' Soul Crystal Lv. 14 (Rare) -->
+		<reward id="92920" count="1" type="ON_FAILURE" /> <!-- Lilith' Soul Crystal Lv. 11 (Rare) -->
+	</item>
+	<item one="92923" two="91173" chance="33"> <!-- Lilith' Soul Crystal Lv. 14 (Rare) / Lilith' Soul Crystal Lv. 1 (Rare) -->
+		<reward id="92924" count="1" type="ON_SUCCESS" /> <!-- Lilith' Soul Crystal Lv. 15 (Rare) -->
+		<reward id="92920" count="1" type="ON_FAILURE" /> <!-- Lilith' Soul Crystal Lv. 11 (Rare) -->
+	</item>
+
+	<!-- Anakim's Soul Crystal -->
+	<item one="91163" two="91163" chance="33"> <!-- Anakim's Soul Crystal Lv. 1 (Rare) / Anakim's Soul Crystal Lv. 1 (Rare) -->
+		<reward id="91164" count="1" type="ON_SUCCESS" /> <!-- Anakim's Soul Crystal Lv. 2 (Rare) -->
+		<reward id="91163" count="1" type="ON_FAILURE" /> <!-- Anakim's Soul Crystal Lv. 1 (Rare) -->
+	</item>
+	<item one="91164" two="91163" chance="33"> <!-- Anakim's Soul Crystal Lv. 2 (Rare) / Anakim's Soul Crystal Lv. 1 (Rare) -->
+		<reward id="91165" count="1" type="ON_SUCCESS" /> <!-- Anakim's Soul Crystal Lv. 3 (Rare) -->
+		<reward id="91163" count="1" type="ON_FAILURE" /> <!-- Anakim's Soul Crystal Lv. 1 (Rare) -->
+	</item>
+	<item one="91165" two="91163" chance="33"> <!-- Anakim's Soul Crystal Lv. 3 (Rare) / Anakim's Soul Crystal Lv. 1 (Rare) -->
+		<reward id="91166" count="1" type="ON_SUCCESS" /> <!-- Anakim's Soul Crystal Lv. 4 (Rare) -->
+		<reward id="91163" count="1" type="ON_FAILURE" /> <!-- Anakim's Soul Crystal Lv. 1 (Rare) -->
+	</item>
+	<item one="91166" two="91163" chance="33"> <!-- Anakim's Soul Crystal Lv. 4 (Rare) / Anakim's Soul Crystal Lv. 1 (Rare) -->
+		<reward id="91167" count="1" type="ON_SUCCESS" /> <!-- Anakim's Soul Crystal Lv. 5 (Rare) -->
+		<reward id="91163" count="1" type="ON_FAILURE" /> <!-- Anakim's Soul Crystal Lv. 1 (Rare) -->
+	</item>
+	<item one="91167" two="91163" chance="33"> <!-- Anakim's Soul Crystal Lv. 5 (Rare) / Anakim's Soul Crystal Lv. 1 (Rare) -->
+		<reward id="91168" count="1" type="ON_SUCCESS" /> <!-- Anakim's Soul Crystal Lv. 6 (Rare) -->
+		<reward id="91163" count="1" type="ON_FAILURE" /> <!-- Anakim's Soul Crystal Lv. 1 (Rare) -->
+	</item>
+	<item one="91168" two="91163" chance="33"> <!-- Anakim's Soul Crystal Lv. 6 (Rare) / Anakim's Soul Crystal Lv. 1 (Rare) -->
+		<reward id="91169" count="1" type="ON_SUCCESS" /> <!-- Anakim's Soul Crystal Lv. 7 (Rare) -->
+		<reward id="91168" count="1" type="ON_FAILURE" /> <!-- Anakim's Soul Crystal Lv. 6 (Rare) -->
+	</item>
+	<item one="91169" two="91163" chance="33"> <!-- Anakim's Soul Crystal Lv. 7 (Rare) / Anakim's Soul Crystal Lv. 1 (Rare) -->
+		<reward id="91170" count="1" type="ON_SUCCESS" /> <!-- Anakim's Soul Crystal Lv. 8 (Rare) -->
+		<reward id="91168" count="1" type="ON_FAILURE" /> <!-- Anakim's Soul Crystal Lv. 6 (Rare) -->
+	</item>
+	<item one="91170" two="91163" chance="33"> <!-- Anakim's Soul Crystal Lv. 8 (Rare) / Anakim's Soul Crystal Lv. 1 (Rare) -->
+		<reward id="91171" count="1" type="ON_SUCCESS" /> <!-- Anakim's Soul Crystal Lv. 9 (Rare) -->
+		<reward id="91168" count="1" type="ON_FAILURE" /> <!-- Anakim's Soul Crystal Lv. 6 (Rare) -->
+	</item>
+	<item one="91171" two="91163" chance="33"> <!-- Anakim's Soul Crystal Lv. 9 (Rare) / Anakim's Soul Crystal Lv. 1 (Rare) -->
+		<reward id="91172" count="1" type="ON_SUCCESS" /> <!-- Anakim's Soul Crystal Lv. 10 (Rare) -->
+		<reward id="91168" count="1" type="ON_FAILURE" /> <!-- Anakim's Soul Crystal Lv. 6 (Rare) -->
+	</item>
+	<item one="91172" two="91163" chance="33"> <!-- Anakim's Soul Crystal Lv. 10 (Rare) / Anakim's Soul Crystal Lv. 1 (Rare) -->
+		<reward id="92925" count="1" type="ON_SUCCESS" /> <!-- Anakim's Soul Crystal Lv. 11 (Rare) -->
+		<reward id="91168" count="1" type="ON_FAILURE" /> <!-- Anakim's Soul Crystal Lv. 6 (Rare) -->
+	</item>
+	<item one="92925" two="91163" chance="33"> <!-- Anakim's Soul Crystal Lv. 11 (Rare) / Anakim's Soul Crystal Lv. 1 (Rare) -->
+		<reward id="92926" count="1" type="ON_SUCCESS" /> <!-- Anakim's Soul Crystal Lv. 12 (Rare) -->
+		<reward id="92925" count="1" type="ON_FAILURE" /> <!-- Anakim's Soul Crystal Lv. 11 (Rare) -->
+	</item>
+	<item one="92926" two="91163" chance="33"> <!-- Anakim's Soul Crystal Lv. 12 (Rare) / Anakim's Soul Crystal Lv. 1 (Rare) -->
+		<reward id="92927" count="1" type="ON_SUCCESS" /> <!-- Anakim's Soul Crystal Lv. 13 (Rare) -->
+		<reward id="92925" count="1" type="ON_FAILURE" /> <!-- Anakim's Soul Crystal Lv. 11 (Rare) -->
+	</item>
+	<item one="92927" two="91163" chance="33"> <!-- Anakim's Soul Crystal Lv. 13 (Rare) / Anakim's Soul Crystal Lv. 1 (Rare) -->
+		<reward id="92928" count="1" type="ON_SUCCESS" /> <!-- Anakim's Soul Crystal Lv. 14 (Rare) -->
+		<reward id="92925" count="1" type="ON_FAILURE" /> <!-- Anakim's Soul Crystal Lv. 11 (Rare) -->
+	</item>
+	<item one="92928" two="91163" chance="33"> <!-- Anakim's Soul Crystal Lv. 14 (Rare) / Anakim's Soul Crystal Lv. 1 (Rare) -->
+		<reward id="92929" count="1" type="ON_SUCCESS" /> <!-- Anakim's Soul Crystal Lv. 15 (Rare) -->
+		<reward id="92925" count="1" type="ON_FAILURE" /> <!-- Anakim's Soul Crystal Lv. 11 (Rare) -->
+	</item>
+
+	<!-- Adventurer's Rough Jewel -->
+	<item one="91936" two="91936" chance="100"> <!-- Adventurer's Rough Jewel (Lv. 1) / Adventurer's Rough Jewel (Lv. 1) -->
+		<reward id="93065" count="1" type="ON_SUCCESS" /> <!-- Adventurer's Rough Jewel (Lv. 2) -->
+		<reward id="93065" count="1" type="ON_FAILURE" /> <!-- Adventurer's Rough Jewel (Lv. 2) -->
+	</item>
+
+	<!-- Agathion Bracelet -->
+	<item one="90888" two="90888" chance="33"> <!-- Agathion Bracelet Lv. 1 / Agathion Bracelet Lv. 1 -->
+		<reward id="90889" count="1" type="ON_SUCCESS" /> <!-- Agathion Bracelet Lv. 2 -->
+		<reward id="90888" count="1" type="ON_FAILURE" /> <!-- Agathion Bracelet Lv. 1 -->
+	</item>
+	<item one="90889" two="90889" chance="33"> <!-- Agathion Bracelet Lv. 2 / Agathion Bracelet Lv. 2 -->
+		<reward id="90890" count="1" type="ON_SUCCESS" /> <!-- Agathion Bracelet Lv. 3 -->
+		<reward id="90889" count="1" type="ON_FAILURE" /> <!-- Agathion Bracelet Lv. 2 -->
+	</item>
+	<item one="90890" two="90890" chance="33"> <!-- Agathion Bracelet Lv. 3 / Agathion Bracelet Lv. 3 -->
+		<reward id="90891" count="1" type="ON_SUCCESS" /> <!-- Agathion Bracelet Lv. 4 -->
+		<reward id="90890" count="1" type="ON_FAILURE" /> <!-- Agathion Bracelet Lv. 3 -->
+	</item>
+	<item one="90891" two="90891" chance="33"> <!-- Agathion Bracelet Lv. 4 / Agathion Bracelet Lv. 4 -->
+		<reward id="91161" count="1" type="ON_SUCCESS" /> <!-- Agathion Bracelet Lv. 5 -->
+		<reward id="90891" count="1" type="ON_FAILURE" /> <!-- Agathion Bracelet Lv. 4 -->
+	</item>
+
+	<!-- Baium's Doll -->
+	<item one="94153" two="94153" chance="33"> <!-- Baium Doll Lv. 1/ Baium Doll Lv. 1 -->
+		<reward id="91256" type="ON_SUCCESS" /> <!-- Baium Doll Lv. 2 -->
+		<reward id="94153" type="ON_FAILURE" /> <!-- Baium Doll Lv. 1 -->
+	</item>
+	<item one="91256" two="91256" chance="33"> <!-- Baium Doll Lv. 2/ Baium Doll Lv. 2 -->
+		<reward id="91423" type="ON_SUCCESS" /> <!-- Baium Doll Lv. 3 -->
+		<reward id="91256" type="ON_FAILURE" /> <!-- Baium Doll Lv. 2 -->
+	</item>
+
+	<!-- Queen Ant's Doll -->
+	<item one="94154" two="94154" chance="33"> <!-- Queen Ant Doll Lv. 1/ Queen Ant Doll Lv. 1 -->
+		<reward id="91257" type="ON_SUCCESS" /> <!-- Queen Ant's Doll Lv. 2 -->
+		<reward id="94154" type="ON_FAILURE" /> <!-- Queen Ant's Doll Lv. 1 -->
+	</item>
+	<item one="91257" two="91257" chance="33"> <!-- Queen Ant Doll Lv. 2/ Queen Ant Doll Lv. 2 -->
+		<reward id="91422" type="ON_SUCCESS" /> <!-- Queen Ant's Doll Lv. 3 -->
+		<reward id="91257" type="ON_FAILURE" /> <!-- Queen Ant's Doll Lv. 2 -->
+	</item>
+
+	<!-- Orfen's Doll -->
+	<item one="94155" two="94155" chance="33"> <!-- Orfen's Doll Lv. 1/ Orfen's Doll Lv. 1 -->
+		<reward id="91258" type="ON_SUCCESS" /> <!-- Orfen's Doll Lv. 2 -->
+		<reward id="94155" type="ON_FAILURE" /> <!-- Orfen's Doll Lv. 1 -->
+	</item>
+	<item one="91258" two="91258" chance="33"> <!-- Orfen's Doll Lv. 2/ Orfen's Doll Lv. 2 -->
+		<reward id="91424" type="ON_SUCCESS" /> <!-- Orfen's Doll Lv. 3 -->
+		<reward id="91258" type="ON_FAILURE" /> <!-- Orfen's Doll Lv. 2 -->
+	</item>
+
+	<!-- Frintezza's Doll -->
+	<item one="94509" two="94509" chance="33"> <!-- Frintezza Doll Lv. 1/ Frintezza Doll Lv. 1 -->
+		<reward id="91604" type="ON_SUCCESS" /> <!-- Frintezza's Doll Lv. 2 -->
+		<reward id="94509" type="ON_FAILURE" /> <!-- Frintezza's Doll Lv. 1 -->
+	</item>
+	<item one="91604" two="91604" chance="33"> <!-- Frintezza Doll Lv. 2/ Frintezza Doll Lv. 2 -->
+		<reward id="91605" type="ON_SUCCESS" /> <!-- Frintezza's Doll Lv. 3 -->
+		<reward id="91604" type="ON_FAILURE" /> <!-- Frintezza's Doll Lv. 2 -->
+	</item>
+
+	<!-- Core Doll -->
+	<item one="94648" two="94648" chance="33"> <!-- Core Doll Lv. 1/ Core Doll Lv. 1 -->
+		<reward id="94649" type="ON_SUCCESS" /> <!-- Core Doll Lv. 2 -->
+		<reward id="94648" type="ON_FAILURE" /> <!-- Core Doll Lv. 1 -->
+	</item>
+	<item one="94649" two="94649" chance="33"> <!-- Core Doll Lv. 2/ Core Doll Lv. 2 -->
+		<reward id="94650" type="ON_SUCCESS" /> <!-- Core Doll Lv. 3 -->
+		<reward id="94649" type="ON_FAILURE" /> <!-- Core Doll Lv. 2 -->
+	</item>
+
+	<!-- Zaken Doll -->
+	<item one="94645" two="94645" chance="33"> <!-- Zaken Doll Lv. 1/ Zaken Doll Lv. 1 -->
+		<reward id="94646" type="ON_SUCCESS" /> <!-- Zaken Doll Lv. 2 -->
+		<reward id="94645" type="ON_FAILURE" /> <!-- Zaken Doll Lv. 1 -->
+	</item>
+	<item one="94646" two="94646" chance="33"> <!-- Zaken Doll Lv. 2/ Zaken Doll Lv. 2 -->
+		<reward id="94647" type="ON_SUCCESS" /> <!-- Zaken Doll Lv. 3 -->
+		<reward id="94646" type="ON_FAILURE" /> <!-- Zaken Doll Lv. 2 -->
+	</item>
+
+	<!-- Chocolate Doll -->
+	<item one="94275" two="94273" chance="33"> <!-- Chocolate Doll (Lv. 1) / Chocolate (Event) -->
+		<reward id="94276" count="1" type="ON_SUCCESS" /> <!-- Chocolate Doll (Lv. 2) -->
+		<reward id="94275" count="1" type="ON_FAILURE" /> <!-- Chocolate Doll (Lv. 1) -->
+	</item>
+	<item one="94276" two="94273" chance="33"> <!-- Chocolate Doll (Lv. 2) / Chocolate (Event) -->
+		<reward id="94277" count="1" type="ON_SUCCESS" /> <!-- Chocolate Doll (Lv. 3) -->
+		<reward id="94275" count="1" type="ON_FAILURE" /> <!-- Chocolate Doll (Lv. 1) -->
+	</item>
+	<item one="94277" two="94273" chance="33"> <!-- Chocolate Doll (Lv. 3) / Chocolate (Event) -->
+		<reward id="94278" count="1" type="ON_SUCCESS" /> <!-- Chocolate Doll (Lv. 4) -->
+		<reward id="94275" count="1" type="ON_FAILURE" /> <!-- Chocolate Doll (Lv. 1) -->
+	</item>
+	<item one="94278" two="94273" chance="33"> <!-- Chocolate Doll (Lv. 4) / Chocolate (Event) -->
+		<reward id="94279" count="1" type="ON_SUCCESS" /> <!-- Chocolate Doll (Lv. 5) -->
+		<reward id="94275" count="1" type="ON_FAILURE" /> <!-- Chocolate Doll (Lv. 1) -->
+	</item>
+	<item one="94279" two="94273" chance="33"> <!-- Chocolate Doll (Lv. 5) / Chocolate (Event) -->
+		<reward id="94280" count="1" type="ON_SUCCESS" /> <!-- Chocolate Doll (Lv. 6) -->
+		<reward id="94275" count="1" type="ON_FAILURE" /> <!-- Chocolate Doll (Lv. 1) -->
+	</item>
+	<item one="94280" two="94273" chance="33"> <!-- Chocolate Doll (Lv. 6) / Chocolate (Event) -->
+		<reward id="94281" count="1" type="ON_SUCCESS" /> <!-- Chocolate Doll (Lv. 7) -->
+		<reward id="94280" count="1" type="ON_FAILURE" /> <!-- Chocolate Doll (Lv. 6) -->
+	</item>
+	<item one="94281" two="94273" chance="33"> <!-- Chocolate Doll (Lv. 7) / Chocolate (Event) -->
+		<reward id="94282" count="1" type="ON_SUCCESS" /> <!-- Chocolate Doll (Lv. 8) -->
+		<reward id="94280" count="1" type="ON_FAILURE" /> <!-- Chocolate Doll (Lv. 6) -->
+	</item>
+	<item one="94282" two="94273" chance="33"> <!-- Chocolate Doll (Lv. 8) / Chocolate (Event) -->
+		<reward id="94283" count="1" type="ON_SUCCESS" /> <!-- Chocolate Doll (Lv. 9) -->
+		<reward id="94280" count="1" type="ON_FAILURE" /> <!-- Chocolate Doll (Lv. 6) -->
+	</item>
+	<item one="94283" two="94273" chance="33"> <!-- Chocolate Doll (Lv. 9) / Chocolate (Event) -->
+		<reward id="94284" count="1" type="ON_SUCCESS" /> <!-- Chocolate Doll (Lv. 10) -->
+		<reward id="94280" count="1" type="ON_FAILURE" /> <!-- Chocolate Doll (Lv. 6) -->
+	</item>
+	<item one="94284" two="94273" chance="33"> <!-- Chocolate Doll (Lv. 10) / Chocolate (Event) -->
+		<reward id="94285" count="1" type="ON_SUCCESS" /> <!-- Chocolate Doll (Lv. 11) -->
+		<reward id="94280" count="1" type="ON_FAILURE" /> <!-- Chocolate Doll (Lv. 6) -->
+	</item>
+	<item one="94285" two="94273" chance="33"> <!-- Chocolate Doll (Lv. 11) / Chocolate (Event) -->
+		<reward id="94286" count="1" type="ON_SUCCESS" /> <!-- Chocolate Doll (Lv. 12) -->
+		<reward id="94285" count="1" type="ON_FAILURE" /> <!-- Chocolate Doll (Lv. 11) -->
+	</item>
+	<item one="94286" two="94273" chance="33"> <!-- Chocolate Doll (Lv. 12) / Chocolate (Event) -->
+		<reward id="94287" count="1" type="ON_SUCCESS" /> <!-- Chocolate Doll (Lv. 13) -->
+		<reward id="94285" count="1" type="ON_FAILURE" /> <!-- Chocolate Doll (Lv. 11) -->
+	</item>
+	<item one="94287" two="94273" chance="33"> <!-- Chocolate Doll (Lv. 13) / Chocolate (Event) -->
+		<reward id="94288" count="1" type="ON_SUCCESS" /> <!-- Chocolate Doll (Lv. 14) -->
+		<reward id="94285" count="1" type="ON_FAILURE" /> <!-- Chocolate Doll (Lv. 11) -->
+	</item>
+	<item one="94288" two="94273" chance="33"> <!-- Chocolate Doll (Lv. 14) / Chocolate (Event) -->
+		<reward id="94289" count="1" type="ON_SUCCESS" /> <!-- Chocolate Doll (Lv. 15) -->
+		<reward id="94285" count="1" type="ON_FAILURE" /> <!-- Chocolate Doll (Lv. 11) -->
+	</item>
+
+	<!-- Aden's Soul Crystal -->
+	<item one="95783" two="95783" chance="70"> <!-- Aden's Soul Crystal Lv. 1 / Aden's Soul Crystal Lv. 1 -->
+		<reward id="95784" count="1" type="ON_SUCCESS" /> <!-- Aden's Soul Crystal Lv. 2 -->
+		<reward id="95783" count="1" type="ON_FAILURE" /> <!-- Aden's Soul Crystal Lv. 1 -->
+	</item>
+	<item one="95784" two="95783" chance="60"> <!-- Aden's Soul Crystal Lv. 2 / Aden's Soul Crystal Lv. 1 -->
+		<reward id="95785" count="1" type="ON_SUCCESS" /> <!-- Sigel Soul Crystal Lv. 3 -->
+		<reward id="95783" count="1" type="ON_FAILURE" /> <!-- Sigel Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90536" two="95783" chance="50"> <!-- Aden's Soul Crystal Lv. 3 / Aden's Soul Crystal Lv. 1 -->
+		<reward id="95786" count="1" type="ON_SUCCESS" /> <!-- Aden's Soul Crystal Lv. 4 -->
+		<reward id="95783" count="1" type="ON_FAILURE" /> <!-- Aden's Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90537" two="95783" chance="40"> <!-- Aden's Soul Crystal Lv. 4 / Aden's Soul Crystal Lv. 1 -->
+		<reward id="95787" count="1" type="ON_SUCCESS" /> <!-- Aden's Soul Crystal Lv. 5 -->
+		<reward id="95783" count="1" type="ON_FAILURE" /> <!-- Aden's Soul Crystal Lv. 1 -->
+	</item>
+	<item one="90538" two="95783" chance="60"> <!-- Aden's Soul Crystal Lv. 5 / Aden's Soul Crystal Lv. 1 -->
+		<reward id="95788" count="1" type="ON_SUCCESS" /> <!-- Aden's Soul Crystal Lv. 6 -->
+		<reward id="95783" count="1" type="ON_FAILURE" /> <!-- Aden's Soul Crystal Lv. 1 -->
+	</item>
+	<item one="95788" two="95783" chance="55"> <!-- Aden's Soul Crystal Lv. 6 / Aden's Soul Crystal Lv. 1 -->
+		<reward id="95789" count="1" type="ON_SUCCESS" /> <!-- Aden's Soul Crystal Lv. 7 -->
+		<reward id="95788" count="1" type="ON_FAILURE" /> <!-- Aden's Soul Crystal Lv. 6 -->
+	</item>
+	<item one="95789" two="95783" chance="50"> <!-- Aden's Soul Crystal Lv. 7 / Aden's Soul Crystal Lv. 1 -->
+		<reward id="95790" count="1" type="ON_SUCCESS" /> <!-- Aden's Soul Crystal Lv. 8 -->
+		<reward id="95788" count="1" type="ON_FAILURE" /> <!-- Aden's Soul Crystal Lv. 6 -->
+	</item>
+	<item one="95790" two="95783" chance="45"> <!-- Aden's Soul Crystal Lv. 8 / Aden's Soul Crystal Lv. 1 -->
+		<reward id="95791" count="1" type="ON_SUCCESS" /> <!-- Aden's Soul Crystal Lv. 9 -->
+		<reward id="95788" count="1" type="ON_FAILURE" /> <!-- Aden's Soul Crystal Lv. 6 -->
+	</item>
+	<item one="95791" two="95783" chance="40"> <!-- Aden's Soul Crystal Lv. 9 / Aden's Soul Crystal Lv. 1 -->
+		<reward id="95792" count="1" type="ON_SUCCESS" /> <!-- Aden's Soul Crystal Lv. 10 -->
+		<reward id="95788" count="1" type="ON_FAILURE" /> <!-- Aden's Soul Crystal Lv. 6 -->
+	</item>
+	<item one="95792" two="95783" chance="50"> <!-- Aden's Soul Crystal Lv. 10 / Aden's Soul Crystal Lv. 1 -->
+		<reward id="95793" count="1" type="ON_SUCCESS" /> <!-- Aden's Soul Crystal Lv. 11 -->
+		<reward id="95788" count="1" type="ON_FAILURE" /> <!-- Aden's Soul Crystal Lv. 6 -->
+	</item>
+	<item one="95793" two="95783" chance="45"> <!-- Aden's Soul Crystal Lv. 11 / Aden's Soul Crystal Lv. 1 -->
+		<reward id="95794" count="1" type="ON_SUCCESS" /> <!-- Aden's Soul Crystal Lv. 12 -->
+		<reward id="95793" count="1" type="ON_FAILURE" /> <!-- Aden's Soul Crystal Lv. 11 -->
+	</item>
+	<item one="95794" two="95783" chance="40"> <!-- Aden's Soul Crystal Lv. 12 / Aden's Soul Crystal Lv. 1 -->
+		<reward id="95795" count="1" type="ON_SUCCESS" /> <!-- Aden's Soul Crystal Lv. 13 -->
+		<reward id="95793" count="1" type="ON_FAILURE" /> <!-- Aden's Soul Crystal Lv. 11 -->
+	</item>
+	<item one="95795" two="95783" chance="35"> <!-- Aden's Soul Crystal Lv. 13 / Aden's Soul Crystal Lv. 1 -->
+		<reward id="95796" count="1" type="ON_SUCCESS" /> <!-- Aden's Soul Crystal Lv. 14 -->
+		<reward id="95793" count="1" type="ON_FAILURE" /> <!-- Aden's Soul Crystal Lv. 11 -->
+	</item>
+	<item one="95796" two="95783" chance="30"> <!-- Aden's Soul Crystal Lv. 14 / Aden's Soul Crystal Lv. 1 -->
+		<reward id="95797" count="1" type="ON_SUCCESS" /> <!-- Aden's Soul Crystal Lv. 15 -->
+		<reward id="95793" count="1" type="ON_FAILURE" /> <!-- Aden's Soul Crystal Lv. 11 -->
+	</item>
+	<item one="95797" two="95783" chance="30"> <!-- Aden's Soul Crystal Lv. 15 / Aden's Soul Crystal Lv. 1 -->
+		<reward id="95798" count="1" type="ON_SUCCESS" /> <!-- Aden's Soul Crystal Lv. 16 -->
+		<reward id="95793" count="1" type="ON_FAILURE" /> <!-- Aden's Soul Crystal Lv. 11 -->
+	</item>
+	<item one="95798" two="95783" chance="25"> <!-- Aden's Soul Crystal Lv. 16 / Aden's Soul Crystal Lv. 1 -->
+		<reward id="95799" count="1" type="ON_SUCCESS" /> <!-- Aden's Soul Crystal Lv. 17 -->
+		<reward id="95798" count="1" type="ON_FAILURE" /> <!-- Aden's Soul Crystal Lv. 16 -->
+	</item>
+	<item one="95799" two="95783" chance="20"> <!-- Aden's Soul Crystal Lv. 17 / Aden's Soul Crystal Lv. 1 -->
+		<reward id="95800" count="1" type="ON_SUCCESS" /> <!-- Aden's Soul Crystal Lv. 18 -->
+		<reward id="95798" count="1" type="ON_FAILURE" /> <!-- Aden's Soul Crystal Lv. 16 -->
+	</item>
+	<item one="95800" two="95783" chance="15"> <!-- Aden's Soul Crystal Lv. 18 / Aden's Soul Crystal Lv. 1 -->
+		<reward id="95801" count="1" type="ON_SUCCESS" /> <!-- Aden's Soul Crystal Lv. 19 -->
+		<reward id="95798" count="1" type="ON_FAILURE" /> <!-- Aden's Soul Crystal Lv. 16 -->
+	</item>
+	<item one="95801" two="95783" chance="10"> <!-- Aden's Soul Crystal Lv. 19 / Aden's Soul Crystal Lv. 1 -->
+		<reward id="95802" count="1" type="ON_SUCCESS" /> <!-- Aden's Soul Crystal Lv. 20 -->
+		<reward id="95798" count="1" type="ON_FAILURE" /> <!-- Aden's Soul Crystal Lv. 16 -->
+	</item>
+
+	<!-- Hardin's Soul Crystal -->
+	<item one="95803" two="95803" chance="60"> <!-- Hardin's Soul Crystal Lv. 1 / Hardin's Crystal Lv. 1 -->
+		<reward id="95804" count="1" type="ON_SUCCESS" /> <!-- Hardins Soul Crystal Lv. 2 -->
+		<reward id="95803" count="1" type="ON_FAILURE" /> <!-- Hardins Soul Crystal Lv. 1 -->
+	</item>
+	<item one="95804" two="95803" chance="55"> <!-- Hardin's Soul Crystal Lv. 2 / Hardin's Crystal Lv. 1 -->
+		<reward id="95805" count="1" type="ON_SUCCESS" /> <!-- Hardins Soul Crystal Lv. 3 -->
+		<reward id="95803" count="1" type="ON_FAILURE" /> <!-- Hardins Soul Crystal Lv. 1 -->
+	</item>
+	<item one="95805" two="95803" chance="50"> <!-- Hardin's Soul Crystal Lv. 3 / Hardin's Crystal Lv. 1 -->
+		<reward id="95806" count="1" type="ON_SUCCESS" /> <!-- Hardins Soul Crystal Lv. 4 -->
+		<reward id="95803" count="1" type="ON_FAILURE" /> <!-- Hardins Soul Crystal Lv. 1 -->
+	</item>
+	<item one="95806" two="95803" chance="45"> <!-- Hardin's Soul Crystal Lv. 4 / Hardin's Crystal Lv. 1 -->
+		<reward id="95807" count="1" type="ON_SUCCESS" /> <!-- Hardins Soul Crystal Lv. 5 -->
+		<reward id="95803" count="1" type="ON_FAILURE" /> <!-- Hardins Soul Crystal Lv. 1 -->
+	</item>
+	<item one="95807" two="95803" chance="45"> <!-- Hardin's Soul Crystal Lv. 5 / Hardin's Crystal Lv. 1 -->
+		<reward id="95808" count="1" type="ON_SUCCESS" /> <!-- Hardins Soul Crystal Lv. 6 -->
+		<reward id="95803" count="1" type="ON_FAILURE" /> <!-- Hardins Soul Crystal Lv. 1 -->
+	</item>
+	<item one="95808" two="95803" chance="40"> <!-- Hardin's Soul Crystal Lv. 6 / Hardin's Crystal Lv. 1 -->
+		<reward id="95809" count="1" type="ON_SUCCESS" /> <!-- Hardins Soul Crystal Lv. 7 -->
+		<reward id="95808" count="1" type="ON_FAILURE" /> <!-- Hardins Soul Crystal Lv. 6 -->
+	</item>
+	<item one="95809" two="95803" chance="35"> <!-- Hardin's Soul Crystal Lv. 7 / Hardin's Crystal Lv. 1 -->
+		<reward id="95810" count="1" type="ON_SUCCESS" /> <!-- Hardins Soul Crystal Lv. 8 -->
+		<reward id="95808" count="1" type="ON_FAILURE" /> <!-- Hardins Soul Crystal Lv. 6 -->
+	</item>
+	<item one="95810" two="95803" chance="30"> <!-- Hardin's Soul Crystal Lv. 8 / Hardin's Crystal Lv. 1 -->
+		<reward id="95811" count="1" type="ON_SUCCESS" /> <!-- Hardins Soul Crystal Lv. 9 -->
+		<reward id="95808" count="1" type="ON_FAILURE" /> <!-- Hardins Soul Crystal Lv. 6 -->
+	</item>
+	<item one="95811" two="95803" chance="25"> <!-- Hardin's Soul Crystal Lv. 9 / Hardin's Crystal Lv. 1 -->
+		<reward id="95812" count="1" type="ON_SUCCESS" /> <!-- Hardins Soul Crystal Lv. 10 -->
+		<reward id="95808" count="1" type="ON_FAILURE" /> <!-- Hardins Soul Crystal Lv. 6 -->
+	</item>
+	<item one="95812" two="95803" chance="35"> <!-- Hardin's Soul Crystal Lv. 10 / Hardin's Crystal Lv. 1 -->
+		<reward id="95813" count="1" type="ON_SUCCESS" /> <!-- Hardins Soul Crystal Lv. 11 -->
+		<reward id="95808" count="1" type="ON_FAILURE" /> <!-- Hardins Soul Crystal Lv. 6 -->
+	</item>
+	<item one="95813" two="95803" chance="30"> <!-- Hardin's Soul Crystal Lv. 11 / Hardin's Crystal Lv. 1 -->
+		<reward id="95814" count="1" type="ON_SUCCESS" /> <!-- Hardins Soul Crystal Lv. 12 -->
+		<reward id="95813" count="1" type="ON_FAILURE" /> <!-- Hardins Soul Crystal Lv. 11 -->
+	</item>
+	<item one="95814" two="95803" chance="25"> <!-- Hardin's Soul Crystal Lv. 12 / Hardin's Crystal Lv. 1 -->
+		<reward id="95815" count="1" type="ON_SUCCESS" /> <!-- Hardins Soul Crystal Lv. 13 -->
+		<reward id="95813" count="1" type="ON_FAILURE" /> <!-- Hardins Soul Crystal Lv. 11 -->
+	</item>
+	<item one="95815" two="95803" chance="20"> <!-- Hardin's Soul Crystal Lv. 13 / Hardin's Crystal Lv. 1 -->
+		<reward id="95816" count="1" type="ON_SUCCESS" /> <!-- Hardins Soul Crystal Lv. 14 -->
+		<reward id="95813" count="1" type="ON_FAILURE" /> <!-- Hardins Soul Crystal Lv. 11 -->
+	</item>
+	<item one="95816" two="95803" chance="15"> <!-- Hardin's Soul Crystal Lv. 14 / Hardin's Crystal Lv. 1 -->
+		<reward id="95817" count="1" type="ON_SUCCESS" /> <!-- Hardins Soul Crystal Lv. 15 -->
+		<reward id="95813" count="1" type="ON_FAILURE" /> <!-- Hardins Soul Crystal Lv. 11 -->
+	</item>
+	<item one="95817" two="95803" chance="25"> <!-- Hardin's Soul Crystal Lv. 15 / Hardin's Crystal Lv. 1 -->
+		<reward id="95818" count="1" type="ON_SUCCESS" /> <!-- Hardins Soul Crystal Lv. 16 -->
+		<reward id="95813" count="1" type="ON_FAILURE" /> <!-- Hardins Soul Crystal Lv. 11 -->
+	</item>
+	<item one="95818" two="95803" chance="20"> <!-- Hardin's Soul Crystal Lv. 16 / Hardin's Crystal Lv. 1 -->
+		<reward id="95819" count="1" type="ON_SUCCESS" /> <!-- Hardins Soul Crystal Lv. 17 -->
+		<reward id="95818" count="1" type="ON_FAILURE" /> <!-- Hardins Soul Crystal Lv. 16 -->
+	</item>
+	<item one="95819" two="95803" chance="15"> <!-- Hardin's Soul Crystal Lv. 17 / Hardin's Crystal Lv. 1 -->
+		<reward id="95820" count="1" type="ON_SUCCESS" /> <!-- Hardins Soul Crystal Lv. 18 -->
+		<reward id="95818" count="1" type="ON_FAILURE" /> <!-- Hardins Soul Crystal Lv. 16 -->
+	</item>
+	<item one="95820" two="95803" chance="10"> <!-- Hardin's Soul Crystal Lv. 18 / Hardin's Crystal Lv. 1 -->
+		<reward id="95821" count="1" type="ON_SUCCESS" /> <!-- Hardins Soul Crystal Lv. 19 -->
+		<reward id="95818" count="1" type="ON_FAILURE" /> <!-- Hardins Soul Crystal Lv. 16 -->
+	</item>
+	<item one="95821" two="95803" chance="5"> <!-- Hardin's Soul Crystal Lv. 19 / Hardin's Crystal Lv. 1 -->
+		<reward id="95822" count="1" type="ON_SUCCESS" /> <!-- Hardins Soul Crystal Lv. 20 -->
+		<reward id="95818" count="1" type="ON_FAILURE" /> <!-- Hardins Soul Crystal Lv. 16 -->
+	</item>
+
+	<!-- Onyx Jewels - ADEN -->
+	<item one="92066" two="92066" chance="65"> <!-- Onyx Lv. 1 / Onyx Lv. 1 -->
+		<reward id="92067" count="1" type="ON_SUCCESS" /> <!-- Onyx Lv. 2 -->
+		<reward id="92066" count="1" type="ON_FAILURE" /> <!-- Onyx Lv. 1 -->
+	</item>
+	<item one="92067" two="92067" chance="40"> <!-- Onyx Lv. 2 / Onyx Lv. 2 -->
+		<reward id="92068" count="1" type="ON_SUCCESS" /> <!-- Onyx Lv. 3 -->
+		<reward id="92067" count="1" type="ON_FAILURE" /> <!-- Onyx Lv. 2 -->
+	</item>
+	<item one="92068" two="92068" chance="35"> <!-- Onyx Lv. 3 / Onyx Lv. 3 -->
+		<reward id="92069" count="1" type="ON_SUCCESS" /> <!-- Onyx Lv. 4 -->
+		<reward id="92068" count="1" type="ON_FAILURE" /> <!-- Onyx Lv. 3 -->
+	</item>
+	<item one="92069" two="92069" chance="30"> <!-- Onyx Lv. 4 / Onyx Lv. 4 -->
+		<reward id="94521" count="1" type="ON_SUCCESS" /> <!-- Onyx Lv. 5 -->
+		<reward id="92069" count="1" type="ON_FAILURE" /> <!-- Onyx Lv. 4 -->
+	</item>
+	<item one="94521" two="94521" chance="25"> <!-- Onyx Lv. 5 / Onyx Lv. 5 -->
+		<reward id="92070" count="1" type="ON_SUCCESS" /> <!-- Onyx Lv. 6 -->
+		<reward id="94521" count="1" type="ON_FAILURE" /> <!-- Onyx Lv. 5 -->
+	</item>
+	<item one="92070" two="92070" chance="20"> <!-- Onyx Lv. 6 / Onyx Lv. 6 -->
+		<reward id="92071" count="1" type="ON_SUCCESS" /> <!-- Onyx Lv. 7 -->
+		<reward id="92070" count="1" type="ON_FAILURE" /> <!-- Onyx Lv. 6 -->
+	</item>
+	<item one="92071" two="92071" chance="15"> <!-- Onyx Lv. 7 / Onyx Lv. 7 -->
+		<reward id="92072" count="1" type="ON_SUCCESS" /> <!-- Onyx Lv. 8 -->
+		<reward id="92071" count="1" type="ON_FAILURE" /> <!-- Onyx Lv. 7 -->
+	</item>
+
+	<!-- Spinel Jewels - ADEN -->
+	<item one="92076" two="92076" chance="65"> <!-- Spinel (Lv. 1) / Spinel (Lv. 1) -->
+		<reward id="92077" count="1" type="ON_SUCCESS" /> <!-- Spinel (Lv. 2) -->
+		<reward id="92076" count="1" type="ON_FAILURE" /> <!-- Spinel (Lv. 1) -->
+	</item>
+	<item one="92077" two="92077" chance="40"> <!-- Spinel (Lv. 2) / Spinel (Lv. 2) -->
+		<reward id="92078" count="1" type="ON_SUCCESS" /> <!-- Spinel (Lv. 3) -->
+		<reward id="92077" count="1" type="ON_FAILURE" /> <!-- Spinel (Lv. 2) -->
+	</item>
+	<item one="92078" two="92078" chance="35"> <!-- Spinel (Lv. 3) / Spinel (Lv. 3) -->
+		<reward id="92079" count="1" type="ON_SUCCESS" /> <!-- Spinel (Lv. 4) -->
+		<reward id="92078" count="1" type="ON_FAILURE" /> <!-- Spinel (Lv. 3) -->
+	</item>
+	<item one="92079" two="92079" chance="30"> <!-- Spinel (Lv. 4) / Spinel (Lv. 4) -->
+		<reward id="94522" count="1" type="ON_SUCCESS" /> <!-- Spinel (Lv. 5) -->
+		<reward id="92079" count="1" type="ON_FAILURE" /> <!-- Spinel (Lv. 4) -->
+	</item>
+	<item one="94522" two="94522" chance="25"> <!-- Spinel (Lv. 5) / Spinel (Lv. 5) -->
+		<reward id="92080" count="1" type="ON_SUCCESS" /> <!-- Spinel (Lv. 6) -->
+		<reward id="94522" count="1" type="ON_FAILURE" /> <!-- Spinel (Lv. 5) -->
+	</item>
+	<item one="92080" two="92080" chance="20"> <!-- Spinel (Lv. 6) / Spinel (Lv. 6) -->
+		<reward id="92081" count="1" type="ON_SUCCESS" /> <!-- Spinel (Lv. 7) -->
+		<reward id="92080" count="1" type="ON_FAILURE" /> <!-- Spinel (Lv. 6) -->
+	</item>
+	<item one="92081" two="92081" chance="15"> <!-- Spinel (Lv. 7) / Spinel (Lv. 7) -->
+		<reward id="92082" count="1" type="ON_SUCCESS" /> <!-- Spinel (Lv. 8) -->
+		<reward id="92081" count="1" type="ON_FAILURE" /> <!-- Spinel (Lv. 7) -->
+	</item>
+
+	<!-- Opal Jewels - ADEN -->
+	<item one="92046" two="92046" chance="65"> <!-- Opal (Lv. 1) / Opal (Lv. 1) -->
+		<reward id="92047" count="1" type="ON_SUCCESS" /> <!-- Opal (Lv. 2) -->
+		<reward id="92046" count="1" type="ON_FAILURE" /> <!-- Opal (Lv. 1) -->
+	</item>
+	<item one="92047" two="92047" chance="40"> <!-- Opal (Lv. 2) / Opal (Lv. 2) -->
+		<reward id="92048" count="1" type="ON_SUCCESS" /> <!-- Opal (Lv. 3) -->
+		<reward id="92047" count="1" type="ON_FAILURE" /> <!-- Opal (Lv. 2) -->
+	</item>
+	<item one="92048" two="92048" chance="35"> <!-- Opal (Lv. 3) / Opal (Lv. 3) -->
+		<reward id="92049" count="1" type="ON_SUCCESS" /> <!-- Opal (Lv. 4) -->
+		<reward id="92048" count="1" type="ON_FAILURE" /> <!-- Opal (Lv. 3) -->
+	</item>
+	<item one="92049" two="92049" chance="30"> <!-- Opal (Lv. 4) / Opal (Lv. 4) -->
+		<reward id="94519" count="1" type="ON_SUCCESS" /> <!-- Opal (Lv. 5) -->
+		<reward id="92049" count="1" type="ON_FAILURE" /> <!-- Opal (Lv. 4) -->
+	</item>
+	<item one="94519" two="94519" chance="25"> <!-- Opal (Lv. 5) / Opal (Lv. 5) -->
+		<reward id="92050" count="1" type="ON_SUCCESS" /> <!-- Opal (Lv. 6) -->
+		<reward id="94519" count="1" type="ON_FAILURE" /> <!-- Opal (Lv. 5) -->
+	</item>
+	<item one="92050" two="92050" chance="20"> <!-- Opal (Lv. 6) / Opal (Lv. 6) -->
+		<reward id="92051" count="1" type="ON_SUCCESS" /> <!-- Opal (Lv. 7) -->
+		<reward id="92050" count="1" type="ON_FAILURE" /> <!-- Opal (Lv. 6) -->
+	</item>
+	<item one="92051" two="92051" chance="15"> <!-- Opal (Lv. 7) / Opal (Lv. 7) -->
+		<reward id="92052" count="1" type="ON_SUCCESS" /> <!-- Opal (Lv. 8) -->
+		<reward id="92051" count="1" type="ON_FAILURE" /> <!-- Opal (Lv. 7) -->
+	</item>
+
+	<!-- Amber Jewels - ADEN -->
+	<item one="92036" two="92036" chance="65"> <!-- Amber (Lv. 1) / Amber (Lv. 1) -->
+		<reward id="92037" count="1" type="ON_SUCCESS" /> <!-- Amber (Lv. 2) -->
+		<reward id="92036" count="1" type="ON_FAILURE" /> <!-- Amber (Lv. 1) -->
+	</item>
+	<item one="92037" two="92037" chance="40"> <!-- Amber (Lv. 2) / Amber (Lv. 2) -->
+		<reward id="92038" count="1" type="ON_SUCCESS" /> <!-- Amber (Lv. 3) -->
+		<reward id="92037" count="1" type="ON_FAILURE" /> <!-- Amber (Lv. 2) -->
+	</item>
+	<item one="92038" two="92038" chance="35"> <!-- Amber (Lv. 3) / Amber (Lv. 3) -->
+		<reward id="92039" count="1" type="ON_SUCCESS" /> <!-- Amber (Lv. 4) -->
+		<reward id="92038" count="1" type="ON_FAILURE" /> <!-- Amber (Lv. 3) -->
+	</item>
+	<item one="92039" two="92039" chance="30"> <!-- Amber (Lv. 4) / Amber (Lv. 4) -->
+		<reward id="94518" count="1" type="ON_SUCCESS" /> <!-- Amber (Lv. 5) -->
+		<reward id="92039" count="1" type="ON_FAILURE" /> <!-- Amber (Lv. 4) -->
+	</item>
+	<item one="94518" two="94518" chance="25"> <!-- Amber (Lv. 5) / Amber (Lv. 5) -->
+		<reward id="92040" count="1" type="ON_SUCCESS" /> <!-- Amber (Lv. 6) -->
+		<reward id="94518" count="1" type="ON_FAILURE" /> <!-- Amber (Lv. 5) -->
+	</item>
+	<item one="92040" two="92040" chance="20"> <!-- Amber (Lv. 6) / Amber (Lv. 6) -->
+		<reward id="92041" count="1" type="ON_SUCCESS" /> <!-- Amber (Lv. 7) -->
+		<reward id="92040" count="1" type="ON_FAILURE" /> <!-- Amber (Lv. 6) -->
+	</item>
+	<item one="92041" two="92041" chance="15"> <!-- Amber (Lv. 7) / Amber (Lv. 7) -->
+		<reward id="92042" count="1" type="ON_SUCCESS" /> <!-- Amber (Lv. 8) -->
+		<reward id="92041" count="1" type="ON_FAILURE" /> <!-- Amber (Lv. 7) -->
+	</item>
+
+	<!-- Coral Jewels - ADEN -->
+	<item one="92056" two="92056" chance="65"> <!-- Coral (Lv. 1) / Coral (Lv. 1) -->
+		<reward id="92057" count="1" type="ON_SUCCESS" /> <!-- Coral (Lv. 2) -->
+		<reward id="92056" count="1" type="ON_FAILURE" /> <!-- Coral (Lv. 1) -->
+	</item>
+	<item one="92057" two="92057" chance="40"> <!-- Coral (Lv. 2) / Coral (Lv. 2) -->
+		<reward id="92058" count="1" type="ON_SUCCESS" /> <!-- Coral (Lv. 3) -->
+		<reward id="92057" count="1" type="ON_FAILURE" /> <!-- Coral (Lv. 2) -->
+	</item>
+	<item one="92058" two="92058" chance="35"> <!-- Coral (Lv. 3) / Coral (Lv. 3) -->
+		<reward id="92059" count="1" type="ON_SUCCESS" /> <!-- Coral (Lv. 4) -->
+		<reward id="92058" count="1" type="ON_FAILURE" /> <!-- Coral (Lv. 3) -->
+	</item>
+	<item one="92059" two="92059" chance="30"> <!-- Coral (Lv. 4) / Coral (Lv. 4) -->
+		<reward id="94520" count="1" type="ON_SUCCESS" /> <!-- Coral (Lv. 5) -->
+		<reward id="92059" count="1" type="ON_FAILURE" /> <!-- Coral (Lv. 4) -->
+	</item>
+	<item one="94520" two="94520" chance="25"> <!-- Coral (Lv. 5) / Coral (Lv. 5) -->
+		<reward id="92060" count="1" type="ON_SUCCESS" /> <!-- Coral (Lv. 6) -->
+		<reward id="94520" count="1" type="ON_FAILURE" /> <!-- Coral (Lv. 5) -->
+	</item>
+	<item one="92060" two="92060" chance="20"> <!-- Coral (Lv. 6) / Coral (Lv. 6) -->
+		<reward id="92061" count="1" type="ON_SUCCESS" /> <!-- Coral (Lv. 7) -->
+		<reward id="92060" count="1" type="ON_FAILURE" /> <!-- Coral (Lv. 6) -->
+	</item>
+	<item one="92061" two="92061" chance="15"> <!-- Coral (Lv. 7) / Coral (Lv. 7) -->
+		<reward id="92062" count="1" type="ON_SUCCESS" /> <!-- Coral (Lv. 8) -->
+		<reward id="92061" count="1" type="ON_FAILURE" /> <!-- Coral (Lv. 7) -->
+	</item>
+
+	<!-- Zircon Jewels - ADEN -->
+	<item one="92086" two="92086" chance="65"> <!-- Zircon (Lv. 1) / Zircon (Lv. 1) -->
+		<reward id="92087" count="1" type="ON_SUCCESS" /> <!-- Zircon (Lv. 2) -->
+		<reward id="92086" count="1" type="ON_FAILURE" /> <!-- Zircon (Lv. 1) -->
+	</item>
+	<item one="92087" two="92087" chance="40"> <!-- Zircon (Lv. 2) / Zircon (Lv. 2) -->
+		<reward id="92088" count="1" type="ON_SUCCESS" /> <!-- Zircon (Lv. 3) -->
+		<reward id="92087" count="1" type="ON_FAILURE" /> <!-- Zircon (Lv. 2) -->
+	</item>
+	<item one="92088" two="92088" chance="35"> <!-- Zircon (Lv. 3) / Zircon (Lv. 3) -->
+		<reward id="92089" count="1" type="ON_SUCCESS" /> <!-- Zircon (Lv. 4) -->
+		<reward id="92088" count="1" type="ON_FAILURE" /> <!-- Zircon (Lv. 3) -->
+	</item>
+	<item one="92089" two="92089" chance="30"> <!-- Zircon (Lv. 4) / Zircon (Lv. 4) -->
+		<reward id="94523" count="1" type="ON_SUCCESS" /> <!-- Zircon (Lv. 5) -->
+		<reward id="92089" count="1" type="ON_FAILURE" /> <!-- Zircon (Lv. 4) -->
+	</item>
+	<item one="94523" two="94523" chance="25"> <!-- Zircon (Lv. 5) / Zircon (Lv. 5) -->
+		<reward id="92090" count="1" type="ON_SUCCESS" /> <!-- Zircon (Lv. 6) -->
+		<reward id="94523" count="1" type="ON_FAILURE" /> <!-- Zircon (Lv. 5) -->
+	</item>
+	<item one="92090" two="92090" chance="20"> <!-- Zircon (Lv. 6) / Zircon (Lv. 6) -->
+		<reward id="92091" count="1" type="ON_SUCCESS" /> <!-- Zircon (Lv. 7) -->
+		<reward id="92090" count="1" type="ON_FAILURE" /> <!-- Zircon (Lv. 6) -->
+	</item>
+	<item one="92091" two="92091" chance="15"> <!-- Zircon (Lv. 7) / Zircon (Lv. 7) -->
+		<reward id="92092" count="1" type="ON_SUCCESS" /> <!-- Zircon (Lv. 8) -->
+		<reward id="92091" count="1" type="ON_FAILURE" /> <!-- Zircon (Lv. 7) -->
+	</item>
+
+	<!-- Moonstone Jewels - ADEN -->
+	<item one="92096" two="92096" chance="65"> <!-- Moonstone (Lv. 1) / Moonstone (Lv. 1) -->
+		<reward id="92097" count="1" type="ON_SUCCESS" /> <!-- Moonstone (Lv. 2) -->
+		<reward id="92096" count="1" type="ON_FAILURE" /> <!-- Moonstone (Lv. 1) -->
+	</item>
+	<item one="92097" two="92097" chance="40"> <!-- Moonstone (Lv. 2) / Moonstone (Lv. 2) -->
+		<reward id="92098" count="1" type="ON_SUCCESS" /> <!-- Moonstone (Lv. 3) -->
+		<reward id="92097" count="1" type="ON_FAILURE" /> <!-- Moonstone (Lv. 2) -->
+	</item>
+	<item one="92098" two="92098" chance="35"> <!-- Moonstone (Lv. 3) / Moonstone (Lv. 3) -->
+		<reward id="92099" count="1" type="ON_SUCCESS" /> <!-- Moonstone (Lv. 4) -->
+		<reward id="92098" count="1" type="ON_FAILURE" /> <!-- Moonstone (Lv. 3) -->
+	</item>
+	<item one="92099" two="92099" chance="30"> <!-- Moonstone (Lv. 4) / Moonstone (Lv. 4) -->
+		<reward id="94524" count="1" type="ON_SUCCESS" /> <!-- Moonstone (Lv. 5) -->
+		<reward id="92099" count="1" type="ON_FAILURE" /> <!-- Moonstone (Lv. 4) -->
+	</item>
+	<item one="94524" two="94524" chance="25"> <!-- Moonstone (Lv. 5) / Moonstone (Lv. 5) -->
+		<reward id="92100" count="1" type="ON_SUCCESS" /> <!-- Moonstone (Lv. 6) -->
+		<reward id="94524" count="1" type="ON_FAILURE" /> <!-- Moonstone (Lv. 5) -->
+	</item>
+	<item one="92100" two="92100" chance="20"> <!-- Moonstone (Lv. 6) / Moonstone (Lv. 6) -->
+		<reward id="92101" count="1" type="ON_SUCCESS" /> <!-- Moonstone (Lv. 7) -->
+		<reward id="92100" count="1" type="ON_FAILURE" /> <!-- Moonstone (Lv. 6) -->
+	</item>
+	<item one="92101" two="92101" chance="15"> <!-- Moonstone (Lv. 7) / Moonstone (Lv. 7) -->
+		<reward id="92102" count="1" type="ON_SUCCESS" /> <!-- Moonstone (Lv. 8) -->
+		<reward id="92101" count="1" type="ON_FAILURE" /> <!-- Moonstone (Lv. 7) -->
+	</item>
+
+	<!-- Hellbound Talisman -->
+	<item one="94706" two="94716" chance="60"> <!-- Talisman of Hellbound Lv. 1 / Talisman of Hellbound Fragment -->
+		<reward id="94707" count="1" type="ON_SUCCESS" /> <!-- Talisman of Hellbound Lv. 2 -->
+		<reward id="94706" count="1" type="ON_FAILURE" /> <!-- Talisman of Hellbound Lv. 1 -->
+	</item>
+	<item one="94707" two="94716" chance="50"> <!-- Talisman of Hellbound Lv. 2 / Talisman of Hellbound Fragment -->
+		<reward id="94708" count="1" type="ON_SUCCESS" /> <!-- Talisman of Hellbound Lv. 3 -->
+		<reward id="94707" count="1" type="ON_FAILURE" /> <!-- Talisman of Hellbound Lv. 2 -->
+	</item>
+	<item one="94708" two="94716" chance="50"> <!-- Talisman of Hellbound Lv. 3 / Talisman of Hellbound Fragment -->
+		<reward id="94709" count="1" type="ON_SUCCESS" /> <!-- Talisman of Hellbound Lv. 4 -->
+		<reward id="94708" count="1" type="ON_FAILURE" /> <!-- Talisman of Hellbound Lv. 3 -->
+	</item>
+	<item one="94709" two="94716" chance="40"> <!-- Talisman of Hellbound Lv. 4 / Talisman of Hellbound Fragment -->
+		<reward id="94710" count="1" type="ON_SUCCESS" /> <!-- Talisman of Hellbound Lv. 5 -->
+		<reward id="94709" count="1" type="ON_FAILURE" /> <!-- Talisman of Hellbound Lv. 4 -->
+	</item>
+	<item one="94710" two="94716" chance="40"> <!-- Talisman of Hellbound Lv. 5 / Talisman of Hellbound Fragment -->
+		<reward id="94711" count="1" type="ON_SUCCESS" /> <!-- Talisman of Hellbound Lv. 6 -->
+		<reward id="94710" count="1" type="ON_FAILURE" /> <!-- Talisman of Hellbound Lv. 5 -->
+	</item>
+	<item one="94711" two="94716" chance="30"> <!-- Talisman of Hellbound Lv. 6 / Talisman of Hellbound Fragment -->
+		<reward id="94712" count="1" type="ON_SUCCESS" /> <!-- Talisman of Hellbound Lv. 7 -->
+		<reward id="94711" count="1" type="ON_FAILURE" /> <!-- Talisman of Hellbound Lv. 6 -->
+	</item>
+	<item one="94712" two="94716" chance="30"> <!-- Talisman of Hellbound Lv. 7 / Talisman of Hellbound Fragment -->
+		<reward id="94713" count="1" type="ON_SUCCESS" /> <!-- Talisman of Hellbound Lv. 8 -->
+		<reward id="94712" count="1" type="ON_FAILURE" /> <!-- Talisman of Hellbound Lv. 7 -->
+	</item>
+	<item one="94713" two="94716" chance="20"> <!-- Talisman of Hellbound Lv. 8 / Talisman of Hellbound Fragment -->
+		<reward id="94714" count="1" type="ON_SUCCESS" /> <!-- Talisman of Hellbound Lv. 9 -->
+		<reward id="94713" count="1" type="ON_FAILURE" /> <!-- Talisman of Hellbound Lv. 8 -->
+	</item>
+	<item one="94714" two="94716" chance="10"> <!-- Talisman of Hellbound Lv. 9 / Talisman of Hellbound Fragment -->
+		<reward id="94715" count="1" type="ON_SUCCESS" /> <!-- Talisman of Hellbound Lv. 10 -->
+		<reward id="94714" count="1" type="ON_FAILURE" /> <!-- Talisman of Hellbound Lv. 9 -->
+	</item>
+
+	<!-- Growth Rune -->
+	<item one="94781" two="94780" chance="70"> <!-- Growth Rune Lv. 1 / Growth Rune Fragment -->
+		<reward id="94782" count="1" type="ON_SUCCESS" /> <!-- Growth Rune Lv. 2 -->
+		<reward id="94781" count="1" type="ON_FAILURE" /> <!-- Growth Rune Lv. 1 -->
+	</item>
+	<item one="94782" two="94780" chance="60"> <!-- Growth Rune Lv. 2 / Growth Rune Fragment -->
+		<reward id="94783" count="1" type="ON_SUCCESS" /> <!-- Growth Rune Lv. 3 -->
+		<reward id="94781" count="1" type="ON_FAILURE" /> <!-- Growth Rune Lv. 1 -->
+	</item>
+	<item one="94783" two="94780" chance="50"> <!-- Growth Rune Lv. 3 / Growth Rune Fragment -->
+		<reward id="94784" count="1" type="ON_SUCCESS" /> <!-- Growth Rune Lv. 4 -->
+		<reward id="94781" count="1" type="ON_FAILURE" /> <!-- Growth Rune Lv. 1 -->
+	</item>
+	<item one="94784" two="94780" chance="40"> <!-- Growth Rune Lv. 4 / Growth Rune Fragment -->
+		<reward id="94785" count="1" type="ON_SUCCESS" /> <!-- Growth Rune Lv. 5 -->
+		<reward id="94781" count="1" type="ON_FAILURE" /> <!-- Growth Rune Lv. 1 -->
+	</item>
+	<item one="94785" two="94780" chance="30"> <!-- Growth Rune Lv. 5 / Growth Rune Fragment -->
+		<reward id="94786" count="1" type="ON_SUCCESS" /> <!-- Growth Rune Lv. 6 -->
+		<reward id="94781" count="1" type="ON_FAILURE" /> <!-- Growth Rune Lv. 1 -->
+	</item>
+	<item one="94786" two="94780" chance="50"> <!-- Growth Rune Lv. 6 / Growth Rune Fragment -->
+		<reward id="94787" count="1" type="ON_SUCCESS" /> <!-- Growth Rune Lv. 7 -->
+		<reward id="94786" count="1" type="ON_FAILURE" /> <!-- Growth Rune Lv. 6 -->
+	</item>
+	<item one="94787" two="94780" chance="40"> <!-- Growth Rune Lv. 7 / Growth Rune Fragment -->
+		<reward id="94788" count="1" type="ON_SUCCESS" /> <!-- Growth Rune Lv. 8 -->
+		<reward id="94786" count="1" type="ON_FAILURE" /> <!-- Growth Rune Lv. 6 -->
+	</item>
+	<item one="94788" two="94780" chance="30"> <!-- Growth Rune Lv. 8 / Growth Rune Fragment -->
+		<reward id="94789" count="1" type="ON_SUCCESS" /> <!-- Growth Rune Lv. 9 -->
+		<reward id="94786" count="1" type="ON_FAILURE" /> <!-- Growth Rune Lv. 6 -->
+	</item>
+	<item one="94789" two="94780" chance="20"> <!-- Growth Rune Lv. 9 / Growth Rune Fragment -->
+		<reward id="94790" count="1" type="ON_SUCCESS" /> <!-- Growth Rune Lv. 10 -->
+		<reward id="94786" count="1" type="ON_FAILURE" /> <!-- Growth Rune Lv. 6 -->
+	</item>
+	<item one="94790" two="94780" chance="50"> <!-- Growth Rune Lv. 10 / Growth Rune Fragment -->
+		<reward id="94791" count="1" type="ON_SUCCESS" /> <!-- Growth Rune Lv. 11 -->
+		<reward id="94790" count="1" type="ON_FAILURE" /> <!-- Growth Rune Lv. 10 -->
+	</item>
+	<item one="94791" two="94780" chance="40"> <!-- Growth Rune Lv. 11 / Growth Rune Fragment -->
+		<reward id="94792" count="1" type="ON_SUCCESS" /> <!-- Growth Rune Lv. 12 -->
+		<reward id="94790" count="1" type="ON_FAILURE" /> <!-- Growth Rune Lv. 10 -->
+	</item>
+	<item one="94782" two="94780" chance="30"> <!-- Growth Rune Lv. 12 / Growth Rune Fragment -->
+		<reward id="94793" count="1" type="ON_SUCCESS" /> <!-- Growth Rune Lv. 13 -->
+		<reward id="94790" count="1" type="ON_FAILURE" /> <!-- Growth Rune Lv. 10 -->
+	</item>
+	<item one="94783" two="94780" chance="20"> <!-- Growth Rune Lv. 13 / Growth Rune Fragment -->
+		<reward id="94794" count="1" type="ON_SUCCESS" /> <!-- Growth Rune Lv. 14 -->
+		<reward id="94790" count="1" type="ON_FAILURE" /> <!-- Growth Rune Lv. 10 -->
+	</item>
+	<item one="94794" two="94780" chance="30"> <!-- Growth Rune Lv. 14 / Growth Rune Fragment -->
+		<reward id="94795" count="1" type="ON_SUCCESS" /> <!-- Growth Rune Lv. 15 -->
+		<reward id="94790" count="1" type="ON_FAILURE" /> <!-- Growth Rune Lv. 10 -->
+	</item>
+
+	<!-- Einhasad's Pendant -->
+	<item one="93296" two="93296" chance="33"> <!-- Einhasad's Pendant Lv. 1 / Einhasad's Pendant Lv. 1 -->
+		<reward id="93297" count="1" type="ON_SUCCESS" /> <!-- Einhasad’s Pendant Lv. 2 -->
+		<reward id="93296" count="1" type="ON_FAILURE" /> <!-- Einhasad's Pendant Lv. 1 -->
+	</item>
+	<item one="93297" two="93297" chance="33"> <!-- Einhasad’s Pendant Lv. 2 / Einhasad’s Pendant Lv. 2 -->
+		<reward id="93298" count="1" type="ON_SUCCESS" /> <!-- Einhasad’s Pendant Lv. 3 -->
+		<reward id="93297" count="1" type="ON_FAILURE" /> <!-- Einhasad’s Pendant Lv. 2 -->
+	</item>
+	<item one="93298" two="93298" chance="33"> <!-- Einhasad’s Pendant Lv. 3 / Einhasad’s Pendant Lv. 3 -->
+		<reward id="93299" count="1" type="ON_SUCCESS" /> <!-- Einhasad's Pendant Lv. 4 -->
+		<reward id="93298" count="1" type="ON_FAILURE" /> <!-- Einhasad’s Pendant Lv. 3 -->
+	</item>
+	<item one="93299" two="93299" chance="33"> <!-- Einhasad's Pendant Lv. 4 / Einhasad's Pendant Lv. 4 -->
+		<reward id="93300" count="1" type="ON_SUCCESS" /> <!-- Einhasad's Pendant Lv. 5 -->
+		<reward id="93299" count="1" type="ON_FAILURE" /> <!-- Einhasad's Pendant Lv. 4 -->
+	</item>
+
 </list>

--- a/data/enchantment.xml
+++ b/data/enchantment.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<enchantment xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xmlns="http://l2j.org"
-             xsi:schemaLocation="http://l2j.org xsd/enchantment.xsd">
+<enchantment xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org xsd/enchantment.xsd">
 
     <chance-group name="ARMOR_GROUP">
         <enchant until="3" chance="100"/>
@@ -102,6 +100,7 @@
         <enchant from="8" until="9" chance="10"/>
         <enchant from="9" until="10" chance="5"/>
     </chance-group>
+
     <chance-group name="DRAGON_BELT">
         <enchant until="1" chance="60"/>
         <enchant from="1" until="2" chance="50"/>
@@ -114,6 +113,7 @@
         <enchant from="8" until="9" chance="22"/>
         <enchant from="9" until="10" chance="20"/>
     </chance-group>
+
     <chance-group name="HAIR_S_ACCESSORY">
         <enchant until="3" chance="100"/>
         <enchant from="3" until="4" chance="50"/>
@@ -122,6 +122,7 @@
         <enchant from="8" until="9" chance="5"/>
         <enchant from="9" until="10" chance="2"/>
     </chance-group>
+
     <chance-group name="INSOLENCE_RING">
         <enchant until="1" chance="100"/>
         <enchant from="1" until="2" chance="90"/>
@@ -134,6 +135,7 @@
         <enchant from="8" until="9" chance="10"/>
         <enchant from="9" until="10" chance="5"/>
     </chance-group>
+
     <chance-group name="ELEMENTAL_NECKLACE">
         <enchant until="2" chance="50"/>
         <enchant from="2" until="4" chance="40"/>
@@ -143,6 +145,7 @@
         <enchant from="8" until="9" chance="3"/>
         <enchant from="9" until="10" chance="1"/>
     </chance-group>
+
     <chance-group name="SAYHA_CLOAK">
         <enchant until="1" chance="95"/>
         <enchant from="1" until="2" chance="85"/>
@@ -155,6 +158,7 @@
         <enchant from="8" until="9" chance="10"/>
         <enchant from="9" until="10" chance="1"/>
     </chance-group>
+
     <chance-group name="PROTECTION_CLOAK">
         <enchant until="1" chance="85"/>
         <enchant from="1" until="2" chance="80"/>
@@ -167,14 +171,20 @@
         <enchant from="8" until="9" chance="15"/>
         <enchant from="9" until="10" chance="7"/>
     </chance-group>
+
     <chance-group name="DEATH_K_SWORD">
         <enchant until="1" chance="23"/>
         <enchant from="1" until="2" chance="13"/>
         <enchant from="2" until="3" chance="3"/>
     </chance-group>
+
     <chance-group name="ADEN_WEAPON">
         <enchant until="4" chance="100"/>
+        <enchant from="4" until="7" chance="66.67"/>
+        <enchant from="7" until="16" chance="30"/>
+        <enchant until="16" chance="20"/>
     </chance-group>
+
     <chance-group name="ELMORE_CLOAK">
         <enchant until="1" chance="70"/>
         <enchant from="1" until="2" chance="65"/>
@@ -184,6 +194,7 @@
         <enchant from="6" until="7" chance="48"/>
         <enchant from="7" until="10" chance="28"/>
     </chance-group>
+
     <chance-group name="ZODIAK_AGATHION">
         <enchant until="3" chance="100"/>
         <enchant from="3" until="4" chance="65"/>
@@ -202,6 +213,7 @@
         <enchant from="3" until="5" chance="50"/>
         <enchant from="4" until="5" chance="30"/>
     </chance-group>
+
     <chance-group name="PEDANT_DRAGON_L2">
         <enchant until="1" chance="100"/>
         <enchant from="1" until="2" chance="80"/>
@@ -209,6 +221,7 @@
         <enchant from="3" until="5" chance="60"/>
         <enchant from="4" until="5" chance="30"/>
     </chance-group>
+
     <chance-group name="PEDANT_DRAGON_L3">
         <enchant until="1" chance="90"/>
         <enchant from="1" until="2" chance="50"/>
@@ -216,6 +229,7 @@
         <enchant from="3" until="5" chance="12"/>
         <enchant from="4" until="5" chance="5"/>
     </chance-group>
+
     <chance-group name="PEDANT_DRAGON_L4">
         <enchant until="1" chance="70"/>
         <enchant from="1" until="2" chance="30"/>
@@ -333,7 +347,7 @@
         </bonus>
     </armor-hp-bonus>
 
-
+    <!-- Group ID's -->
     <group id="0">
         <enchant-chance group="ARMOR_GROUP">
             <slots>
@@ -602,8 +616,8 @@
     </scroll>
 
     <!-- Enchant Scroll Weapon of Aden -->
-    <scroll id="93038" grade="D" max-enchant="4" group="14">
-        <items>93028 93029 93030 93031 93032 93033 93034 93035 93036 93037</items>
+    <scroll id="93038" grade="D" max-enchant="16" group="14">
+        <items>93028 93029 93030 93031 93032 93033 93034 93035 93036 93037 94897 95691</items>
     </scroll>
 
     <!-- Enchant Scroll Death Knight Fire Sword -->
@@ -646,78 +660,28 @@
     <!-- Eva's Scroll: Enchant Hair Accessory -->
     <scroll id="70753" max-enchant="10" group="8">
         <items>
-            70687  <!-- Artisan Goggles <STR+1 INT+1> -->
-            70688  <!-- Artisan Goggles <DEX+1 WIT+1> -->
-            70689  <!-- Artisan Goggles <CON+1 MEN+1> -->
-            70690  <!-- Uniform Hat <STR+1 INT+1> -->
-            70691  <!-- Uniform Hat <DEX+1 WIT+1> -->
-            70692  <!-- Uniform Hat <CON+1 MEN+1> -->
-            70693  <!-- Assassin's Bamboo Hat <STR+1 INT+1> -->
-            70694  <!-- Assassin's Bamboo Hat <DEX+1 WIT+1> -->
-            70695  <!-- Assassin's Bamboo Hat <CON+1 MEN+1> -->
-            70696  <!-- Valkyrie Hat <STR+1 WIT+1> -->
-            70697  <!-- Valkyrie Hat <DEX+1 WIT+1> -->
-            70698  <!-- Valkyrie Hat <CON+1 MEN+1> -->
-            70699  <!-- Gatekeeper Hat <STR+1 INT+1> -->
-            70700  <!-- Gatekeeper Hat <DEX+1 WIT+1> -->
-            70701  <!-- Gatekeeper Hat <CON+1 MEN+1> -->
-            70702  <!-- Wedding Veil <STR+1 INT+1> -->
-            70703  <!-- Wedding Veil <DEX+1 WIT+1> -->
-            70704  <!-- Wedding Veil <CON+1 MEN+1> -->
-            70705  <!-- Maid Hair Accessory <STR+1 INT+1> -->
-            70706  <!-- Maid Hair Accessory <DEX+1 WIT+1> -->
-            70707  <!-- Maid Hair Accessory <CON+1 MEN+1> -->
-            70708  <!-- Refined Romantic Chapeau: Red <STR+1 INT+1> -->
-            70709  <!-- Refined Romantic Chapeau: Red <DEX+1 WIT+1> -->
-            70710  <!-- Refined Romantic Chapeau: Red <CON+1 MEN+1> -->
-            70711  <!-- Refined Angel Ring <STR+1 INT+1> -->
-            70712  <!-- Refined Angel Ring <DEX+1 WIT+1> -->
-            70713  <!-- Refined Angel Ring <CON+1 MEN+1> -->
-            70714  <!-- Refined Wizard Hat <STR+1 INT+1> -->
-            70715  <!-- Refined Wizard Hat <DEX+1 WIT+1> -->
-            70716  <!-- Refined Wizard Hat <CON+1 MEN+1> -->
-            70717  <!-- Laborer Hat <STR+1 INT+1> -->
-            70718  <!-- Laborer Hat <DEX+1 WIT+1> -->
-            70719  <!-- Laborer Hat <CON+1 MEN+1> -->
-            70720  <!-- Top Hat <STR+1 INT+1> -->
-            70721  <!-- Top Hat <DEX+1 WIT+1> -->
-            70722  <!-- Top Hat <CON+1 MEN+1> -->
-            70723  <!-- Vigilante Hat <STR+1 INT+1> -->
-            70724  <!-- Vigilante Hat <DEX+1 WIT+1> -->
-            70725  <!-- Vigilante Hat <CON+1 MEN+1> -->
-            70750  <!-- Afro Hair <STR+1 INT+1> -->
-            70751  <!-- Afro Hair <DEX+1 WIT+1> -->
-            70752  <!-- Afro Hair <CON+1 MEN+1> -->
-            70749  <!-- Chic Silver Chapeau <CON+1 MEN+1> -->
-            70748  <!-- Chic Silver Chapeau <DEX +1 WIT +1> -->
-            70747  <!-- Chic Silver Chapeau <STR+1 INT+1> -->
-            70734  <!-- First Mate Hat <CON+1 MEN+1> -->
-            70733  <!-- First Mate Hat <DEX+1 WIT+1> -->
-            70732  <!-- First Mate Hat <STR+1 INT+1> -->
-            70740  <!-- Gold-rimmed Glasses <CON+1 MEN+1> -->
-            70739  <!-- Gold-rimmed Glasses <DEX+1 WIT+1> -->
-            70738  <!-- Gold-rimmed Glasses <STR+1 INT+1> -->
-            70743  <!-- Horn-rimmed Glasses <CON+1 MEN+1> -->
-            70742  <!-- Horn-rimmed Glasses <DEX+1 WIT+1> -->
-            70741  <!-- Horn-rimmed Glasses <STR+1 INT+1> -->
-            70737  <!-- Refined Romantic Chapeau: Blue <CON+1 MEN+1> -->
-            70736  <!-- Refined Romantic Chapeau: Blue <DEX+1 WIT+1> -->
-            70735  <!-- Refined Romantic Chapeau: Blue <STR+1 INT+1> -->
-            70746  <!-- Stylish Straw Hat <CON+1 MEN+1> -->
-            70745  <!-- Stylish Straw Hat <DEX+1 WIT+1> -->
-            70744  <!-- Stylish Straw Hat <STR+1 INT+1> -->
-            70731  <!-- Warrior's Helmet <CON+1 MEN+1> -->
-            70730  <!-- Warrior's Helmet <DEX+1 WIT+1> -->
-            70729  <!-- Warrior's Helmet <STR+1 INT+1> -->
-            70728  <!-- White Uniform Hat <CON+1 MEN+1> -->
-            70727  <!-- White Uniform Hat <DEX+1 WIT+1> -->
-            70726  <!-- White Uniform Hat <STR+1 INT+1> -->
+            13519  <!-- Black Mask <STR+1 INT+1> -->
+            49521  <!-- Refined Romantic Chapeau <STR+1 INT+1> -->
+            49522  <!-- Pirate King Hat <STR+1 INT+1> -->
+            49687  <!-- Refined Romantic Chapeau <STR+1 INT+1> -->
+            90837  <!-- White Uniform Hat <CON+1 MEN+1> -->
+            90838  <!-- White Uniform Hat <DEX+1 WIT+1> -->
+            90839  <!-- White Uniform Hat <STR+1 INT+1> -->
             90840  <!-- Napoleon Hat <STR+1 INT+1> -->
             90841  <!-- Napoleon Hat <DEX+1 WIT+1> -->
             90842  <!-- Napoleon Hat <CON+1 MEN+1> -->
             90843  <!-- Ninja Hair Accessory <STR+1 INT+1> -->
             90844  <!-- Ninja Hair Accessory <DEX+1 WIT+1> -->
             90845  <!-- Ninja Hair Accessory <CON+1 MEN+1> -->
+            90846  <!-- Warrior's Helmet <CON+1 MEN+1> -->
+            90847  <!-- Warrior's Helmet <DEX+1 WIT+1> -->
+            90848  <!-- Warrior's Helmet <STR+1 INT+1> -->
+            90849  <!-- First Mate Hat <CON+1 MEN+1> -->
+            90850  <!-- First Mate Hat <DEX+1 WIT+1> -->
+            90851  <!-- First Mate Hat <STR+1 INT+1> -->
+            90852  <!-- Artisan Goggles <STR+1 INT+1> -->
+            90853  <!-- Artisan Goggles <DEX+1 WIT+1> -->
+            90854  <!-- Artisan Goggles <CON+1 MEN+1> -->
         </items>
     </scroll>
 
@@ -767,7 +731,7 @@
     </scroll>
 
     <!-- Aden Talisman Enchant Scroll -->
-    <scroll id="91756" max-enchant="10" group="2">
+    <scroll id="91756" max-enchant="11" group="2">
         <items>91745</items> <!-- Talisman of Aden -->
     </scroll>
 
@@ -781,14 +745,9 @@
         <items>92403</items> <!-- Talisman - Speed -->
     </scroll>
 
-    <!-- Enchant Scroll: Talisman of Baium -->
-    <scroll id="99002" max-enchant="5" group="5">
-        <items>49683</items> <!-- Talisman of Baium -->
-    </scroll>
-
     <!-- Enchant Scroll Talisman of Baium -->
     <scroll id="91951" max-enchant="5" group="5">
-        <items>49683 90527 99001</items>
+        <items>49683 94119</items>
     </scroll>
 
     <!-- Enchant Scroll: Dragon Valley Earring -->
@@ -800,7 +759,6 @@
     <!-- Enchant Scroll: Dragon's Belt -->
     <scroll id="91863" max-enchant="10" group="7">
         <items>
-            91788 <!-- Dragon's Belt -->
             91862 <!-- Dragon's Belt -->
         </items>
     </scroll>
@@ -813,91 +771,35 @@
     <!-- Pendant Polish -->
     <scroll id="49469" max-enchant="10">
         <items>
-            29704 29705 29706 29707 29708 29709 29710 29711 29712 29713 29714
-            29715 29716 29717 29718 29719 29720 29721 29722 29723 49467 49468
+            49467 49468
         </items>
-    </scroll>
-
-    <!-- Enchant Scroll of Fate -->
-    <scroll id="70299" max-enchant="10">
-        <items>70294 70295 70296 70297 70298 71818</items>
     </scroll>
 
     <!-- Eva's Scroll Enchant Hair Accessory -->
     <scroll id="90494" max-enchant="10" group="8">
         <items>
-            70687  <!-- Artisan Goggles <STR+1 INT+1> -->
-            70688  <!-- Artisan Goggles <DEX+1 WIT+1> -->
-            70689  <!-- Artisan Goggles <CON+1 MEN+1> -->
-            70690  <!-- Uniform Hat <STR+1 INT+1> -->
-            70691  <!-- Uniform Hat <DEX+1 WIT+1> -->
-            70692  <!-- Uniform Hat <CON+1 MEN+1> -->
-            70693  <!-- Assassin's Bamboo Hat <STR+1 INT+1> -->
-            70694  <!-- Assassin's Bamboo Hat <DEX+1 WIT+1> -->
-            70695  <!-- Assassin's Bamboo Hat <CON+1 MEN+1> -->
-            70696  <!-- Valkyrie Hat <STR+1 WIT+1> -->
-            70697  <!-- Valkyrie Hat <DEX+1 WIT+1> -->
-            70698  <!-- Valkyrie Hat <CON+1 MEN+1> -->
-            70699  <!-- Gatekeeper Hat <STR+1 INT+1> -->
-            70700  <!-- Gatekeeper Hat <DEX+1 WIT+1> -->
-            70701  <!-- Gatekeeper Hat <CON+1 MEN+1> -->
-            70702  <!-- Wedding Veil <STR+1 INT+1> -->
-            70703  <!-- Wedding Veil <DEX+1 WIT+1> -->
-            70704  <!-- Wedding Veil <CON+1 MEN+1> -->
-            70705  <!-- Maid Hair Accessory <STR+1 INT+1> -->
-            70706  <!-- Maid Hair Accessory <DEX+1 WIT+1> -->
-            70707  <!-- Maid Hair Accessory <CON+1 MEN+1> -->
-            70708  <!-- Refined Romantic Chapeau: Red <STR+1 INT+1> -->
-            70709  <!-- Refined Romantic Chapeau: Red <DEX+1 WIT+1> -->
-            70710  <!-- Refined Romantic Chapeau: Red <CON+1 MEN+1> -->
-            70711  <!-- Refined Angel Ring <STR+1 INT+1> -->
-            70712  <!-- Refined Angel Ring <DEX+1 WIT+1> -->
-            70713  <!-- Refined Angel Ring <CON+1 MEN+1> -->
-            70714  <!-- Refined Wizard Hat <STR+1 INT+1> -->
-            70715  <!-- Refined Wizard Hat <DEX+1 WIT+1> -->
-            70716  <!-- Refined Wizard Hat <CON+1 MEN+1> -->
-            70717  <!-- Laborer Hat <STR+1 INT+1> -->
-            70718  <!-- Laborer Hat <DEX+1 WIT+1> -->
-            70719  <!-- Laborer Hat <CON+1 MEN+1> -->
-            70720  <!-- Top Hat <STR+1 INT+1> -->
-            70721  <!-- Top Hat <DEX+1 WIT+1> -->
-            70722  <!-- Top Hat <CON+1 MEN+1> -->
-            70723  <!-- Vigilante Hat <STR+1 INT+1> -->
-            70724  <!-- Vigilante Hat <DEX+1 WIT+1> -->
-            70725  <!-- Vigilante Hat <CON+1 MEN+1> -->
-            70750  <!-- Afro Hair <STR+1 INT+1> -->
-            70751  <!-- Afro Hair <DEX+1 WIT+1> -->
-            70752  <!-- Afro Hair <CON+1 MEN+1> -->
-            70749  <!-- Chic Silver Chapeau <CON+1 MEN+1> -->
-            70748  <!-- Chic Silver Chapeau <DEX +1 WIT +1> -->
-            70747  <!-- Chic Silver Chapeau <STR+1 INT+1> -->
-            70734  <!-- First Mate Hat <CON+1 MEN+1> -->
-            70733  <!-- First Mate Hat <DEX+1 WIT+1> -->
-            70732  <!-- First Mate Hat <STR+1 INT+1> -->
-            70740  <!-- Gold-rimmed Glasses <CON+1 MEN+1> -->
-            70739  <!-- Gold-rimmed Glasses <DEX+1 WIT+1> -->
-            70738  <!-- Gold-rimmed Glasses <STR+1 INT+1> -->
-            70743  <!-- Horn-rimmed Glasses <CON+1 MEN+1> -->
-            70742  <!-- Horn-rimmed Glasses <DEX+1 WIT+1> -->
-            70741  <!-- Horn-rimmed Glasses <STR+1 INT+1> -->
-            70737  <!-- Refined Romantic Chapeau: Blue <CON+1 MEN+1> -->
-            70736  <!-- Refined Romantic Chapeau: Blue <DEX+1 WIT+1> -->
-            70735  <!-- Refined Romantic Chapeau: Blue <STR+1 INT+1> -->
-            70746  <!-- Stylish Straw Hat <CON+1 MEN+1> -->
-            70745  <!-- Stylish Straw Hat <DEX+1 WIT+1> -->
-            70744  <!-- Stylish Straw Hat <STR+1 INT+1> -->
-            70731  <!-- Warrior's Helmet <CON+1 MEN+1> -->
-            70730  <!-- Warrior's Helmet <DEX+1 WIT+1> -->
-            70729  <!-- Warrior's Helmet <STR+1 INT+1> -->
-            70728  <!-- White Uniform Hat <CON+1 MEN+1> -->
-            70727  <!-- White Uniform Hat <DEX+1 WIT+1> -->
-            70726  <!-- White Uniform Hat <STR+1 INT+1> -->
+            13519  <!-- Black Mask <STR+1 INT+1> -->
+            49521  <!-- Refined Romantic Chapeau <STR+1 INT+1> -->
+            49522  <!-- Pirate King Hat <STR+1 INT+1> -->
+            49687  <!-- Refined Romantic Chapeau <STR+1 INT+1> -->
+            90837  <!-- White Uniform Hat <CON+1 MEN+1> -->
+            90838  <!-- White Uniform Hat <DEX+1 WIT+1> -->
+            90839  <!-- White Uniform Hat <STR+1 INT+1> -->
             90840  <!-- Napoleon Hat <STR+1 INT+1> -->
             90841  <!-- Napoleon Hat <DEX+1 WIT+1> -->
             90842  <!-- Napoleon Hat <CON+1 MEN+1> -->
             90843  <!-- Ninja Hair Accessory <STR+1 INT+1> -->
             90844  <!-- Ninja Hair Accessory <DEX+1 WIT+1> -->
             90845  <!-- Ninja Hair Accessory <CON+1 MEN+1> -->
+            90846  <!-- Warrior's Helmet <CON+1 MEN+1> -->
+            90847  <!-- Warrior's Helmet <DEX+1 WIT+1> -->
+            90848  <!-- Warrior's Helmet <STR+1 INT+1> -->
+            90849  <!-- First Mate Hat <CON+1 MEN+1> -->
+            90850  <!-- First Mate Hat <DEX+1 WIT+1> -->
+            90851  <!-- First Mate Hat <STR+1 INT+1> -->
+            90852  <!-- Artisan Goggles <STR+1 INT+1> -->
+            90853  <!-- Artisan Goggles <DEX+1 WIT+1> -->
+            90854  <!-- Artisan Goggles <CON+1 MEN+1> -->
         </items>
     </scroll>
 
@@ -912,11 +814,11 @@
     </scroll>
 
     <!-- Enchant Scroll Talisman of Power -->
-    <scroll id="93329">
-        <items>71080</items>
+    <scroll id="93329" max-enchant="10">
+        <items>91061</items>
     </scroll>
 
-    <!-- Spirit Varnish -->
+    <!-- Scroll: Enchant Spirit Accessory -->
     <scroll id="91187" max-enchant="10" group="9">
         <items>
             91117 <!-- Nebula Necklace -->
@@ -926,7 +828,7 @@
         </items>
     </scroll>
 
-    <!-- Blessed Spirit Varnish -->
+    <!-- Blessed Scroll: Enchant Spirit Accessory -->
     <scroll id="91188" max-enchant="10" group="9">
         <items>
             91117 <!-- Nebula Necklace -->
@@ -945,8 +847,17 @@
         </items>
     </scroll>
 
-    <!-- Balthus Knights Matte Varnish -->
-    <scroll id="90996" max-enchant="6">
+    <!-- Balthus Knights Shining Varnish -->
+    <scroll id="90997" max-enchant="10">
+        <items>
+            90993 <!-- Damaged Antharas' Earring -->
+            90994 <!-- Damaged Baium's Ring -->
+            91006 <!-- Damaged Zaken's Earring -->
+        </items>
+    </scroll>
+
+    <!-- Balthus Knights Glittering Varnish -->
+    <scroll id="90995" max-enchant="10">
         <items>
             90993 <!-- Damaged Antharas' Earring -->
             90994 <!-- Damaged Baium's Ring -->
@@ -977,78 +888,28 @@
     <!-- Stabilized Eva's Scroll: Enchant Hair Accessory -->
     <scroll id="70754" min-enchant="6" max-enchant="10" group="8">
         <items>
-            70687  <!-- Artisan Goggles <STR+1 INT+1> -->
-            70688  <!-- Artisan Goggles <DEX+1 WIT+1> -->
-            70689  <!-- Artisan Goggles <CON+1 MEN+1> -->
-            70690  <!-- Uniform Hat <STR+1 INT+1> -->
-            70691  <!-- Uniform Hat <DEX+1 WIT+1> -->
-            70692  <!-- Uniform Hat <CON+1 MEN+1> -->
-            70693  <!-- Assassin's Bamboo Hat <STR+1 INT+1> -->
-            70694  <!-- Assassin's Bamboo Hat <DEX+1 WIT+1> -->
-            70695  <!-- Assassin's Bamboo Hat <CON+1 MEN+1> -->
-            70696  <!-- Valkyrie Hat <STR+1 WIT+1> -->
-            70697  <!-- Valkyrie Hat <DEX+1 WIT+1> -->
-            70698  <!-- Valkyrie Hat <CON+1 MEN+1> -->
-            70699  <!-- Gatekeeper Hat <STR+1 INT+1> -->
-            70700  <!-- Gatekeeper Hat <DEX+1 WIT+1> -->
-            70701  <!-- Gatekeeper Hat <CON+1 MEN+1> -->
-            70702  <!-- Wedding Veil <STR+1 INT+1> -->
-            70703  <!-- Wedding Veil <DEX+1 WIT+1> -->
-            70704  <!-- Wedding Veil <CON+1 MEN+1> -->
-            70705  <!-- Maid Hair Accessory <STR+1 INT+1> -->
-            70706  <!-- Maid Hair Accessory <DEX+1 WIT+1> -->
-            70707  <!-- Maid Hair Accessory <CON+1 MEN+1> -->
-            70708  <!-- Refined Romantic Chapeau: Red <STR+1 INT+1> -->
-            70709  <!-- Refined Romantic Chapeau: Red <DEX+1 WIT+1> -->
-            70710  <!-- Refined Romantic Chapeau: Red <CON+1 MEN+1> -->
-            70711  <!-- Refined Angel Ring <STR+1 INT+1> -->
-            70712  <!-- Refined Angel Ring <DEX+1 WIT+1> -->
-            70713  <!-- Refined Angel Ring <CON+1 MEN+1> -->
-            70714  <!-- Refined Wizard Hat <STR+1 INT+1> -->
-            70715  <!-- Refined Wizard Hat <DEX+1 WIT+1> -->
-            70716  <!-- Refined Wizard Hat <CON+1 MEN+1> -->
-            70717  <!-- Laborer Hat <STR+1 INT+1> -->
-            70718  <!-- Laborer Hat <DEX+1 WIT+1> -->
-            70719  <!-- Laborer Hat <CON+1 MEN+1> -->
-            70720  <!-- Top Hat <STR+1 INT+1> -->
-            70721  <!-- Top Hat <DEX+1 WIT+1> -->
-            70722  <!-- Top Hat <CON+1 MEN+1> -->
-            70723  <!-- Vigilante Hat <STR+1 INT+1> -->
-            70724  <!-- Vigilante Hat <DEX+1 WIT+1> -->
-            70725  <!-- Vigilante Hat <CON+1 MEN+1> -->
-            70750  <!-- Afro Hair <STR+1 INT+1> -->
-            70751  <!-- Afro Hair <DEX+1 WIT+1> -->
-            70752  <!-- Afro Hair <CON+1 MEN+1> -->
-            70749  <!-- Chic Silver Chapeau <CON+1 MEN+1> -->
-            70748  <!-- Chic Silver Chapeau <DEX +1 WIT +1> -->
-            70747  <!-- Chic Silver Chapeau <STR+1 INT+1> -->
-            70734  <!-- First Mate Hat <CON+1 MEN+1> -->
-            70733  <!-- First Mate Hat <DEX+1 WIT+1> -->
-            70732  <!-- First Mate Hat <STR+1 INT+1> -->
-            70740  <!-- Gold-rimmed Glasses <CON+1 MEN+1> -->
-            70739  <!-- Gold-rimmed Glasses <DEX+1 WIT+1> -->
-            70738  <!-- Gold-rimmed Glasses <STR+1 INT+1> -->
-            70743  <!-- Horn-rimmed Glasses <CON+1 MEN+1> -->
-            70742  <!-- Horn-rimmed Glasses <DEX+1 WIT+1> -->
-            70741  <!-- Horn-rimmed Glasses <STR+1 INT+1> -->
-            70737  <!-- Refined Romantic Chapeau: Blue <CON+1 MEN+1> -->
-            70736  <!-- Refined Romantic Chapeau: Blue <DEX+1 WIT+1> -->
-            70735  <!-- Refined Romantic Chapeau: Blue <STR+1 INT+1> -->
-            70746  <!-- Stylish Straw Hat <CON+1 MEN+1> -->
-            70745  <!-- Stylish Straw Hat <DEX+1 WIT+1> -->
-            70744  <!-- Stylish Straw Hat <STR+1 INT+1> -->
-            70731  <!-- Warrior's Helmet <CON+1 MEN+1> -->
-            70730  <!-- Warrior's Helmet <DEX+1 WIT+1> -->
-            70729  <!-- Warrior's Helmet <STR+1 INT+1> -->
-            70728  <!-- White Uniform Hat <CON+1 MEN+1> -->
-            70727  <!-- White Uniform Hat <DEX+1 WIT+1> -->
-            70726  <!-- White Uniform Hat <STR+1 INT+1> -->
+            13519  <!-- Black Mask <STR+1 INT+1> -->
+            49521  <!-- Refined Romantic Chapeau <STR+1 INT+1> -->
+            49522  <!-- Pirate King Hat <STR+1 INT+1> -->
+            49687  <!-- Refined Romantic Chapeau <STR+1 INT+1> -->
+            90837  <!-- White Uniform Hat <CON+1 MEN+1> -->
+            90838  <!-- White Uniform Hat <DEX+1 WIT+1> -->
+            90839  <!-- White Uniform Hat <STR+1 INT+1> -->
             90840  <!-- Napoleon Hat <STR+1 INT+1> -->
             90841  <!-- Napoleon Hat <DEX+1 WIT+1> -->
             90842  <!-- Napoleon Hat <CON+1 MEN+1> -->
             90843  <!-- Ninja Hair Accessory <STR+1 INT+1> -->
             90844  <!-- Ninja Hair Accessory <DEX+1 WIT+1> -->
             90845  <!-- Ninja Hair Accessory <CON+1 MEN+1> -->
+            90846  <!-- Warrior's Helmet <CON+1 MEN+1> -->
+            90847  <!-- Warrior's Helmet <DEX+1 WIT+1> -->
+            90848  <!-- Warrior's Helmet <STR+1 INT+1> -->
+            90849  <!-- First Mate Hat <CON+1 MEN+1> -->
+            90850  <!-- First Mate Hat <DEX+1 WIT+1> -->
+            90851  <!-- First Mate Hat <STR+1 INT+1> -->
+            90852  <!-- Artisan Goggles <STR+1 INT+1> -->
+            90853  <!-- Artisan Goggles <DEX+1 WIT+1> -->
+            90854  <!-- Artisan Goggles <CON+1 MEN+1> -->
         </items>
     </scroll>
 
@@ -1088,102 +949,23 @@
         </items>
     </scroll>
 
-    <!-- Scroll: Enchant Cloak -->
-    <scroll id="70885" max-enchant="10" safe-fail-step="1" group="15">
-        <items>
-            70877 <!-- Elmoreden Cloak -->
-            70878 <!-- Aden Cloak -->
-            70879 <!-- Elmore Cloak -->
-            70880 <!-- Ferios Cloak -->
-            70881 <!-- Elmoreden Cloak - Legendary -->
-            70882 <!-- Aden Cloak - Legendary -->
-            70883 <!-- Elmore Cloak - Legendary -->
-            70884 <!-- Ferios Cloak - Legendary -->
-        </items>
-    </scroll>
-
-    <!-- Scroll: Enchant Cloak - Legendary -->
-    <scroll id="70886" min-enchant="10" max-enchant="20" safe-fail-step="1" group="15">
-        <items>
-            70877 <!-- Elmoreden Cloak -->
-            70878 <!-- Aden Cloak -->
-            70879 <!-- Elmore Cloak -->
-            70880 <!-- Ferios Cloak -->
-            70881 <!-- Elmoreden Cloak - Legendary -->
-            70882 <!-- Aden Cloak - Legendary -->
-            70883 <!-- Elmore Cloak - Legendary -->
-            70884 <!-- Ferios Cloak - Legendary -->
-        </items>
-    </scroll>
-
-    <!-- Scroll: Ancient Cloak - Legendary -->
-    <scroll id="70887" min-enchant="7" max-enchant="20" chance-percent-bonus="10" safe-fail-step="1" group="15">
-        <items>
-            70877 <!-- Elmoreden Cloak -->
-            70878 <!-- Aden Cloak -->
-            70879 <!-- Elmore Cloak -->
-            70880 <!-- Ferios Cloak -->
-            70881 <!-- Elmoreden Cloak - Legendary -->
-            70882 <!-- Aden Cloak - Legendary -->
-            70883 <!-- Elmore Cloak - Legendary -->
-            70884 <!-- Ferios Cloak - Legendary -->
-        </items>
-    </scroll>
-
-    <!-- Stable Cloak Enchantment Scroll - Legendary -->
-    <scroll id="70906" min-enchant="10" max-enchant="15" group="15">
-        <items>
-            70877 <!-- Elmoreden Cloak -->
-            70878 <!-- Aden Cloak -->
-            70879 <!-- Elmore Cloak -->
-            70880 <!-- Ferios Cloak -->
-            70881 <!-- Elmoreden Cloak - Legendary -->
-            70882 <!-- Aden Cloak - Legendary -->
-            70883 <!-- Elmore Cloak - Legendary -->
-            70884 <!-- Ferios Cloak - Legendary -->
-        </items>
-    </scroll>
-
-    <!-- Advanced Stable Scroll Enchant Cloak -->
-    <scroll id="71981" min-enchant="15" max-enchant="18" group="15">
-        <items>
-            70877 <!-- Elmoreden Cloak -->
-            70878 <!-- Aden Cloak -->
-            70879 <!-- Elmore Cloak -->
-            70880 <!-- Ferios Cloak -->
-            70881 <!-- Elmoreden Cloak - Legendary -->
-            70882 <!-- Aden Cloak - Legendary -->
-            70883 <!-- Elmore Cloak - Legendary -->
-            70884 <!-- Ferios Cloak - Legendary -->
-        </items>
-    </scroll>
-
-
     <!-- Dragon Varnish -->
     <scroll id="91249" max-enchant="5" group="17">
         <items>
-            71691 <!-- Dragon Pedant - Attack Type Lv. 1 -->
-            71692 <!-- Dragon Pedant - Attack Type Lv. 2 -->
-            71693 <!-- Dragon Pedant - Attack Type Lv. 3 -->
-            71694 <!-- Dragon Pedant - Attack Type Lv. 4 -->
-            71695 <!-- Dragon Pedant - Magic Type Lv. 1 -->
-            71696 <!-- Dragon Pedant - Magic Type Lv. 2 -->
-            71697 <!-- Dragon Pedant - Magic Type Lv. 3 -->
-            71698 <!-- Dragon Pedant - Magic Type Lv. 4 -->
+            91244 <!-- Dragon Pendant Lv. 1 -->
+            91245 <!-- Dragon Pendant Lv. 2 -->
+            91246 <!-- Dragon Pendant Lv. 3 -->
+            91247 <!-- Dragon Pendant Lv. 4 -->
         </items>
     </scroll>
 
     <!-- Brilliant Dragon Varnish -->
-    <scroll id="91250" max-enchant="5">
+    <scroll id="91250" max-enchant="5" group="17">
         <items>
-            71691 <!-- Dragon Pedant - Attack Type Lv. 1 -->
-            71692 <!-- Dragon Pedant - Attack Type Lv. 2 -->
-            71693 <!-- Dragon Pedant - Attack Type Lv. 3 -->
-            71694 <!-- Dragon Pedant - Attack Type Lv. 4 -->
-            71695 <!-- Dragon Pedant - Magic Type Lv. 1 -->
-            71696 <!-- Dragon Pedant - Magic Type Lv. 2 -->
-            71697 <!-- Dragon Pedant - Magic Type Lv. 3 -->
-            71698 <!-- Dragon Pedant - Magic Type Lv. 4 -->
+            91244 <!-- Dragon Pendant Lv. 1 -->
+            91245 <!-- Dragon Pendant Lv. 2 -->
+            91246 <!-- Dragon Pendant Lv. 3 -->
+            91247 <!-- Dragon Pendant Lv. 4 -->
         </items>
     </scroll>
 
@@ -1248,172 +1030,70 @@
     <!-- Matte Pendant Varnish -->
     <scroll id="90137" max-enchant="6">
         <items>
-            29704 29705 29706 29707 29708 29709 29710 29711 29712 29713 29714 29715 29716
-            29717 29718 29719 29720 29721 29722 29723 49467 49468 71701 71702 71703 71704
+            49467 49468
         </items>
     </scroll>
 
-    <!-- Pendant Glittering Varnish -->
+    <!-- Glittering Pendant Varnish -->
     <scroll id="90138" max-enchant="9">
         <items>
-            29704 29705 29706 29707 29708 29709 29710 29711 29712 29713 29714 29715 29716
-            29717 29718 29719 29720 29721 29722 29723 49467 49468 71701 71702 71703 71704
+            49467 49468
         </items>
     </scroll>
 
     <!-- Stabilized Eva's Scroll Enchant Hair Accessory -->
     <scroll id="90855" max-enchant="9" group="8">
         <items>
-            70687  <!-- Artisan Goggles <STR+1 INT+1> -->
-            70688  <!-- Artisan Goggles <DEX+1 WIT+1> -->
-            70689  <!-- Artisan Goggles <CON+1 MEN+1> -->
-            70690  <!-- Uniform Hat <STR+1 INT+1> -->
-            70691  <!-- Uniform Hat <DEX+1 WIT+1> -->
-            70692  <!-- Uniform Hat <CON+1 MEN+1> -->
-            70693  <!-- Assassin's Bamboo Hat <STR+1 INT+1> -->
-            70694  <!-- Assassin's Bamboo Hat <DEX+1 WIT+1> -->
-            70695  <!-- Assassin's Bamboo Hat <CON+1 MEN+1> -->
-            70696  <!-- Valkyrie Hat <STR+1 WIT+1> -->
-            70697  <!-- Valkyrie Hat <DEX+1 WIT+1> -->
-            70698  <!-- Valkyrie Hat <CON+1 MEN+1> -->
-            70699  <!-- Gatekeeper Hat <STR+1 INT+1> -->
-            70700  <!-- Gatekeeper Hat <DEX+1 WIT+1> -->
-            70701  <!-- Gatekeeper Hat <CON+1 MEN+1> -->
-            70702  <!-- Wedding Veil <STR+1 INT+1> -->
-            70703  <!-- Wedding Veil <DEX+1 WIT+1> -->
-            70704  <!-- Wedding Veil <CON+1 MEN+1> -->
-            70705  <!-- Maid Hair Accessory <STR+1 INT+1> -->
-            70706  <!-- Maid Hair Accessory <DEX+1 WIT+1> -->
-            70707  <!-- Maid Hair Accessory <CON+1 MEN+1> -->
-            70708  <!-- Refined Romantic Chapeau: Red <STR+1 INT+1> -->
-            70709  <!-- Refined Romantic Chapeau: Red <DEX+1 WIT+1> -->
-            70710  <!-- Refined Romantic Chapeau: Red <CON+1 MEN+1> -->
-            70711  <!-- Refined Angel Ring <STR+1 INT+1> -->
-            70712  <!-- Refined Angel Ring <DEX+1 WIT+1> -->
-            70713  <!-- Refined Angel Ring <CON+1 MEN+1> -->
-            70714  <!-- Refined Wizard Hat <STR+1 INT+1> -->
-            70715  <!-- Refined Wizard Hat <DEX+1 WIT+1> -->
-            70716  <!-- Refined Wizard Hat <CON+1 MEN+1> -->
-            70717  <!-- Laborer Hat <STR+1 INT+1> -->
-            70718  <!-- Laborer Hat <DEX+1 WIT+1> -->
-            70719  <!-- Laborer Hat <CON+1 MEN+1> -->
-            70720  <!-- Top Hat <STR+1 INT+1> -->
-            70721  <!-- Top Hat <DEX+1 WIT+1> -->
-            70722  <!-- Top Hat <CON+1 MEN+1> -->
-            70723  <!-- Vigilante Hat <STR+1 INT+1> -->
-            70724  <!-- Vigilante Hat <DEX+1 WIT+1> -->
-            70725  <!-- Vigilante Hat <CON+1 MEN+1> -->
-            70750  <!-- Afro Hair <STR+1 INT+1> -->
-            70751  <!-- Afro Hair <DEX+1 WIT+1> -->
-            70752  <!-- Afro Hair <CON+1 MEN+1> -->
-            70749  <!-- Chic Silver Chapeau <CON+1 MEN+1> -->
-            70748  <!-- Chic Silver Chapeau <DEX +1 WIT +1> -->
-            70747  <!-- Chic Silver Chapeau <STR+1 INT+1> -->
-            70734  <!-- First Mate Hat <CON+1 MEN+1> -->
-            70733  <!-- First Mate Hat <DEX+1 WIT+1> -->
-            70732  <!-- First Mate Hat <STR+1 INT+1> -->
-            70740  <!-- Gold-rimmed Glasses <CON+1 MEN+1> -->
-            70739  <!-- Gold-rimmed Glasses <DEX+1 WIT+1> -->
-            70738  <!-- Gold-rimmed Glasses <STR+1 INT+1> -->
-            70743  <!-- Horn-rimmed Glasses <CON+1 MEN+1> -->
-            70742  <!-- Horn-rimmed Glasses <DEX+1 WIT+1> -->
-            70741  <!-- Horn-rimmed Glasses <STR+1 INT+1> -->
-            70737  <!-- Refined Romantic Chapeau: Blue <CON+1 MEN+1> -->
-            70736  <!-- Refined Romantic Chapeau: Blue <DEX+1 WIT+1> -->
-            70735  <!-- Refined Romantic Chapeau: Blue <STR+1 INT+1> -->
-            70746  <!-- Stylish Straw Hat <CON+1 MEN+1> -->
-            70745  <!-- Stylish Straw Hat <DEX+1 WIT+1> -->
-            70744  <!-- Stylish Straw Hat <STR+1 INT+1> -->
-            70731  <!-- Warrior's Helmet <CON+1 MEN+1> -->
-            70730  <!-- Warrior's Helmet <DEX+1 WIT+1> -->
-            70729  <!-- Warrior's Helmet <STR+1 INT+1> -->
-            70728  <!-- White Uniform Hat <CON+1 MEN+1> -->
-            70727  <!-- White Uniform Hat <DEX+1 WIT+1> -->
-            70726  <!-- White Uniform Hat <STR+1 INT+1> -->
+            13519  <!-- Black Mask <STR+1 INT+1> -->
+            49521  <!-- Refined Romantic Chapeau <STR+1 INT+1> -->
+            49522  <!-- Pirate King Hat <STR+1 INT+1> -->
+            49687  <!-- Refined Romantic Chapeau <STR+1 INT+1> -->
+            90837  <!-- White Uniform Hat <CON+1 MEN+1> -->
+            90838  <!-- White Uniform Hat <DEX+1 WIT+1> -->
+            90839  <!-- White Uniform Hat <STR+1 INT+1> -->
             90840  <!-- Napoleon Hat <STR+1 INT+1> -->
             90841  <!-- Napoleon Hat <DEX+1 WIT+1> -->
             90842  <!-- Napoleon Hat <CON+1 MEN+1> -->
             90843  <!-- Ninja Hair Accessory <STR+1 INT+1> -->
             90844  <!-- Ninja Hair Accessory <DEX+1 WIT+1> -->
             90845  <!-- Ninja Hair Accessory <CON+1 MEN+1> -->
+            90846  <!-- Warrior's Helmet <CON+1 MEN+1> -->
+            90847  <!-- Warrior's Helmet <DEX+1 WIT+1> -->
+            90848  <!-- Warrior's Helmet <STR+1 INT+1> -->
+            90849  <!-- First Mate Hat <CON+1 MEN+1> -->
+            90850  <!-- First Mate Hat <DEX+1 WIT+1> -->
+            90851  <!-- First Mate Hat <STR+1 INT+1> -->
+            90852  <!-- Artisan Goggles <STR+1 INT+1> -->
+            90853  <!-- Artisan Goggles <DEX+1 WIT+1> -->
+            90854  <!-- Artisan Goggles <CON+1 MEN+1> -->
         </items>
     </scroll>
 
     <!-- Stable Eva's Enhancement Scroll Hair Accessories -->
     <scroll id="90882" min-enchant="6" max-enchant="10" group="8">
         <items>
-            70687  <!-- Artisan Goggles <STR+1 INT+1> -->
-            70688  <!-- Artisan Goggles <DEX+1 WIT+1> -->
-            70689  <!-- Artisan Goggles <CON+1 MEN+1> -->
-            70690  <!-- Uniform Hat <STR+1 INT+1> -->
-            70691  <!-- Uniform Hat <DEX+1 WIT+1> -->
-            70692  <!-- Uniform Hat <CON+1 MEN+1> -->
-            70693  <!-- Assassin's Bamboo Hat <STR+1 INT+1> -->
-            70694  <!-- Assassin's Bamboo Hat <DEX+1 WIT+1> -->
-            70695  <!-- Assassin's Bamboo Hat <CON+1 MEN+1> -->
-            70696  <!-- Valkyrie Hat <STR+1 WIT+1> -->
-            70697  <!-- Valkyrie Hat <DEX+1 WIT+1> -->
-            70698  <!-- Valkyrie Hat <CON+1 MEN+1> -->
-            70699  <!-- Gatekeeper Hat <STR+1 INT+1> -->
-            70700  <!-- Gatekeeper Hat <DEX+1 WIT+1> -->
-            70701  <!-- Gatekeeper Hat <CON+1 MEN+1> -->
-            70702  <!-- Wedding Veil <STR+1 INT+1> -->
-            70703  <!-- Wedding Veil <DEX+1 WIT+1> -->
-            70704  <!-- Wedding Veil <CON+1 MEN+1> -->
-            70705  <!-- Maid Hair Accessory <STR+1 INT+1> -->
-            70706  <!-- Maid Hair Accessory <DEX+1 WIT+1> -->
-            70707  <!-- Maid Hair Accessory <CON+1 MEN+1> -->
-            70708  <!-- Refined Romantic Chapeau: Red <STR+1 INT+1> -->
-            70709  <!-- Refined Romantic Chapeau: Red <DEX+1 WIT+1> -->
-            70710  <!-- Refined Romantic Chapeau: Red <CON+1 MEN+1> -->
-            70711  <!-- Refined Angel Ring <STR+1 INT+1> -->
-            70712  <!-- Refined Angel Ring <DEX+1 WIT+1> -->
-            70713  <!-- Refined Angel Ring <CON+1 MEN+1> -->
-            70714  <!-- Refined Wizard Hat <STR+1 INT+1> -->
-            70715  <!-- Refined Wizard Hat <DEX+1 WIT+1> -->
-            70716  <!-- Refined Wizard Hat <CON+1 MEN+1> -->
-            70717  <!-- Laborer Hat <STR+1 INT+1> -->
-            70718  <!-- Laborer Hat <DEX+1 WIT+1> -->
-            70719  <!-- Laborer Hat <CON+1 MEN+1> -->
-            70720  <!-- Top Hat <STR+1 INT+1> -->
-            70721  <!-- Top Hat <DEX+1 WIT+1> -->
-            70722  <!-- Top Hat <CON+1 MEN+1> -->
-            70723  <!-- Vigilante Hat <STR+1 INT+1> -->
-            70724  <!-- Vigilante Hat <DEX+1 WIT+1> -->
-            70725  <!-- Vigilante Hat <CON+1 MEN+1> -->
-            70750  <!-- Afro Hair <STR+1 INT+1> -->
-            70751  <!-- Afro Hair <DEX+1 WIT+1> -->
-            70752  <!-- Afro Hair <CON+1 MEN+1> -->
-            70749  <!-- Chic Silver Chapeau <CON+1 MEN+1> -->
-            70748  <!-- Chic Silver Chapeau <DEX +1 WIT +1> -->
-            70747  <!-- Chic Silver Chapeau <STR+1 INT+1> -->
-            70734  <!-- First Mate Hat <CON+1 MEN+1> -->
-            70733  <!-- First Mate Hat <DEX+1 WIT+1> -->
-            70732  <!-- First Mate Hat <STR+1 INT+1> -->
-            70740  <!-- Gold-rimmed Glasses <CON+1 MEN+1> -->
-            70739  <!-- Gold-rimmed Glasses <DEX+1 WIT+1> -->
-            70738  <!-- Gold-rimmed Glasses <STR+1 INT+1> -->
-            70743  <!-- Horn-rimmed Glasses <CON+1 MEN+1> -->
-            70742  <!-- Horn-rimmed Glasses <DEX+1 WIT+1> -->
-            70741  <!-- Horn-rimmed Glasses <STR+1 INT+1> -->
-            70737  <!-- Refined Romantic Chapeau: Blue <CON+1 MEN+1> -->
-            70736  <!-- Refined Romantic Chapeau: Blue <DEX+1 WIT+1> -->
-            70735  <!-- Refined Romantic Chapeau: Blue <STR+1 INT+1> -->
-            70746  <!-- Stylish Straw Hat <CON+1 MEN+1> -->
-            70745  <!-- Stylish Straw Hat <DEX+1 WIT+1> -->
-            70744  <!-- Stylish Straw Hat <STR+1 INT+1> -->
-            70731  <!-- Warrior's Helmet <CON+1 MEN+1> -->
-            70730  <!-- Warrior's Helmet <DEX+1 WIT+1> -->
-            70729  <!-- Warrior's Helmet <STR+1 INT+1> -->
-            70728  <!-- White Uniform Hat <CON+1 MEN+1> -->
-            70727  <!-- White Uniform Hat <DEX+1 WIT+1> -->
-            70726  <!-- White Uniform Hat <STR+1 INT+1> -->
+            13519  <!-- Black Mask <STR+1 INT+1> -->
+            49521  <!-- Refined Romantic Chapeau <STR+1 INT+1> -->
+            49522  <!-- Pirate King Hat <STR+1 INT+1> -->
+            49687  <!-- Refined Romantic Chapeau <STR+1 INT+1> -->
+            90837  <!-- White Uniform Hat <CON+1 MEN+1> -->
+            90838  <!-- White Uniform Hat <DEX+1 WIT+1> -->
+            90839  <!-- White Uniform Hat <STR+1 INT+1> -->
             90840  <!-- Napoleon Hat <STR+1 INT+1> -->
             90841  <!-- Napoleon Hat <DEX+1 WIT+1> -->
             90842  <!-- Napoleon Hat <CON+1 MEN+1> -->
             90843  <!-- Ninja Hair Accessory <STR+1 INT+1> -->
             90844  <!-- Ninja Hair Accessory <DEX+1 WIT+1> -->
             90845  <!-- Ninja Hair Accessory <CON+1 MEN+1> -->
+            90846  <!-- Warrior's Helmet <CON+1 MEN+1> -->
+            90847  <!-- Warrior's Helmet <DEX+1 WIT+1> -->
+            90848  <!-- Warrior's Helmet <STR+1 INT+1> -->
+            90849  <!-- First Mate Hat <CON+1 MEN+1> -->
+            90850  <!-- First Mate Hat <DEX+1 WIT+1> -->
+            90851  <!-- First Mate Hat <STR+1 INT+1> -->
+            90852  <!-- Artisan Goggles <STR+1 INT+1> -->
+            90853  <!-- Artisan Goggles <DEX+1 WIT+1> -->
+            90854  <!-- Artisan Goggles <CON+1 MEN+1> -->
         </items>
     </scroll>
 
@@ -1426,5 +1106,4 @@
     <scroll id="71211" max-enchant="7" group="16">
         <items>71184 71185 71186 71187 71188 71189 71190 71191 71192 71193 71194 71195 71196 71197 71198 71199 71200 71201 71202 71203 71204 71205 71206 71207 71208 71209 71210</items>
     </scroll>
-
-</enchantment>
+ </enchantment>

--- a/data/extension/events/ChefMonkeyEvent/config.xml
+++ b/data/extension/events/ChefMonkeyEvent/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <event xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../../xsd/eventConfig.xsd"
-	   name="Chef Monkey Event" start-date="2020-10-05" end-date="2023-10-25"
+	   name="Chef Monkey Event" start-date="2018-10-05" end-date="2019-10-25"
 	   end-message="Chef Monkey Event ends!"
 	   start-message="Chef Monkey Event active!">
 

--- a/data/extension/events/L2Coins/config.xml
+++ b/data/extension/events/L2Coins/config.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<event xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../../xsd/eventConfig.xsd"
+       name="L2 Coins" start-date="2020-10-05" end-date="2029-10-25"
+       start-message="L2 Coins for all!"
+       end-message="Event is over" >
+    <drop>
+        <item id="91663" min="1" max="2" chance="65" min-level="1" max-level="20"/> <!-- LCoin -->
+        <item id="91663" min="3" max="4" chance="60" min-level="21" max-level="40"/> <!-- LCoin -->
+        <item id="91663" min="5" max="10" chance="55" min-level="41" max-level="75"/> <!-- LCoin -->
+        <item id="91663" min="7" max="14" chance="50" min-level="76" max-level="85"/> <!-- LCoin -->
+        <item id="91663" min="9" max="18" chance="48" min-level="86" max-level="89"/> <!-- LCoin -->
+        <item id="91663" min="11" max="22" chance="46" min-level="90" max-level="94"/> <!-- LCoin -->
+        <item id="91663" min="13" max="26" chance="44" min-level="95" max-level="100"/> <!-- LCoin -->
+        <item id="91663" min="15" max="30" chance="42" min-level="101" max-level="104"/> <!-- LCoin -->
+        <item id="91663" min="17" max="34" chance="40" min-level="105" max-level="106"/> <!-- LCoin -->
+    </drop>
+</event>

--- a/data/level-data.xml
+++ b/data/level-data.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org xsd/level-data.xsd"
-      max-level="90">
+      max-level="106">
     <level-data level="1" experience="0" xp-percent-lost="10.0"/>
     <level-data level="2" experience="68" xp-percent-lost="9.875"/>
     <level-data level="3" experience="363" xp-percent-lost="9.75"/>
@@ -91,5 +91,21 @@
     <level-data level="88" experience="22982942552790" characteristic-points="13" />
     <level-data level="89" experience="35581233716425" characteristic-points="14" />
     <level-data level="90" experience="50699183112788" characteristic-points="15" />
-    <level-data level="91" experience="80935183110000" />
+    <level-data level="91" experience="60839019735345" characteristic-points="16" />
+    <level-data level="92" experience="73006823682414" characteristic-points="17" />
+    <level-data level="93" experience="87608188418897" characteristic-points="18" />
+    <level-data level="94" experience="105129826102677" characteristic-points="19" />
+    <level-data level="95" experience="126155791323212" characteristic-points="20" />
+    <level-data level="96" experience="420519304410708" />
+    <level-data level="97" experience="504623165292849"/>
+    <level-data level="98" experience="605547798351419"/>
+    <level-data level="99" experience="726657358021703"/>
+    <level-data level="100" experience="2906629432086814"/>
+    <level-data level="101" experience="3487955318504176"/>
+    <level-data level="102" experience="4185546382205012"/>
+    <level-data level="103" experience="5022655658646014"/>
+    <level-data level="104" experience="6027186790375217"/>
+    <level-data level="105" experience="7232624148450260"/>
+    <level-data level="106" experience="8679148978140312"/>
+    <level-data level="107" experience="8679148978140312"/>
 </list>

--- a/data/skillTrees/1stClass/Artisan.xml
+++ b/data/skillTrees/1stClass/Artisan.xml
@@ -1,107 +1,153 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="56" parentClassId="53">
-		<skill name="Shock Attack" id="100" level="1" required-level="20" sp="1000" />
-		<skill name="Shock Attack" id="100" level="2" required-level="20" sp="1000" />
-		<skill name="Shock Attack" id="100" level="3" required-level="20" sp="1000" />
+
+		<!-- Master Buffs Lv.20 -->
+		<skill name="Maphr's Shield" id="45120" level="2" required-level="20" sp="1000" />
+		<skill name="Maphr's Might" id="45119" level="2" required-level="20" sp="1000" />
+		<skill name="Maphr's Acumen" id="45130" level="1" required-level="20" sp="1000" />
+		<skill name="Maphr's Empower" id="45131" level="1" required-level="20" sp="1000" />
+		<skill name="Maphr's Focus" id="45114" level="1" required-level="20" sp="1000" />
+		<skill name="Maphr's Death Whisper" id="45115" level="1" required-level="20" sp="1000" />
+		<skill name="Maphr's Wind Walk" id="45117" level="1" required-level="20" sp="1000" />
+		<skill name="Maphr's Haste" id="45116" level="1" required-level="20" sp="1000" />
+		<skill name="Maphr's Clarity" id="45134" level="1" required-level="20" sp="1000" />
+		<skill name="Recover HP" id="45176" level="1" required-level="20" sp="1000" />
+		<skill name="Recover MP" id="45177" level="1" required-level="20" sp="1000" />
+
+		<!-- Skills Lv20 -->
+		<skill name="Power Strike" id="3" level="10" required-level="20" sp="1000" />
+		<skill name="Power Strike" id="3" level="11" required-level="20" sp="1000" />
+		<skill name="Power Strike" id="3" level="12" required-level="20" sp="1000" />
+		<skill name="Bandage" id="34" level="1" required-level="20" sp="1000" />
+		<skill name="Ability to Protect" id="91" level="2" required-level="20" sp="1000" />
+		<skill name="Shock Mastery" id="100" level="1" required-level="20" sp="1000" />
+		<skill name="Shock Mastery" id="100" level="2" required-level="20" sp="1000" />
+		<skill name="Shock Mastery" id="100" level="3" required-level="20" sp="1000" />
+		<skill name="Shock Mastery" id="100" level="4" required-level="20" sp="1000" />
+		<skill name="Shock Mastery" id="100" level="5" required-level="20" sp="1000" />
+		<skill name="Create Item" id="172" level="2" required-level="20" sp="1000" />
+		<skill name="Boost HP" id="211" level="1" required-level="20" sp="1000" />
+		<skill name="Dwarven Weapon Mastery" id="47235" level="1" required-level="20"  />
+		<skill name="Dwarven Armor Mastery" id="47236" level="1" required-level="20"  />
 		<skill name="Polearm Mastery" id="216" level="1" required-level="20" sp="1000" />
-		<skill name="Light Armor Mastery" id="227" level="1" required-level="20" sp="1000" />
-		<skill name="Light Armor Mastery" id="227" level="2" required-level="20" sp="1000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="1" required-level="20" sp="1000" />
-		<skill name="Heavy Armor Mastery" id="231" level="1" required-level="20" sp="1000" />
-		<skill name="Heavy Armor Mastery" id="231" level="2" required-level="20" sp="1000" />
 		<skill name="Wild Sweep" id="245" level="1" required-level="20" sp="1000" />
 		<skill name="Wild Sweep" id="245" level="2" required-level="20" sp="1000" />
 		<skill name="Wild Sweep" id="245" level="3" required-level="20" sp="1000" />
 		<skill name="Crystallize" id="248" level="1" required-level="20" sp="1000" />
-		<skill name="Bandage" id="34" level="1" required-level="20" sp="1000" />
-		<skill name="Create Item" id="172" level="2" required-level="20" sp="1000" />
-		<skill name="Boost HP" id="211" level="1" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="1" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="2" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="3" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="4" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="5" required-level="20" sp="1000" />
+		<skill name="Emergency Rescue" id="70" level="3" required-level="20" sp="1000" />
 
-		<skill name="Shock Attack" id="100" level="4" required-level="22" sp="2800" />
-		<skill name="Light Armor Mastery" id="227" level="3" required-level="22" sp="2800" />
-		<skill name="Heavy Armor Mastery" id="231" level="3" required-level="22" sp="2800" />
+
+		<!-- Skills Lv21 -->
+		<skill name="Shock Mastery" id="100" level="6" required-level="21" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="6" required-level="21" sp="1000" />
+
+		<!-- Skills Lv22 -->
+		<skill name="Power Strike" id="3" level="13" required-level="22" sp="2800" />
+		<skill name="Shock Mastery" id="100" level="7" required-level="22" sp="2800" />
 		<skill name="Wild Sweep" id="245" level="4" required-level="22" sp="2800" />
-		
-		<skill name="Shock Attack" id="100" level="5" required-level="23" sp="2800" />
+		<skill name="Enhanced Weapon" id="255" level="7" required-level="22" sp="2800" />
+
+		<!-- Skills Lv23 -->
+		<skill name="Power Strike" id="3" level="14" required-level="23" sp="2800" />
+		<skill name="Shock Mastery" id="100" level="8" required-level="23" sp="2800" />
 		<skill name="Wild Sweep" id="245" level="5" required-level="23" sp="2800" />
-		
-		<skill name="Shock Attack" id="100" level="6" required-level="24" sp="2800" />
-		<skill name="Fast HP Recovery" id="212" level="1" required-level="24" sp="2800" />
-		<skill name="Polearm Mastery" id="216" level="2" required-level="24" sp="2800" />
-		<skill name="Light Armor Mastery" id="227" level="4" required-level="24" sp="2800" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="2" required-level="24" sp="2800" />
-		<skill name="Heavy Armor Mastery" id="231" level="4" required-level="24" sp="2800" />
-		<skill name="Wild Sweep" id="245" level="6" required-level="24" sp="2800" />
-		<skill name="Vital Force" id="148" level="1" required-level="24" sp="2800" />
+		<skill name="Enhanced Weapon" id="255" level="8" required-level="23" sp="2800" />
+
+		<!-- Skills Lv24 -->
+		<skill name="Power Strike" id="3" level="15" required-level="24" sp="2800" />
+		<skill name="Shock Mastery" id="100" level="9" required-level="24" sp="2800" />
 		<skill name="Weight Limit" id="150" level="2" required-level="24" sp="2800" />
-		
-		<skill name="Shock Attack" id="100" level="7" required-level="26" sp="5700" />
-		<skill name="Polearm Mastery" id="216" level="3" required-level="26" sp="5700" />
-		<skill name="Light Armor Mastery" id="227" level="5" required-level="26" sp="5700" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="3" required-level="26" sp="5700" />
-		<skill name="Heavy Armor Mastery" id="231" level="5" required-level="26" sp="5700" />
+		<skill name="Wild Sweep" id="245" level="6" required-level="24" sp="2800" />
+		<skill name="Enhanced Weapon" id="255" level="9" required-level="24" sp="2800" />
+		<skill name="Fast HP Recovery" id="212" level="1" required-level="24" sp="2800" />
+
+		<!-- Skills Lv25 -->
+		<skill name="Ability to Attack" id="77" level="2" required-level="25" sp="2800" />
+		<skill name="Shock Mastery" id="100" level="10" required-level="25" sp="2800" />
+		<skill name="Enhanced Weapon" id="255" level="10" required-level="25" sp="2800" />
+		<skill name="Emergency Rescue" id="70" level="4" required-level="25" sp="2800" />
+
+
+		<!-- Skills Lv26 -->
+		<skill name="Power Strike" id="3" level="16" required-level="26" sp="5700" />
+		<skill name="Shock Mastery" id="100" level="11" required-level="26" sp="5700" />
 		<skill name="Wild Sweep" id="245" level="7" required-level="26" sp="5700" />
-		
-		<skill name="Shock Attack" id="100" level="8" required-level="27" sp="5700" />
-		<skill name="Light Armor Mastery" id="227" level="6" required-level="27" sp="5700" />
-		<skill name="Heavy Armor Mastery" id="231" level="6" required-level="27" sp="5700" />
+		<skill name="Enhanced Weapon" id="255" level="11" required-level="26" sp="5700" />
+
+		<!-- Skills Lv27 -->
+		<skill name="Power Strike" id="3" level="17" required-level="27" sp="5700" />
+		<skill name="Shock Mastery" id="100" level="12" required-level="27" sp="5700" />
 		<skill name="Wild Sweep" id="245" level="8" required-level="27" sp="5700" />
-		
-		<skill name="Shock Attack" id="100" level="9" required-level="28" sp="5700" />
-		<skill name="Polearm Mastery" id="216" level="4" required-level="28" sp="5700" />
-		<skill name="Light Armor Mastery" id="227" level="7" required-level="28" sp="5700" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="4" required-level="28" sp="5700" />
-		<skill name="Heavy Armor Mastery" id="231" level="7" required-level="28" sp="5700" />
-		<skill name="Wild Sweep" id="245" level="9" required-level="28" sp="5700" />
+		<skill name="Enhanced Weapon" id="255" level="12" required-level="27" sp="5700" />
+
+		<!-- Skills Lv28 -->
+		<skill name="Power Strike" id="3" level="18" required-level="28" sp="5700" />
+		<skill name="Summon Mechanic Golem" id="25" level="1" required-level="28" sp="5700" />
+		<skill name="Shock Mastery" id="100" level="13" required-level="28" sp="5700" />
 		<skill name="Create Item" id="172" level="3" required-level="28" sp="5700" />
 		<skill name="Boost HP" id="211" level="2" required-level="28" sp="5700" />
-		<skill name="Summon Mechanic Golem" id="25" level="1" required-level="28" sp="5700">
-			<item id="3038"/>
-		</skill>
+		<skill name="Wild Sweep" id="245" level="9" required-level="28" sp="5700" />
+		<skill name="Enhanced Weapon" id="255" level="13" required-level="28" sp="5700" />
 
-		<skill name="Shock Attack" id="100" level="10" required-level="30" sp="11000" />
-		<skill name="Polearm Mastery" id="216" level="5" required-level="30" sp="11000" />
-		<skill name="Light Armor Mastery" id="227" level="8" required-level="30" sp="11000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="5" required-level="30" sp="11000" />
-		<skill name="Heavy Armor Mastery" id="231" level="8" required-level="30" sp="11000" />
+
+		<!-- Skills Lv29 -->
+		<skill name="Shock Mastery" id="100" level="14" required-level="29" sp="11000" />
+		<skill name="Enhanced Weapon" id="255" level="14" required-level="29" sp="11000" />
+
+		<!-- Master Buffs Lv. 30 -->
+		<skill name="Maphr's Empower" id="45131" level="2" required-level="30" sp="11000" />
+		<skill name="Maphr's Wild Magic" id="45132" level="1" required-level="30" sp="11000" />
+		<skill name="Maphr's Berserker Spirit" id="45133" level="1" required-level="30" sp="11000" />
+		<skill name="Maphr's Wind Walk" id="45117" level="2" required-level="30" sp="11000" />
+		<skill name="Maphr's Magic Barrier" id="45118" level="1" required-level="30" sp="11000" />
+		<skill name="Maphr's Acumen" id="45130" level="2" required-level="30" sp="11000" />
+		<skill name="Maphr's Focus" id="45114" level="2" required-level="30" sp="11000" />
+		<skill name="Maphr's Clarity" id="45134" level="2" required-level="30" sp="11000" />
+		<skill name="Maphr's Death Whisper" id="45115" level="2" required-level="30" sp="11000" />
+
+
+		<!-- Skills Lv30 -->
+		<skill name="Power Strike" id="3" level="19" required-level="30" sp="11000" />
+		<skill name="Shock Mastery" id="100" level="15" required-level="30" sp="11000" />
 		<skill name="Wild Sweep" id="245" level="10" required-level="30" sp="11000" />
-		
-		<skill name="Shock Attack" id="100" level="11" required-level="31" sp="11000" />
-		<skill name="Light Armor Mastery" id="227" level="9" required-level="31" sp="11000" />
-		<skill name="Heavy Armor Mastery" id="231" level="9" required-level="31" sp="11000" />
+		<skill name="Enhanced Weapon" id="255" level="15" required-level="30" sp="11000" />
+		<skill name="Emergency Rescue" id="70" level="5" required-level="30" sp="11000" />
+
+
+		<!-- Skills Lv31 -->
 		<skill name="Wild Sweep" id="245" level="11" required-level="31" sp="11000" />
+		<skill name="Power Strike" id="3" level="20" required-level="31" sp="11000" />
 
-		<skill name="Shock Attack" id="100" level="12" required-level="32" sp="11000" />
-		<skill name="Fast HP Recovery" id="212" level="2" required-level="32" sp="11000" />
-		<skill name="Polearm Mastery" id="216" level="6" required-level="32" sp="11000" />
-		<skill name="Light Armor Mastery" id="227" level="10" required-level="32" sp="11000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="6" required-level="32" sp="11000" />
-		<skill name="Heavy Armor Mastery" id="231" level="10" required-level="32" sp="11000" />
+		<!-- Skills Lv32 -->
+		<skill name="Power Strike" id="3" level="21" required-level="32" sp="11000" />
 		<skill name="Wild Sweep" id="245" level="12" required-level="32" sp="11000" />
-		<skill name="Vital Force" id="148" level="2" required-level="32" sp="11000" />
+		<skill name="Emergency Rescue" id="70" level="6" required-level="32" sp="11000" />
 
-		<skill name="Shock Attack" id="100" level="13" required-level="34" sp="20000" />
-		<skill name="Polearm Mastery" id="216" level="7" required-level="34" sp="20000" />
-		<skill name="Light Armor Mastery" id="227" level="11" required-level="34" sp="20000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="7" required-level="34" sp="20000" />
-		<skill name="Heavy Armor Mastery" id="231" level="11" required-level="34" sp="20000" />
+		<!-- Skills Lv34 -->
+		<skill name="Power Strike" id="3" level="22" required-level="34" sp="20000" />
 		<skill name="Wild Sweep" id="245" level="13" required-level="34" sp="20000" />
+		<skill name="Emergency Rescue" id="70" level="7" required-level="34" sp="20000" />
 
-		<skill name="Shock Attack" id="100" level="14" required-level="35" sp="20000" />
-		<skill name="Light Armor Mastery" id="227" level="12" required-level="35" sp="20000" />
-		<skill name="Heavy Armor Mastery" id="231" level="12" required-level="35" sp="20000" />
+		<!-- Skills Lv35 -->
+		<skill name="Power Strike" id="3" level="23" required-level="35" sp="20000" />
 		<skill name="Wild Sweep" id="245" level="14" required-level="35" sp="20000" />
-		
-		<skill name="Shock Attack" id="100" level="15" required-level="36" sp="20000" />
-		<skill name="Polearm Mastery" id="216" level="8" required-level="36" sp="20000" />
-		<skill name="Light Armor Mastery" id="227" level="13" required-level="36" sp="20000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="8" required-level="36" sp="20000" />
-		<skill name="Heavy Armor Mastery" id="231" level="13" required-level="36" sp="20000" />
-		<skill name="Wild Sweep" id="245" level="15" required-level="36" sp="20000" />
-		<skill name="Lionheart" id="287" level="1" required-level="36" sp="20000" />
+
+		<!-- Skills Lv36 -->
+		<skill name="Power Strike" id="3" level="24" required-level="36" sp="20000" />
 		<skill name="Summon Mechanic Golem" id="25" level="2" required-level="36" sp="20000" />
 		<skill name="Create Item" id="172" level="4" required-level="36" sp="20000" />
 		<skill name="Boost HP" id="211" level="3" required-level="36" sp="20000" />
+		<skill name="Wild Sweep" id="245" level="15" required-level="36" sp="20000" />
+		<skill name="Lionheart" id="287" level="1" required-level="36" sp="20000" />
+		<skill name="Emergency Rescue" id="70" level="8" required-level="36" sp="20000" />
+
+		<!-- Skills Lv38 -->
+		<skill name="Emergency Rescue" id="70" level="9" required-level="38" sp="20000" />
 	</skillTree>
 </list>

--- a/data/skillTrees/1stClass/Assassin.xml
+++ b/data/skillTrees/1stClass/Assassin.xml
@@ -1,48 +1,65 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="35" parentClassId="31">
+
+		<!-- Master Buffs Lv. 20 -->
+		<skill name="Empower" id="45105" level="1" required-level="20" sp="1000" />
+		<skill name="Might" id="1068" level="2" required-level="20" sp="1000" />
+		<skill name="Wind Walk" id="45107" level="1" required-level="20" sp="1000" />
+		<skill name="Acumen" id="45104" level="1" required-level="20" sp="1000" />
+		<skill name="Haste" id="45111" level="1" required-level="20" sp="1000" />
+		<skill name="Focus" id="45109" level="1" required-level="20" sp="1000" />
+		<skill name="Clarity" id="45113" level="1" required-level="20" sp="1000" />
+		<skill name="Death Whisper" id="45110" level="1" required-level="20" sp="1000" />
+		<skill name="Shield" id="1040" level="2" required-level="20" sp="1000" />
+
+		<!-- Skills Lv20 -->	
 		<skill name="Acrobatics" id="173" level="1" required-level="20" sp="1000" />
-		<skill name="Defense Aura" id="91" level="2" required-level="20" sp="1000" />
 		<skill name="Vicious Stance" id="312" level="1" required-level="20" sp="1000" />
+		<skill name="Fast Run" id="4" level="1" required-level="20" sp="1000" />
 		<skill name="Dagger Mastery" id="209" level="1" required-level="20" sp="1000" />
 		<skill name="Light Armor Mastery" id="233" level="1" required-level="20" sp="1000" />
 		<skill name="Light Armor Mastery" id="233" level="2" required-level="20" sp="1000" />
 		<skill name="Bow Mastery" id="208" level="1" required-level="20" sp="1000" />
 		<skill name="Bow Mastery" id="208" level="2" required-level="20" sp="1000" />
 		<skill name="Bow Mastery" id="208" level="3" required-level="20" sp="1000" />
+		<skill name="Recover HP" id="45176" level="1" required-level="20" sp="1000" />
+		<skill name="Recover MP" id="45177" level="1" required-level="20" sp="1000" />
 		<skill name="Boost Breath" id="195" level="1" required-level="20" sp="1000" />
 		<skill name="Long Shot" id="113" level="1" required-level="20" sp="1000" />
-		<skill name="Drain Energy" id="70" level="3" required-level="20" sp="1000" />
-		<skill name="Drain Energy" id="70" level="4" required-level="20" sp="1000" />
+		<skill name="Dark Elven Spirit" id="129" level="1" required-level="20" sp="1000" />
+		<skill name="Drain Energy" id="45250" level="1" required-level="20" sp="1000" />
+		<skill name="Blood Attack" id="223" level="1" required-level="20" sp="1000" />
 		<skill name="Power Shot" id="56" level="10" required-level="20" sp="1000" />
 		<skill name="Power Shot" id="56" level="11" required-level="20" sp="1000" />
 		<skill name="Power Shot" id="56" level="12" required-level="20" sp="1000" />
 		<skill name="Unlock" id="27" level="1" required-level="20" sp="1000" />
-		<skill name="Poison" id="129" level="1" required-level="20" sp="1000" />
 		<skill name="Mortal Blow" id="16" level="10" required-level="20" sp="1000" />
 		<skill name="Mortal Blow" id="16" level="11" required-level="20" sp="1000" />
 		<skill name="Mortal Blow" id="16" level="12" required-level="20" sp="1000" />
+		<skill name="Ability to Protect" id="91" level="2" required-level="20" sp="1000" />
 
+		<skill name="Emergency Rescue" id="70" level="3" required-level="20" sp="1000" />
+
+		<!-- Skills Lv22 -->
 		<skill name="Light Armor Mastery" id="233" level="3" required-level="22" sp="2800" />
 		<skill name="Bow Mastery" id="208" level="4" required-level="22" sp="2800" />
-		<skill name="Sting" id="223" level="1" required-level="22" sp="2800" />
-		<skill name="Drain Energy" id="70" level="5" required-level="22" sp="2800" />
 		<skill name="Power Shot" id="56" level="13" required-level="22" sp="2800" />
 		<skill name="Mortal Blow" id="16" level="13" required-level="22" sp="2800" />
-		
+
+		<!-- Skills Lv23 -->
 		<skill name="Bow Mastery" id="208" level="5" required-level="23" sp="2800" />
-		<skill name="Sting" id="223" level="2" required-level="23" sp="2800" />
-		<skill name="Drain Energy" id="70" level="6" required-level="23" sp="2800" />
+		<skill name="Blood Attack" id="223" level="2" required-level="23" sp="2800" />
 		<skill name="Power Shot" id="56" level="14" required-level="23" sp="2800" />
 		<skill name="Mortal Blow" id="16" level="14" required-level="23" sp="2800" />
-		
+
+		<!-- Skills Lv24 -->
 		<skill name="Vicious Stance" id="312" level="2" required-level="24" sp="2800" />
 		<skill name="Dagger Mastery" id="209" level="2" required-level="24" sp="2800" />
 		<skill name="Light Armor Mastery" id="233" level="4" required-level="24" sp="2800" />
 		<skill name="Bow Mastery" id="208" level="6" required-level="24" sp="2800" />
-		<skill name="Sting" id="223" level="3" required-level="24" sp="2800" />
 		<skill name="Confusion" id="2" level="1" required-level="24" sp="2800" />
-		<skill name="Drain Energy" id="70" level="7" required-level="24" sp="2800" />
+		<skill name="Drain Energy" id="45250" level="2" required-level="24" sp="2800" />
 		<skill name="Critical Damage" id="193" level="1" required-level="24" sp="2800" />
 		<skill name="Bleed" id="96" level="1" required-level="24" sp="2800" />
 		<skill name="Power Shot" id="56" level="15" required-level="24" sp="2800" />
@@ -51,98 +68,132 @@
 		<skill name="Accuracy" id="256" level="1" required-level="24" sp="2800" />
 		<skill name="Boost Evasion" id="198" level="1" required-level="24" sp="2800" />
 
+		<!-- Skills Lv25 -->
+		<skill name="Ability to Attack" id="77" level="2" required-level="25" sp="2800" />
+		<skill name="Emergency Rescue" id="70" level="4" required-level="25" sp="2800" />
+
+		<!-- Skills Lv26 -->
 		<skill name="Dagger Mastery" id="209" level="3" required-level="26" sp="5700" />
 		<skill name="Light Armor Mastery" id="233" level="5" required-level="26" sp="5700" />
 		<skill name="Bow Mastery" id="208" level="7" required-level="26" sp="5700" />
-		<skill name="Sting" id="223" level="4" required-level="26" sp="5700" />
-		<skill name="Drain Energy" id="70" level="8" required-level="26" sp="5700" />
+		<skill name="Blood Attack" id="223" level="3" required-level="26" sp="5700" />
 		<skill name="Power Shot" id="56" level="16" required-level="26" sp="5700" />
 		<skill name="Mortal Blow" id="16" level="16" required-level="26" sp="5700" />
-		
+
+		<!-- Skills Lv27 -->
 		<skill name="Bow Mastery" id="208" level="8" required-level="27" sp="5700" />
-		<skill name="Sting" id="223" level="5" required-level="27" sp="5700" />
-		<skill name="Drain Energy" id="70" level="9" required-level="27" sp="5700" />
 		<skill name="Power Shot" id="56" level="17" required-level="27" sp="5700" />
 		<skill name="Mortal Blow" id="16" level="17" required-level="27" sp="5700" />
-		
+
+		<!-- Skills Lv28 -->
 		<skill name="Ultimate Evasion" id="111" level="1" required-level="28" sp="5700" />
 		<skill name="Acrobatic Move" id="225" level="1" required-level="28" sp="5700" />
-		<skill name="Attack Aura" id="77" level="2" required-level="28" sp="5700" />
 		<skill name="Vicious Stance" id="312" level="3" required-level="28" sp="5700" />
 		<skill name="Quick Step" id="169" level="1" required-level="28" sp="5700" />
 		<skill name="Dagger Mastery" id="209" level="4" required-level="28" sp="5700" />
 		<skill name="Light Armor Mastery" id="233" level="6" required-level="28" sp="5700" />
 		<skill name="Bow Mastery" id="208" level="9" required-level="28" sp="5700" />
-		<skill name="Sting" id="223" level="6" required-level="28" sp="5700" />
 		<skill name="Confusion" id="2" level="2" required-level="28" sp="5700" />
-		<skill name="Drain Energy" id="70" level="10" required-level="28" sp="5700" />
+		<skill name="Drain Energy" id="45250" level="3" required-level="28" sp="5700" />
+		<skill name="Blood Attack" id="223" level="4" required-level="28" sp="5700" />
 		<skill name="Power Shot" id="56" level="18" required-level="28" sp="5700" />
 		<skill name="Unlock" id="27" level="3" required-level="28" sp="5700" />
 		<skill name="Mortal Blow" id="16" level="18" required-level="28" sp="5700" />
 
+		<!-- Master Buffs Lv. 30 -->
+		<skill name="Empower" id="45105" level="2" required-level="30" sp="11000" />
+		<skill name="Wild Magic" id="45106" level="1" required-level="30" sp="11000" />
+		<skill name="Berserker Spirit" id="45112" level="1" required-level="30" sp="11000" />
+		<skill name="Wind Walk" id="45107" level="2" required-level="30" sp="11000" />
+		<skill name="Magic Barrier" id="45108" level="1" required-level="30" sp="11000" />
+		<skill name="Acumen" id="45104" level="2" required-level="30" sp="11000" />
+		<skill name="Clarity" id="45113" level="2" required-level="30" sp="11000" />
+		<skill name="Death Whisper" id="45110" level="2" required-level="30" sp="11000" />
+		<skill name="Focus" id="45109" level="2" required-level="30" sp="11000" />
+
+
+		<!-- Skills Lv30 -->
 		<skill name="Dagger Mastery" id="209" level="5" required-level="30" sp="11000" />
 		<skill name="Light Armor Mastery" id="233" level="7" required-level="30" sp="11000" />
 		<skill name="Bow Mastery" id="208" level="10" required-level="30" sp="11000" />
-		<skill name="Sting" id="223" level="7" required-level="30" sp="11000" />
-		<skill name="Drain Energy" id="70" level="11" required-level="30" sp="11000" />
+		<skill name="Freezing Weapon" id="105" level="1" required-level="30" sp="11000" />
+		<skill name="Blood Attack" id="223" level="5" required-level="30" sp="11000" />
 		<skill name="Power Shot" id="56" level="19" required-level="30" sp="11000" />
 		<skill name="Mortal Blow" id="16" level="19" required-level="30" sp="11000" />
-		
+		<skill name="Emergency Rescue" id="70" level="5" required-level="30" sp="11000" />
+
+		<!-- Skills Lv31 -->
 		<skill name="Bow Mastery" id="208" level="11" required-level="31" sp="11000" />
-		<skill name="Sting" id="223" level="8" required-level="31" sp="11000" />
-		<skill name="Drain Energy" id="70" level="12" required-level="31" sp="11000" />
+		<skill name="Blood Attack" id="223" level="6" required-level="31" sp="11000" />
 		<skill name="Power Shot" id="56" level="20" required-level="31" sp="11000" />
 		<skill name="Mortal Blow" id="16" level="20" required-level="31" sp="11000" />
-		
+
+		<!-- Skills Lv32 -->
 		<skill name="Vicious Stance" id="312" level="4" required-level="32" sp="11000" />
 		<skill name="Rapid Shot" id="99" level="1" required-level="32" sp="11000" />
 		<skill name="Dagger Mastery" id="209" level="6" required-level="32" sp="11000" />
 		<skill name="Light Armor Mastery" id="233" level="8" required-level="32" sp="11000" />
 		<skill name="Bow Mastery" id="208" level="12" required-level="32" sp="11000" />
-		<skill name="Sting" id="223" level="9" required-level="32" sp="11000" />
 		<skill name="Confusion" id="2" level="3" required-level="32" sp="11000" />
-		<skill name="Drain Energy" id="70" level="13" required-level="32" sp="11000" />
+		<skill name="Drain Energy" id="45250" level="4" required-level="32" sp="11000" />
 		<skill name="Critical Damage" id="193" level="2" required-level="32" sp="11000" />
+		<skill name="Blood Attack" id="223" level="7" required-level="32" sp="11000" />
 		<skill name="Bleed" id="96" level="2" required-level="32" sp="11000" />
 		<skill name="Power Shot" id="56" level="21" required-level="32" sp="11000" />
 		<skill name="Unlock" id="27" level="4" required-level="32" sp="11000" />
+		<skill name="Power Break" id="115" level="1" required-level="32" sp="10000" />
 		<skill name="Mortal Blow" id="16" level="21" required-level="32" sp="11000" />
-		<skill name="Power Break" id="115" level="1" required-level="32" sp="11000">
-			<item id="1382"/>
-		</skill>
+		<skill name="Emergency Rescue" id="70" level="6" required-level="32" sp="11000" />
 
+		<!-- Skills Lv33 -->
+		<skill name="Freezing Weapon" id="105" level="2" required-level="33" sp="20000" />
+		<skill name="Blood Attack" id="223" level="8" required-level="33" sp="20000" />
+
+		<!-- Skills Lv34 -->
 		<skill name="Dagger Mastery" id="209" level="7" required-level="34" sp="20000" />
 		<skill name="Light Armor Mastery" id="233" level="9" required-level="34" sp="20000" />
 		<skill name="Bow Mastery" id="208" level="13" required-level="34" sp="20000" />
-		<skill name="Sting" id="223" level="10" required-level="34" sp="20000" />
-		<skill name="Drain Energy" id="70" level="14" required-level="34" sp="20000" />
+		<skill name="Blood Attack" id="223" level="9" required-level="34" sp="20000" />
 		<skill name="Power Shot" id="56" level="22" required-level="34" sp="20000" />
 		<skill name="Stun Shot" id="101" level="1" required-level="34" sp="20000" />
 		<skill name="Mortal Blow" id="16" level="22" required-level="34" sp="20000" />
-		<skill name="Freezing Strike" id="105" level="1" required-level="34" sp="20000">
-			<item id="1381"/>
-		</skill>
-		
+		<skill name="Emergency Rescue" id="70" level="7" required-level="34" sp="20000" />
+
+		<!-- Skills Lv35 -->
 		<skill name="Bow Mastery" id="208" level="14" required-level="35" sp="20000" />
-		<skill name="Sting" id="223" level="11" required-level="35" sp="20000" />
-		<skill name="Drain Energy" id="70" level="15" required-level="35" sp="20000" />
+		<skill name="Dark Elven Spirit" id="129" level="2" required-level="35" sp="20000" />
+		<skill name="Blood Attack" id="223" level="10" required-level="35" sp="20000" />
 		<skill name="Power Shot" id="56" level="23" required-level="35" sp="20000" />
 		<skill name="Stun Shot" id="101" level="2" required-level="35" sp="20000" />
 		<skill name="Mortal Blow" id="16" level="23" required-level="35" sp="20000" />
-		
+
+		<!-- Skills Lv36 -->
 		<skill name="Vicious Stance" id="312" level="5" required-level="36" sp="20000" />
 		<skill name="Esprit" id="171" level="1" required-level="36" sp="20000" />
 		<skill name="Dagger Mastery" id="209" level="8" required-level="36" sp="20000" />
 		<skill name="Light Armor Mastery" id="233" level="10" required-level="36" sp="20000" />
 		<skill name="Bow Mastery" id="208" level="15" required-level="36" sp="20000" />
-		<skill name="Sting" id="223" level="12" required-level="36" sp="20000" />
 		<skill name="Confusion" id="2" level="4" required-level="36" sp="20000" />
-		<skill name="Freezing Strike" id="105" level="2" required-level="36" sp="20000" />
-		<skill name="Drain Energy" id="70" level="16" required-level="36" sp="20000" />
+		<skill name="Freezing Weapon" id="105" level="3" required-level="36" sp="20000" />
+		<skill name="Drain Energy" id="45250" level="5" required-level="36" sp="20000" />
+		<skill name="Blood Attack" id="223" level="11" required-level="36" sp="20000" />
 		<skill name="Power Shot" id="56" level="24" required-level="36" sp="20000" />
 		<skill name="Stun Shot" id="101" level="3" required-level="36" sp="20000" />
 		<skill name="Unlock" id="27" level="5" required-level="36" sp="20000" />
-		<skill name="Mortal Blow" id="16" level="24" required-level="36" sp="20000" />
 		<skill name="Power Break" id="115" level="2" required-level="36" sp="20000" />
+		<skill name="Mortal Blow" id="16" level="24" required-level="36" sp="20000" />
+		<skill name="Emergency Rescue" id="70" level="8" required-level="36" sp="20000" />
+
+		<!-- Skills Lv37 -->
+		<skill name="Blood Attack" id="223" level="12" required-level="37" sp="20000" />
+
+		<!-- Skills Lv38 -->
+		<skill name="Freezing Weapon" id="105" level="4" required-level="38" sp="20000" />
+		<skill name="Blood Attack" id="223" level="13" required-level="38" sp="20000" />
+		<skill name="Emergency Rescue" id="70" level="9" required-level="38" sp="20000" />
+
+		<!-- Skills Lv39 -->
+		<skill name="Blood Attack" id="223" level="14" required-level="39" sp="20000" />
+		
 	</skillTree>
 </list>

--- a/data/skillTrees/1stClass/Cleric.xml
+++ b/data/skillTrees/1stClass/Cleric.xml
@@ -1,39 +1,57 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="15" parentClassId="10">
+
+		<!-- Master Buffs Lv. 20 -->
+		<skill name="Shield" id="1040" level="2" required-level="20" sp="500" />
+		<skill name="Might" id="1068" level="2" required-level="20" sp="500" />
+		<skill name="Acumen" id="1085" level="1" required-level="20" sp="500" />
+		<skill name="Empower" id="1059" level="1" required-level="20" sp="500" />
+		<skill name="Focus" id="1077" level="1" required-level="20" sp="500" />
+		<skill name="Death Whisper" id="1242" level="1" required-level="20" sp="500" />
+		<skill name="Haste" id="1086" level="1" required-level="20" sp="500" />
+		<skill name="Wind Walk" id="1204" level="1" required-level="20" sp="500" />
+		<skill name="Concentration" id="1078" level="1" required-level="20" sp="600" />
+		<skill name="Clarity" id="45113" level="1" required-level="20" sp="500" />
+
+
+		<!-- Skills Lv20 -->
 		<skill name="Anti Magic" id="146" level="5" required-level="20" sp="600" />
 		<skill name="Anti Magic" id="146" level="6" required-level="20" sp="600" />
 		<skill name="Battle Heal" id="1015" level="4" required-level="20" sp="600" />
 		<skill name="Battle Heal" id="1015" level="5" required-level="20" sp="600" />
 		<skill name="Battle Heal" id="1015" level="6" required-level="20" sp="600" />
+		<skill name="Divine Strike" id="1031" level="1" required-level="20" sp="600" />
+		<skill name="Divine Strike" id="1031" level="2" required-level="20" sp="600" />
 		<skill name="Quick Recovery" id="164" level="1" required-level="20" sp="600" />
 		<skill name="Light Armor Mastery" id="236" level="1" required-level="20" sp="600" />
 		<skill name="Light Armor Mastery" id="236" level="2" required-level="20" sp="600" />
 		<skill name="Robe Mastery" id="235" level="1" required-level="20" sp="600" />
 		<skill name="Robe Mastery" id="235" level="2" required-level="20" sp="600" />
 		<skill name="Weapon Mastery" id="249" level="3" required-level="20" sp="600" />
+		<skill name="Resurrection" id="1016" level="1" required-level="20" sp="600" />
+		<skill name="Recover HP" id="45176" level="1" required-level="20" sp="500" />
+		<skill name="Recover MP" id="45177" level="1" required-level="20" sp="500" />
 		<skill name="Group Heal" id="1027" level="4" required-level="20" sp="600" />
 		<skill name="Group Heal" id="1027" level="5" required-level="20" sp="600" />
 		<skill name="Group Heal" id="1027" level="6" required-level="20" sp="600" />
-		<skill name="Wind Walk" id="1204" level="1" required-level="20" sp="600" />
+		<skill name="Dryad Root" id="1201" level="1" required-level="20" sp="600" />
 		<skill name="Heal" id="1011" level="7" required-level="20" sp="600" />
 		<skill name="Heal" id="1011" level="8" required-level="20" sp="600" />
 		<skill name="Heal" id="1011" level="9" required-level="20" sp="600" />
-		<skill name="Might" id="1068" level="2" required-level="20" sp="600" />
-		<skill name="Eva's Kiss" id="1073" level="1" required-level="20" sp="600" />
-		<skill name="Disrupt Undead" id="1031" level="1" required-level="20" sp="600" />
-		<skill name="Disrupt Undead" id="1031" level="2" required-level="20" sp="600" />
+		<skill name="Poison" id="1168" level="2" required-level="20" sp="600" />
+		<skill name="Self Heal" id="1216" level="4" required-level="20" sp="600" />
+		<skill name="Weakness" id="1164" level="2" required-level="20" sp="600" />
 		<skill name="Boost Mana" id="213" level="1" required-level="20" sp="600" />
-		<skill name="Resurrection" id="1016" level="1" required-level="20" sp="600">
-			<item id="1514"/>
-		</skill>
-		<skill name="Concentration" id="1078" level="1" required-level="20" sp="600">
-			<item id="1399"/>
-		</skill>
-		<skill name="Acumen" id="1085" level="1" required-level="20" sp="600">
-			<item id="1401"/>
-		</skill>
-		
+		<skill name="Increased Power of Magic" id="1073" level="1" required-level="20" sp="600" />
+		<skill name="Sleep" id="1069" level="1" required-level="20" sp="600" />
+
+		<!-- Skills Lv22 -->
+		<skill name="Divine Strike" id="1031" level="3" required-level="22" sp="2300" />
+		<skill name="Dryad Root" id="1201" level="2" required-level="22" sp="2300" />
+		<skill name="Sleep" id="1069" level="2" required-level="22" sp="2300" />
+
+		<!-- Skills Lv23 -->
 		<skill name="Anti Magic" id="146" level="7" required-level="23" sp="2300" />
 		<skill name="Battle Heal" id="1015" level="7" required-level="23" sp="2300" />
 		<skill name="Light Armor Mastery" id="236" level="3" required-level="23" sp="2300" />
@@ -41,21 +59,18 @@
 		<skill name="Weapon Mastery" id="249" level="4" required-level="23" sp="2300" />
 		<skill name="Group Heal" id="1027" level="7" required-level="23" sp="2300" />
 		<skill name="Heal" id="1011" level="10" required-level="23" sp="2300" />
-		<skill name="Disrupt Undead" id="1031" level="3" required-level="23" sp="2300" />
-		<skill name="Sleep" id="1069" level="1" required-level="23" sp="2300">
-			<item id="1394"/>
-		</skill>
-		<skill name="Dryad Root" id="1201" level="1" required-level="23" sp="2300">
-			<item id="1415"/>
-		</skill>
-		
-		<skill name="Battle Heal" id="1015" level="8" required-level="24" sp="2300" />
-		<skill name="Group Heal" id="1027" level="8" required-level="24" sp="2300" />
-		<skill name="Dryad Root" id="1201" level="2" required-level="24" sp="2300" />
-		<skill name="Heal" id="1011" level="11" required-level="24" sp="2300" />
-		<skill name="Sleep" id="1069" level="2" required-level="24" sp="2300" />
 
+		<!-- Skills Lv24 -->
+		<skill name="Battle Heal" id="1015" level="8" required-level="24" sp="2300" />
+		<skill name="Divine Strike" id="1031" level="4" required-level="24" sp="2300" />
+		<skill name="Group Heal" id="1027" level="8" required-level="24" sp="2300" />
+		<skill name="Dryad Root" id="1201" level="3" required-level="24" sp="2300" />
+		<skill name="Heal" id="1011" level="11" required-level="24" sp="2300" />
+		<skill name="Sleep" id="1069" level="3" required-level="24" sp="2300" />
+
+		<!-- Skills Lv25 -->
 		<skill name="Anti Magic" id="146" level="8" required-level="25" sp="2300" />
+		<skill name="Mage's Blessing" id="1043" level="1" required-level="25" sp="2300" />
 		<skill name="Battle Heal" id="1015" level="9" required-level="25" sp="2300" />
 		<skill name="Fast Mana Recovery" id="229" level="1" required-level="25" sp="2300" />
 		<skill name="Fast Spell Casting" id="228" level="1" required-level="25" sp="2300" />
@@ -63,69 +78,88 @@
 		<skill name="Robe Mastery" id="235" level="4" required-level="25" sp="2300" />
 		<skill name="Weapon Mastery" id="249" level="5" required-level="25" sp="2300" />
 		<skill name="Group Heal" id="1027" level="9" required-level="25" sp="2300" />
-		<skill name="Dryad Root" id="1201" level="3" required-level="25" sp="2300" />
 		<skill name="Heal" id="1011" level="12" required-level="25" sp="2300" />
-		<skill name="Disrupt Undead" id="1031" level="4" required-level="25" sp="2300" />
-		<skill name="Holy Weapon" id="1043" level="1" required-level="25" sp="2300" />
-		<skill name="Sleep" id="1069" level="3" required-level="25" sp="2300" />
-		<skill name="Shield" id="1040" level="2" required-level="25" sp="2300" />
-		<skill name="Mental Shield" id="1035" level="1" required-level="25" sp="2300">
-			<item id="1388"/>
-		</skill>
-		<skill name="Focus" id="1077" level="1" required-level="25" sp="2300">
-			<item id="1398"/>
-		</skill>
-		
+		<skill name="Mental Shield" id="1035" level="1" required-level="25" sp="2300" />
+		<skill name="Self Heal" id="1216" level="5" required-level="25" sp="2300" />
+		<skill name="Weakness" id="1164" level="3" required-level="25" sp="2300" />
+
+		<!-- Skills Lv26 -->
+		<skill name="Divine Strike" id="1031" level="5" required-level="26" sp="2300" />
+		<skill name="Dryad Root" id="1201" level="4" required-level="26" sp="2300" />
+		<skill name="Sleep" id="1069" level="4" required-level="26" sp="2300" />
+
+		<!-- Skills Lv28 -->
 		<skill name="Anti Magic" id="146" level="9" required-level="28" sp="5700" />
 		<skill name="Battle Heal" id="1015" level="10" required-level="28" sp="5700" />
+		<skill name="Divine Strike" id="1031" level="6" required-level="28" sp="5700" />
 		<skill name="Light Armor Mastery" id="236" level="5" required-level="28" sp="5700" />
 		<skill name="Robe Mastery" id="235" level="5" required-level="28" sp="5700" />
 		<skill name="Weapon Mastery" id="249" level="6" required-level="28" sp="5700" />
 		<skill name="Group Heal" id="1027" level="10" required-level="28" sp="5700" />
-		<skill name="Dryad Root" id="1201" level="4" required-level="28" sp="5700" />
+		<skill name="Dryad Root" id="1201" level="5" required-level="28" sp="5700" />
 		<skill name="Heal" id="1011" level="13" required-level="28" sp="5700" />
-		<skill name="Disrupt Undead" id="1031" level="5" required-level="28" sp="5700" />
-		<skill name="Sleep" id="1069" level="4" required-level="28" sp="5700" />
-		
+		<skill name="Sleep" id="1069" level="5" required-level="28" sp="5700" />
+		<skill name="Mana Effect Boost" id="1013" level="1" required-level="28" sp="5700" />
+
+		<!-- Skills Lv29 -->
 		<skill name="Battle Heal" id="1015" level="11" required-level="29" sp="5700" />
 		<skill name="Group Heal" id="1027" level="11" required-level="29" sp="5700" />
-		<skill name="Dryad Root" id="1201" level="5" required-level="29" sp="5700" />
 		<skill name="Heal" id="1011" level="14" required-level="29" sp="5700" />
-		<skill name="Sleep" id="1069" level="5" required-level="29" sp="5700" />
 
+		<!-- Master Buffs Lv. 30 -->
+		<skill name="Empower" id="1059" level="2" required-level="30" sp="5000" />
+		<skill name="Wild Magic" id="1303" level="1" required-level="30" sp="5000" />
+		<skill name="Berserker Spirit" id="1062" level="1" required-level="30" sp="5000" />
+		<skill name="Concentration" id="1078" level="2" required-level="30" sp="5700" />
+		<skill name="Wind Walk" id="1204" level="2" required-level="30" sp="5000" />
+		<skill name="Magic Barrier" id="1036" level="1" required-level="30" sp="5000" />
+		<skill name="Acumen" id="1085" level="2" required-level="30" sp="5000" />
+		<skill name="Focus" id="1077" level="2" required-level="30" sp="5000" />
+		<skill name="Death Whisper" id="1242" level="2" required-level="30" sp="5000" />
+		<skill name="Clarity" id="45113" level="2" required-level="30" sp="5000" />
+
+		<!-- Skills Lv30 -->
 		<skill name="Anti Magic" id="146" level="10" required-level="30" sp="5700" />
 		<skill name="Battle Heal" id="1015" level="12" required-level="30" sp="5700" />
+		<skill name="Divine Strike" id="1031" level="7" required-level="30" sp="5700" />
 		<skill name="Quick Recovery" id="164" level="2" required-level="30" sp="5700" />
 		<skill name="Light Armor Mastery" id="236" level="6" required-level="30" sp="5700" />
 		<skill name="Robe Mastery" id="235" level="6" required-level="30" sp="5700" />
 		<skill name="Weapon Mastery" id="249" level="7" required-level="30" sp="5700" />
 		<skill name="Resurrection" id="1016" level="2" required-level="30" sp="5700" />
 		<skill name="Group Heal" id="1027" level="12" required-level="30" sp="5700" />
-		<skill name="Concentration" id="1078" level="2" required-level="30" sp="5700" />
 		<skill name="Dryad Root" id="1201" level="6" required-level="30" sp="5700" />
-		<skill name="Wind Walk" id="1204" level="2" required-level="30" sp="5700" />
 		<skill name="Heal" id="1011" level="15" required-level="30" sp="5700" />
-		<skill name="Disrupt Undead" id="1031" level="6" required-level="30" sp="5700" />
+		<skill name="Poison" id="1168" level="3" required-level="30" sp="5700" />
+		<skill name="Weakness" id="1164" level="4" required-level="30" sp="5700" />
 		<skill name="Boost Mana" id="213" level="2" required-level="30" sp="5700" />
 		<skill name="Sleep" id="1069" level="6" required-level="30" sp="5700" />
-		
+		<skill name="Mana Effect Boost" id="1013" level="2" required-level="30" sp="5700" />
+
+		<!-- Skills Lv32 -->
+		<skill name="Divine Strike" id="1031" level="8" required-level="32" sp="5700" />
+		<skill name="Dryad Root" id="1201" level="7" required-level="32" sp="5700" />
+		<skill name="Sleep" id="1069" level="7" required-level="32" sp="5700" />
+
+		<!-- Skills Lv33 -->
 		<skill name="Anti Magic" id="146" level="11" required-level="33" sp="13000" />
 		<skill name="Battle Heal" id="1015" level="13" required-level="33" sp="13000" />
 		<skill name="Light Armor Mastery" id="236" level="7" required-level="33" sp="13000" />
 		<skill name="Robe Mastery" id="235" level="7" required-level="33" sp="13000" />
 		<skill name="Weapon Mastery" id="249" level="8" required-level="33" sp="13000" />
 		<skill name="Group Heal" id="1027" level="13" required-level="33" sp="13000" />
-		<skill name="Dryad Root" id="1201" level="7" required-level="33" sp="13000" />
 		<skill name="Heal" id="1011" level="16" required-level="33" sp="13000" />
-		<skill name="Disrupt Undead" id="1031" level="7" required-level="33" sp="13000" />
-		<skill name="Sleep" id="1069" level="7" required-level="33" sp="13000" />
-				
+		<skill name="Mana Effect Boost" id="1013" level="3" required-level="33" sp="13000" />
+
+		<!-- Skills Lv34 -->
 		<skill name="Battle Heal" id="1015" level="14" required-level="34" sp="13000" />
+		<skill name="Divine Strike" id="1031" level="9" required-level="34" sp="13000" />
 		<skill name="Group Heal" id="1027" level="14" required-level="34" sp="13000" />
 		<skill name="Dryad Root" id="1201" level="8" required-level="34" sp="13000" />
 		<skill name="Heal" id="1011" level="17" required-level="34" sp="13000" />
 		<skill name="Sleep" id="1069" level="8" required-level="34" sp="13000" />
 
+		<!-- Skills Lv35 -->
 		<skill name="Anti Magic" id="146" level="12" required-level="35" sp="13000" />
 		<skill name="Battle Heal" id="1015" level="15" required-level="35" sp="13000" />
 		<skill name="Fast HP Recovery" id="212" level="1" required-level="35" sp="13000" />
@@ -134,16 +168,21 @@
 		<skill name="Robe Mastery" id="235" level="8" required-level="35" sp="13000" />
 		<skill name="Weapon Mastery" id="249" level="9" required-level="35" sp="13000" />
 		<skill name="Group Heal" id="1027" level="15" required-level="35" sp="13000" />
-		<skill name="Cure Poison" id="1012" level="2" required-level="35" sp="13000" />
-		<skill name="Dryad Root" id="1201" level="9" required-level="35" sp="13000" />
+		<skill name="Cure" id="1012" level="2" required-level="35" sp="13000" />
 		<skill name="Heal" id="1011" level="18" required-level="35" sp="13000" />
 		<skill name="Peace" id="1075" level="1" required-level="35" sp="13000" />
-		<skill name="Acumen" id="1085" level="2" required-level="35" sp="13000" />
-		<skill name="Disrupt Undead" id="1031" level="8" required-level="35" sp="13000" />
 		<skill name="Regeneration" id="1044" level="1" required-level="35" sp="13000" />
-		<skill name="Sleep" id="1069" level="9" required-level="35" sp="13000" />
-		<skill name="Soul of Berserker" id="1062" level="1" required-level="35" sp="13000" >
-			<item id="1392"/>
-		</skill>
+		<skill name="Weakness" id="1164" level="5" required-level="35" sp="13000" />
+		<skill name="Mana Effect Boost" id="1013" level="4" required-level="35" sp="13000" />
+
+		<!-- Skills Lv36 -->
+		<skill name="Divine Strike" id="1031" level="10" required-level="36" sp="13000" />
+		<skill name="Dryad Root" id="1201" level="9" required-level="36" sp="13000" />
+		<skill name="Sleep" id="1069" level="9" required-level="36" sp="13000" />
+
+		<!-- Skills Lv38 -->
+		<skill name="Dryad Root" id="1201" level="10" required-level="38" sp="13000" />
+		<skill name="Sleep" id="1069" level="10" required-level="38" sp="13000" />
+
 	</skillTree>
 </list>

--- a/data/skillTrees/1stClass/DarkDeathBlader.xml
+++ b/data/skillTrees/1stClass/DarkDeathBlader.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
+	<skillTree type="classSkillTree" classId="205" parentClassId="204">
+
+		<!-- Master Buffs Lv. 20 -->
+		<skill name="Empower" id="45105" level="1" required-level="20" sp="1000" />
+		<skill name="Wind Walk" id="45107" level="1" required-level="20" sp="1000" />
+		<skill name="Might" id="1068" level="2" required-level="20" sp="1000" />
+		<skill name="Acumen" id="45104" level="1" required-level="20" sp="1000" />
+		<skill name="Haste" id="45111" level="1" required-level="20" sp="1000" />
+		<skill name="Focus" id="45109" level="1" required-level="20" sp="1000" />
+		<skill name="Clarity" id="45113" level="1" required-level="20" sp="1000" />
+		<skill name="Death Whisper" id="45110" level="1" required-level="20" sp="1000" />
+		<skill name="Shield" id="1040" level="2" required-level="20" sp="1000" />
+
+		<!-- Skills Lv20 -->
+		<skill name="Death Armor Mastery" id="45354" level="4" required-level="20" sp="1000" />
+		<skill name="Death Sword Mastery" id="45353" level="4" required-level="20" sp="1000" />
+		<skill name="Recover HP" id="45176" level="1" required-level="20" sp="1000" />
+		<skill name="Recover MP" id="45177" level="1" required-level="20" sp="1000" />
+		<skill name="Punishment" id="45301" level="1" required-level="20" auto-learn="true" />
+		<skill name="Enhanced Weapon" id="255" level="1" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="2" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="3" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="4" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="5" required-level="20" sp="1000" />
+		<skill name="Ability to Protect" id="91" level="2" required-level="20" sp="1000" />
+		<skill name="Emergency Rescue" id="70" level="3" required-level="20" sp="1000" />
+		<skill name="Dark Elven Spirit" id="129" level="1" required-level="20" sp="1000" />
+
+		<!-- Skills Lv21 -->
+		<skill name="Enhanced Weapon" id="255" level="6" required-level="21" sp="2500" />
+
+		<!-- Skills Lv22 -->
+		<skill name="Enhanced Weapon" id="255" level="7" required-level="22" sp="2500" />
+
+		<!-- Skills Lv23 -->
+		<skill name="Enhanced Weapon" id="255" level="8" required-level="23" sp="2500" />
+
+		<!-- Skills Lv24 -->
+		<skill name="Confusion" id="2" level="1" required-level="24" sp="2500" />
+		<skill name="Confusion" id="2" level="2" required-level="24" sp="2500" />
+		<skill name="Enhanced Weapon" id="255" level="9" required-level="24" sp="2500" />
+
+		<!-- Skills Lv25 -->
+		<skill name="Confusion" id="2" level="3" required-level="25" sp="5500" />
+		<skill name="Death Armor Mastery" id="45354" level="5" required-level="25" sp="5500" />
+		<skill name="Death Sword Mastery" id="45353" level="5" required-level="25" sp="5500" />
+		<skill name="Enhanced Weapon" id="255" level="10" required-level="25" sp="5500" />
+		<skill name="Ability to Attack" id="77" level="2" required-level="25" sp="5500" />
+		<skill name="Emergency Rescue" id="70" level="4" required-level="25" sp="5500" />
+
+		<!-- Skills Lv26 -->
+		<skill name="Confusion" id="2" level="4" required-level="26" sp="5500" />
+		<skill name="Punishment" id="45301" level="2" required-level="26" sp="5500" />
+		<skill name="Enhanced Weapon" id="255" level="11" required-level="26" sp="5500" />
+
+		<!-- Skills Lv27 -->
+		<skill name="Confusion" id="2" level="5" required-level="27" sp="5500" />
+		<skill name="Enhanced Weapon" id="255" level="12" required-level="27" sp="5500" />
+
+		<!-- Skills Lv28 -->
+		<skill name="Confusion" id="2" level="6" required-level="28" sp="5500" />
+		<skill name="Confusion" id="2" level="7" required-level="28" sp="5500" />
+		<skill name="Enhanced Weapon" id="255" level="13" required-level="28" sp="5500" />
+
+		<!-- Skills Lv29 -->
+		<skill name="Confusion" id="2" level="8" required-level="29" sp="10000" />
+		<skill name="Enhanced Weapon" id="255" level="14" required-level="29" sp="10000" />
+
+		<!-- Master Buff Lv. 30 -->
+		<skill name="Empower" id="45105" level="2" required-level="30" sp="11000" />
+		<skill name="Wild Magic" id="45106" level="1" required-level="30" sp="11000" />
+		<skill name="Berserker Spirit" id="45112" level="1" required-level="30" sp="11000" />
+		<skill name="Wind Walk" id="45107" level="2" required-level="30" sp="11000" />
+		<skill name="Magic Barrier" id="45108" level="1" required-level="30" sp="11000" />
+		<skill name="Acumen" id="45104" level="2" required-level="30" sp="11000" />
+		<skill name="Focus" id="45109" level="2" required-level="30" sp="11000" />
+		<skill name="Clarity" id="45113" level="2" required-level="30" sp="11000" />
+		<skill name="Death Whisper" id="45110" level="2" required-level="30" sp="11000" />
+
+		<!-- Skills Lv30 -->
+		<skill name="Confusion" id="2" level="9" required-level="30" sp="10000" />
+		<skill name="Death Armor Mastery" id="45354" level="6" required-level="30" sp="10000" />
+		<skill name="Death Sword Mastery" id="45353" level="6" required-level="30" sp="10000" />
+		<skill name="Enhanced Weapon" id="255" level="15" required-level="30" sp="10000" />
+		<skill name="Roar of Death" id="45328" level="1" required-level="30" sp="10000" />
+		<skill name="Emergency Rescue" id="70" level="5" required-level="30" sp="10000" />
+
+		<!-- Skills Lv31 -->
+		<skill name="Confusion" id="2" level="10" required-level="31" sp="10000" />
+
+		<!-- Skills Lv32 -->
+		<skill name="Confusion" id="2" level="11" required-level="32" sp="10000" />
+		<skill name="Confusion" id="2" level="12" required-level="32" sp="10000" />
+		<skill name="Punishment" id="45301" level="3" required-level="32" sp="10000" />
+		<skill name="Emergency Rescue" id="70" level="6" required-level="32" sp="10000" />
+		<skill name="Power Break" id="115" level="1" required-level="32" sp="10000"/>
+
+		<!-- Skills Lv33 -->
+		<skill name="Confusion" id="2" level="13" required-level="33" sp="20000" />
+
+		<!-- Skills Lv34 -->
+		<skill name="Confusion" id="2" level="14" required-level="34" sp="20000" />
+		<skill name="Emergency Rescue" id="70" level="7" required-level="34" sp="20000" />
+
+		<!-- Skills Lv35 -->
+		<skill name="Confusion" id="2" level="15" required-level="35" sp="20000" />
+		<skill name="Dark Elven Spirit" id="129" level="2" required-level="35" sp="20000" />
+		<skill name="Death Armor Mastery" id="45354" level="7" required-level="35" sp="20000" />
+		<skill name="Death Sword Mastery" id="45353" level="7" required-level="35" sp="20000" />
+
+		<!-- Skills Lv36 -->
+		<skill name="Confusion" id="2" level="16" required-level="36" sp="20000" />
+		<skill name="Confusion" id="2" level="17" required-level="36" sp="20000" />
+		<skill name="Emergency Rescue" id="70" level="8" required-level="36" sp="20000" />
+		<skill name="Power Break" id="115" level="2" required-level="36" sp="20000" />
+
+		<!-- Skills Lv37 -->
+		<skill name="Confusion" id="2" level="18" required-level="37" sp="20000" />
+
+		<!-- Skills Lv38 -->
+		<skill name="Confusion" id="2" level="19" required-level="38" sp="20000" />
+		<skill name="Punishment" id="45301" level="4" required-level="38" sp="20000" />
+		<skill name="Emergency Rescue" id="70" level="9" required-level="38" sp="20000" />
+
+		<!-- Skills Lv39 -->
+		<skill name="Confusion" id="2" level="20" required-level="39" sp="20000" />
+		
+	</skillTree>
+</list>

--- a/data/skillTrees/1stClass/DarkWizard.xml
+++ b/data/skillTrees/1stClass/DarkWizard.xml
@@ -1,142 +1,208 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="39" parentClassId="38">
+
+		<!-- Master Buffs Lv. 20 -->
+		<skill name="Empower" id="45105" level="1" required-level="20" sp="500" />
+		<skill name="Concentration" id="1078" level="1" required-level="20" sp="600" />
+		<skill name="Wind Walk" id="45107" level="1" required-level="20" sp="500" />
+		<skill name="Might" id="1068" level="2" required-level="20" sp="500" />
+		<skill name="Acumen" id="45104" level="1" required-level="20" sp="500" />
+		<skill name="Haste" id="45111" level="1" required-level="20" sp="500" />
+		<skill name="Focus" id="45109" level="1" required-level="20" sp="500" />
+		<skill name="Clarity" id="45113" level="1" required-level="20" sp="500" />
+		<skill name="Death Whisper" id="45110" level="1" required-level="20" sp="500" />
+		<skill name="Shield" id="1040" level="2" required-level="20" sp="500" />
+
+		<!-- Skills Lv20 -->
 		<skill name="Anti Magic" id="146" level="5" required-level="20" sp="600" />
 		<skill name="Anti Magic" id="146" level="6" required-level="20" sp="600" />
 		<skill name="Quick Recovery" id="164" level="1" required-level="20" sp="600" />
 		<skill name="Robe Mastery" id="234" level="1" required-level="20" sp="600" />
 		<skill name="Robe Mastery" id="234" level="2" required-level="20" sp="600" />
 		<skill name="Weapon Mastery" id="249" level="3" required-level="20" sp="600" />
-		<skill name="Ice Bolt" id="1184" level="5" required-level="20" sp="600" />
+		<skill name="Recover HP" id="45176" level="1" required-level="20" sp="500" />
+		<skill name="Recover MP" id="45177" level="1" required-level="20" sp="500" />
 		<skill name="Ice Bolt" id="1184" level="6" required-level="20" sp="600" />
+		<skill name="Ice Bolt" id="1184" level="7" required-level="20" sp="600" />
 		<skill name="Servitor Heal" id="1127" level="1" required-level="20" sp="600" />
 		<skill name="Servitor Heal" id="1127" level="2" required-level="20" sp="600" />
 		<skill name="Servitor Heal" id="1127" level="3" required-level="20" sp="600" />
+		<skill name="Fireball" id="1147" level="4" required-level="20" sp="600" />
+		<skill name="Wind Shackle" id="1206" level="2" required-level="20" sp="600" />
+		<skill name="Poison" id="1168" level="2" required-level="20" sp="600" />
 		<skill name="Summon Silhouette" id="1228" level="1" required-level="20" sp="600" />
 		<skill name="Summon Shadow" id="1128" level="1" required-level="20" sp="600" />
-		<skill name="Vampiric Touch" id="1147" level="3" required-level="20" sp="600" />
-		<skill name="Vampiric Touch" id="1147" level="4" required-level="20" sp="600" />
-		<skill name="Curse Poison" id="1168" level="2" required-level="20" sp="600" />
+		<skill name="Vampiric Touch" id="45247" level="1" required-level="20" sp="600" />
 		<skill name="Aura Burn" id="1172" level="1" required-level="20" sp="600" />
 		<skill name="Aura Burn" id="1172" level="2" required-level="20" sp="600" />
 		<skill name="Twister" id="1178" level="1" required-level="20" sp="600" />
 		<skill name="Twister" id="1178" level="2" required-level="20" sp="600" />
 		<skill name="Boost Mana" id="213" level="1" required-level="20" sp="600" />
+		<skill name="Increased Power of Magic" id="1073" level="1" required-level="20" sp="600" />
 		<skill name="Flame Strike" id="1181" level="1" required-level="20" sp="600" />
+		<skill name="Swift Servitor Heal" id="45362" level="1" required-level="20" sp="600" />
+		<skill name="Swift Servitor Heal" id="45362" level="2" required-level="20" sp="600" />
+		<skill name="Swift Servitor Heal" id="45362" level="3" required-level="20" sp="600" />
 		<skill name="Higher Mana Gain" id="285" level="1" required-level="20" sp="600" />
 		<skill name="Higher Mana Gain" id="285" level="2" required-level="20" sp="600" />
-		<skill name="Concentration" id="1078" level="1" required-level="20" sp="600">
-			<item id="1399"/>
-		</skill>
-		
+		<skill name="Sleep" id="1069" level="1" required-level="20" sp="600" />
+
+		<!-- Skills Lv22 -->
+		<skill name="Vampiric Touch" id="45247" level="2" required-level="22" sp="2300" />
+		<skill name="Sleep" id="1069" level="2" required-level="22" sp="2300" />
+
+		<!-- Skills Lv23 -->
 		<skill name="Anti Magic" id="146" level="7" required-level="23" sp="2300" />
 		<skill name="Robe Mastery" id="234" level="3" required-level="23" sp="2300" />
 		<skill name="Weapon Mastery" id="249" level="4" required-level="23" sp="2300" />
-		<skill name="Servitor Heal" id="1127" level="4" required-level="23" sp="2300" />
 		<skill name="Servitor Recharge" id="1126" level="1" required-level="23" sp="2300" />
-		<skill name="Vampiric Touch" id="1147" level="5" required-level="23" sp="2300" />
+		<skill name="Servitor Heal" id="1127" level="4" required-level="23" sp="2300" />
 		<skill name="Aura Burn" id="1172" level="3" required-level="23" sp="2300" />
 		<skill name="Twister" id="1178" level="3" required-level="23" sp="2300" />
+		<skill name="Swift Servitor Heal" id="45362" level="4" required-level="23" sp="2300" />
 		<skill name="Higher Mana Gain" id="285" level="3" required-level="23" sp="2300" />
-		<skill name="Sleep" id="1069" level="1" required-level="23" sp="2300">
-			<item id="1394"/>
-		</skill>
-		
-		<skill name="Servitor Heal" id="1127" level="5" required-level="24" sp="2300" />
-		<skill name="Sleep" id="1069" level="2" required-level="24" sp="2300" />
 
+		<!-- Skills Lv24 -->
+		<skill name="Servitor Heal" id="1127" level="5" required-level="24" sp="2300" />
+		<skill name="Vampiric Touch" id="45247" level="3" required-level="24" sp="2300" />
+		<skill name="Swift Servitor Heal" id="45362" level="5" required-level="24" sp="2300" />
+		<skill name="Sleep" id="1069" level="3" required-level="24" sp="2300" />
+
+		<!-- Skills Lv25 -->
 		<skill name="Anti Magic" id="146" level="8" required-level="25" sp="2300" />
 		<skill name="Fast Mana Recovery" id="229" level="1" required-level="25" sp="2300" />
 		<skill name="Fast Spell Casting" id="228" level="1" required-level="25" sp="2300" />
 		<skill name="Robe Mastery" id="234" level="4" required-level="25" sp="2300" />
 		<skill name="Weapon Mastery" id="249" level="5" required-level="25" sp="2300" />
-		<skill name="Shadow Spark" id="1266" level="1" required-level="25" sp="2300" />
-		<skill name="Servitor Heal" id="1127" level="6" required-level="25" sp="2300" />
 		<skill name="Servitor Recharge" id="1126" level="2" required-level="25" sp="2300" />
+		<skill name="Shadow Spark" id="1266" level="1" required-level="25" sp="2300" />
+		<skill name="Ice Bolt" id="1184" level="8" required-level="25" sp="2300" />
+		<skill name="Servitor Heal" id="1127" level="6" required-level="25" sp="2300" />
+		<skill name="Fireball" id="1147" level="5" required-level="25" sp="2300" />
+		<skill name="Wind Shackle" id="1206" level="3" required-level="25" sp="2300" />
 		<skill name="Surrender to Poison" id="1224" level="1" required-level="25" sp="2300" />
 		<skill name="Summon Silhouette" id="1228" level="2" required-level="25" sp="2300" />
 		<skill name="Summon Shadow" id="1128" level="2" required-level="25" sp="2300" />
-		<skill name="Vampiric Touch" id="1147" level="6" required-level="25" sp="2300" />
+		<skill name="Body to Mind" id="1157" level="1" required-level="25" sp="2300" />
 		<skill name="Aura Burn" id="1172" level="4" required-level="25" sp="2300" />
 		<skill name="Twister" id="1178" level="4" required-level="25" sp="2300" />
 		<skill name="Flame Strike" id="1181" level="2" required-level="25" sp="2300" />
+		<skill name="Swift Servitor Heal" id="45362" level="6" required-level="25" sp="2300" />
 		<skill name="Higher Mana Gain" id="285" level="4" required-level="25" sp="2300" />
-		<skill name="Sleep" id="1069" level="3" required-level="25" sp="2300" />
 		<skill name="Poisonous Cloud" id="1167" level="1" required-level="25" sp="2300" />
-		<skill name="Body To Mind" id="1157" level="1" required-level="25" sp="2300">
-			<item id="1517"/>
-		</skill>
-		
 
+		<!-- Skills Lv26 -->
+		<skill name="Vampiric Touch" id="45247" level="4" required-level="26" sp="2300" />
+		<skill name="Sleep" id="1069" level="4" required-level="26" sp="2300" />
+
+		<!-- Skills Lv28 -->
 		<skill name="Anti Magic" id="146" level="9" required-level="28" sp="5700" />
-		<skill name="Robe Mastery" id="235" level="5" required-level="28" sp="5700" />
+		<skill name="Robe Mastery" id="234" level="5" required-level="28" sp="5700" />
 		<skill name="Weapon Mastery" id="249" level="6" required-level="28" sp="5700" />
-		<skill name="Servitor Heal" id="1127" level="7" required-level="28" sp="5700" />
 		<skill name="Servitor Recharge" id="1126" level="3" required-level="28" sp="5700" />
+		<skill name="Servitor Heal" id="1127" level="7" required-level="28" sp="5700" />
+		<skill name="Vampiric Touch" id="45247" level="5" required-level="28" sp="5700" />
 		<skill name="Aura Burn" id="1172" level="5" required-level="28" sp="5700" />
 		<skill name="Twister" id="1178" level="5" required-level="28" sp="5700" />
+		<skill name="Swift Servitor Heal" id="45362" level="7" required-level="28" sp="5700" />
 		<skill name="Higher Mana Gain" id="285" level="5" required-level="28" sp="5700" />
-		<skill name="Sleep" id="1069" level="4" required-level="28" sp="5700" />
-		
-		<skill name="Servitor Heal" id="1127" level="8" required-level="29" sp="5700" />
-		<skill name="Sleep" id="1069" level="5" required-level="29" sp="5700" />
-		
-		<skill name="Weapon Mastery" id="249" level="7" required-level="30" sp="5700" />
-		<skill name="Robe Mastery" id="235" level="6" required-level="30" sp="5700" />
-		<skill name="Anti Magic" id="146" level="10" required-level="30" sp="5700" />
-		<skill name="Higher Mana Gain" id="285" level="6" required-level="30" sp="5700" />
-		<skill name="Boost Mana" id="213" level="2" required-level="30" sp="5700" />
-		<skill name="Quick Recovery" id="164" level="2" required-level="30" sp="5700" />
-		<skill name="Twister" id="1178" level="6" required-level="30" sp="5700" />
-		<skill name="Aura Burn" id="1172" level="6" required-level="30" sp="5700" />
-		<skill name="Servitor Heal" id="1127" level="9" required-level="30" sp="5700" />
-		<skill name="Servitor Recharge" id="1126" level="4" required-level="30" sp="5700" />
-		<skill name="Sleep" id="1069" level="6" required-level="30" sp="5700" />
-		<skill name="Surrender To Poison" id="1224" level="2" required-level="30" sp="5700" />
-		<skill name="Shadow Spark" id="1266" level="2" required-level="30" sp="5700" />
-		<skill name="Corpse Life Drain" id="1151" level="1" required-level="30" sp="5700" />
-		<skill name="Flame Strike" id="1181" level="3" required-level="30" sp="5700" />
-		<skill name="Summon Shadow" id="1128" level="3" required-level="30" sp="5700" />
-		<skill name="Summon Silhouette" id="1228" level="3" required-level="30" sp="5700" />
-		<skill name="Curse Poison" id="1168" level="3" required-level="30" sp="5700" />
-		<skill name="Concentration" id="1078" level="2" required-level="30" sp="5700" />
+		<skill name="Sleep" id="1069" level="5" required-level="28" sp="5700" />
 
+		<!-- Skills Lv29 -->
+		<skill name="Servitor Heal" id="1127" level="8" required-level="29" sp="5700" />
+		<skill name="Swift Servitor Heal" id="45362" level="8" required-level="29" sp="5700" />
+
+		<!-- Master Buffs Lv.30 -->
+		<skill name="Empower" id="45105" level="2" required-level="30" sp="5000" />
+		<skill name="Wild Magic" id="45106" level="1" required-level="30" sp="5000" />
+		<skill name="Berserker Spirit" id="45112" level="1" required-level="30" sp="5000" />
+		<skill name="Concentration" id="1078" level="2" required-level="30" sp="5700" />
+		<skill name="Magic Barrier" id="45108" level="1" required-level="30" sp="5000" />
+		<skill name="Acumen" id="45104" level="2" required-level="30" sp="5000" />
+		<skill name="Clarity" id="45113" level="2" required-level="30" sp="5000" />
+		<skill name="Death Whisper" id="45110" level="2" required-level="30" sp="5000" />
+		<skill name="Focus" id="45109" level="2" required-level="30" sp="5000" />
+		<skill name="Wind Walk" id="45107" level="2" required-level="30" sp="5000" />
+
+		<!-- Skills Lv30 -->
+		<skill name="Anti Magic" id="146" level="10" required-level="30" sp="5700" />
+		<skill name="Quick Recovery" id="164" level="2" required-level="30" sp="5700" />
+		<skill name="Robe Mastery" id="234" level="6" required-level="30" sp="5700" />
+		<skill name="Weapon Mastery" id="249" level="7" required-level="30" sp="5700" />
+		<skill name="Servitor Recharge" id="1126" level="4" required-level="30" sp="5700" />
+		<skill name="Shadow Spark" id="1266" level="2" required-level="30" sp="5700" />
+		<skill name="Ice Bolt" id="1184" level="9" required-level="30" sp="5700" />
+		<skill name="Servitor Heal" id="1127" level="9" required-level="30" sp="5700" />
+		<skill name="Fireball" id="1147" level="6" required-level="30" sp="5700" />
+		<skill name="Wind Shackle" id="1206" level="4" required-level="30" sp="5700" />
+		<skill name="Poison" id="1168" level="3" required-level="30" sp="5700" />
+		<skill name="Corpse Life Drain" id="1151" level="1" required-level="30" sp="5700" />
+		<skill name="Surrender to Poison" id="1224" level="2" required-level="30" sp="5700" />
+		<skill name="Summon Silhouette" id="1228" level="3" required-level="30" sp="5700" />
+		<skill name="Summon Shadow" id="1128" level="3" required-level="30" sp="5700" />
+		<skill name="Vampiric Touch" id="45247" level="6" required-level="30" sp="5700" />
+		<skill name="Aura Burn" id="1172" level="6" required-level="30" sp="5700" />
+		<skill name="Twister" id="1178" level="6" required-level="30" sp="5700" />
+		<skill name="Boost Mana" id="213" level="2" required-level="30" sp="5700" />
+		<skill name="Flame Strike" id="1181" level="3" required-level="30" sp="5700" />
+		<skill name="Swift Servitor Heal" id="45362" level="9" required-level="30" sp="5700" />
+		<skill name="Higher Mana Gain" id="285" level="6" required-level="30" sp="5700" />
+		<skill name="Sleep" id="1069" level="6" required-level="30" sp="5700" />
+
+
+		<!-- Skills Lv32 -->
+		<skill name="Vampiric Touch" id="45247" level="7" required-level="32" sp="5700" />
+		<skill name="Sleep" id="1069" level="7" required-level="32" sp="5700" />
+
+		<!-- Skills Lv33 -->
 		<skill name="Anti Magic" id="146" level="11" required-level="33" sp="13000" />
-		<skill name="Robe Mastery" id="235" level="7" required-level="33" sp="13000" />
+		<skill name="Robe Mastery" id="234" level="7" required-level="33" sp="13000" />
 		<skill name="Weapon Mastery" id="249" level="8" required-level="33" sp="13000" />
-		<skill name="Servitor Heal" id="1127" level="10" required-level="33" sp="13000" />
 		<skill name="Servitor Recharge" id="1126" level="5" required-level="33" sp="13000" />
+		<skill name="Servitor Heal" id="1127" level="10" required-level="33" sp="13000" />
 		<skill name="Aura Burn" id="1172" level="7" required-level="33" sp="13000" />
 		<skill name="Twister" id="1178" level="7" required-level="33" sp="13000" />
+		<skill name="Swift Servitor Heal" id="45362" level="10" required-level="33" sp="13000" />
 		<skill name="Higher Mana Gain" id="285" level="7" required-level="33" sp="13000" />
-		<skill name="Sleep" id="1069" level="7" required-level="33" sp="13000" />
-		
+
+		<!-- Skills Lv34 -->
 		<skill name="Servitor Heal" id="1127" level="11" required-level="34" sp="13000" />
+		<skill name="Vampiric Touch" id="45247" level="8" required-level="34" sp="13000" />
+		<skill name="Swift Servitor Heal" id="45362" level="11" required-level="34" sp="13000" />
 		<skill name="Sleep" id="1069" level="8" required-level="34" sp="13000" />
-		
-		<skill name="Weapon Mastery" id="249" level="9" required-level="35" sp="13000" />
-		<skill name="Robe Mastery" id="235" level="8" required-level="35" sp="13000" />
+
+		<!-- Skills Lv35 -->
 		<skill name="Anti Magic" id="146" level="12" required-level="35" sp="13000" />
-		<skill name="Higher Mana Gain" id="285" level="8" required-level="35" sp="13000" />
 		<skill name="Fast HP Recovery" id="212" level="1" required-level="35" sp="13000" />
 		<skill name="Fast Mana Recovery" id="229" level="2" required-level="35" sp="13000" />
-		<skill name="Twister" id="1178" level="8" required-level="35" sp="13000" />
-		<skill name="Aura Burn" id="1172" level="8" required-level="35" sp="13000" />
-		<skill name="Servitor Heal" id="1127" level="12" required-level="35" sp="13000" />
+		<skill name="Robe Mastery" id="234" level="8" required-level="35" sp="13000" />
+		<skill name="Weapon Mastery" id="249" level="9" required-level="35" sp="13000" />
 		<skill name="Servitor Recharge" id="1126" level="6" required-level="35" sp="13000" />
-		<skill name="Sleep" id="1069" level="9" required-level="35" sp="13000" />
-		<skill name="Surrender To Poison" id="1224" level="3" required-level="35" sp="13000" />
 		<skill name="Shadow Spark" id="1266" level="3" required-level="35" sp="13000" />
-		<skill name="Corpse Life Drain" id="1151" level="2" required-level="35" sp="13000" />
-		<skill name="Summon Shadow" id="1128" level="4" required-level="35" sp="13000" />
-		<skill name="Summon Silhouette" id="1228" level="4" required-level="35" sp="13000" />
-		<skill name="Poisonous Cloud" id="1167" level="2" required-level="35" sp="13000" />
+		<skill name="Slow" id="1160" level="1" required-level="35" sp="13000" />
+		<skill name="Ice Bolt" id="1184" level="10" required-level="35" sp="13000" />
+		<skill name="Servitor Heal" id="1127" level="12" required-level="35" sp="13000" />
 		<skill name="Mighty Servitor" id="1146" level="1" required-level="35" sp="13000" />
-		<skill name="Slow" id="1160" level="1" required-level="35" sp="13000">
-			<item id="1409"/>
-		</skill>
-		<skill name="Curse Chaos" id="1222" level="1" required-level="35" sp="13000">
-			<item id="1416"/>
-		</skill>
+		<skill name="Wind Shackle" id="1206" level="5" required-level="35" sp="13000" />
+		<skill name="Corpse Life Drain" id="1151" level="2" required-level="35" sp="13000" />
+		<skill name="Surrender to Poison" id="1224" level="3" required-level="35" sp="13000" />
+		<skill name="Summon Silhouette" id="1228" level="4" required-level="35" sp="13000" />
+		<skill name="Summon Shadow" id="1128" level="4" required-level="35" sp="13000" />
+		<skill name="Curse Chaos" id="1222" level="1" required-level="35" sp="13000" />
+		<skill name="Aura Burn" id="1172" level="8" required-level="35" sp="13000" />
+		<skill name="Twister" id="1178" level="8" required-level="35" sp="13000" />
+		<skill name="Swift Servitor Heal" id="45362" level="12" required-level="35" sp="13000" />
+		<skill name="Higher Mana Gain" id="285" level="8" required-level="35" sp="13000" />
+		<skill name="Poisonous Cloud" id="1167" level="2" required-level="35" sp="13000" />
+
+		<!-- Skills Lv36 -->
+		<skill name="Vampiric Touch" id="45247" level="9" required-level="36" sp="13000" />
+		<skill name="Sleep" id="1069" level="9" required-level="36" sp="13000" />
+
+		<!-- Skills Lv38 -->
+		<skill name="Vampiric Touch" id="45247" level="10" required-level="38" sp="13000" />
+		<skill name="Sleep" id="1069" level="10" required-level="38" sp="13000" />
+
 	</skillTree>
 </list>

--- a/data/skillTrees/1stClass/ElvenDeathBlader.xml
+++ b/data/skillTrees/1stClass/ElvenDeathBlader.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
+	<skillTree type="classSkillTree" classId="201" parentClassId="200">
+
+		<!-- Master Buffs Lv. 20 -->
+		<skill name="Empower" id="45105" level="1" required-level="20" sp="1000" />
+		<skill name="Wind Walk" id="45107" level="1" required-level="20" sp="1000" />
+		<skill name="Might" id="1068" level="2" required-level="20" sp="1000" />
+		<skill name="Acumen" id="45104" level="1" required-level="20" sp="1000" />
+		<skill name="Haste" id="45111" level="1" required-level="20" sp="1000" />
+		<skill name="Focus" id="45109" level="1" required-level="20" sp="1000" />
+		<skill name="Clarity" id="45113" level="1" required-level="20" sp="1000" />
+		<skill name="Death Whisper" id="45110" level="1" required-level="20" sp="1000" />
+		<skill name="Shield" id="1040" level="2" required-level="20" sp="1000" />
+
+
+		<!-- Skills Lv20 -->
+		<skill name="Death Armor Mastery" id="45354" level="4" required-level="20" sp="1000" />
+		<skill name="Death Sword Mastery" id="45353" level="4" required-level="20" sp="1000" />
+		<skill name="Recover HP" id="45176" level="1" required-level="20" sp="1000" />
+		<skill name="Recover MP" id="45177" level="1" required-level="20" sp="1000" />
+		<skill name="Punishment" id="45301" level="1" required-level="20" auto-learn="true" />
+		<skill name="Enhanced Weapon" id="255" level="1" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="2" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="3" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="4" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="5" required-level="20" sp="1000" />
+		<skill name="Ability to Protect" id="91" level="2" required-level="20" sp="1000" />
+		<skill name="Emergency Rescue" id="70" level="3" required-level="20" sp="1000" />
+		<skill name="Slowdown" id="15" level="3" required-level="20" sp="1000" />
+
+		<!-- Skills Lv21 -->
+		<skill name="Enhanced Weapon" id="255" level="6" required-level="21" sp="2500" />
+
+		<!-- Skills Lv22 -->
+		<skill name="Slowdown" id="15" level="4" required-level="22" sp="2500" />
+		<skill name="Enhanced Weapon" id="255" level="7" required-level="22" sp="2500" />
+
+		<!-- Skills Lv23 -->
+		<skill name="Slowdown" id="15" level="5" required-level="23" sp="2500" />
+		<skill name="Enhanced Weapon" id="255" level="8" required-level="23" sp="2500" />
+
+		<!-- Skills Lv24 -->
+		<skill name="Slowdown" id="15" level="6" required-level="24" sp="2500" />
+		<skill name="Enhanced Weapon" id="255" level="9" required-level="24" sp="2500" />
+
+		<!-- Skills Lv25 -->
+		<skill name="Death Armor Mastery" id="45354" level="5" required-level="25" sp="5500" />
+		<skill name="Death Sword Mastery" id="45353" level="5" required-level="25" sp="5500" />
+		<skill name="Enhanced Weapon" id="255" level="10" required-level="25" sp="5500" />
+		<skill name="Ability to Attack" id="77" level="2" required-level="25" sp="5500" />
+		<skill name="Emergency Rescue" id="70" level="4" required-level="25" sp="5500" />
+
+		<!-- Skills Lv26 -->
+		<skill name="Slowdown" id="15" level="7" required-level="26" sp="5500" />
+		<skill name="Punishment" id="45301" level="2" required-level="26" sp="5700" />
+		<skill name="Enhanced Weapon" id="255" level="11" required-level="26" sp="5500" />
+
+		<!-- Skills Lv27 -->
+		<skill name="Slowdown" id="15" level="8" required-level="27" sp="5500" />
+		<skill name="Enhanced Weapon" id="255" level="12" required-level="27" sp="5500" />
+
+		<!-- Skills Lv28 -->
+		<skill name="Slowdown" id="15" level="9" required-level="28" sp="5500" />
+		<skill name="Enhanced Weapon" id="255" level="13" required-level="28" sp="5500" />
+
+		<!-- Skills Lv29 -->
+		<skill name="Enhanced Weapon" id="255" level="14" required-level="29" sp="10000" />
+
+		<!-- Master Buffs Lv. 30 -->
+		<skill name="Empower" id="45105" level="2" required-level="30" sp="11000" />
+		<skill name="Wild Magic" id="45106" level="1" required-level="30" sp="11000" />
+		<skill name="Berserker Spirit" id="45112" level="1" required-level="30" sp="11000" />
+		<skill name="Wind Walk" id="45107" level="2" required-level="30" sp="11000" />
+		<skill name="Magic Barrier" id="45108" level="1" required-level="30" sp="11000" />
+		<skill name="Acumen" id="45104" level="2" required-level="30" sp="11000" />
+		<skill name="Focus" id="45109" level="2" required-level="30" sp="11000" />
+		<skill name="Clarity" id="45113" level="2" required-level="30" sp="11000" />
+		<skill name="Death Whisper" id="45110" level="2" required-level="30" sp="11000" />
+
+		<!-- Skills Lv30 -->
+		<skill name="Slowdown" id="15" level="10" required-level="30" sp="10000" />
+		<skill name="Death Armor Mastery" id="45354" level="6" required-level="30" sp="10000" />
+		<skill name="Death Sword Mastery" id="45353" level="6" required-level="30" sp="10000" />
+		<skill name="Enhanced Weapon" id="255" level="15" required-level="30" sp="10000" />
+		<skill name="Roar of Death" id="45328" level="1" required-level="30" sp="10000" />
+		<skill name="Emergency Rescue" id="70" level="5" required-level="30" sp="10000" />
+		<skill name="Sprint" id="230" level="1" required-level="30" sp="10000" />
+
+		<!-- Skills Lv31 -->
+		<skill name="Slowdown" id="15" level="11" required-level="31" sp="10000" />
+
+		<!-- Skills Lv32 -->
+		<skill name="Slowdown" id="15" level="12" required-level="32" sp="10000" />
+		<skill name="Punishment" id="45301" level="3" required-level="32" sp="11000" />
+		<skill name="Emergency Rescue" id="70" level="6" required-level="32" sp="10000" />
+
+		<!-- Skills Lv34 -->
+		<skill name="Slowdown" id="15" level="13" required-level="34" sp="20000" />
+		<skill name="Emergency Rescue" id="70" level="7" required-level="34" sp="20000" />
+
+		<!-- Skills Lv35 -->
+		<skill name="Slowdown" id="15" level="14" required-level="35" sp="20000" />
+		<skill name="Death Armor Mastery" id="45354" level="7" required-level="35" sp="20000" />
+		<skill name="Death Sword Mastery" id="45353" level="7" required-level="35" sp="20000" />
+
+		<!-- Skills Lv36 -->
+		<skill name="Slowdown" id="15" level="15" required-level="36" sp="20000" />
+		<skill name="Emergency Rescue" id="70" level="8" required-level="36" sp="20000" />
+		<skill name="Entangle" id="102" level="1" required-level="36" sp="20000" />
+
+		<!-- Skills Lv38 -->
+		<skill name="Slowdown" id="15" level="16" required-level="38" sp="20000" />
+		<skill name="Punishment" id="45301" level="4" required-level="38" sp="20000" />
+		<skill name="Emergency Rescue" id="70" level="9" required-level="38" sp="20000" />
+
+		<skill name="Slowdown" id="15" level="17" required-level="39" sp="20000" />
+		
+	</skillTree>
+</list>

--- a/data/skillTrees/1stClass/ElvenKnight.xml
+++ b/data/skillTrees/1stClass/ElvenKnight.xml
@@ -1,112 +1,208 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="19" parentClassId="18">
+
+		<!-- Master Buffs Lv. 20 -->
+		<skill name="Empower" id="45105" level="1" required-level="20" sp="1000" />
+		<skill name="Wind Walk" id="45107" level="1" required-level="20" sp="1000" />
+		<skill name="Might" id="1068" level="2" required-level="20" sp="1000" />
+		<skill name="Acumen" id="45104" level="1" required-level="20" sp="1000" />
+		<skill name="Haste" id="45111" level="1" required-level="20" sp="1000" />
+		<skill name="Focus" id="45109" level="1" required-level="20" sp="1000" />
+		<skill name="Clarity" id="45113" level="1" required-level="20" sp="1000" />
+		<skill name="Death Whisper" id="45110" level="1" required-level="20" sp="1000" />
+		<skill name="Shield" id="1040" level="2" required-level="20" sp="1000" />
+
+		<!-- Skills Lv20 -->
 		<skill name="Ultimate Defense" id="110" level="1" required-level="20" sp="1000" />
-		<skill name="Defense Aura" id="91" level="2" required-level="20" sp="1000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="1" required-level="20" sp="1000" />
+		<skill name="Majesty" id="82" level="1" required-level="20" sp="1000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="1" required-level="20" sp="1000" />
+		<skill name="Stun Mastery" id="100" level="1" required-level="20" sp="1000" />
+		<skill name="Stun Mastery" id="100" level="2" required-level="20" sp="1000" />
+		<skill name="Stun Mastery" id="100" level="3" required-level="20" sp="1000" />
+		<skill name="Stun Mastery" id="100" level="4" required-level="20" sp="1000" />
+		<skill name="Stun Mastery" id="100" level="5" required-level="20" sp="1000" />
 		<skill name="Heavy Armor Mastery" id="232" level="1" required-level="20" sp="1000" />
 		<skill name="Heavy Armor Mastery" id="232" level="2" required-level="20" sp="1000" />
 		<skill name="Heavy Armor Mastery" id="232" level="3" required-level="20" sp="1000" />
 		<skill name="Shield Mastery" id="153" level="1" required-level="20" sp="1000" />
-		<skill name="Poison Recovery" id="21" level="1" required-level="20" sp="1000" />
+		<skill name="Recovery" id="21" level="1" required-level="20" sp="1000" />
+		<skill name="Recover HP" id="45176" level="1" required-level="20" sp="1000" />
+		<skill name="Recover MP" id="45177" level="1" required-level="20" sp="1000" />
 		<skill name="Magic Resistance" id="147" level="1" required-level="20" sp="1000" />
 		<skill name="Magic Resistance" id="147" level="2" required-level="20" sp="1000" />
-		<skill name="Charm" id="15" level="1" required-level="20" sp="1000" />
-		<skill name="Charm" id="15" level="2" required-level="20" sp="1000" />
-		<skill name="Charm" id="15" level="3" required-level="20" sp="1000" />
-		<skill name="Elemental Heal" id="58" level="4" required-level="20" sp="1000" />
-		<skill name="Elemental Heal" id="58" level="5" required-level="20" sp="1000" />
-		<skill name="Elemental Heal" id="58" level="6" required-level="20" sp="1000" />
-		
+		<skill name="Enhanced Weapon" id="255" level="1" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="2" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="3" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="4" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="5" required-level="20" sp="1000" />
+		<skill name="Power Strike" id="3" level="10" required-level="20" sp="1000" />
+		<skill name="Power Strike" id="3" level="11" required-level="20" sp="1000" />
+		<skill name="Power Strike" id="3" level="12" required-level="20" sp="1000" />
+		<skill name="Slowdown" id="15" level="3" required-level="20" sp="1000" />
+		<skill name="Elemental Heal" id="58" level="10" required-level="20" sp="1000" />
+		<skill name="Ability to Protect" id="91" level="2" required-level="20" sp="1000" />
+
+		<skill name="Emergency Rescue" id="70" level="3" required-level="20" sp="1000" />
+
+		<!-- Skills Lv21 -->
+		<skill name="Stun Mastery" id="100" level="6" required-level="21" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="6" required-level="21" sp="1000" />
+		<skill name="Elemental Heal" id="58" level="11" required-level="21" sp="1000" />
+
+		<!-- Skills Lv22 -->
 		<skill name="Aggression" id="28" level="1" required-level="22" sp="2800" />
+		<skill name="Stun Mastery" id="100" level="7" required-level="22" sp="2800" />
 		<skill name="Heavy Armor Mastery" id="232" level="4" required-level="22" sp="2800" />
 		<skill name="Magic Resistance" id="147" level="3" required-level="22" sp="2800" />
-		<skill name="Charm" id="15" level="4" required-level="22" sp="2800" />
-		<skill name="Elemental Heal" id="58" level="7" required-level="22" sp="2800" />
-		
+		<skill name="Enhanced Weapon" id="255" level="7" required-level="22" sp="2800" />
+		<skill name="Power Strike" id="3" level="13" required-level="22" sp="2800" />
+		<skill name="Slowdown" id="15" level="4" required-level="22" sp="2800" />
+		<skill name="Elemental Heal" id="58" level="12" required-level="22" sp="2800" />
+
+		<!-- Skills Lv23 -->
 		<skill name="Aggression" id="28" level="2" required-level="23" sp="2800" />
+		<skill name="Stun Mastery" id="100" level="8" required-level="23" sp="2800" />
 		<skill name="Heavy Armor Mastery" id="232" level="5" required-level="23" sp="2800" />
 		<skill name="Magic Resistance" id="147" level="4" required-level="23" sp="2800" />
-		<skill name="Charm" id="15" level="5" required-level="23" sp="2800" />
-		<skill name="Elemental Heal" id="58" level="8" required-level="23" sp="2800" />
-		
+		<skill name="Enhanced Weapon" id="255" level="8" required-level="23" sp="2800" />
+		<skill name="Power Strike" id="3" level="14" required-level="23" sp="2800" />
+		<skill name="Slowdown" id="15" level="5" required-level="23" sp="2800" />
+		<skill name="Elemental Heal" id="58" level="13" required-level="23" sp="2800" />
+
+		<!-- Skills Lv24 -->
 		<skill name="Aggression" id="28" level="3" required-level="24" sp="2800" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="2" required-level="24" sp="2800" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="2" required-level="24" sp="2800" />
+		<skill name="Stun Mastery" id="100" level="9" required-level="24" sp="2800" />
 		<skill name="Heavy Armor Mastery" id="232" level="6" required-level="24" sp="2800" />
-		<skill name="Cure Bleed" id="61" level="1" required-level="24" sp="2800" />
 		<skill name="Magic Resistance" id="147" level="5" required-level="24" sp="2800" />
+		<skill name="Enhanced Weapon" id="255" level="9" required-level="24" sp="2800" />
+		<skill name="Power Strike" id="3" level="15" required-level="24" sp="2800" />
 		<skill name="Deflect Arrow" id="112" level="1" required-level="24" sp="2800" />
-		<skill name="Charm" id="15" level="6" required-level="24" sp="2800" />
-		<skill name="Elemental Heal" id="58" level="9" required-level="24" sp="2800" />
-		
+		<skill name="Slowdown" id="15" level="6" required-level="24" sp="2800" />
+		<skill name="Elemental Heal" id="58" level="14" required-level="24" sp="2800" />
+
+		<!-- Skills Lv25 -->
+		<skill name="Stun Mastery" id="100" level="10" required-level="25" sp="2800" />
+		<skill name="Enhanced Weapon" id="255" level="10" required-level="25" sp="2800" />
+		<skill name="Elemental Heal" id="58" level="15" required-level="25" sp="2800" />
+		<skill name="Ability to Attack" id="77" level="2" required-level="25" sp="2800" />
+		<skill name="Emergency Rescue" id="70" level="4" required-level="25" sp="2800" />
+
+		<!-- Skills Lv26 -->
 		<skill name="Aggression" id="28" level="4" required-level="26" sp="5700" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="3" required-level="26" sp="5700" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="3" required-level="26" sp="5700" />
+		<skill name="Stun Mastery" id="100" level="11" required-level="26" sp="5700" />
 		<skill name="Heavy Armor Mastery" id="232" level="7" required-level="26" sp="5700" />
 		<skill name="Magic Resistance" id="147" level="6" required-level="26" sp="5700" />
-		<skill name="Charm" id="15" level="7" required-level="26" sp="5700" />
-		<skill name="Elemental Heal" id="58" level="10" required-level="26" sp="5700" />
-		
+		<skill name="Enhanced Weapon" id="255" level="11" required-level="26" sp="5700" />
+		<skill name="Power Strike" id="3" level="16" required-level="26" sp="5700" />
+		<skill name="Slowdown" id="15" level="7" required-level="26" sp="5700" />
+		<skill name="Elemental Heal" id="58" level="16" required-level="26" sp="5700" />
+
+		<!-- Skills Lv27 -->
 		<skill name="Aggression" id="28" level="5" required-level="27" sp="5700" />
+		<skill name="Stun Mastery" id="100" level="12" required-level="27" sp="5700" />
 		<skill name="Heavy Armor Mastery" id="232" level="8" required-level="27" sp="5700" />
 		<skill name="Magic Resistance" id="147" level="7" required-level="27" sp="5700" />
-		<skill name="Charm" id="15" level="8" required-level="27" sp="5700" />
-		<skill name="Elemental Heal" id="58" level="11" required-level="27" sp="5700" />
-		
+		<skill name="Enhanced Weapon" id="255" level="12" required-level="27" sp="5700" />
+		<skill name="Power Strike" id="3" level="17" required-level="27" sp="5700" />
+		<skill name="Slowdown" id="15" level="8" required-level="27" sp="5700" />
+		<skill name="Elemental Heal" id="58" level="17" required-level="27" sp="5700" />
+
+		<!-- Skills Lv28 -->
 		<skill name="Aggression" id="28" level="6" required-level="28" sp="5700" />
-		<skill name="Attack Aura" id="77" level="2" required-level="28" sp="5700" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="4" required-level="28" sp="5700" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="4" required-level="28" sp="5700" />
+		<skill name="Stun Mastery" id="100" level="13" required-level="28" sp="5700" />
 		<skill name="Heavy Armor Mastery" id="232" level="9" required-level="28" sp="5700" />
 		<skill name="Shield Mastery" id="153" level="2" required-level="28" sp="5700" />
 		<skill name="Magic Resistance" id="147" level="8" required-level="28" sp="5700" />
-		<skill name="Charm" id="15" level="9" required-level="28" sp="5700" />
-		<skill name="Elemental Heal" id="58" level="12" required-level="28" sp="5700" />
-		
+		<skill name="Enhanced Weapon" id="255" level="13" required-level="28" sp="5700" />
+		<skill name="Power Strike" id="3" level="18" required-level="28" sp="5700" />
+		<skill name="Slowdown" id="15" level="9" required-level="28" sp="5700" />
+		<skill name="Elemental Heal" id="58" level="18" required-level="28" sp="5700" />
+
+		<!-- Skills Lv29 -->
+		<skill name="Stun Mastery" id="100" level="14" required-level="29" sp="11000" />
+		<skill name="Enhanced Weapon" id="255" level="14" required-level="29" sp="11000" />
+		<skill name="Elemental Heal" id="58" level="19" required-level="29" sp="11000" />
+
+		<!-- Skills Lv30 -->
 		<skill name="Aggression" id="28" level="7" required-level="30" sp="11000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="5" required-level="30" sp="11000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="5" required-level="30" sp="11000" />
+		<skill name="Stun Mastery" id="100" level="15" required-level="30" sp="11000" />
 		<skill name="Heavy Armor Mastery" id="232" level="10" required-level="30" sp="11000" />
+		<skill name="Empower" id="45105" level="2" required-level="30" sp="11000" />
+		<skill name="Wild Magic" id="45106" level="1" required-level="30" sp="11000" />
+		<skill name="Berserker Spirit" id="45112" level="1" required-level="30" sp="11000" />
+		<skill name="Wind Walk" id="45107" level="2" required-level="30" sp="11000" />
+		<skill name="Magic Barrier" id="45108" level="1" required-level="30" sp="11000" />
 		<skill name="Magic Resistance" id="147" level="9" required-level="30" sp="11000" />
-		<skill name="Charm" id="15" level="10" required-level="30" sp="11000" />
-		<skill name="Elemental Heal" id="58" level="13" required-level="30" sp="11000" />
-			
+		<skill name="Enhanced Weapon" id="255" level="15" required-level="30" sp="11000" />
+		<skill name="Power Strike" id="3" level="19" required-level="30" sp="11000" />
+		<skill name="Slowdown" id="15" level="10" required-level="30" sp="11000" />
+		<skill name="Elemental Heal" id="58" level="20" required-level="30" sp="11000" />
+		<skill name="Acumen" id="45104" level="2" required-level="30" sp="11000" />
+		<skill name="Sprint" id="230" level="1" required-level="30" sp="11000" />
+		<skill name="Focus" id="45109" level="2" required-level="30" sp="11000" />
+		<skill name="Clarity" id="45113" level="2" required-level="30" sp="11000" />
+		<skill name="Death Whisper" id="45110" level="2" required-level="30" sp="11000" />
+		<skill name="Emergency Rescue" id="70" level="5" required-level="30" sp="11000" />
+
+		<!-- Skills Lv31 -->
 		<skill name="Aggression" id="28" level="8" required-level="31" sp="11000" />
 		<skill name="Heavy Armor Mastery" id="232" level="11" required-level="31" sp="11000" />
 		<skill name="Magic Resistance" id="147" level="10" required-level="31" sp="11000" />
-		<skill name="Charm" id="15" level="11" required-level="31" sp="11000" />
-		<skill name="Elemental Heal" id="58" level="14" required-level="31" sp="11000" />
-		
+		<skill name="Power Strike" id="3" level="20" required-level="31" sp="11000" />
+		<skill name="Slowdown" id="15" level="11" required-level="31" sp="11000" />
+
+		<!-- Skills Lv32 -->
 		<skill name="Aggression" id="28" level="9" required-level="32" sp="11000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="6" required-level="32" sp="11000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="6" required-level="32" sp="11000" />
 		<skill name="Heavy Armor Mastery" id="232" level="12" required-level="32" sp="11000" />
 		<skill name="Magic Resistance" id="147" level="11" required-level="32" sp="11000" />
+		<skill name="Power Strike" id="3" level="21" required-level="32" sp="11000" />
 		<skill name="Deflect Arrow" id="112" level="2" required-level="32" sp="11000" />
-		<skill name="Charm" id="15" level="12" required-level="32" sp="11000" />
-		<skill name="Elemental Heal" id="58" level="15" required-level="32" sp="11000" />
-		<skill name="Sprint" id="230" level="1" required-level="32" sp="11000">
-			<item id="1384"/>
-		</skill>
-		
+		<skill name="Slowdown" id="15" level="12" required-level="32" sp="11000" />
+		<skill name="Elemental Heal" id="58" level="21" required-level="32" sp="11000" />
+		<skill name="Emergency Rescue" id="70" level="6" required-level="32" sp="11000" />
+
+		<!-- Skills Lv34 -->
 		<skill name="Aggression" id="28" level="10" required-level="34" sp="20000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="7" required-level="34" sp="20000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="7" required-level="34" sp="20000" />
 		<skill name="Heavy Armor Mastery" id="232" level="13" required-level="34" sp="20000" />
 		<skill name="Magic Resistance" id="147" level="12" required-level="34" sp="20000" />
-		<skill name="Charm" id="15" level="13" required-level="34" sp="20000" />
-		<skill name="Elemental Heal" id="58" level="16" required-level="34" sp="20000" />
-		
+		<skill name="Power Strike" id="3" level="22" required-level="34" sp="20000" />
+		<skill name="Slowdown" id="15" level="13" required-level="34" sp="20000" />
+		<skill name="Elemental Heal" id="58" level="22" required-level="34" sp="20000" />
+		<skill name="Emergency Rescue" id="70" level="7" required-level="34" sp="20000" />
+
+		<!-- Skills Lv35 -->
 		<skill name="Aggression" id="28" level="11" required-level="35" sp="20000" />
 		<skill name="Heavy Armor Mastery" id="232" level="14" required-level="35" sp="20000" />
 		<skill name="Magic Resistance" id="147" level="13" required-level="35" sp="20000" />
-		<skill name="Charm" id="15" level="14" required-level="35" sp="20000" />
-		<skill name="Elemental Heal" id="58" level="17" required-level="35" sp="20000" />
-		
+		<skill name="Power Strike" id="3" level="23" required-level="35" sp="20000" />
+		<skill name="Slowdown" id="15" level="14" required-level="35" sp="20000" />
+
+		<!-- Skills Lv36 -->
 		<skill name="Aggression" id="28" level="12" required-level="36" sp="20000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="8" required-level="36" sp="20000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="8" required-level="36" sp="20000" />
 		<skill name="Heavy Armor Mastery" id="232" level="15" required-level="36" sp="20000" />
 		<skill name="Magic Resistance" id="147" level="14" required-level="36" sp="20000" />
-		<skill name="Charm" id="15" level="15" required-level="36" sp="20000" />
-		<skill name="Elemental Heal" id="58" level="18" required-level="36" sp="20000" />
+		<skill name="Power Strike" id="3" level="24" required-level="36" sp="20000" />
+		<skill name="Entangle" id="102" level="1" required-level="36" sp="20000" />
+		<skill name="Slowdown" id="15" level="15" required-level="36" sp="20000" />
+		<skill name="Elemental Heal" id="58" level="23" required-level="36" sp="20000" />
 		<skill name="Focus Mind" id="191" level="1" required-level="36" sp="20000" />
-		<skill name="Entangle" id="102" level="1" required-level="36" sp="20000">
-			<item id="1380"/>
-		</skill>
+		<skill name="Emergency Rescue" id="70" level="8" required-level="36" sp="20000" />
+
+		<!-- Skills Lv38 -->
+		<skill name="Slowdown" id="15" level="16" required-level="38" sp="20000" />
+		<skill name="Elemental Heal" id="58" level="24" required-level="38" sp="20000" />
+		<skill name="Emergency Rescue" id="70" level="9" required-level="38" sp="20000" />
+
+		<!-- Skills Lv39 -->
+		<skill name="Slowdown" id="15" level="17" required-level="39" sp="20000" />
+
 	</skillTree>
 </list>

--- a/data/skillTrees/1stClass/ElvenOracle.xml
+++ b/data/skillTrees/1stClass/ElvenOracle.xml
@@ -1,37 +1,58 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="29" parentClassId="25">
+
+		<!-- Master Buffs Lv. 20 -->
+		<skill name="Empower" id="45105" level="1" required-level="20" sp="500" />
+		<skill name="Concentration" id="1078" level="1" required-level="20" sp="600" />
+		<skill name="Wind Walk" id="1204" level="1" required-level="20" sp="500" />
+		<skill name="Might" id="1068" level="2" required-level="20" sp="500" />
+		<skill name="Agility" id="1087" level="1" required-level="20" sp="500" />
+		<skill name="Acumen" id="45104" level="1" required-level="20" sp="500" />
+		<skill name="Haste" id="45111" level="1" required-level="20" sp="500" />
+		<skill name="Focus" id="45109" level="1" required-level="20" sp="500" />
+		<skill name="Clarity" id="1397" level="1" required-level="20" sp="500" />
+		<skill name="Death Whisper" id="45110" level="1" required-level="20" sp="500" />
+		<skill name="Shield" id="1040" level="2" required-level="20" sp="500" />
+
+		<!-- Skills Lv20 -->
 		<skill name="Anti Magic" id="146" level="5" required-level="20" sp="600" />
 		<skill name="Anti Magic" id="146" level="6" required-level="20" sp="600" />
 		<skill name="Battle Heal" id="1015" level="4" required-level="20" sp="600" />
 		<skill name="Battle Heal" id="1015" level="5" required-level="20" sp="600" />
 		<skill name="Battle Heal" id="1015" level="6" required-level="20" sp="600" />
+		<skill name="Divine Strike" id="1031" level="1" required-level="20" sp="600" />
+		<skill name="Divine Strike" id="1031" level="2" required-level="20" sp="600" />
 		<skill name="Quick Recovery" id="164" level="1" required-level="20" sp="600" />
 		<skill name="Light Armor Mastery" id="236" level="1" required-level="20" sp="600" />
 		<skill name="Light Armor Mastery" id="236" level="2" required-level="20" sp="600" />
 		<skill name="Robe Mastery" id="235" level="1" required-level="20" sp="600" />
 		<skill name="Robe Mastery" id="235" level="2" required-level="20" sp="600" />
 		<skill name="Weapon Mastery" id="249" level="3" required-level="20" sp="600" />
+		<skill name="Resurrection" id="1016" level="1" required-level="20" sp="600" />
+		<skill name="Recover HP" id="45176" level="1" required-level="20" sp="500" />
+		<skill name="Recover MP" id="45177" level="1" required-level="20" sp="500" />
 		<skill name="Group Heal" id="1027" level="4" required-level="20" sp="600" />
 		<skill name="Group Heal" id="1027" level="5" required-level="20" sp="600" />
 		<skill name="Group Heal" id="1027" level="6" required-level="20" sp="600" />
-		<skill name="Wind Walk" id="1204" level="1" required-level="20" sp="600" />
+		<skill name="Dryad Root" id="1201" level="1" required-level="20" sp="600" />
 		<skill name="Heal" id="1011" level="7" required-level="20" sp="600" />
 		<skill name="Heal" id="1011" level="8" required-level="20" sp="600" />
 		<skill name="Heal" id="1011" level="9" required-level="20" sp="600" />
-		<skill name="Might" id="1068" level="2" required-level="20" sp="600" />
 		<skill name="Wind Shackle" id="1206" level="2" required-level="20" sp="600" />
-		<skill name="Eva's Kiss" id="1073" level="1" required-level="20" sp="600" />
-		<skill name="Disrupt Undead" id="1031" level="1" required-level="20" sp="600" />
-		<skill name="Disrupt Undead" id="1031" level="2" required-level="20" sp="600" />
+		<skill name="Self Heal" id="1216" level="4" required-level="20" sp="600" />
+		<skill name="Weakness" id="1164" level="2" required-level="20" sp="600" />
 		<skill name="Boost Mana" id="213" level="1" required-level="20" sp="600" />
-		<skill name="Concentration" id="1078" level="1" required-level="20" sp="600">
-			<item id="1399"/>
-		</skill>
-		<skill name="Resurrection" id="1016" level="1" required-level="20" sp="600">
-			<item id="1514"/>
-		</skill>
-		
+		<skill name="Increased Power of Magic" id="1073" level="1" required-level="20" sp="600" />
+		<skill name="Sleep" id="1069" level="1" required-level="20" sp="600" />
+
+
+		<!-- Skills Lv22 -->
+		<skill name="Divine Strike" id="1031" level="3" required-level="22" sp="2300" />
+		<skill name="Dryad Root" id="1201" level="2" required-level="22" sp="2300" />
+		<skill name="Sleep" id="1069" level="2" required-level="22" sp="2300" />
+
+		<!-- Skills Lv23 -->
 		<skill name="Anti Magic" id="146" level="7" required-level="23" sp="2300" />
 		<skill name="Battle Heal" id="1015" level="7" required-level="23" sp="2300" />
 		<skill name="Light Armor Mastery" id="236" level="3" required-level="23" sp="2300" />
@@ -39,21 +60,18 @@
 		<skill name="Weapon Mastery" id="249" level="4" required-level="23" sp="2300" />
 		<skill name="Group Heal" id="1027" level="7" required-level="23" sp="2300" />
 		<skill name="Heal" id="1011" level="10" required-level="23" sp="2300" />
-		<skill name="Disrupt Undead" id="1031" level="3" required-level="23" sp="2300" />
-		<skill name="Sleep" id="1069" level="1" required-level="23" sp="2300">
-			<item id="1394"/>
-		</skill>
-		<skill name="Dryad Root" id="1201" level="1" required-level="23" sp="2300">
-			<item id="1415"/>
-		</skill>
-		
-		<skill name="Battle Heal" id="1015" level="8" required-level="24" sp="2300" />
-		<skill name="Group Heal" id="1027" level="8" required-level="24" sp="2300" />
-		<skill name="Dryad Root" id="1201" level="2" required-level="24" sp="2300" />
-		<skill name="Heal" id="1011" level="11" required-level="24" sp="2300" />
-		<skill name="Sleep" id="1069" level="2" required-level="24" sp="2300" />
 
+		<!-- Skills Lv24 -->
+		<skill name="Battle Heal" id="1015" level="8" required-level="24" sp="2300" />
+		<skill name="Divine Strike" id="1031" level="4" required-level="24" sp="2300" />
+		<skill name="Group Heal" id="1027" level="8" required-level="24" sp="2300" />
+		<skill name="Dryad Root" id="1201" level="3" required-level="24" sp="2300" />
+		<skill name="Heal" id="1011" level="11" required-level="24" sp="2300" />
+		<skill name="Sleep" id="1069" level="3" required-level="24" sp="2300" />
+
+		<!-- Skills Lv25 -->
 		<skill name="Anti Magic" id="146" level="8" required-level="25" sp="2300" />
+		<skill name="Mage's Blessing" id="1043" level="1" required-level="25" sp="2300" />
 		<skill name="Battle Heal" id="1015" level="9" required-level="25" sp="2300" />
 		<skill name="Fast Mana Recovery" id="229" level="1" required-level="25" sp="2300" />
 		<skill name="Fast Spell Casting" id="228" level="1" required-level="25" sp="2300" />
@@ -61,74 +79,94 @@
 		<skill name="Robe Mastery" id="235" level="4" required-level="25" sp="2300" />
 		<skill name="Weapon Mastery" id="249" level="5" required-level="25" sp="2300" />
 		<skill name="Group Heal" id="1027" level="9" required-level="25" sp="2300" />
-		<skill name="Dryad Root" id="1201" level="3" required-level="25" sp="2300" />
 		<skill name="Heal" id="1011" level="12" required-level="25" sp="2300" />
+		<skill name="Mental Shield" id="1035" level="1" required-level="25" sp="2300" />
 		<skill name="Wind Shackle" id="1206" level="3" required-level="25" sp="2300" />
-		<skill name="Agility" id="1087" level="1" required-level="25" sp="2300" />
-		<skill name="Disrupt Undead" id="1031" level="4" required-level="25" sp="2300" />
-		<skill name="Holy Weapon" id="1043" level="1" required-level="25" sp="2300" />
-		<skill name="Sleep" id="1069" level="3" required-level="25" sp="2300" />
-		<skill name="Shield" id="1040" level="2" required-level="25" sp="2300" />
-		<skill name="Mental Shield" id="1035" level="1" required-level="25" sp="2300">
-			<item id="1388"/>
-		</skill>
-		
+		<skill name="Self Heal" id="1216" level="5" required-level="25" sp="2300" />
+		<skill name="Weakness" id="1164" level="3" required-level="25" sp="2300" />
+
+		<!-- Skills Lv26 -->
+		<skill name="Divine Strike" id="1031" level="5" required-level="26" sp="2300" />
+		<skill name="Dryad Root" id="1201" level="4" required-level="26" sp="2300" />
+		<skill name="Sleep" id="1069" level="4" required-level="26" sp="2300" />
+
+		<!-- Skills Lv28 -->
 		<skill name="Anti Magic" id="146" level="9" required-level="28" sp="5700" />
 		<skill name="Battle Heal" id="1015" level="10" required-level="28" sp="5700" />
+		<skill name="Divine Strike" id="1031" level="6" required-level="28" sp="5700" />
 		<skill name="Light Armor Mastery" id="236" level="5" required-level="28" sp="5700" />
 		<skill name="Robe Mastery" id="235" level="5" required-level="28" sp="5700" />
 		<skill name="Weapon Mastery" id="249" level="6" required-level="28" sp="5700" />
 		<skill name="Group Heal" id="1027" level="10" required-level="28" sp="5700" />
-		<skill name="Dryad Root" id="1201" level="4" required-level="28" sp="5700" />
+		<skill name="Dryad Root" id="1201" level="5" required-level="28" sp="5700" />
 		<skill name="Heal" id="1011" level="13" required-level="28" sp="5700" />
-		<skill name="Disrupt Undead" id="1031" level="5" required-level="28" sp="5700" />
-		<skill name="Sleep" id="1069" level="4" required-level="28" sp="5700" />
-		<skill name="Recharge" id="1013" level="1" required-level="28" sp="5700">
-			<item id="1385"/>
-		</skill>
-		
+		<skill name="Boost Mana" id="1013" level="1" required-level="28" sp="5700" />
+		<skill name="Sleep" id="1069" level="5" required-level="28" sp="5700" />
+		<skill name="Mana Effect Boost" id="1013" level="1" required-level="28" sp="5700" />
+
+		<!-- Skills Lv29 -->
 		<skill name="Battle Heal" id="1015" level="11" required-level="29" sp="5700" />
 		<skill name="Group Heal" id="1027" level="11" required-level="29" sp="5700" />
-		<skill name="Dryad Root" id="1201" level="5" required-level="29" sp="5700" />
 		<skill name="Heal" id="1011" level="14" required-level="29" sp="5700" />
-		<skill name="Sleep" id="1069" level="5" required-level="29" sp="5700" />
 
+		<!-- Master Buffs Lv. 30 -->
+		<skill name="Empower" id="45105" level="2" required-level="30" sp="5000" />
+		<skill name="Wild Magic" id="1303" level="1" required-level="30" sp="5000" />
+		<skill name="Berserker Spirit" id="45112" level="1" required-level="30" sp="5000" />
+		<skill name="Concentration" id="1078" level="2" required-level="30" sp="5700" />
+		<skill name="Wind Walk" id="1204" level="2" required-level="30" sp="5000" />
+		<skill name="Decrease Weight" id="1257" level="1" required-level="30" sp="5000" />
+		<skill name="Magic Barrier" id="45108" level="1" required-level="30" sp="5000" />
+		<skill name="Acumen" id="45104" level="2" required-level="30" sp="5000" />
+		<skill name="Focus" id="45109" level="2" required-level="30" sp="5000" />
+		<skill name="Clarity" id="1397" level="2" required-level="30" sp="5000" />
+		<skill name="Death Whisper" id="45110" level="2" required-level="30" sp="5000" />
+
+		<!-- Skills Lv30 -->
 		<skill name="Anti Magic" id="146" level="10" required-level="30" sp="5700" />
 		<skill name="Battle Heal" id="1015" level="12" required-level="30" sp="5700" />
+		<skill name="Divine Strike" id="1031" level="7" required-level="30" sp="5700" />
 		<skill name="Quick Recovery" id="164" level="2" required-level="30" sp="5700" />
 		<skill name="Light Armor Mastery" id="236" level="6" required-level="30" sp="5700" />
 		<skill name="Robe Mastery" id="235" level="6" required-level="30" sp="5700" />
 		<skill name="Weapon Mastery" id="249" level="7" required-level="30" sp="5700" />
 		<skill name="Resurrection" id="1016" level="2" required-level="30" sp="5700" />
 		<skill name="Group Heal" id="1027" level="12" required-level="30" sp="5700" />
-		<skill name="Concentration" id="1078" level="2" required-level="30" sp="5700" />
 		<skill name="Dryad Root" id="1201" level="6" required-level="30" sp="5700" />
-		<skill name="Wind Walk" id="1204" level="2" required-level="30" sp="5700" />
 		<skill name="Heal" id="1011" level="15" required-level="30" sp="5700" />
 		<skill name="Wind Shackle" id="1206" level="4" required-level="30" sp="5700" />
-		<skill name="Recharge" id="1013" level="2" required-level="30" sp="5700" />
-		<skill name="Disrupt Undead" id="1031" level="6" required-level="30" sp="5700" />
+		<skill name="Weakness" id="1164" level="4" required-level="30" sp="5700" />
 		<skill name="Boost Mana" id="213" level="2" required-level="30" sp="5700" />
+		<skill name="Boost Mana" id="1013" level="2" required-level="30" sp="5700" />
 		<skill name="Sleep" id="1069" level="6" required-level="30" sp="5700" />
-		
+
+		<skill name="Mana Effect Boost" id="1013" level="2" required-level="30" sp="5700" />
+
+		<!-- Skills Lv32 -->
+		<skill name="Divine Strike" id="1031" level="8" required-level="32" sp="5700" />
+		<skill name="Dryad Root" id="1201" level="7" required-level="32" sp="5700" />
+		<skill name="Sleep" id="1069" level="7" required-level="32" sp="5700" />
+
+		<!-- Skills Lv33 -->
 		<skill name="Anti Magic" id="146" level="11" required-level="33" sp="13000" />
 		<skill name="Battle Heal" id="1015" level="13" required-level="33" sp="13000" />
 		<skill name="Light Armor Mastery" id="236" level="7" required-level="33" sp="13000" />
 		<skill name="Robe Mastery" id="235" level="7" required-level="33" sp="13000" />
 		<skill name="Weapon Mastery" id="249" level="8" required-level="33" sp="13000" />
 		<skill name="Group Heal" id="1027" level="13" required-level="33" sp="13000" />
-		<skill name="Dryad Root" id="1201" level="7" required-level="33" sp="13000" />
 		<skill name="Heal" id="1011" level="16" required-level="33" sp="13000" />
-		<skill name="Recharge" id="1013" level="3" required-level="33" sp="13000" />
-		<skill name="Disrupt Undead" id="1031" level="7" required-level="33" sp="13000" />
-		<skill name="Sleep" id="1069" level="7" required-level="33" sp="13000" />
-		
+		<skill name="Boost Mana" id="1013" level="3" required-level="33" sp="13000" />
+		<skill name="Mana Effect Boost" id="1013" level="3" required-level="33" sp="13000" />
+
+		<!-- Skills Lv34 -->
 		<skill name="Battle Heal" id="1015" level="14" required-level="34" sp="13000" />
+		<skill name="Divine Strike" id="1031" level="9" required-level="34" sp="13000" />
 		<skill name="Group Heal" id="1027" level="14" required-level="34" sp="13000" />
 		<skill name="Dryad Root" id="1201" level="8" required-level="34" sp="13000" />
 		<skill name="Heal" id="1011" level="17" required-level="34" sp="13000" />
 		<skill name="Sleep" id="1069" level="8" required-level="34" sp="13000" />
 
+		<!-- Skills Lv35 -->
 		<skill name="Anti Magic" id="146" level="12" required-level="35" sp="13000" />
 		<skill name="Battle Heal" id="1015" level="15" required-level="35" sp="13000" />
 		<skill name="Fast HP Recovery" id="212" level="1" required-level="35" sp="13000" />
@@ -137,17 +175,23 @@
 		<skill name="Robe Mastery" id="235" level="8" required-level="35" sp="13000" />
 		<skill name="Weapon Mastery" id="249" level="9" required-level="35" sp="13000" />
 		<skill name="Group Heal" id="1027" level="15" required-level="35" sp="13000" />
-		<skill name="Cure Poison" id="1012" level="2" required-level="35" sp="13000" />
-		<skill name="Dryad Root" id="1201" level="9" required-level="35" sp="13000" />
+		<skill name="Cure" id="1012" level="2" required-level="35" sp="13000" />
 		<skill name="Heal" id="1011" level="18" required-level="35" sp="13000" />
 		<skill name="Wind Shackle" id="1206" level="5" required-level="35" sp="13000" />
-		<skill name="Recharge" id="1013" level="4" required-level="35" sp="13000" />
-		<skill name="Disrupt Undead" id="1031" level="8" required-level="35" sp="13000" />
 		<skill name="Regeneration" id="1044" level="1" required-level="35" sp="13000" />
-		<skill name="Poison Resistance" id="1033" level="1" required-level="35" sp="13000" />
-		<skill name="Sleep" id="1069" level="9" required-level="35" sp="13000" />
-		<skill name="Decrease Weight" id="1257" level="1" required-level="35" sp="13000">
-			<item id="3944"/>
-		</skill>
+		<skill name="Weakness" id="1164" level="5" required-level="35" sp="13000" />
+		<skill name="Infection Mitigation" id="1033" level="1" required-level="35" sp="13000" />
+		<skill name="Boost Mana" id="1013" level="4" required-level="35" sp="13000" />
+		<skill name="Mana Effect Boost" id="1013" level="4" required-level="35" sp="13000" />
+
+		<!-- Skills Lv36 -->
+		<skill name="Divine Strike" id="1031" level="10" required-level="36" sp="13000" />
+		<skill name="Dryad Root" id="1201" level="9" required-level="36" sp="13000" />
+		<skill name="Sleep" id="1069" level="9" required-level="36" sp="13000" />
+
+		<!-- Skills Lv38 -->
+		<skill name="Dryad Root" id="1201" level="10" required-level="38" sp="13000" />
+		<skill name="Sleep" id="1069" level="10" required-level="38" sp="13000" />
+
 	</skillTree>
 </list>

--- a/data/skillTrees/1stClass/ElvenScout.xml
+++ b/data/skillTrees/1stClass/ElvenScout.xml
@@ -1,76 +1,102 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="22" parentClassId="18">
+
+		<!-- Master Buffs Lv. 20 -->
+		<skill name="Empower" id="45105" level="1" required-level="20" sp="1000" />
+		<skill name="Wind Walk" id="45107" level="1" required-level="20" sp="1000" />
+		<skill name="Might" id="1068" level="2" required-level="20" sp="1000" />
+		<skill name="Acumen" id="45104" level="1" required-level="20" sp="1000" />
+		<skill name="Haste" id="45111" level="1" required-level="20" sp="1000" />
+		<skill name="Focus" id="45109" level="1" required-level="20" sp="1000" />
+		<skill name="Clarity" id="45113" level="1" required-level="20" sp="1000" />
+		<skill name="Death Whisper" id="45110" level="1" required-level="20" sp="1000" />
+		<skill name="Shield" id="1040" level="2" required-level="20" sp="1000" />
+
+		<!-- Skills Lv20 -->
 		<skill name="Acrobatics" id="173" level="1" required-level="20" sp="1000" />
-		<skill name="Defense Aura" id="91" level="2" required-level="20" sp="1000" />
 		<skill name="Vicious Stance" id="312" level="1" required-level="20" sp="1000" />
+		<skill name="Fast Run" id="4" level="1" required-level="20" sp="1000" />
 		<skill name="Dagger Mastery" id="209" level="1" required-level="20" sp="1000" />
 		<skill name="Light Armor Mastery" id="233" level="1" required-level="20" sp="1000" />
 		<skill name="Light Armor Mastery" id="233" level="2" required-level="20" sp="1000" />
 		<skill name="Bow Mastery" id="208" level="1" required-level="20" sp="1000" />
 		<skill name="Bow Mastery" id="208" level="2" required-level="20" sp="1000" />
 		<skill name="Bow Mastery" id="208" level="3" required-level="20" sp="1000" />
+		<skill name="Recovery" id="21" level="1" required-level="20" sp="1000" />
+		<skill name="Recover HP" id="45176" level="1" required-level="20" sp="1000" />
+		<skill name="Recover MP" id="45177" level="1" required-level="20" sp="1000" />
 		<skill name="Boost Breath" id="195" level="1" required-level="20" sp="1000" />
 		<skill name="Long Shot" id="113" level="1" required-level="20" sp="1000" />
 		<skill name="Power Shot" id="56" level="10" required-level="20" sp="1000" />
 		<skill name="Power Shot" id="56" level="11" required-level="20" sp="1000" />
 		<skill name="Power Shot" id="56" level="12" required-level="20" sp="1000" />
 		<skill name="Unlock" id="27" level="1" required-level="20" sp="1000" />
-		<skill name="Charm" id="15" level="1" required-level="20" sp="1000" />
-		<skill name="Charm" id="15" level="2" required-level="20" sp="1000" />
-		<skill name="Charm" id="15" level="3" required-level="20" sp="1000" />
-		<skill name="Elemental Heal" id="58" level="4" required-level="20" sp="1000" />
-		<skill name="Elemental Heal" id="58" level="5" required-level="20" sp="1000" />
-		<skill name="Elemental Heal" id="58" level="6" required-level="20" sp="1000" />
+		<skill name="Slowdown" id="15" level="3" required-level="20" sp="1000" />
+		<skill name="Elemental Heal" id="58" level="10" required-level="20" sp="1000" />
 		<skill name="Mortal Blow" id="16" level="10" required-level="20" sp="1000" />
 		<skill name="Mortal Blow" id="16" level="11" required-level="20" sp="1000" />
 		<skill name="Mortal Blow" id="16" level="12" required-level="20" sp="1000" />
-		
+		<skill name="Ability to Protect" id="91" level="2" required-level="20" sp="1000" />
+
+		<skill name="Emergency Rescue" id="70" level="3" required-level="20" sp="1000" />
+
+		<!-- Skills Lv21 -->
+		<skill name="Elemental Heal" id="58" level="11" required-level="21" sp="1000" />
+
+		<!-- Skills Lv22 -->
 		<skill name="Light Armor Mastery" id="233" level="3" required-level="22" sp="2800" />
 		<skill name="Bow Mastery" id="208" level="4" required-level="22" sp="2800" />
 		<skill name="Power Shot" id="56" level="13" required-level="22" sp="2800" />
-		<skill name="Charm" id="15" level="4" required-level="22" sp="2800" />
-		<skill name="Elemental Heal" id="58" level="7" required-level="22" sp="2800" />
+		<skill name="Slowdown" id="15" level="4" required-level="22" sp="2800" />
+		<skill name="Elemental Heal" id="58" level="12" required-level="22" sp="2800" />
 		<skill name="Mortal Blow" id="16" level="13" required-level="22" sp="2800" />
-		
+
+		<!-- Skills Lv23 -->
 		<skill name="Bow Mastery" id="208" level="5" required-level="23" sp="2800" />
 		<skill name="Power Shot" id="56" level="14" required-level="23" sp="2800" />
-		<skill name="Charm" id="15" level="5" required-level="23" sp="2800" />
-		<skill name="Elemental Heal" id="58" level="8" required-level="23" sp="2800" />
+		<skill name="Slowdown" id="15" level="5" required-level="23" sp="2800" />
+		<skill name="Elemental Heal" id="58" level="13" required-level="23" sp="2800" />
 		<skill name="Mortal Blow" id="16" level="14" required-level="23" sp="2800" />
-		
+
+		<!-- Skills Lv24 -->
 		<skill name="Vicious Stance" id="312" level="2" required-level="24" sp="2800" />
 		<skill name="Dagger Mastery" id="209" level="2" required-level="24" sp="2800" />
 		<skill name="Light Armor Mastery" id="233" level="4" required-level="24" sp="2800" />
 		<skill name="Bow Mastery" id="208" level="6" required-level="24" sp="2800" />
-		<skill name="Poison Recovery" id="21" level="1" required-level="24" sp="2800" />
-		<skill name="Cure Bleed" id="61" level="1" required-level="24" sp="2800" />
 		<skill name="Bleed" id="96" level="1" required-level="24" sp="2800" />
 		<skill name="Power Shot" id="56" level="15" required-level="24" sp="2800" />
 		<skill name="Unlock" id="27" level="2" required-level="24" sp="2800" />
-		<skill name="Charm" id="15" level="6" required-level="24" sp="2800" />
-		<skill name="Elemental Heal" id="58" level="9" required-level="24" sp="2800" />
+		<skill name="Slowdown" id="15" level="6" required-level="24" sp="2800" />
+		<skill name="Elemental Heal" id="58" level="14" required-level="24" sp="2800" />
 		<skill name="Mortal Blow" id="16" level="15" required-level="24" sp="2800" />
 		<skill name="Accuracy" id="256" level="1" required-level="24" sp="2800" />
 		<skill name="Boost Evasion" id="198" level="1" required-level="24" sp="2800" />
-		
+
+		<!-- Skills Lv25 -->
+		<skill name="Elemental Heal" id="58" level="15" required-level="25" sp="2800" />
+		<skill name="Ability to Attack" id="77" level="2" required-level="25" sp="2800" />
+		<skill name="Emergency Rescue" id="70" level="4" required-level="25" sp="2800" />
+
+		<!-- Skills Lv26 -->
 		<skill name="Dagger Mastery" id="209" level="3" required-level="26" sp="5700" />
 		<skill name="Light Armor Mastery" id="233" level="5" required-level="26" sp="5700" />
 		<skill name="Bow Mastery" id="208" level="7" required-level="26" sp="5700" />
 		<skill name="Power Shot" id="56" level="16" required-level="26" sp="5700" />
-		<skill name="Charm" id="15" level="7" required-level="26" sp="5700" />
-		<skill name="Elemental Heal" id="58" level="10" required-level="26" sp="5700" />
+		<skill name="Slowdown" id="15" level="7" required-level="26" sp="5700" />
+		<skill name="Elemental Heal" id="58" level="16" required-level="26" sp="5700" />
 		<skill name="Mortal Blow" id="16" level="16" required-level="26" sp="5700" />
-		
+
+		<!-- Skills Lv27 -->
 		<skill name="Bow Mastery" id="208" level="8" required-level="27" sp="5700" />
 		<skill name="Power Shot" id="56" level="17" required-level="27" sp="5700" />
-		<skill name="Charm" id="15" level="8" required-level="27" sp="5700" />
-		<skill name="Elemental Heal" id="58" level="11" required-level="27" sp="5700" />
+		<skill name="Slowdown" id="15" level="8" required-level="27" sp="5700" />
+		<skill name="Elemental Heal" id="58" level="17" required-level="27" sp="5700" />
 		<skill name="Mortal Blow" id="16" level="17" required-level="27" sp="5700" />
-		
+
+		<!-- Skills Lv28 -->
 		<skill name="Ultimate Evasion" id="111" level="1" required-level="28" sp="5700" />
 		<skill name="Acrobatic Move" id="225" level="1" required-level="28" sp="5700" />
-		<skill name="Attack Aura" id="77" level="2" required-level="28" sp="5700" />
 		<skill name="Vicious Stance" id="312" level="3" required-level="28" sp="5700" />
 		<skill name="Quick Step" id="169" level="1" required-level="28" sp="5700" />
 		<skill name="Dagger Mastery" id="209" level="4" required-level="28" sp="5700" />
@@ -78,24 +104,42 @@
 		<skill name="Bow Mastery" id="208" level="9" required-level="28" sp="5700" />
 		<skill name="Power Shot" id="56" level="18" required-level="28" sp="5700" />
 		<skill name="Unlock" id="27" level="3" required-level="28" sp="5700" />
-		<skill name="Charm" id="15" level="9" required-level="28" sp="5700" />
-		<skill name="Elemental Heal" id="58" level="12" required-level="28" sp="5700" />
+		<skill name="Slowdown" id="15" level="9" required-level="28" sp="5700" />
+		<skill name="Elemental Heal" id="58" level="18" required-level="28" sp="5700" />
 		<skill name="Mortal Blow" id="16" level="18" required-level="28" sp="5700" />
-		
+
+		<!-- Skills Lv29 -->
+		<skill name="Elemental Heal" id="58" level="19" required-level="29" sp="11000" />
+
+		<!-- Master Skills Lv. 30 -->
+		<skill name="Empower" id="45105" level="2" required-level="30" sp="11000" />
+		<skill name="Wild Magic" id="45106" level="1" required-level="30" sp="11000" />
+		<skill name="Berserker Spirit" id="45112" level="1" required-level="30" sp="11000" />
+		<skill name="Wind Walk" id="45107" level="2" required-level="30" sp="11000" />
+		<skill name="Magic Barrier" id="45108" level="1" required-level="30" sp="11000" />
+		<skill name="Acumen" id="45104" level="2" required-level="30" sp="11000" />
+		<skill name="Focus" id="45109" level="2" required-level="30" sp="11000" />
+		<skill name="Clarity" id="45113" level="2" required-level="30" sp="11000" />
+		<skill name="Death Whisper" id="45110" level="2" required-level="30" sp="11000" />
+
+		<!-- Skills Lv30 -->
 		<skill name="Dagger Mastery" id="209" level="5" required-level="30" sp="11000" />
 		<skill name="Light Armor Mastery" id="233" level="7" required-level="30" sp="11000" />
 		<skill name="Bow Mastery" id="208" level="10" required-level="30" sp="11000" />
 		<skill name="Power Shot" id="56" level="19" required-level="30" sp="11000" />
-		<skill name="Charm" id="15" level="10" required-level="30" sp="11000" />
-		<skill name="Elemental Heal" id="58" level="13" required-level="30" sp="11000" />
+		<skill name="Slowdown" id="15" level="10" required-level="30" sp="11000" />
+		<skill name="Elemental Heal" id="58" level="20" required-level="30" sp="11000" />
 		<skill name="Mortal Blow" id="16" level="19" required-level="30" sp="11000" />
-		
+		<skill name="Sprint" id="230" level="1" required-level="30" sp="11000" />
+		<skill name="Emergency Rescue" id="70" level="5" required-level="30" sp="11000" />
+
+		<!-- Skills Lv31 -->
 		<skill name="Bow Mastery" id="208" level="11" required-level="31" sp="11000" />
 		<skill name="Power Shot" id="56" level="20" required-level="31" sp="11000" />
-		<skill name="Charm" id="15" level="11" required-level="31" sp="11000" />
-		<skill name="Elemental Heal" id="58" level="14" required-level="31" sp="11000" />
+		<skill name="Slowdown" id="15" level="11" required-level="31" sp="11000" />
 		<skill name="Mortal Blow" id="16" level="20" required-level="31" sp="11000" />
-		
+
+		<!-- Skills Lv32 -->
 		<skill name="Vicious Stance" id="312" level="4" required-level="32" sp="11000" />
 		<skill name="Rapid Shot" id="99" level="1" required-level="32" sp="11000" />
 		<skill name="Dagger Mastery" id="209" level="6" required-level="32" sp="11000" />
@@ -104,30 +148,31 @@
 		<skill name="Bleed" id="96" level="2" required-level="32" sp="11000" />
 		<skill name="Power Shot" id="56" level="21" required-level="32" sp="11000" />
 		<skill name="Unlock" id="27" level="4" required-level="32" sp="11000" />
-		<skill name="Charm" id="15" level="12" required-level="32" sp="11000" />
-		<skill name="Elemental Heal" id="58" level="15" required-level="32" sp="11000" />
+		<skill name="Slowdown" id="15" level="12" required-level="32" sp="11000" />
+		<skill name="Elemental Heal" id="58" level="21" required-level="32" sp="11000" />
 		<skill name="Mortal Blow" id="16" level="21" required-level="32" sp="11000" />
 		<skill name="Critical Chance" id="137" level="1" required-level="32" sp="11000" />
-		<skill name="Sprint" id="230" level="1" required-level="32" sp="11000">
-			<item id="1384"/>
-		</skill>
-		
+		<skill name="Emergency Rescue" id="70" level="6" required-level="32" sp="11000" />
+
+		<!-- Skills Lv34 -->
 		<skill name="Dagger Mastery" id="209" level="7" required-level="34" sp="20000" />
 		<skill name="Light Armor Mastery" id="233" level="9" required-level="34" sp="20000" />
 		<skill name="Bow Mastery" id="208" level="13" required-level="34" sp="20000" />
 		<skill name="Power Shot" id="56" level="22" required-level="34" sp="20000" />
 		<skill name="Stun Shot" id="101" level="1" required-level="34" sp="20000" />
-		<skill name="Charm" id="15" level="13" required-level="34" sp="20000" />
-		<skill name="Elemental Heal" id="58" level="16" required-level="34" sp="20000" />
+		<skill name="Slowdown" id="15" level="13" required-level="34" sp="20000" />
+		<skill name="Elemental Heal" id="58" level="22" required-level="34" sp="20000" />
 		<skill name="Mortal Blow" id="16" level="22" required-level="34" sp="20000" />
-		
+		<skill name="Emergency Rescue" id="70" level="7" required-level="34" sp="20000" />
+
+		<!-- Skills Lv35 -->
 		<skill name="Bow Mastery" id="208" level="14" required-level="35" sp="20000" />
 		<skill name="Power Shot" id="56" level="23" required-level="35" sp="20000" />
 		<skill name="Stun Shot" id="101" level="2" required-level="35" sp="20000" />
-		<skill name="Charm" id="15" level="14" required-level="35" sp="20000" />
-		<skill name="Elemental Heal" id="58" level="17" required-level="35" sp="20000" />
+		<skill name="Slowdown" id="15" level="14" required-level="35" sp="20000" />
 		<skill name="Mortal Blow" id="16" level="23" required-level="35" sp="20000" />
-		
+
+		<!-- Skills Lv36 -->
 		<skill name="Vicious Stance" id="312" level="5" required-level="36" sp="20000" />
 		<skill name="Esprit" id="171" level="1" required-level="36" sp="20000" />
 		<skill name="Dagger Mastery" id="209" level="8" required-level="36" sp="20000" />
@@ -135,12 +180,22 @@
 		<skill name="Bow Mastery" id="208" level="15" required-level="36" sp="20000" />
 		<skill name="Power Shot" id="56" level="24" required-level="36" sp="20000" />
 		<skill name="Stun Shot" id="101" level="3" required-level="36" sp="20000" />
-		<skill name="Unlock" id="27" level="5" required-level="36" sp="20000" />
-		<skill name="Charm" id="15" level="15" required-level="36" sp="20000" />
-		<skill name="Elemental Heal" id="58" level="18" required-level="36" sp="20000" />
-		<skill name="Mortal Blow" id="16" level="24" required-level="36" sp="20000" />
-		<skill name="Entangle" id="102" level="1" required-level="36" sp="20000">
-			<item id="1380"/>
+		<skill name="Entangle" id="102" level="1" required-level="36" sp="20000" >
+			<item id="1380" count="1" /> <!-- Spellbook: Entangle -->
 		</skill>
+		<skill name="Unlock" id="27" level="5" required-level="36" sp="20000" />
+		<skill name="Slowdown" id="15" level="15" required-level="36" sp="20000" />
+		<skill name="Elemental Heal" id="58" level="23" required-level="36" sp="20000" />
+		<skill name="Mortal Blow" id="16" level="24" required-level="36" sp="20000" />
+		<skill name="Emergency Rescue" id="70" level="8" required-level="36" sp="20000" />
+
+		<!-- Skills Lv38 -->
+		<skill name="Slowdown" id="15" level="16" required-level="38" sp="20000" />
+		<skill name="Elemental Heal" id="58" level="24" required-level="38" sp="20000" />
+		<skill name="Emergency Rescue" id="70" level="9" required-level="38" sp="20000" />
+
+		<!-- Skills Lv39 -->
+		<skill name="Slowdown" id="15" level="17" required-level="39" sp="20000" />
+		
 	</skillTree>
 </list>

--- a/data/skillTrees/1stClass/ElvenWizard.xml
+++ b/data/skillTrees/1stClass/ElvenWizard.xml
@@ -1,6 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="26" parentClassId="25">
+
+		<!-- Master Buffs Lv. 20 -->
+		<skill name="Empower" id="45105" level="1" required-level="20" sp="500" />
+		<skill name="Concentration" id="1078" level="1" required-level="20" sp="600" />
+		<skill name="Wind Walk" id="45107" level="1" required-level="20" sp="500" />
+		<skill name="Might" id="1068" level="2" required-level="20" sp="500" />
+		<skill name="Acumen" id="45104" level="1" required-level="20" sp="500" />
+		<skill name="Haste" id="45111" level="1" required-level="20" sp="500" />
+		<skill name="Focus" id="45109" level="1" required-level="20" sp="500" />
+		<skill name="Clarity" id="45113" level="1" required-level="20" sp="500" />
+		<skill name="Death Whisper" id="45110" level="1" required-level="20" sp="500" />
+		<skill name="Shield" id="1040" level="2" required-level="20" sp="500" />
+
+		<!-- Skills Lv20 -->	
 		<skill name="Anti Magic" id="146" level="5" required-level="20" sp="600" />
 		<skill name="Anti Magic" id="146" level="6" required-level="20" sp="600" />
 		<skill name="Quick Recovery" id="164" level="1" required-level="20" sp="600" />
@@ -9,120 +23,173 @@
 		<skill name="Weapon Mastery" id="249" level="3" required-level="20" sp="600" />
 		<skill name="Aqua Swirl" id="1175" level="1" required-level="20" sp="600" />
 		<skill name="Aqua Swirl" id="1175" level="2" required-level="20" sp="600" />
-		<skill name="Ice Bolt" id="1184" level="5" required-level="20" sp="600" />
+		<skill name="Recover HP" id="45176" level="1" required-level="20" sp="500" />
+		<skill name="Recover MP" id="45177" level="1" required-level="20" sp="500" />
 		<skill name="Ice Bolt" id="1184" level="6" required-level="20" sp="600" />
+		<skill name="Ice Bolt" id="1184" level="7" required-level="20" sp="600" />
 		<skill name="Servitor Heal" id="1127" level="1" required-level="20" sp="600" />
 		<skill name="Servitor Heal" id="1127" level="2" required-level="20" sp="600" />
 		<skill name="Servitor Heal" id="1127" level="3" required-level="20" sp="600" />
+		<skill name="Fireball" id="1147" level="4" required-level="20" sp="600" />
+		<skill name="Wind Shackle" id="1206" level="2" required-level="20" sp="600" />
 		<skill name="Summon Boxer the Unicorn" id="1226" level="1" required-level="20" sp="600" />
 		<skill name="Summon Mirage the Unicorn" id="1227" level="1" required-level="20" sp="600" />
-		<skill name="Curse Weakness" id="1164" level="2" required-level="20" sp="600" />
 		<skill name="Aura Burn" id="1172" level="1" required-level="20" sp="600" />
 		<skill name="Aura Burn" id="1172" level="2" required-level="20" sp="600" />
+		<skill name="Weakness" id="1164" level="2" required-level="20" sp="600" />
 		<skill name="Boost Mana" id="213" level="1" required-level="20" sp="600" />
+		<skill name="Increased Power of Magic" id="1073" level="1" required-level="20" sp="600" />
 		<skill name="Flame Strike" id="1181" level="1" required-level="20" sp="600" />
+		<skill name="Swift Servitor Heal" id="45362" level="1" required-level="20" sp="600" />
+		<skill name="Swift Servitor Heal" id="45362" level="2" required-level="20" sp="600" />
+		<skill name="Swift Servitor Heal" id="45362" level="3" required-level="20" sp="600" />
 		<skill name="Higher Mana Gain" id="285" level="1" required-level="20" sp="600" />
 		<skill name="Higher Mana Gain" id="285" level="2" required-level="20" sp="600" />
-		<skill name="Energy Bolt" id="1274" level="1" required-level="20" sp="600" />
-		<skill name="Concentration" id="1078" level="1" required-level="20" sp="600">
-			<item id="1399"/>
-		</skill>
+		<skill name="Sleep" id="1069" level="1" required-level="20" sp="600" />
 
+		<skill name="Energy Bolt" id="1274" level="1" required-level="20" sp="600" />
+
+		<!-- Skills Lv22 -->
+		<skill name="Sleep" id="1069" level="2" required-level="22" sp="2300" />
+
+		<!-- Skills Lv23 -->
 		<skill name="Anti Magic" id="146" level="7" required-level="23" sp="2300" />
 		<skill name="Robe Mastery" id="234" level="3" required-level="23" sp="2300" />
 		<skill name="Weapon Mastery" id="249" level="4" required-level="23" sp="2300" />
 		<skill name="Aqua Swirl" id="1175" level="3" required-level="23" sp="2300" />
 		<skill name="Servitor Heal" id="1127" level="4" required-level="23" sp="2300" />
 		<skill name="Aura Burn" id="1172" level="3" required-level="23" sp="2300" />
+		<skill name="Swift Servitor Heal" id="45362" level="4" required-level="23" sp="2300" />
 		<skill name="Higher Mana Gain" id="285" level="3" required-level="23" sp="2300" />
-		<skill name="Sleep" id="1069" level="1" required-level="23" sp="2300">
-			<item id="1394"/>
-		</skill>
-		
-		<skill name="Servitor Heal" id="1127" level="5" required-level="24" sp="2300" />
-		<skill name="Sleep" id="1069" level="2" required-level="24" sp="2300" />
 
+		<!-- Skills Lv24 -->
+		<skill name="Servitor Heal" id="1127" level="5" required-level="24" sp="2300" />
+		<skill name="Swift Servitor Heal" id="45362" level="5" required-level="24" sp="2300" />
+		<skill name="Sleep" id="1069" level="3" required-level="24" sp="2300" />
+
+		<!-- Skills Lv25 -->
 		<skill name="Anti Magic" id="146" level="8" required-level="25" sp="2300" />
 		<skill name="Fast Mana Recovery" id="229" level="1" required-level="25" sp="2300" />
 		<skill name="Fast Spell Casting" id="228" level="1" required-level="25" sp="2300" />
 		<skill name="Robe Mastery" id="234" level="4" required-level="25" sp="2300" />
 		<skill name="Weapon Mastery" id="249" level="5" required-level="25" sp="2300" />
 		<skill name="Aqua Swirl" id="1175" level="4" required-level="25" sp="2300" />
-		<skill name="Servitor Heal" id="1127" level="6" required-level="25" sp="2300" />
 		<skill name="Servitor Recharge" id="1126" level="1" required-level="25" sp="2300" />
 		<skill name="Servitor Recharge" id="1126" level="2" required-level="25" sp="2300" />
+		<skill name="Ice Bolt" id="1184" level="8" required-level="25" sp="2300" />
+		<skill name="Servitor Heal" id="1127" level="6" required-level="25" sp="2300" />
+		<skill name="Fireball" id="1147" level="5" required-level="25" sp="2300" />
+		<skill name="Wind Shackle" id="1206" level="3" required-level="25" sp="2300" />
 		<skill name="Summon Boxer the Unicorn" id="1226" level="2" required-level="25" sp="2300" />
 		<skill name="Summon Mirage the Unicorn" id="1227" level="2" required-level="25" sp="2300" />
-		<skill name="Curse Weakness" id="1164" level="3" required-level="25" sp="2300" />
-		<skill name="Body To Mind" id="1157" level="1" required-level="25" sp="2300" />
+		<skill name="Body to Mind" id="1157" level="1" required-level="25" sp="2300" />
 		<skill name="Aura Burn" id="1172" level="4" required-level="25" sp="2300" />
+		<skill name="Weakness" id="1164" level="3" required-level="25" sp="2300" />
 		<skill name="Solar Spark" id="1264" level="1" required-level="25" sp="2300" />
 		<skill name="Flame Strike" id="1181" level="2" required-level="25" sp="2300" />
+		<skill name="Swift Servitor Heal" id="45362" level="6" required-level="25" sp="2300" />
 		<skill name="Higher Mana Gain" id="285" level="4" required-level="25" sp="2300" />
-		<skill name="Sleep" id="1069" level="3" required-level="25" sp="2300" />
 		<skill name="Energy Bolt" id="1274" level="2" required-level="25" sp="2300" />
-		
+
+		<!-- Skills Lv26 -->
+		<skill name="Sleep" id="1069" level="4" required-level="26" sp="2300" />
+
+		<!-- Skills Lv28 -->
 		<skill name="Anti Magic" id="146" level="9" required-level="28" sp="5700" />
 		<skill name="Robe Mastery" id="234" level="5" required-level="28" sp="5700" />
 		<skill name="Weapon Mastery" id="249" level="6" required-level="28" sp="5700" />
 		<skill name="Aqua Swirl" id="1175" level="5" required-level="28" sp="5700" />
 		<skill name="Servitor Heal" id="1127" level="7" required-level="28" sp="5700" />
 		<skill name="Aura Burn" id="1172" level="5" required-level="28" sp="5700" />
+		<skill name="Swift Servitor Heal" id="45362" level="7" required-level="28" sp="5700" />
 		<skill name="Higher Mana Gain" id="285" level="5" required-level="28" sp="5700" />
-		<skill name="Sleep" id="1069" level="4" required-level="28" sp="5700" />
-		
-		<skill name="Servitor Heal" id="1127" level="8" required-level="29" sp="5700" />
-		<skill name="Sleep" id="1069" level="5" required-level="29" sp="5700" />
+		<skill name="Sleep" id="1069" level="5" required-level="28" sp="5700" />
 
+		<!-- Skills Lv29 -->
+		<skill name="Servitor Heal" id="1127" level="8" required-level="29" sp="5700" />
+		<skill name="Swift Servitor Heal" id="45362" level="8" required-level="29" sp="5700" />
+
+		<!-- Master Buffs Lv. 30 -->
+		<skill name="Empower" id="45105" level="2" required-level="30" sp="5000" />
+		<skill name="Wild Magic" id="45106" level="1" required-level="30" sp="5000" />
+		<skill name="Berserker Spirit" id="45112" level="1" required-level="30" sp="5000" />
+		<skill name="Wind Walk" id="45107" level="2" required-level="30" sp="5000" />
+		<skill name="Magic Barrier" id="45108" level="1" required-level="30" sp="5000" />
+		<skill name="Acumen" id="45104" level="2" required-level="30" sp="5000" />
+		<skill name="Focus" id="45109" level="2" required-level="30" sp="5000" />
+		<skill name="Clarity" id="45113" level="2" required-level="30" sp="5000" />
+		<skill name="Death Whisper" id="45110" level="2" required-level="30" sp="5000" />
+
+		<!-- Skills Lv30 -->
 		<skill name="Anti Magic" id="146" level="10" required-level="30" sp="5700" />
 		<skill name="Quick Recovery" id="164" level="2" required-level="30" sp="5700" />
 		<skill name="Robe Mastery" id="234" level="6" required-level="30" sp="5700" />
 		<skill name="Weapon Mastery" id="249" level="7" required-level="30" sp="5700" />
 		<skill name="Aqua Swirl" id="1175" level="6" required-level="30" sp="5700" />
-		<skill name="Concentration" id="1078" level="2" required-level="30" sp="5700" />
-		<skill name="Servitor Heal" id="1127" level="9" required-level="30" sp="5700" />
 		<skill name="Servitor Recharge" id="1126" level="3" required-level="30" sp="5700" />
 		<skill name="Servitor Recharge" id="1126" level="4" required-level="30" sp="5700" />
+		<skill name="Concentration" id="1078" level="2" required-level="30" sp="5700" />
+		<skill name="Ice Bolt" id="1184" level="9" required-level="30" sp="5700" />
+		<skill name="Servitor Heal" id="1127" level="9" required-level="30" sp="5700" />
+		<skill name="Fireball" id="1147" level="6" required-level="30" sp="5700" />
+		<skill name="Wind Shackle" id="1206" level="4" required-level="30" sp="5700" />
 		<skill name="Summon Boxer the Unicorn" id="1226" level="3" required-level="30" sp="5700" />
 		<skill name="Summon Mirage the Unicorn" id="1227" level="3" required-level="30" sp="5700" />
-		<skill name="Curse Weakness" id="1164" level="4" required-level="30" sp="5700" />
 		<skill name="Aura Burn" id="1172" level="6" required-level="30" sp="5700" />
+		<skill name="Weakness" id="1164" level="4" required-level="30" sp="5700" />
 		<skill name="Solar Spark" id="1264" level="2" required-level="30" sp="5700" />
 		<skill name="Boost Mana" id="213" level="2" required-level="30" sp="5700" />
 		<skill name="Flame Strike" id="1181" level="3" required-level="30" sp="5700" />
+		<skill name="Swift Servitor Heal" id="45362" level="9" required-level="30" sp="5700" />
 		<skill name="Higher Mana Gain" id="285" level="6" required-level="30" sp="5700" />
 		<skill name="Sleep" id="1069" level="6" required-level="30" sp="5700" />
+
 		<skill name="Energy Bolt" id="1274" level="3" required-level="30" sp="5700" />
-		
+
+		<!-- Skills Lv32 -->
+		<skill name="Sleep" id="1069" level="7" required-level="32" sp="5700" />
+
+		<!-- Skills Lv33 -->
 		<skill name="Anti Magic" id="146" level="11" required-level="33" sp="13000" />
 		<skill name="Robe Mastery" id="234" level="7" required-level="33" sp="13000" />
 		<skill name="Weapon Mastery" id="249" level="8" required-level="33" sp="13000" />
 		<skill name="Aqua Swirl" id="1175" level="7" required-level="33" sp="13000" />
 		<skill name="Servitor Heal" id="1127" level="10" required-level="33" sp="13000" />
 		<skill name="Aura Burn" id="1172" level="7" required-level="33" sp="13000" />
+		<skill name="Swift Servitor Heal" id="45362" level="10" required-level="33" sp="13000" />
 		<skill name="Higher Mana Gain" id="285" level="7" required-level="33" sp="13000" />
-		<skill name="Sleep" id="1069" level="7" required-level="33" sp="13000" />
-		
+
+		<!-- Skills Lv34 -->
 		<skill name="Servitor Heal" id="1127" level="11" required-level="34" sp="13000" />
+		<skill name="Swift Servitor Heal" id="45362" level="11" required-level="34" sp="13000" />
 		<skill name="Sleep" id="1069" level="8" required-level="34" sp="13000" />
 
+		<!-- Skills Lv35 -->
 		<skill name="Anti Magic" id="146" level="12" required-level="35" sp="13000" />
 		<skill name="Fast HP Recovery" id="212" level="1" required-level="35" sp="13000" />
 		<skill name="Fast Mana Recovery" id="229" level="2" required-level="35" sp="13000" />
 		<skill name="Robe Mastery" id="234" level="8" required-level="35" sp="13000" />
 		<skill name="Weapon Mastery" id="249" level="9" required-level="35" sp="13000" />
 		<skill name="Aqua Swirl" id="1175" level="8" required-level="35" sp="13000" />
-		<skill name="Servitor Heal" id="1127" level="12" required-level="35" sp="13000" />
 		<skill name="Servitor Recharge" id="1126" level="5" required-level="35" sp="13000" />
 		<skill name="Servitor Recharge" id="1126" level="6" required-level="35" sp="13000" />
+		<skill name="Ice Bolt" id="1184" level="10" required-level="35" sp="13000" />
+		<skill name="Servitor Heal" id="1127" level="12" required-level="35" sp="13000" />
+		<skill name="Wind Shackle" id="1206" level="5" required-level="35" sp="13000" />
 		<skill name="Summon Boxer the Unicorn" id="1226" level="4" required-level="35" sp="13000" />
 		<skill name="Summon Mirage the Unicorn" id="1227" level="4" required-level="35" sp="13000" />
-		<skill name="Curse Weakness" id="1164" level="5" required-level="35" sp="13000" />
 		<skill name="Aura Burn" id="1172" level="8" required-level="35" sp="13000" />
+		<skill name="Weakness" id="1164" level="5" required-level="35" sp="13000" />
 		<skill name="Solar Spark" id="1264" level="3" required-level="35" sp="13000" />
 		<skill name="Servitor Magic Boost" id="1145" level="1" required-level="35" sp="13000" />
+		<skill name="Swift Servitor Heal" id="45362" level="12" required-level="35" sp="13000" />
 		<skill name="Higher Mana Gain" id="285" level="8" required-level="35" sp="13000" />
-		<skill name="Sleep" id="1069" level="9" required-level="35" sp="13000" />
 		<skill name="Energy Bolt" id="1274" level="4" required-level="35" sp="13000" />
+
+		<!-- Skills Lv36 -->
+		<skill name="Sleep" id="1069" level="9" required-level="36" sp="13000" />
+
+		<!-- Skills Lv38 -->
+		<skill name="Sleep" id="1069" level="10" required-level="38" sp="13000" />
 	</skillTree>
 </list>

--- a/data/skillTrees/1stClass/HumanDeathBlader.xml
+++ b/data/skillTrees/1stClass/HumanDeathBlader.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
+	<skillTree type="classSkillTree" classId="197" parentClassId="196">
+
+		<!-- Master Buffs Lv. 20 -->
+		<skill name="Empower" id="45105" level="1" required-level="20" sp="1000" />
+		<skill name="Wind Walk" id="45107" level="1" required-level="20" sp="1000" />
+		<skill name="Might" id="1068" level="2" required-level="20" sp="1000" />
+		<skill name="Acumen" id="45104" level="1" required-level="20" sp="1000" />
+		<skill name="Haste" id="45111" level="1" required-level="20" sp="1000" />
+		<skill name="Focus" id="45109" level="1" required-level="20" sp="1000" />
+		<skill name="Clarity" id="45113" level="1" required-level="20" sp="1000" />
+		<skill name="Death Whisper" id="45110" level="1" required-level="20" sp="1000" />
+		<skill name="Shield" id="1040" level="2" required-level="20" sp="1000" />
+
+		<!-- Skills Lv20 -->
+		<skill name="Death Armor Mastery" id="45354" level="4" required-level="20" sp="1000" />
+		<skill name="Death Sword Mastery" id="45353" level="4" required-level="20" sp="1000" />
+		<skill name="Recover HP" id="45176" level="1" required-level="20" sp="1000" />
+		<skill name="Recover MP" id="45177" level="1" required-level="20" sp="1000" />
+		<skill name="Punishment" id="45301" level="1" required-level="20" auto-learn="true" />
+		<skill name="Enhanced Weapon" id="255" level="1" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="2" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="3" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="4" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="5" required-level="20" sp="1000" />
+		<skill name="Ability to Protect" id="91" level="2" required-level="20" sp="1000" />
+		<skill name="Belief" id="80" level="1" required-level="20" sp="1000" />
+		<skill name="Emergency Rescue" id="70" level="3" required-level="20" sp="1000" />
+
+		<!-- Skills Lv21 -->
+		<skill name="Enhanced Weapon" id="255" level="6" required-level="21" sp="2500" />
+
+		<!-- Skills Lv22 -->
+		<skill name="Enhanced Weapon" id="255" level="7" required-level="22" sp="2500" />
+
+		<!-- Skills Lv23 -->
+		<skill name="Enhanced Weapon" id="255" level="8" required-level="23" sp="2500" />
+
+		<!-- Skills Lv24 -->
+		<skill name="Enhanced Weapon" id="255" level="9" required-level="24" sp="2500" />
+
+		<!-- Skills Lv25 -->
+		<skill name="Death Armor Mastery" id="45354" level="5" required-level="25" sp="5500" />
+		<skill name="Death Sword Mastery" id="45353" level="5" required-level="25" sp="5500" />
+		<skill name="Enhanced Weapon" id="255" level="10" required-level="25" sp="5500" />
+		<skill name="Ability to Attack" id="77" level="2" required-level="25" sp="5500" />
+		<skill name="Emergency Rescue" id="70" level="4" required-level="25" sp="5500" />
+
+		<!-- Skills Lv26 -->
+		<skill name="Punishment" id="45301" level="2" required-level="26" sp="5500" />
+		<skill name="Enhanced Weapon" id="255" level="11" required-level="26" sp="5500" />
+
+		<!-- Skills Lv27 -->
+		<skill name="Enhanced Weapon" id="255" level="12" required-level="27" sp="5500" />
+
+		<!-- Skills Lv28 -->
+		<skill name="Enhanced Weapon" id="255" level="13" required-level="28" sp="5500" />
+
+		<!-- Skills Lv29 -->
+		<skill name="Enhanced Weapon" id="255" level="14" required-level="29" sp="10000" />
+
+		<!-- Master Buffs Lv. 30 -->
+		<skill name="Empower" id="45105" level="2" required-level="30" sp="11000" />
+		<skill name="Wild Magic" id="45106" level="1" required-level="30" sp="11000" />
+		<skill name="Berserker Spirit" id="45112" level="1" required-level="30" sp="11000" />
+		<skill name="Wind Walk" id="45107" level="2" required-level="30" sp="11000" />
+		<skill name="Magic Barrier" id="45108" level="1" required-level="30" sp="11000" />
+		<skill name="Acumen" id="45104" level="2" required-level="30" sp="11000" />
+		<skill name="Focus" id="45109" level="2" required-level="30" sp="11000" />
+		<skill name="Clarity" id="45113" level="2" required-level="30" sp="11000" />
+		<skill name="Death Whisper" id="45110" level="2" required-level="30" sp="11000" />
+
+		<!-- Skills Lv30 -->
+		<skill name="Death Armor Mastery" id="45354" level="6" required-level="30" sp="10000" />
+		<skill name="Death Sword Mastery" id="45353" level="6" required-level="30" sp="10000" />
+		<skill name="Enhanced Weapon" id="255" level="15" required-level="30" sp="10000" />
+		<skill name="Struggle" id="87" level="1" required-level="30" sp="10000" />
+		<skill name="Roar of Death" id="45328" level="1" required-level="30" sp="10000" />
+		<skill name="Emergency Rescue" id="70" level="5" required-level="30" sp="10000" />
+
+		<!-- Skills Lv32 -->
+		<skill name="Punishment" id="45301" level="3" required-level="32" sp="10000" />
+		<skill name="Emergency Rescue" id="70" level="6" required-level="32" sp="10000" />
+
+		<!-- Skills Lv34 -->
+		<skill name="Emergency Rescue" id="70" level="7" required-level="34" sp="20000" />
+
+		<!-- Skills Lv35 -->
+		<skill name="Death Armor Mastery" id="45354" level="7" required-level="35" sp="20000" />
+		<skill name="Death Sword Mastery" id="45353" level="7" required-level="35" sp="20000" />
+
+		<!-- Skills Lv36 -->
+		<skill name="Emergency Rescue" id="70" level="8" required-level="36" sp="20000" />
+
+		<!-- Skills Lv38 -->
+		<skill name="Punishment" id="45301" level="4" required-level="38" sp="20000" />
+		<skill name="Emergency Rescue" id="70" level="9" required-level="38" sp="20000" />
+		
+	</skillTree>
+</list>

--- a/data/skillTrees/1stClass/HumanKnight.xml
+++ b/data/skillTrees/1stClass/HumanKnight.xml
@@ -1,114 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="4" parentClassId="0">
+
+		<!-- Master Buffs Lv. 20 -->
+		<skill name="Empower" id="45105" level="1" required-level="20" sp="1000" />
+		<skill name="Wind Walk" id="45107" level="1" required-level="20" sp="1000" />
+		<skill name="Might" id="1068" level="2" required-level="20" sp="1000" />
+		<skill name="Acumen" id="45104" level="1" required-level="20" sp="1000" />
+		<skill name="Haste" id="45111" level="1" required-level="20" sp="1000" />
+		<skill name="Focus" id="45109" level="1" required-level="20" sp="1000" />
+		<skill name="Clarity" id="45113" level="1" required-level="20" sp="1000" />
+		<skill name="Death Whisper" id="45110" level="1" required-level="20" sp="1000" />
+		<skill name="Shield" id="1040" level="2" required-level="20" sp="1000" />
+
+		<!-- Skills Lv20 -->
 		<skill name="Ultimate Defense" id="110" level="1" required-level="20" sp="1000" />
+		<skill name="Quick Heal" id="45" level="1" required-level="20" sp="1000" />
 		<skill name="Majesty" id="82" level="1" required-level="20" sp="1000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="1" required-level="20" sp="1000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="1" required-level="20" sp="1000" />
+		<skill name="Stun Mastery" id="100" level="1" required-level="20" sp="1000" />
+		<skill name="Stun Mastery" id="100" level="2" required-level="20" sp="1000" />
+		<skill name="Stun Mastery" id="100" level="3" required-level="20" sp="1000" />
+		<skill name="Stun Mastery" id="100" level="4" required-level="20" sp="1000" />
+		<skill name="Stun Mastery" id="100" level="5" required-level="20" sp="1000" />
 		<skill name="Heavy Armor Mastery" id="232" level="1" required-level="20" sp="1000" />
 		<skill name="Heavy Armor Mastery" id="232" level="2" required-level="20" sp="1000" />
 		<skill name="Heavy Armor Mastery" id="232" level="3" required-level="20" sp="1000" />
 		<skill name="Shield Mastery" id="153" level="1" required-level="20" sp="1000" />
+		<skill name="Recover HP" id="45176" level="1" required-level="20" sp="1000" />
+		<skill name="Recover MP" id="45177" level="1" required-level="20" sp="1000" />
 		<skill name="Magic Resistance" id="147" level="1" required-level="20" sp="1000" />
 		<skill name="Magic Resistance" id="147" level="2" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="1" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="2" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="3" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="4" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="5" required-level="20" sp="1000" />
+		<skill name="Power Strike" id="3" level="10" required-level="20" sp="1000" />
+		<skill name="Power Strike" id="3" level="11" required-level="20" sp="1000" />
+		<skill name="Power Strike" id="3" level="12" required-level="20" sp="1000" />
 		<skill name="Shield Stun" id="92" level="1" required-level="20" sp="1000" />
 		<skill name="Shield Stun" id="92" level="2" required-level="20" sp="1000" />
 		<skill name="Shield Stun" id="92" level="3" required-level="20" sp="1000" />
-		<skill name="Drain Energy" id="70" level="1" required-level="20" sp="1000">
-			<item id="1097"/>
-		</skill>
+		<skill name="Ability to Protect" id="91" level="2" required-level="20" sp="1000" />
 
+		<skill name="Emergency Rescue" id="70" level="3" required-level="20" sp="1000" />
+
+		<!-- Skills Lv21 -->
+		<skill name="Stun Mastery" id="100" level="6" required-level="21" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="6" required-level="21" sp="1000" />
+
+		<!-- Skills Lv22 -->
 		<skill name="Aggression" id="28" level="1" required-level="22" sp="2800" />
+		<skill name="Stun Mastery" id="100" level="7" required-level="22" sp="2800" />
 		<skill name="Heavy Armor Mastery" id="232" level="4" required-level="22" sp="2800" />
-		<skill name="Drain Energy" id="70" level="2" required-level="22" sp="2800" />
 		<skill name="Magic Resistance" id="147" level="3" required-level="22" sp="2800" />
+		<skill name="Enhanced Weapon" id="255" level="7" required-level="22" sp="2800" />
+		<skill name="Power Strike" id="3" level="13" required-level="22" sp="2800" />
 		<skill name="Shield Stun" id="92" level="4" required-level="22" sp="2800" />
 
+		<!-- Skills Lv23 -->
 		<skill name="Aggression" id="28" level="2" required-level="23" sp="2800" />
+		<skill name="Quick Heal" id="45" level="2" required-level="23" sp="2800" />
+		<skill name="Stun Mastery" id="100" level="8" required-level="23" sp="2800" />
 		<skill name="Heavy Armor Mastery" id="232" level="5" required-level="23" sp="2800" />
-		<skill name="Drain Energy" id="70" level="3" required-level="23" sp="2800" />
 		<skill name="Magic Resistance" id="147" level="4" required-level="23" sp="2800" />
+		<skill name="Enhanced Weapon" id="255" level="8" required-level="23" sp="2800" />
+		<skill name="Power Strike" id="3" level="14" required-level="23" sp="2800" />
 		<skill name="Shield Stun" id="92" level="5" required-level="23" sp="2800" />
-		
+
+		<!-- Skills Lv24 -->
 		<skill name="Aggression" id="28" level="3" required-level="24" sp="2800" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="2" required-level="24" sp="2800" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="2" required-level="24" sp="2800" />
+		<skill name="Stun Mastery" id="100" level="9" required-level="24" sp="2800" />
 		<skill name="Heavy Armor Mastery" id="232" level="6" required-level="24" sp="2800" />
-		<skill name="Drain Energy" id="70" level="4" required-level="24" sp="2800" />
 		<skill name="Magic Resistance" id="147" level="5" required-level="24" sp="2800" />
+		<skill name="Enhanced Weapon" id="255" level="9" required-level="24" sp="2800" />
+		<skill name="Power Strike" id="3" level="15" required-level="24" sp="2800" />
 		<skill name="Shield Stun" id="92" level="6" required-level="24" sp="2800" />
 		<skill name="Deflect Arrow" id="112" level="1" required-level="24" sp="2800" />
-		
+
+		<!-- Skills Lv25 -->
+		<skill name="Stun Mastery" id="100" level="10" required-level="25" sp="2800" />
+		<skill name="Enhanced Weapon" id="255" level="10" required-level="25" sp="2800" />
+		<skill name="Ability to Attack" id="77" level="2" required-level="25" sp="2800" />
+		<skill name="Emergency Rescue" id="70" level="4" required-level="25" sp="2800" />
+
+		<!-- Skills Lv26 -->
 		<skill name="Aggression" id="28" level="4" required-level="26" sp="5700" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="3" required-level="26" sp="5700" />
+		<skill name="Quick Heal" id="45" level="3" required-level="26" sp="5700" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="3" required-level="26" sp="5700" />
+		<skill name="Stun Mastery" id="100" level="11" required-level="26" sp="5700" />
 		<skill name="Heavy Armor Mastery" id="232" level="7" required-level="26" sp="5700" />
-		<skill name="Drain Energy" id="70" level="5" required-level="26" sp="5700" />
 		<skill name="Magic Resistance" id="147" level="6" required-level="26" sp="5700" />
+		<skill name="Enhanced Weapon" id="255" level="11" required-level="26" sp="5700" />
+		<skill name="Power Strike" id="3" level="16" required-level="26" sp="5700" />
 		<skill name="Shield Stun" id="92" level="7" required-level="26" sp="5700" />
-		<skill name="Divine Heal" id="45" level="1" required-level="26" sp="5700">
-			<item id="1378"/>
-		</skill>
-		
+
+		<!-- Skills Lv27 -->
 		<skill name="Aggression" id="28" level="5" required-level="27" sp="5700" />
+		<skill name="Stun Mastery" id="100" level="12" required-level="27" sp="5700" />
 		<skill name="Heavy Armor Mastery" id="232" level="8" required-level="27" sp="5700" />
-		<skill name="Drain Energy" id="70" level="6" required-level="27" sp="5700" />
 		<skill name="Magic Resistance" id="147" level="7" required-level="27" sp="5700" />
+		<skill name="Enhanced Weapon" id="255" level="12" required-level="27" sp="5700" />
+		<skill name="Power Strike" id="3" level="17" required-level="27" sp="5700" />
 		<skill name="Shield Stun" id="92" level="8" required-level="27" sp="5700" />
-		<skill name="Divine Heal" id="45" level="2" required-level="27" sp="5700" />
-		
+
+		<!-- Skills Lv28 -->
 		<skill name="Aggression" id="28" level="6" required-level="28" sp="5700" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="4" required-level="28" sp="5700" />
+		<skill name="Quick Heal" id="45" level="4" required-level="28" sp="5700" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="4" required-level="28" sp="5700" />
+		<skill name="Stun Mastery" id="100" level="13" required-level="28" sp="5700" />
 		<skill name="Heavy Armor Mastery" id="232" level="9" required-level="28" sp="5700" />
 		<skill name="Shield Mastery" id="153" level="2" required-level="28" sp="5700" />
-		<skill name="Drain Energy" id="70" level="7" required-level="28" sp="5700" />
 		<skill name="Magic Resistance" id="147" level="8" required-level="28" sp="5700" />
+		<skill name="Enhanced Weapon" id="255" level="13" required-level="28" sp="5700" />
+		<skill name="Power Strike" id="3" level="18" required-level="28" sp="5700" />
 		<skill name="Shield Stun" id="92" level="9" required-level="28" sp="5700" />
-		<skill name="Divine Heal" id="45" level="3" required-level="28" sp="5700" />
-		
+
+		<!-- Skills Lv29 -->
+		<skill name="Stun Mastery" id="100" level="14" required-level="29" sp="11000" />
+		<skill name="Enhanced Weapon" id="255" level="14" required-level="29" sp="11000" />
+
+		<!-- Master Buffs Lv. 30 -->
+		<skill name="Empower" id="45105" level="2" required-level="30" sp="11000" />
+		<skill name="Wild Magic" id="45106" level="1" required-level="30" sp="11000" />
+		<skill name="Berserker Spirit" id="45112" level="1" required-level="30" sp="11000" />
+		<skill name="Wind Walk" id="45107" level="2" required-level="30" sp="11000" />
+		<skill name="Magic Barrier" id="45108" level="1" required-level="30" sp="11000" />
+		<skill name="Acumen" id="45104" level="2" required-level="30" sp="11000" />
+		<skill name="Focus" id="45109" level="2" required-level="30" sp="11000" />
+		<skill name="Clarity" id="45113" level="2" required-level="30" sp="11000" />
+		<skill name="Death Whisper" id="45110" level="2" required-level="30" sp="11000" />
+
+		<!-- Skills Lv30 -->
 		<skill name="Aggression" id="28" level="7" required-level="30" sp="11000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="5" required-level="30" sp="11000" />
+		<skill name="Quick Heal" id="45" level="5" required-level="30" sp="11000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="5" required-level="30" sp="11000" />
+		<skill name="Stun Mastery" id="100" level="15" required-level="30" sp="11000" />
 		<skill name="Heavy Armor Mastery" id="232" level="10" required-level="30" sp="11000" />
-		<skill name="Drain Energy" id="70" level="8" required-level="30" sp="11000" />
 		<skill name="Magic Resistance" id="147" level="9" required-level="30" sp="11000" />
+		<skill name="Enhanced Weapon" id="255" level="15" required-level="30" sp="11000" />
+		<skill name="Power Strike" id="3" level="19" required-level="30" sp="11000" />
 		<skill name="Shield Stun" id="92" level="10" required-level="30" sp="11000" />
-		<skill name="Divine Heal" id="45" level="4" required-level="30" sp="11000" />
-		
+
+		<skill name="Emergency Rescue" id="70" level="5" required-level="30" sp="11000" />
+
+		<!-- Skills Lv31 -->
 		<skill name="Aggression" id="28" level="8" required-level="31" sp="11000" />
 		<skill name="Heavy Armor Mastery" id="232" level="11" required-level="31" sp="11000" />
-		<skill name="Drain Energy" id="70" level="9" required-level="31" sp="11000" />
 		<skill name="Magic Resistance" id="147" level="10" required-level="31" sp="11000" />
+		<skill name="Power Strike" id="3" level="20" required-level="31" sp="11000" />
 		<skill name="Shield Stun" id="92" level="11" required-level="31" sp="11000" />
-		<skill name="Divine Heal" id="45" level="5" required-level="31" sp="11000" />
-		
+
+		<!-- Skills Lv32 -->
 		<skill name="Aggression" id="28" level="9" required-level="32" sp="11000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="6" required-level="32" sp="11000" />
+		<skill name="Quick Heal" id="45" level="6" required-level="32" sp="11000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="6" required-level="32" sp="11000" />
 		<skill name="Heavy Armor Mastery" id="232" level="12" required-level="32" sp="11000" />
-		<skill name="Drain Energy" id="70" level="10" required-level="32" sp="11000" />
 		<skill name="Magic Resistance" id="147" level="11" required-level="32" sp="11000" />
+		<skill name="Power Strike" id="3" level="21" required-level="32" sp="11000" />
 		<skill name="Shield Stun" id="92" level="12" required-level="32" sp="11000" />
 		<skill name="Deflect Arrow" id="112" level="2" required-level="32" sp="11000" />
-		<skill name="Divine Heal" id="45" level="6" required-level="32" sp="11000" />
+		<skill name="Emergency Rescue" id="70" level="6" required-level="32" sp="11000" />
 
+		<!-- Skills Lv34 -->
 		<skill name="Aggression" id="28" level="10" required-level="34" sp="20000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="7" required-level="34" sp="20000" />
+		<skill name="Quick Heal" id="45" level="7" required-level="34" sp="20000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="7" required-level="34" sp="20000" />
 		<skill name="Heavy Armor Mastery" id="232" level="13" required-level="34" sp="20000" />
-		<skill name="Drain Energy" id="70" level="11" required-level="34" sp="20000" />
 		<skill name="Magic Resistance" id="147" level="12" required-level="34" sp="20000" />
+		<skill name="Power Strike" id="3" level="22" required-level="34" sp="20000" />
 		<skill name="Shield Stun" id="92" level="13" required-level="34" sp="20000" />
-		<skill name="Divine Heal" id="45" level="7" required-level="34" sp="20000" />
-		
+		<skill name="Emergency Rescue" id="70" level="7" required-level="34" sp="20000" />
+
+		<!-- Skills Lv35 -->
 		<skill name="Aggression" id="28" level="11" required-level="35" sp="20000" />
 		<skill name="Heavy Armor Mastery" id="232" level="14" required-level="35" sp="20000" />
-		<skill name="Drain Energy" id="70" level="12" required-level="35" sp="20000" />
 		<skill name="Magic Resistance" id="147" level="13" required-level="35" sp="20000" />
+		<skill name="Power Strike" id="3" level="23" required-level="35" sp="20000" />
 		<skill name="Shield Stun" id="92" level="14" required-level="35" sp="20000" />
-		<skill name="Divine Heal" id="45" level="8" required-level="35" sp="20000" />
-		
+
+		<!-- Skills Lv36 -->
 		<skill name="Aggression" id="28" level="12" required-level="36" sp="20000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="8" required-level="36" sp="20000" />
+		<skill name="Quick Heal" id="45" level="8" required-level="36" sp="20000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="8" required-level="36" sp="20000" />
 		<skill name="Heavy Armor Mastery" id="232" level="15" required-level="36" sp="20000" />
-		<skill name="Drain Energy" id="70" level="13" required-level="36" sp="20000" />
 		<skill name="Magic Resistance" id="147" level="14" required-level="36" sp="20000" />
+		<skill name="Power Strike" id="3" level="24" required-level="36" sp="20000" />
 		<skill name="Shield Stun" id="92" level="15" required-level="36" sp="20000" />
-		<skill name="Divine Heal" id="45" level="9" required-level="36" sp="20000" />
 		<skill name="Focus Mind" id="191" level="1" required-level="36" sp="20000" />
+		<skill name="Emergency Rescue" id="70" level="8" required-level="36" sp="20000" />
+
+		<!-- Skills Lv38 -->
+		<skill name="Quick Heal" id="45" level="9" required-level="38" sp="20000" />
+		<skill name="Emergency Rescue" id="70" level="9" required-level="38" sp="20000" />
+		
 	</skillTree>
 </list>

--- a/data/skillTrees/1stClass/HumanWizard.xml
+++ b/data/skillTrees/1stClass/HumanWizard.xml
@@ -1,143 +1,208 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="11" parentClassId="10">
+
+		<!-- Master Buffs Lv. 20 -->
+		<skill name="Empower" id="45105" level="1" required-level="20" sp="500" />
+		<skill name="Concentration" id="1078" level="1" required-level="20" sp="600" />
+		<skill name="Might" id="1068" level="2" required-level="20" sp="500" />
+		<skill name="Acumen" id="45104" level="1" required-level="20" sp="500" />
+		<skill name="Wind Walk" id="45107" level="1" required-level="20" sp="500" />
+		<skill name="Haste" id="45111" level="1" required-level="20" sp="500" />
+		<skill name="Focus" id="45109" level="1" required-level="20" sp="500" />
+		<skill name="Clarity" id="45113" level="1" required-level="20" sp="500" />
+		<skill name="Death Whisper" id="45110" level="1" required-level="20" sp="500" />
+		<skill name="Shield" id="1040" level="2" required-level="20" sp="500" />
+
+
+		<!-- Skills Lv20 -->	
 		<skill name="Anti Magic" id="146" level="5" required-level="20" sp="600" />
 		<skill name="Anti Magic" id="146" level="6" required-level="20" sp="600" />
 		<skill name="Quick Recovery" id="164" level="1" required-level="20" sp="600" />
 		<skill name="Robe Mastery" id="234" level="1" required-level="20" sp="600" />
 		<skill name="Robe Mastery" id="234" level="2" required-level="20" sp="600" />
 		<skill name="Weapon Mastery" id="249" level="3" required-level="20" sp="600" />
+		<skill name="Recover HP" id="45176" level="1" required-level="20" sp="500" />
+		<skill name="Recover MP" id="45177" level="1" required-level="20" sp="500" />
 		<skill name="Blaze" id="1220" level="1" required-level="20" sp="600" />
 		<skill name="Blaze" id="1220" level="2" required-level="20" sp="600" />
-		<skill name="Ice Bolt" id="1184" level="5" required-level="20" sp="600" />
 		<skill name="Ice Bolt" id="1184" level="6" required-level="20" sp="600" />
+		<skill name="Ice Bolt" id="1184" level="7" required-level="20" sp="600" />
 		<skill name="Servitor Heal" id="1127" level="1" required-level="20" sp="600" />
 		<skill name="Servitor Heal" id="1127" level="2" required-level="20" sp="600" />
 		<skill name="Servitor Heal" id="1127" level="3" required-level="20" sp="600" />
+		<skill name="Fireball" id="1147" level="4" required-level="20" sp="600" />
+		<skill name="Poison" id="1168" level="2" required-level="20" sp="600" />
 		<skill name="Summon Kat the Cat" id="1111" level="1" required-level="20" sp="600" />
 		<skill name="Summon Mew the Cat" id="1225" level="1" required-level="20" sp="600" />
-		<skill name="Vampiric Touch" id="1147" level="3" required-level="20" sp="600" />
-		<skill name="Vampiric Touch" id="1147" level="4" required-level="20" sp="600" />
-		<skill name="Curse Weakness" id="1164" level="2" required-level="20" sp="600" />
-		<skill name="Curse Poison" id="1168" level="2" required-level="20" sp="600" />
+		<skill name="Vampiric Touch" id="45247" level="1" required-level="20" sp="600" />
 		<skill name="Aura Burn" id="1172" level="1" required-level="20" sp="600" />
 		<skill name="Aura Burn" id="1172" level="2" required-level="20" sp="600" />
+		<skill name="Weakness" id="1164" level="2" required-level="20" sp="600" />
 		<skill name="Boost Mana" id="213" level="1" required-level="20" sp="600" />
+		<skill name="Increased Power of Magic" id="1073" level="1" required-level="20" sp="600" />
 		<skill name="Flame Strike" id="1181" level="1" required-level="20" sp="600" />
+		<skill name="Swift Servitor Heal" id="45362" level="1" required-level="20" sp="600" />
+		<skill name="Swift Servitor Heal" id="45362" level="2" required-level="20" sp="600" />
+		<skill name="Swift Servitor Heal" id="45362" level="3" required-level="20" sp="600" />
 		<skill name="Higher Mana Gain" id="285" level="1" required-level="20" sp="600" />
 		<skill name="Higher Mana Gain" id="285" level="2" required-level="20" sp="600" />
+		<skill name="Sleep" id="1069" level="1" required-level="20" sp="600" />
+
 		<skill name="Energy Bolt" id="1274" level="1" required-level="20" sp="600" />
-		<skill name="Concentration" id="1078" level="1" required-level="20" sp="600">
-			<item id="1399"/>
-		</skill>
-		
+
+		<!-- Skills Lv22 -->
+		<skill name="Vampiric Touch" id="45247" level="2" required-level="22" sp="2300" />
+		<skill name="Sleep" id="1069" level="2" required-level="22" sp="2300" />
+
+		<!-- Skills Lv23 -->
 		<skill name="Anti Magic" id="146" level="7" required-level="23" sp="2300" />
 		<skill name="Robe Mastery" id="234" level="3" required-level="23" sp="2300" />
 		<skill name="Weapon Mastery" id="249" level="4" required-level="23" sp="2300" />
+		<skill name="Servitor Recharge" id="1126" level="1" required-level="23" sp="2300" />
 		<skill name="Blaze" id="1220" level="3" required-level="23" sp="2300" />
 		<skill name="Servitor Heal" id="1127" level="4" required-level="23" sp="2300" />
-		<skill name="Servitor Recharge" id="1126" level="1" required-level="23" sp="2300" />
-		<skill name="Vampiric Touch" id="1147" level="5" required-level="23" sp="2300" />
 		<skill name="Aura Burn" id="1172" level="3" required-level="23" sp="2300" />
+		<skill name="Swift Servitor Heal" id="45362" level="4" required-level="23" sp="2300" />
 		<skill name="Higher Mana Gain" id="285" level="3" required-level="23" sp="2300" />
-		<skill name="Sleep" id="1069" level="1" required-level="23" sp="2300">
-			<item id="1394"/>
-		</skill>
-		
-		<skill name="Servitor Heal" id="1127" level="5" required-level="24" sp="2300" />
-		<skill name="Sleep" id="1069" level="2" required-level="24" sp="2300" />
 
+		<!-- Skills Lv24 -->
+		<skill name="Servitor Heal" id="1127" level="5" required-level="24" sp="2300" />
+		<skill name="Vampiric Touch" id="45247" level="3" required-level="24" sp="2300" />
+		<skill name="Swift Servitor Heal" id="45362" level="5" required-level="24" sp="2300" />
+		<skill name="Sleep" id="1069" level="3" required-level="24" sp="2300" />
+
+		<!-- Skills Lv25 -->
 		<skill name="Anti Magic" id="146" level="8" required-level="25" sp="2300" />
 		<skill name="Fast Mana Recovery" id="229" level="1" required-level="25" sp="2300" />
 		<skill name="Fast Spell Casting" id="228" level="1" required-level="25" sp="2300" />
 		<skill name="Robe Mastery" id="234" level="4" required-level="25" sp="2300" />
 		<skill name="Weapon Mastery" id="249" level="5" required-level="25" sp="2300" />
-		<skill name="Blaze" id="1220" level="4" required-level="25" sp="2300" />
-		<skill name="Servitor Heal" id="1127" level="6" required-level="25" sp="2300" />
 		<skill name="Servitor Recharge" id="1126" level="2" required-level="25" sp="2300" />
+		<skill name="Blaze" id="1220" level="4" required-level="25" sp="2300" />
+		<skill name="Ice Bolt" id="1184" level="8" required-level="25" sp="2300" />
+		<skill name="Servitor Heal" id="1127" level="6" required-level="25" sp="2300" />
+		<skill name="Fireball" id="1147" level="5" required-level="25" sp="2300" />
 		<skill name="Summon Kat the Cat" id="1111" level="2" required-level="25" sp="2300" />
 		<skill name="Summon Mew the Cat" id="1225" level="2" required-level="25" sp="2300" />
-		<skill name="Vampiric Touch" id="1147" level="6" required-level="25" sp="2300" />
-		<skill name="Curse Weakness" id="1164" level="3" required-level="25" sp="2300" />
+		<skill name="Body to Mind" id="1157" level="1" required-level="25" sp="2300" />
 		<skill name="Aura Burn" id="1172" level="4" required-level="25" sp="2300" />
+		<skill name="Weakness" id="1164" level="3" required-level="25" sp="2300" />
 		<skill name="Flame Strike" id="1181" level="2" required-level="25" sp="2300" />
+		<skill name="Swift Servitor Heal" id="45362" level="6" required-level="25" sp="2300" />
 		<skill name="Higher Mana Gain" id="285" level="4" required-level="25" sp="2300" />
-		<skill name="Sleep" id="1069" level="3" required-level="25" sp="2300" />
 		<skill name="Energy Bolt" id="1274" level="2" required-level="25" sp="2300" />
 		<skill name="Poisonous Cloud" id="1167" level="1" required-level="25" sp="2300" />
-		<skill name="Body To Mind" id="1157" level="1" required-level="25" sp="2300">
-			<item id="1517"/>
-		</skill>
-		
+
+		<!-- Skills Lv26 -->
+		<skill name="Vampiric Touch" id="45247" level="4" required-level="26" sp="2300" />
+		<skill name="Sleep" id="1069" level="4" required-level="26" sp="2300" />
+
+		<!-- Skills Lv28 -->
 		<skill name="Anti Magic" id="146" level="9" required-level="28" sp="5700" />
 		<skill name="Robe Mastery" id="234" level="5" required-level="28" sp="5700" />
 		<skill name="Weapon Mastery" id="249" level="6" required-level="28" sp="5700" />
+		<skill name="Servitor Recharge" id="1126" level="3" required-level="28" sp="5700" />
 		<skill name="Blaze" id="1220" level="5" required-level="28" sp="5700" />
 		<skill name="Servitor Heal" id="1127" level="7" required-level="28" sp="5700" />
-		<skill name="Servitor Recharge" id="1126" level="3" required-level="28" sp="5700" />
+		<skill name="Vampiric Touch" id="45247" level="5" required-level="28" sp="5700" />
 		<skill name="Aura Burn" id="1172" level="5" required-level="28" sp="5700" />
+		<skill name="Swift Servitor Heal" id="45362" level="7" required-level="28" sp="5700" />
 		<skill name="Higher Mana Gain" id="285" level="5" required-level="28" sp="5700" />
-		<skill name="Sleep" id="1069" level="4" required-level="28" sp="5700" />
-		
-		<skill name="Servitor Heal" id="1127" level="8" required-level="29" sp="5700" />
-		<skill name="Sleep" id="1069" level="5" required-level="29" sp="5700" />
+		<skill name="Sleep" id="1069" level="5" required-level="28" sp="5700" />
 
+		<!-- Skills Lv29 -->
+		<skill name="Servitor Heal" id="1127" level="8" required-level="29" sp="5700" />
+		<skill name="Swift Servitor Heal" id="45362" level="8" required-level="29" sp="5700" />
+
+		<!-- Master Buffs Lv. 30 -->
+		<skill name="Empower" id="45105" level="2" required-level="30" sp="5000" />
+		<skill name="Wild Magic" id="45106" level="1" required-level="30" sp="5000" />
+		<skill name="Berserker Spirit" id="45112" level="1" required-level="30" sp="5000" />
+		<skill name="Concentration" id="1078" level="2" required-level="30" sp="5700" />
+		<skill name="Wind Walk" id="45107" level="2" required-level="30" sp="5000" />
+		<skill name="Magic Barrier" id="45108" level="1" required-level="30" sp="5000" />
+		<skill name="Acumen" id="45104" level="2" required-level="30" sp="5000" />
+		<skill name="Focus" id="45109" level="2" required-level="30" sp="5000" />
+		<skill name="Clarity" id="45113" level="2" required-level="30" sp="5000" />
+		<skill name="Death Whisper" id="45110" level="2" required-level="30" sp="5000" />
+
+		<!-- Skills Lv30 -->
 		<skill name="Anti Magic" id="146" level="10" required-level="30" sp="5700" />
 		<skill name="Quick Recovery" id="164" level="2" required-level="30" sp="5700" />
 		<skill name="Robe Mastery" id="234" level="6" required-level="30" sp="5700" />
 		<skill name="Weapon Mastery" id="249" level="7" required-level="30" sp="5700" />
-		<skill name="Blaze" id="1220" level="6" required-level="30" sp="5700" />
-		<skill name="Concentration" id="1078" level="2" required-level="30" sp="5700" />
-		<skill name="Servitor Heal" id="1127" level="9" required-level="30" sp="5700" />
-		<skill name="Corpse Life Drain" id="1151" level="1" required-level="30" sp="5700" />
 		<skill name="Servitor Recharge" id="1126" level="4" required-level="30" sp="5700" />
+		<skill name="Blaze" id="1220" level="6" required-level="30" sp="5700" />
+		<skill name="Ice Bolt" id="1184" level="9" required-level="30" sp="5700" />
+		<skill name="Servitor Heal" id="1127" level="9" required-level="30" sp="5700" />
+		<skill name="Fireball" id="1147" level="6" required-level="30" sp="5700" />
+		<skill name="Poison" id="1168" level="3" required-level="30" sp="5700" />
+		<skill name="Corpse Life Drain" id="1151" level="1" required-level="30" sp="5700" />
 		<skill name="Summon Kat the Cat" id="1111" level="3" required-level="30" sp="5700" />
 		<skill name="Summon Mew the Cat" id="1225" level="3" required-level="30" sp="5700" />
-		<skill name="Curse Weakness" id="1164" level="4" required-level="30" sp="5700" />
-		<skill name="Curse Poison" id="1168" level="3" required-level="30" sp="5700" />
+		<skill name="Vampiric Touch" id="45247" level="6" required-level="30" sp="5700" />
 		<skill name="Aura Burn" id="1172" level="6" required-level="30" sp="5700" />
+		<skill name="Weakness" id="1164" level="4" required-level="30" sp="5700" />
 		<skill name="Boost Mana" id="213" level="2" required-level="30" sp="5700" />
 		<skill name="Flame Strike" id="1181" level="3" required-level="30" sp="5700" />
+		<skill name="Swift Servitor Heal" id="45362" level="9" required-level="30" sp="5700" />
 		<skill name="Higher Mana Gain" id="285" level="6" required-level="30" sp="5700" />
 		<skill name="Sleep" id="1069" level="6" required-level="30" sp="5700" />
+
 		<skill name="Energy Bolt" id="1274" level="3" required-level="30" sp="5700" />
-		
+
+		<!-- Skills Lv32 -->
+		<skill name="Vampiric Touch" id="45247" level="7" required-level="32" sp="5700" />
+		<skill name="Sleep" id="1069" level="7" required-level="32" sp="5700" />
+
+		<!-- Skills Lv33 -->
 		<skill name="Anti Magic" id="146" level="11" required-level="33" sp="13000" />
 		<skill name="Robe Mastery" id="234" level="7" required-level="33" sp="13000" />
 		<skill name="Weapon Mastery" id="249" level="8" required-level="33" sp="13000" />
+		<skill name="Servitor Recharge" id="1126" level="5" required-level="33" sp="13000" />
 		<skill name="Blaze" id="1220" level="7" required-level="33" sp="13000" />
 		<skill name="Servitor Heal" id="1127" level="10" required-level="33" sp="13000" />
-		<skill name="Servitor Recharge" id="1126" level="5" required-level="33" sp="13000" />
 		<skill name="Aura Burn" id="1172" level="7" required-level="33" sp="13000" />
+		<skill name="Swift Servitor Heal" id="45362" level="10" required-level="33" sp="13000" />
 		<skill name="Higher Mana Gain" id="285" level="7" required-level="33" sp="13000" />
-		<skill name="Sleep" id="1069" level="7" required-level="33" sp="13000" />
-		
+
+		<!-- Skills Lv34 -->
 		<skill name="Servitor Heal" id="1127" level="11" required-level="34" sp="13000" />
+		<skill name="Vampiric Touch" id="45247" level="8" required-level="34" sp="13000" />
+		<skill name="Swift Servitor Heal" id="45362" level="11" required-level="34" sp="13000" />
 		<skill name="Sleep" id="1069" level="8" required-level="34" sp="13000" />
 
+		<!-- Skills Lv35 -->
 		<skill name="Anti Magic" id="146" level="12" required-level="35" sp="13000" />
 		<skill name="Fast HP Recovery" id="212" level="1" required-level="35" sp="13000" />
 		<skill name="Fast Mana Recovery" id="229" level="2" required-level="35" sp="13000" />
 		<skill name="Robe Mastery" id="234" level="8" required-level="35" sp="13000" />
 		<skill name="Weapon Mastery" id="249" level="9" required-level="35" sp="13000" />
+		<skill name="Servitor Recharge" id="1126" level="6" required-level="35" sp="13000" />
 		<skill name="Blaze" id="1220" level="8" required-level="35" sp="13000" />
+		<skill name="Slow" id="1160" level="1" required-level="35" sp="13000" />
 		<skill name="Servitor Wind Walk" id="1144" level="1" required-level="35" sp="13000" />
+		<skill name="Ice Bolt" id="1184" level="10" required-level="35" sp="13000" />
 		<skill name="Servitor Heal" id="1127" level="12" required-level="35" sp="13000" />
 		<skill name="Corpse Life Drain" id="1151" level="2" required-level="35" sp="13000" />
-		<skill name="Servitor Recharge" id="1126" level="6" required-level="35" sp="13000" />
 		<skill name="Summon Kat the Cat" id="1111" level="4" required-level="35" sp="13000" />
 		<skill name="Summon Mew the Cat" id="1225" level="4" required-level="35" sp="13000" />
-		<skill name="Curse Weakness" id="1164" level="5" required-level="35" sp="13000" />
+		<skill name="Curse Chaos" id="1222" level="1" required-level="35" sp="13000" />
 		<skill name="Aura Burn" id="1172" level="8" required-level="35" sp="13000" />
+		<skill name="Weakness" id="1164" level="5" required-level="35" sp="13000" />
+		<skill name="Swift Servitor Heal" id="45362" level="12" required-level="35" sp="13000" />
 		<skill name="Higher Mana Gain" id="285" level="8" required-level="35" sp="13000" />
-		<skill name="Sleep" id="1069" level="9" required-level="35" sp="13000" />
 		<skill name="Energy Bolt" id="1274" level="4" required-level="35" sp="13000" />
 		<skill name="Poisonous Cloud" id="1167" level="2" required-level="35" sp="13000" />
-		<skill name="Slow" id="1160" level="1" required-level="35" sp="13000">
-			<item id="1409"/>
-		</skill>
-		<skill name="Curse Chaos" id="1222" level="1" required-level="35" sp="13000">
-			<item id="1416"/>
-		</skill>
+
+		<!-- Skills Lv36 -->
+		<skill name="Vampiric Touch" id="45247" level="9" required-level="36" sp="13000" />
+		<skill name="Sleep" id="1069" level="9" required-level="36" sp="13000" />
+
+		<!-- Skills Lv38 -->
+		<skill name="Vampiric Touch" id="45247" level="10" required-level="38" sp="13000" />
+		<skill name="Sleep" id="1069" level="10" required-level="38" sp="13000" />
+
 	</skillTree>
 </list>

--- a/data/skillTrees/1stClass/OrcMonk.xml
+++ b/data/skillTrees/1stClass/OrcMonk.xml
@@ -1,93 +1,175 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="47" parentClassId="44">
+
+		<!-- Master Buffs Lv. 20 -->
+		<skill name="Chant of Empower" id="45136" level="1" required-level="20" sp="1000" />
+		<skill name="Chant of Wind Walk" id="45124" level="1" required-level="20" sp="1000" />
+		<skill name="Chant of Might" id="45126" level="2" required-level="20" sp="1000" />
+		<skill name="Chant of Acumen" id="45135" level="1" required-level="20" sp="1000" />
+		<skill name="Chant of Haste" id="45123" level="1" required-level="20" sp="1000" />
+		<skill name="Chant of Focus" id="45121" level="1" required-level="20" sp="1000" />
+		<skill name="Chant of Clarity" id="45129" level="1" required-level="20" sp="1000" />
+		<skill name="Chant of Death Whisper" id="45122" level="1" required-level="20" sp="1000" />
+		<skill name="Chant of Shield" id="45127" level="2" required-level="20" sp="1000" />
+
+
+		<!-- Skills Lv20 -->
 		<skill name="Fist Weapon Mastery" id="210" level="1" required-level="20" sp="1000" />
 		<skill name="Light Armor Mastery" id="233" level="1" required-level="20" sp="1000" />
 		<skill name="Light Armor Mastery" id="233" level="2" required-level="20" sp="1000" />
+		<skill name="Recover HP" id="45176" level="1" required-level="20" sp="1000" />
+		<skill name="Recover MP" id="45177" level="1" required-level="20" sp="1000" />
 		<skill name="Iron Punch" id="29" level="10" required-level="20" sp="1000" />
 		<skill name="Iron Punch" id="29" level="11" required-level="20" sp="1000" />
 		<skill name="Iron Punch" id="29" level="12" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="1" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="2" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="3" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="4" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="5" required-level="20" sp="1000" />
+		<skill name="Wolf Nature" id="83" level="1" required-level="20" sp="1000" />
 		<skill name="Stunning Fist" id="120" level="1" required-level="20" sp="1000" />
 		<skill name="Stunning Fist" id="120" level="2" required-level="20" sp="1000" />
 		<skill name="Stunning Fist" id="120" level="3" required-level="20" sp="1000" />
-		<skill name="Wolf Spirit Totem" id="83" level="1" required-level="20" sp="1000" />
+		<skill name="Stunning Fist" id="120" level="4" required-level="20" sp="1000" />
+		<skill name="Stunning Fist" id="120" level="5" required-level="20" sp="1000" />
+		<skill name="Bandage" id="34" level="1" required-level="20" sp="1000" />
+		<skill name="Ability to Protect" id="91" level="2" required-level="20" sp="1000" />
 		<skill name="Cripple" id="95" level="1" required-level="20" sp="1000" />
+		<skill name="Emergency Rescue" id="70" level="3" required-level="20" sp="1000" />
 
+		<!-- Skills Lv21 -->
+		<skill name="Enhanced Weapon" id="255" level="6" required-level="21" sp="1000" />
+		<skill name="Stunning Fist" id="120" level="6" required-level="21" sp="1000" />
+
+		<!-- Skills Lv22 -->
 		<skill name="Light Armor Mastery" id="233" level="3" required-level="22" sp="2800" />
 		<skill name="Iron Punch" id="29" level="13" required-level="22" sp="2800" />
 		<skill name="Force Blaster" id="54" level="1" required-level="22" sp="2800" />
-		<skill name="Stunning Fist" id="120" level="4" required-level="22" sp="2800" />
-		
+		<skill name="Enhanced Weapon" id="255" level="7" required-level="22" sp="2800" />
+		<skill name="Stunning Fist" id="120" level="7" required-level="22" sp="2800" />
+
+		<!-- Skills Lv23 -->
 		<skill name="Iron Punch" id="29" level="14" required-level="23" sp="2800" />
 		<skill name="Force Blaster" id="54" level="2" required-level="23" sp="2800" />
-		<skill name="Stunning Fist" id="120" level="5" required-level="23" sp="2800" />
-		
+		<skill name="Enhanced Weapon" id="255" level="8" required-level="23" sp="2800" />
+		<skill name="Stunning Fist" id="120" level="8" required-level="23" sp="2800" />
+		<skill name="Cripple" id="95" level="2" required-level="23" sp="2800" />
+
+		<!-- Skills Lv24 -->
 		<skill name="Fist Weapon Mastery" id="210" level="2" required-level="24" sp="2800" />
 		<skill name="Light Armor Mastery" id="233" level="4" required-level="24" sp="2800" />
 		<skill name="Force Mastery" id="993" level="1" required-level="24" sp="2800" />
 		<skill name="Iron Punch" id="29" level="15" required-level="24" sp="2800" />
 		<skill name="Force Blaster" id="54" level="3" required-level="24" sp="2800" />
-		<skill name="Stunning Fist" id="120" level="6" required-level="24" sp="2800" />
+		<skill name="Enhanced Weapon" id="255" level="9" required-level="24" sp="2800" />
+		<skill name="Stunning Fist" id="120" level="9" required-level="24" sp="2800" />
 		<skill name="Focus Force" id="50" level="1" required-level="24" sp="2800" />
-		<skill name="Cripple" id="95" level="2" required-level="24" sp="2800" />
-		
+
+		<!-- Skills Lv25 -->
+		<skill name="Enhanced Weapon" id="255" level="10" required-level="25" sp="2800" />
+		<skill name="Bear Nature" id="76" level="1" required-level="25" sp="2800" />
+		<skill name="Stunning Fist" id="120" level="10" required-level="25" sp="2800" />
+		<skill name="Ability to Attack" id="77" level="2" required-level="25" sp="2800" />
+		<skill name="Emergency Rescue" id="70" level="4" required-level="25" sp="2800" />
+
+		<!-- Skills Lv26 -->
 		<skill name="Fist Weapon Mastery" id="210" level="3" required-level="26" sp="5700" />
 		<skill name="Light Armor Mastery" id="233" level="5" required-level="26" sp="5700" />
 		<skill name="Iron Punch" id="29" level="16" required-level="26" sp="5700" />
 		<skill name="Force Blaster" id="54" level="4" required-level="26" sp="5700" />
-		<skill name="Stunning Fist" id="120" level="7" required-level="26" sp="5700" />
-		
+		<skill name="Enhanced Weapon" id="255" level="11" required-level="26" sp="5700" />
+		<skill name="Stunning Fist" id="120" level="11" required-level="26" sp="5700" />
+		<skill name="Cripple" id="95" level="3" required-level="26" sp="5700" />
+
+		<!-- Skills Lv27 -->
 		<skill name="Iron Punch" id="29" level="17" required-level="27" sp="5700" />
 		<skill name="Force Blaster" id="54" level="5" required-level="27" sp="5700" />
-		<skill name="Stunning Fist" id="120" level="8" required-level="27" sp="5700" />
+		<skill name="Enhanced Weapon" id="255" level="12" required-level="27" sp="5700" />
+		<skill name="Stunning Fist" id="120" level="12" required-level="27" sp="5700" />
 
+		<!-- Skills Lv28 -->
 		<skill name="Fist Weapon Mastery" id="210" level="4" required-level="28" sp="5700" />
 		<skill name="Light Armor Mastery" id="233" level="6" required-level="28" sp="5700" />
 		<skill name="Iron Punch" id="29" level="18" required-level="28" sp="5700" />
 		<skill name="Force Blaster" id="54" level="6" required-level="28" sp="5700" />
-		<skill name="Stunning Fist" id="120" level="9" required-level="28" sp="5700" />
-		<skill name="Bear Spirit Totem" id="76" level="1" required-level="28" sp="5700" />
-		<skill name="Cripple" id="95" level="3" required-level="28" sp="5700" />
+		<skill name="Enhanced Weapon" id="255" level="13" required-level="28" sp="5700" />
+		<skill name="Stunning Fist" id="120" level="13" required-level="28" sp="5700" />
+		<skill name="Cripple" id="95" level="4" required-level="28" sp="5700" />
 
+		<!-- Skills Lv29 -->
+		<skill name="Enhanced Weapon" id="255" level="14" required-level="29" sp="11000" />
+		<skill name="Stunning Fist" id="120" level="14" required-level="29" sp="11000" />
+
+		<!-- Master Buffs Lv. 30 -->
+		<skill name="Chant of Empower" id="45136" level="2" required-level="30" sp="11000" />
+		<skill name="Chant of Wild Magic" id="45137" level="1" required-level="30" sp="11000" />
+		<skill name="Chant of Berserker Spirit" id="45128" level="1" required-level="30" sp="11000" />
+		<skill name="Chant of Wind Walk" id="45124" level="2" required-level="30" sp="11000" />
+		<skill name="Chant of Magic Barrier" id="45125" level="1" required-level="30" sp="11000" />
+		<skill name="Chant of Acumen" id="45135" level="2" required-level="30" sp="11000" />
+		<skill name="Chant of Focus" id="45121" level="2" required-level="30" sp="11000" />
+		<skill name="Chant of Clarity" id="45129" level="2" required-level="30" sp="11000" />
+		<skill name="Chant of Death Whisper" id="45122" level="2" required-level="30" sp="11000" />
+
+
+		<!-- Skills Lv30 -->
 		<skill name="Fist Weapon Mastery" id="210" level="5" required-level="30" sp="11000" />
 		<skill name="Light Armor Mastery" id="233" level="7" required-level="30" sp="11000" />
 		<skill name="Iron Punch" id="29" level="19" required-level="30" sp="11000" />
 		<skill name="Force Blaster" id="54" level="7" required-level="30" sp="11000" />
-		<skill name="Stunning Fist" id="120" level="10" required-level="30" sp="11000" />
-		
+		<skill name="Enhanced Weapon" id="255" level="15" required-level="30" sp="11000" />
+		<skill name="Stunning Fist" id="120" level="15" required-level="30" sp="11000" />
+		<skill name="Cripple" id="95" level="5" required-level="30" sp="11000" />
+		<skill name="Emergency Rescue" id="70" level="5" required-level="30" sp="11000" />
+
+		<!-- Skills Lv31 -->
 		<skill name="Iron Punch" id="29" level="20" required-level="31" sp="11000" />
 		<skill name="Force Blaster" id="54" level="8" required-level="31" sp="11000" />
-		<skill name="Stunning Fist" id="120" level="11" required-level="31" sp="11000" />
-		
+		<skill name="Hurricane Assault" id="284" level="1" required-level="31" sp="11000" />
+
+		<!-- Skills Lv32 -->
 		<skill name="Fist Weapon Mastery" id="210" level="6" required-level="32" sp="11000" />
 		<skill name="Light Armor Mastery" id="233" level="8" required-level="32" sp="11000" />
 		<skill name="Force Mastery" id="993" level="2" required-level="32" sp="11000" />
 		<skill name="Iron Punch" id="29" level="21" required-level="32" sp="11000" />
 		<skill name="Force Blaster" id="54" level="9" required-level="32" sp="11000" />
-		<skill name="Stunning Fist" id="120" level="12" required-level="32" sp="11000" />
+		<skill name="Hurricane Assault" id="284" level="2" required-level="32" sp="11000" />
 		<skill name="Focus Force" id="50" level="2" required-level="32" sp="11000" />
-		<skill name="Cripple" id="95" level="4" required-level="32" sp="11000" />
-		
+		<skill name="Cripple" id="95" level="6" required-level="32" sp="11000" />
+		<skill name="Emergency Rescue" id="70" level="6" required-level="32" sp="11000" />
+
+		<!-- Skills Lv33 -->
+		<skill name="Hurricane Assault" id="284" level="3" required-level="33" sp="20000" />
+
+		<!-- Skills Lv34 -->
 		<skill name="Fist Weapon Mastery" id="210" level="7" required-level="34" sp="20000" />
 		<skill name="Light Armor Mastery" id="233" level="9" required-level="34" sp="20000" />
 		<skill name="Iron Punch" id="29" level="22" required-level="34" sp="20000" />
 		<skill name="Force Blaster" id="54" level="10" required-level="34" sp="20000" />
-		<skill name="Stunning Fist" id="120" level="13" required-level="34" sp="20000" />
-		<skill name="Hurricane Assault" id="284" level="1" required-level="34" sp="20000" />
-		
+		<skill name="Hurricane Assault" id="284" level="4" required-level="34" sp="20000" />
+		<skill name="Cripple" id="95" level="7" required-level="34" sp="20000" />
+		<skill name="Emergency Rescue" id="70" level="7" required-level="34" sp="20000" />
+
+		<!-- Skills Lv35 -->
 		<skill name="Iron Punch" id="29" level="23" required-level="35" sp="20000" />
 		<skill name="Force Blaster" id="54" level="11" required-level="35" sp="20000" />
-		<skill name="Stunning Fist" id="120" level="14" required-level="35" sp="20000" />
-		<skill name="Hurricane Assault" id="284" level="2" required-level="35" sp="20000" />
-		
+		<skill name="Hurricane Assault" id="284" level="5" required-level="35" sp="20000" />
+
+		<!-- Skills Lv36 -->
 		<skill name="Fist Weapon Mastery" id="210" level="8" required-level="36" sp="20000" />
 		<skill name="Light Armor Mastery" id="233" level="10" required-level="36" sp="20000" />
 		<skill name="Iron Punch" id="29" level="24" required-level="36" sp="20000" />
 		<skill name="Force Blaster" id="54" level="12" required-level="36" sp="20000" />
 		<skill name="Lionheart" id="287" level="1" required-level="36" sp="20000" />
-		<skill name="Stunning Fist" id="120" level="15" required-level="36" sp="20000" />
-		<skill name="Boost Atk. Spd." id="168" level="1" required-level="36" sp="20000" />
-		<skill name="Hurricane Assault" id="284" level="3" required-level="36" sp="20000" />
-		<skill name="Cripple" id="95" level="5" required-level="36" sp="20000" />
+		<skill name="Attack Speed Boost" id="168" level="1" required-level="36" sp="20000" />
+		<skill name="Cripple" id="95" level="8" required-level="36" sp="20000" />
+		<skill name="Emergency Rescue" id="70" level="8" required-level="36" sp="20000" />
+
+		<!-- Skills Lv38 -->
+		<skill name="Cripple" id="95" level="9" required-level="38" sp="20000" />
+		<skill name="Emergency Rescue" id="70" level="9" required-level="38" sp="20000" />
+		
 	</skillTree>
 </list>

--- a/data/skillTrees/1stClass/OrcRaider.xml
+++ b/data/skillTrees/1stClass/OrcRaider.xml
@@ -1,128 +1,202 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="45" parentClassId="44">
-		<skill name="Shock Attack" id="100" level="1" required-level="20" sp="1000" />
-		<skill name="Shock Attack" id="100" level="2" required-level="20" sp="1000" />
-		<skill name="Shock Attack" id="100" level="3" required-level="20" sp="1000" />
+
+		<!-- Master Buffs Lv. 20 -->
+		<skill name="Chant of Empower" id="45136" level="1" required-level="20" sp="1000" />
+		<skill name="Chant of Wind Walk" id="45124" level="1" required-level="20" sp="1000" />
+		<skill name="Chant of Might" id="45126" level="2" required-level="20" sp="1000" />
+		<skill name="Chant of Acumen" id="45135" level="1" required-level="20" sp="1000" />
+		<skill name="Chant of Haste" id="45123" level="1" required-level="20" sp="1000" />
+		<skill name="Chant of Focus" id="45121" level="1" required-level="20" sp="1000" />
+		<skill name="Chant of Clarity" id="45129" level="1" required-level="20" sp="1000" />
+		<skill name="Chant of Death Whisper" id="45122" level="1" required-level="20" sp="1000" />
+		<skill name="Chant of Shield" id="45127" level="2" required-level="20" sp="1000" />
+
+
+
+		<!-- Skills Lv20 -->
 		<skill name="Vicious Stance" id="312" level="1" required-level="20" sp="1000" />
 		<skill name="Two-handed Weapon Mastery" id="293" level="1" required-level="20" sp="1000" />
 		<skill name="Polearm Mastery" id="216" level="1" required-level="20" sp="1000" />
 		<skill name="Light Armor Mastery" id="227" level="1" required-level="20" sp="1000" />
 		<skill name="Light Armor Mastery" id="227" level="2" required-level="20" sp="1000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="1" required-level="20" sp="1000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="1" required-level="20" sp="1000" />
+		<skill name="Stun Mastery" id="100" level="1" required-level="20" sp="1000" />
+		<skill name="Stun Mastery" id="100" level="2" required-level="20" sp="1000" />
+		<skill name="Stun Mastery" id="100" level="3" required-level="20" sp="1000" />
+		<skill name="Stun Mastery" id="100" level="4" required-level="20" sp="1000" />
+		<skill name="Stun Mastery" id="100" level="5" required-level="20" sp="1000" />
 		<skill name="Heavy Armor Mastery" id="231" level="1" required-level="20" sp="1000" />
 		<skill name="Heavy Armor Mastery" id="231" level="2" required-level="20" sp="1000" />
+		<skill name="Recover HP" id="45176" level="1" required-level="20" sp="1000" />
+		<skill name="Recover MP" id="45177" level="1" required-level="20" sp="1000" />
 		<skill name="Wild Sweep" id="245" level="1" required-level="20" sp="1000" />
 		<skill name="Wild Sweep" id="245" level="2" required-level="20" sp="1000" />
 		<skill name="Wild Sweep" id="245" level="3" required-level="20" sp="1000" />
-		<skill name="Power Smash" id="255" level="1" required-level="20" sp="1000" />
-		<skill name="Power Smash" id="255" level="2" required-level="20" sp="1000" />
-		<skill name="Power Smash" id="255" level="3" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="1" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="2" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="3" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="4" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="5" required-level="20" sp="1000" />
+		<skill name="Power Strike" id="3" level="10" required-level="20" sp="1000" />
+		<skill name="Power Strike" id="3" level="11" required-level="20" sp="1000" />
+		<skill name="Power Strike" id="3" level="12" required-level="20" sp="1000" />
 		<skill name="Bandage" id="34" level="1" required-level="20" sp="1000" />
+		<skill name="Ability to Protect" id="91" level="2" required-level="20" sp="1000" />
 		<skill name="Boost HP" id="211" level="1" required-level="20" sp="1000" />
+		<skill name="Emergency Rescue" id="70" level="3" required-level="20" sp="1000" />
 
-		<skill name="Shock Attack" id="100" level="4" required-level="22" sp="2800" />
+		<!-- Skills Lv21 -->
+		<skill name="Stun Mastery" id="100" level="6" required-level="21" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="6" required-level="21" sp="1000" />
+
+		<!-- Skills Lv22 -->
 		<skill name="Light Armor Mastery" id="227" level="3" required-level="22" sp="2800" />
+		<skill name="Stun Mastery" id="100" level="7" required-level="22" sp="2800" />
 		<skill name="Heavy Armor Mastery" id="231" level="3" required-level="22" sp="2800" />
 		<skill name="Wild Sweep" id="245" level="4" required-level="22" sp="2800" />
-		<skill name="Power Smash" id="255" level="4" required-level="22" sp="2800" />
-		
-		<skill name="Shock Attack" id="100" level="5" required-level="23" sp="2800" />
+		<skill name="Enhanced Weapon" id="255" level="7" required-level="22" sp="2800" />
+		<skill name="Power Strike" id="3" level="13" required-level="22" sp="2800" />
+
+		<!-- Skills Lv23 -->
+		<skill name="Stun Mastery" id="100" level="8" required-level="23" sp="2800" />
 		<skill name="Wild Sweep" id="245" level="5" required-level="23" sp="2800" />
-		<skill name="Power Smash" id="255" level="5" required-level="23" sp="2800" />
-		
-		<skill name="Shock Attack" id="100" level="6" required-level="24" sp="2800" />
+		<skill name="Enhanced Weapon" id="255" level="8" required-level="23" sp="2800" />
+		<skill name="Power Strike" id="3" level="14" required-level="23" sp="2800" />
+
+		<!-- Skills Lv24 -->
 		<skill name="Vicious Stance" id="312" level="2" required-level="24" sp="2800" />
 		<skill name="Fast HP Recovery" id="212" level="1" required-level="24" sp="2800" />
 		<skill name="Two-handed Weapon Mastery" id="293" level="2" required-level="24" sp="2800" />
 		<skill name="Polearm Mastery" id="216" level="2" required-level="24" sp="2800" />
 		<skill name="Light Armor Mastery" id="227" level="4" required-level="24" sp="2800" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="2" required-level="24" sp="2800" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="2" required-level="24" sp="2800" />
+		<skill name="Stun Mastery" id="100" level="9" required-level="24" sp="2800" />
 		<skill name="Heavy Armor Mastery" id="231" level="4" required-level="24" sp="2800" />
 		<skill name="Rage" id="94" level="1" required-level="24" sp="2800" />
 		<skill name="Wild Sweep" id="245" level="6" required-level="24" sp="2800" />
 		<skill name="Vital Force" id="148" level="1" required-level="24" sp="2800" />
-		<skill name="Power Smash" id="255" level="6" required-level="24" sp="2800" />
+		<skill name="Enhanced Weapon" id="255" level="9" required-level="24" sp="2800" />
+		<skill name="Power Strike" id="3" level="15" required-level="24" sp="2800" />
 		<skill name="Accuracy" id="256" level="1" required-level="24" sp="2800" />
-		
-		<skill name="Shock Attack" id="100" level="7" required-level="26" sp="5700" />
+
+		<!-- Skills Lv25 -->
+		<skill name="Stun Mastery" id="100" level="10" required-level="25" sp="2800" />
+		<skill name="Enhanced Weapon" id="255" level="10" required-level="25" sp="2800" />
+		<skill name="Ability to Attack" id="77" level="2" required-level="25" sp="2800" />
+		<skill name="Emergency Rescue" id="70" level="4" required-level="25" sp="2800" />
+
+		<!-- Skills Lv26 -->
 		<skill name="Polearm Mastery" id="216" level="3" required-level="26" sp="5700" />
 		<skill name="Light Armor Mastery" id="227" level="5" required-level="26" sp="5700" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="3" required-level="26" sp="5700" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="3" required-level="26" sp="5700" />
+		<skill name="Stun Mastery" id="100" level="11" required-level="26" sp="5700" />
 		<skill name="Heavy Armor Mastery" id="231" level="5" required-level="26" sp="5700" />
 		<skill name="Wild Sweep" id="245" level="7" required-level="26" sp="5700" />
-		<skill name="Power Smash" id="255" level="7" required-level="26" sp="5700" />
-		
-		<skill name="Shock Attack" id="100" level="8" required-level="27" sp="5700" />
+		<skill name="Enhanced Weapon" id="255" level="11" required-level="26" sp="5700" />
+		<skill name="Power Strike" id="3" level="16" required-level="26" sp="5700" />
+
+		<!-- Skills Lv27 -->
 		<skill name="Light Armor Mastery" id="227" level="6" required-level="27" sp="5700" />
+		<skill name="Stun Mastery" id="100" level="12" required-level="27" sp="5700" />
 		<skill name="Heavy Armor Mastery" id="231" level="6" required-level="27" sp="5700" />
 		<skill name="Wild Sweep" id="245" level="8" required-level="27" sp="5700" />
-		<skill name="Power Smash" id="255" level="8" required-level="27" sp="5700" />
-		
-		<skill name="Shock Attack" id="100" level="9" required-level="28" sp="5700" />
+		<skill name="Enhanced Weapon" id="255" level="12" required-level="27" sp="5700" />
+		<skill name="Power Strike" id="3" level="17" required-level="27" sp="5700" />
+
+		<!-- Skills Lv28 -->
 		<skill name="Vicious Stance" id="312" level="3" required-level="28" sp="5700" />
 		<skill name="Battle Roar" id="121" level="1" required-level="28" sp="5700" />
 		<skill name="Two-handed Weapon Mastery" id="293" level="3" required-level="28" sp="5700" />
 		<skill name="Polearm Mastery" id="216" level="4" required-level="28" sp="5700" />
 		<skill name="Light Armor Mastery" id="227" level="7" required-level="28" sp="5700" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="4" required-level="28" sp="5700" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="4" required-level="28" sp="5700" />
+		<skill name="Stun Mastery" id="100" level="13" required-level="28" sp="5700" />
 		<skill name="Heavy Armor Mastery" id="231" level="7" required-level="28" sp="5700" />
 		<skill name="Wild Sweep" id="245" level="9" required-level="28" sp="5700" />
-		<skill name="Power Smash" id="255" level="9" required-level="28" sp="5700" />
+		<skill name="Enhanced Weapon" id="255" level="13" required-level="28" sp="5700" />
+		<skill name="Power Strike" id="3" level="18" required-level="28" sp="5700" />
 		<skill name="Boost HP" id="211" level="2" required-level="28" sp="5700" />
-		
-		<skill name="Shock Attack" id="100" level="10" required-level="30" sp="11000" />
+
+		<!-- Skills Lv29 -->
+		<skill name="Stun Mastery" id="100" level="14" required-level="29" sp="11000" />
+		<skill name="Enhanced Weapon" id="255" level="14" required-level="29" sp="11000" />
+
+		<!-- Master Buffs Lv. 30 -->
+		<skill name="Chant of Empower" id="45136" level="2" required-level="30" sp="11000" />
+		<skill name="Chant of Wild Magic" id="45137" level="1" required-level="30" sp="11000" />
+		<skill name="Chant of Berserker Spirit" id="45128" level="1" required-level="30" sp="11000" />
+		<skill name="Chant of Wind Walk" id="45124" level="2" required-level="30" sp="11000" />
+		<skill name="Chant of Magic Barrier" id="45125" level="1" required-level="30" sp="11000" />
+		<skill name="Chant of Acumen" id="45135" level="2" required-level="30" sp="11000" />
+		<skill name="Chant of Focus" id="45121" level="2" required-level="30" sp="11000" />
+		<skill name="Chant of Clarity" id="45129" level="2" required-level="30" sp="11000" />
+		<skill name="Chant of Death Whisper" id="45122" level="2" required-level="30" sp="11000" />
+
+
+		<!-- Skills Lv30 -->
 		<skill name="Polearm Mastery" id="216" level="5" required-level="30" sp="11000" />
 		<skill name="Light Armor Mastery" id="227" level="8" required-level="30" sp="11000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="5" required-level="30" sp="11000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="5" required-level="30" sp="11000" />
+		<skill name="Stun Mastery" id="100" level="15" required-level="30" sp="11000" />
 		<skill name="Heavy Armor Mastery" id="231" level="8" required-level="30" sp="11000" />
 		<skill name="Wild Sweep" id="245" level="10" required-level="30" sp="11000" />
-		<skill name="Power Smash" id="255" level="10" required-level="30" sp="11000" />
-		
-		<skill name="Shock Attack" id="100" level="11" required-level="31" sp="11000" />
+		<skill name="Enhanced Weapon" id="255" level="15" required-level="30" sp="11000" />
+		<skill name="Power Strike" id="3" level="19" required-level="30" sp="11000" />
+		<skill name="Emergency Rescue" id="70" level="5" required-level="30" sp="11000" />
+
+		<!-- Skills Lv31 -->
 		<skill name="Light Armor Mastery" id="227" level="9" required-level="31" sp="11000" />
 		<skill name="Heavy Armor Mastery" id="231" level="9" required-level="31" sp="11000" />
 		<skill name="Wild Sweep" id="245" level="11" required-level="31" sp="11000" />
-		<skill name="Power Smash" id="255" level="11" required-level="31" sp="11000" />
-		
-		<skill name="Shock Attack" id="100" level="12" required-level="32" sp="11000" />
+		<skill name="Power Strike" id="3" level="20" required-level="31" sp="11000" />
+
+		<!-- Skills Lv32 -->
 		<skill name="Frenzy" id="176" level="1" required-level="32" sp="11000" />
 		<skill name="Vicious Stance" id="312" level="4" required-level="32" sp="11000" />
 		<skill name="Fast HP Recovery" id="212" level="2" required-level="32" sp="11000" />
 		<skill name="Two-handed Weapon Mastery" id="293" level="4" required-level="32" sp="11000" />
 		<skill name="Polearm Mastery" id="216" level="6" required-level="32" sp="11000" />
 		<skill name="Light Armor Mastery" id="227" level="10" required-level="32" sp="11000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="6" required-level="32" sp="11000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="6" required-level="32" sp="11000" />
 		<skill name="Heavy Armor Mastery" id="231" level="10" required-level="32" sp="11000" />
 		<skill name="Wild Sweep" id="245" level="12" required-level="32" sp="11000" />
 		<skill name="Vital Force" id="148" level="2" required-level="32" sp="11000" />
-		<skill name="Power Smash" id="255" level="12" required-level="32" sp="11000" />
-		
-		<skill name="Shock Attack" id="100" level="13" required-level="34" sp="20000" />
+		<skill name="Power Strike" id="3" level="21" required-level="32" sp="11000" />
+		<skill name="Emergency Rescue" id="70" level="6" required-level="32" sp="11000" />
+
+		<!-- Skills Lv34 -->
 		<skill name="Polearm Mastery" id="216" level="7" required-level="34" sp="20000" />
 		<skill name="Light Armor Mastery" id="227" level="11" required-level="34" sp="20000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="7" required-level="34" sp="20000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="7" required-level="34" sp="20000" />
 		<skill name="Heavy Armor Mastery" id="231" level="11" required-level="34" sp="20000" />
 		<skill name="Wild Sweep" id="245" level="13" required-level="34" sp="20000" />
-		<skill name="Power Smash" id="255" level="13" required-level="34" sp="20000" />
-		
-		<skill name="Shock Attack" id="100" level="14" required-level="35" sp="20000" />
+		<skill name="Power Strike" id="3" level="22" required-level="34" sp="20000" />
+		<skill name="Emergency Rescue" id="70" level="7" required-level="34" sp="20000" />
+
+		<!-- Skills Lv35 -->
 		<skill name="Light Armor Mastery" id="227" level="12" required-level="35" sp="20000" />
 		<skill name="Heavy Armor Mastery" id="231" level="12" required-level="35" sp="20000" />
 		<skill name="Wild Sweep" id="245" level="14" required-level="35" sp="20000" />
-		<skill name="Power Smash" id="255" level="14" required-level="35" sp="20000" />
-		
-		<skill name="Shock Attack" id="100" level="15" required-level="36" sp="20000" />
+		<skill name="Power Strike" id="3" level="23" required-level="35" sp="20000" />
+
+		<!-- Skills Lv36 -->
 		<skill name="Vicious Stance" id="312" level="5" required-level="36" sp="20000" />
 		<skill name="Two-handed Weapon Mastery" id="293" level="5" required-level="36" sp="20000" />
 		<skill name="Polearm Mastery" id="216" level="8" required-level="36" sp="20000" />
 		<skill name="Light Armor Mastery" id="227" level="13" required-level="36" sp="20000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="8" required-level="36" sp="20000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="8" required-level="36" sp="20000" />
 		<skill name="Heavy Armor Mastery" id="231" level="13" required-level="36" sp="20000" />
 		<skill name="Wild Sweep" id="245" level="15" required-level="36" sp="20000" />
 		<skill name="Lionheart" id="287" level="1" required-level="36" sp="20000" />
-		<skill name="Power Smash" id="255" level="15" required-level="36" sp="20000" />
+		<skill name="Power Strike" id="3" level="24" required-level="36" sp="20000" />
 		<skill name="Guts" id="139" level="1" required-level="36" sp="20000" />
 		<skill name="Boost HP" id="211" level="3" required-level="36" sp="20000" />
+		<skill name="Emergency Rescue" id="70" level="8" required-level="36" sp="20000" />
+
+		<!-- Skills Lv38 -->
+		<skill name="Emergency Rescue" id="70" level="9" required-level="38" sp="20000" />
+		
 	</skillTree>
 </list>

--- a/data/skillTrees/1stClass/OrcShaman.xml
+++ b/data/skillTrees/1stClass/OrcShaman.xml
@@ -1,138 +1,175 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="50" parentClassId="49">
+
+		<!-- Master Buffs Lv. 20 -->
+		<skill name="Chant of Empower" id="1006" level="1" required-level="20" sp="500" />
+		<skill name="Chant of Life" id="1229" level="1" required-level="20" sp="600" />
+		<skill name="Chant of Wind Walk" id="1535" level="1" required-level="20" sp="500" />
+		<skill name="Chant of Might" id="1007" level="2" required-level="20" sp="500" />
+		<skill name="Chant of Acumen" id="1002" level="1" required-level="20" sp="500" />
+		<skill name="Chant of Haste" id="1251" level="1" required-level="20" sp="500" />
+		<skill name="Chant of Focus" id="1308" level="1" required-level="20" sp="500" />
+		<skill name="Chant of Clarity" id="45138" level="1" required-level="20" sp="500" />
+		<skill name="Chant of Death Whisper" id="1253" level="1" required-level="20" sp="500" />
+		<skill name="Chant of Shield" id="1009" level="2" required-level="20" sp="500" />
+
+
+		<!-- Skills Lv20 -->
 		<skill name="Anti Magic" id="146" level="5" required-level="20" sp="600" />
 		<skill name="Anti Magic" id="146" level="6" required-level="20" sp="600" />
-		<skill name="Shock Attack" id="100" level="1" required-level="20" sp="600" />
-		<skill name="Shock Attack" id="100" level="2" required-level="20" sp="600" />
-		<skill name="Shock Attack" id="100" level="3" required-level="20" sp="600" />
-		<skill name="Venom" id="1095" level="3" required-level="20" sp="600" />
 		<skill name="Quick Recovery" id="164" level="1" required-level="20" sp="600" />
 		<skill name="Light Armor Mastery" id="252" level="5" required-level="20" sp="600" />
 		<skill name="Light Armor Mastery" id="252" level="6" required-level="20" sp="600" />
 		<skill name="Robe Mastery" id="251" level="5" required-level="20" sp="600" />
 		<skill name="Robe Mastery" id="251" level="6" required-level="20" sp="600" />
+		<skill name="Stun Mastery" id="100" level="1" required-level="20" sp="5000" />
+		<skill name="Stun Mastery" id="100" level="2" required-level="20" sp="5000" />
+		<skill name="Stun Mastery" id="100" level="3" required-level="20" sp="5000" />
+		<skill name="Stun Mastery" id="100" level="4" required-level="20" sp="5000" />
+		<skill name="Stun Mastery" id="100" level="5" required-level="20" sp="5000" />
 		<skill name="Weapon Mastery" id="250" level="3" required-level="20" sp="600" />
 		<skill name="Heavy Armor Mastery" id="253" level="3" required-level="20" sp="600" />
 		<skill name="Heavy Armor Mastery" id="253" level="4" required-level="20" sp="600" />
-		<skill name="Life Drain" id="1090" level="3" required-level="20" sp="600" />
+		<skill name="Recover HP" id="45176" level="1" required-level="20" sp="500" />
+		<skill name="Recover MP" id="45177" level="1" required-level="20" sp="500" />
+		<skill name="Eagle Spirit" id="1003" level="2" required-level="20" sp="500" />
+		<skill name="Soul Evasion" id="1005" level="2" required-level="20" sp="500" />
+		<skill name="Drain Energy" id="1090" level="6" required-level="20" sp="600" />
 		<skill name="Frost Flame" id="1107" level="1" required-level="20" sp="600" />
-		<skill name="Chant of Life" id="1229" level="1" required-level="20" sp="600" />
-		<skill name="Seal of Poison" id="1209" level="1" required-level="20" sp="600" />
+		<skill name="Venom" id="1095" level="3" required-level="20" sp="600" />
+		<skill name="Venom Seal" id="1209" level="1" required-level="20" sp="600" />
 		<skill name="Dreaming Spirit" id="1097" level="3" required-level="20" sp="600" />
 		<skill name="Life Rescue" id="1610" level="1" required-level="20" sp="600" />
 		<skill name="Fear" id="1092" level="2" required-level="20" sp="600" />
 		<skill name="Madness" id="1105" level="1" required-level="20" sp="600" />
 		<skill name="Boost Mana" id="213" level="1" required-level="20" sp="600" />
-		<skill name="Chant of Shielding" id="1009" level="1" required-level="20" sp="600">
-			<item id="1523"/>
-		</skill>
-		<skill name="Chant of Fire" id="1006" level="1" required-level="20" sp="600">
-			<item id="1521"/>
-		</skill>
 
+		<!-- Skills Lv21 -->
+		<skill name="Stun Mastery" id="100" level="6" required-level="21" sp="5000" />
+
+		<!-- Skills Lv22 -->
+		<skill name="Stun Mastery" id="100" level="7" required-level="22" sp="5000" />
 		<skill name="Life Rescue" id="1610" level="2" required-level="22" sp="2300" />
-		
+
+		<!-- Skills Lv23 -->
 		<skill name="Anti Magic" id="146" level="7" required-level="23" sp="2300" />
-		<skill name="Shock Attack" id="100" level="4" required-level="23" sp="2300" />
 		<skill name="Light Armor Mastery" id="252" level="7" required-level="23" sp="2300" />
 		<skill name="Robe Mastery" id="251" level="7" required-level="23" sp="2300" />
+		<skill name="Stun Mastery" id="100" level="8" required-level="23" sp="5000" />
 		<skill name="Weapon Mastery" id="250" level="4" required-level="23" sp="2300" />
 		<skill name="Heavy Armor Mastery" id="253" level="5" required-level="23" sp="2300" />
-		
-		<skill name="Shock Attack" id="100" level="5" required-level="24" sp="2300" />
 
+		<!-- Skills Lv24 -->
+		<skill name="Stun Mastery" id="100" level="9" required-level="24" sp="5000" />
+		<skill name="Drain Energy" id="1090" level="7" required-level="24" sp="2300" />
+
+		<!-- Skills Lv25 -->
 		<skill name="Anti Magic" id="146" level="8" required-level="25" sp="2300" />
-		<skill name="Shock Attack" id="100" level="6" required-level="25" sp="2300" />
+		<skill name="Battle Cry" id="1001" level="3" required-level="25" sp="2300" />
 		<skill name="Fast Mana Recovery" id="229" level="1" required-level="25" sp="2300" />
 		<skill name="Fast Spell Casting" id="228" level="1" required-level="25" sp="2300" />
 		<skill name="Light Armor Mastery" id="252" level="8" required-level="25" sp="2300" />
 		<skill name="Robe Mastery" id="251" level="8" required-level="25" sp="2300" />
+		<skill name="Stun Mastery" id="100" level="10" required-level="25" sp="5000" />
 		<skill name="Weapon Mastery" id="250" level="5" required-level="25" sp="2300" />
 		<skill name="Heavy Armor Mastery" id="253" level="6" required-level="25" sp="2300" />
 		<skill name="Blaze Quake" id="1101" level="1" required-level="25" sp="2300" />
-		<skill name="Life Drain" id="1090" level="4" required-level="25" sp="2300" />
-		<skill name="Soul Cry" id="1001" level="3" required-level="25" sp="2300" />
-		<skill name="Chant of Battle" id="1007" level="2" required-level="25" sp="2300" />
+		<skill name="Spirit Shield" id="1010" level="2" required-level="25" sp="2300" />
 		<skill name="Chant of Life" id="1229" level="2" required-level="25" sp="2300" />
 		<skill name="Aura Sink" id="1102" level="1" required-level="25" sp="2300" />
+		<skill name="Seal of Binding" id="1208" level="1" required-level="25" sp="2300" />
 		<skill name="Dreaming Spirit" id="1097" level="4" required-level="25" sp="2300" />
 		<skill name="Fear" id="1092" level="3" required-level="25" sp="2300" />
 		<skill name="Madness" id="1105" level="2" required-level="25" sp="2300" />
-		<skill name="Soul Shield" id="1010" level="2" required-level="25" sp="2300" />
-		<skill name="Seal of Binding" id="1208" level="1" required-level="25" sp="2300">
-			<item id="1536"/>
-		</skill>
 
+		<!-- Skills Lv26 -->
+		<skill name="Stun Mastery" id="100" level="11" required-level="26" sp="5000" />
 		<skill name="Life Rescue" id="1610" level="3" required-level="26" sp="2300" />
-		
+
+		<!-- Skills Lv27 -->
+		<skill name="Stun Mastery" id="100" level="12" required-level="27" sp="5000" />
+
+		<!-- Skills Lv28 -->
 		<skill name="Anti Magic" id="146" level="9" required-level="28" sp="5700" />
-		<skill name="Shock Attack" id="100" level="7" required-level="28" sp="5700" />
 		<skill name="Light Armor Mastery" id="252" level="9" required-level="28" sp="5700" />
 		<skill name="Robe Mastery" id="251" level="9" required-level="28" sp="5700" />
+		<skill name="Stun Mastery" id="100" level="13" required-level="28" sp="5000" />
 		<skill name="Weapon Mastery" id="250" level="6" required-level="28" sp="5700" />
 		<skill name="Heavy Armor Mastery" id="253" level="7" required-level="28" sp="5700" />
-		
-		<skill name="Shock Attack" id="100" level="8" required-level="29" sp="5700" />
+		<skill name="Drain Energy" id="1090" level="8" required-level="28" sp="5700" />
 
+		<!-- Skills Lv29 -->
+		<skill name="Stun Mastery" id="100" level="14" required-level="29" sp="5000" />
+
+		<!-- Master Buffs Lv. 30 -->
+		<skill name="Chant of Empower" id="1006" level="2" required-level="30" sp="5000" />
+		<skill name="Chant of Wild Magic" id="1413" level="1" required-level="30" sp="5000" />
+		<skill name="Chant of Berserker Spirit" id="1261" level="1" required-level="30" sp="5000" />
+		<skill name="Chant of Life" id="1229" level="3" required-level="30" sp="5700" />
+		<skill name="Chant of Wind Walk" id="1535" level="2" required-level="30" sp="5000" />
+		<skill name="Chant of Magic Barrier" id="1549" level="1" required-level="30" sp="5000" />
+		<skill name="Chant of Acumen" id="1002" level="2" required-level="30" sp="5000" />
+		<skill name="Chant of Focus" id="1308" level="2" required-level="30" sp="5000" />
+		<skill name="Chant of Clarity" id="45138" level="2" required-level="30" sp="5000" />
+		<skill name="Chant of Death Whisper" id="1253" level="2" required-level="30" sp="5000" />
+
+
+		<!-- Skills Lv30 -->
 		<skill name="Anti Magic" id="146" level="10" required-level="30" sp="5700" />
-		<skill name="Shock Attack" id="100" level="9" required-level="30" sp="5700" />
 		<skill name="Quick Recovery" id="164" level="2" required-level="30" sp="5700" />
 		<skill name="Light Armor Mastery" id="252" level="10" required-level="30" sp="5700" />
 		<skill name="Robe Mastery" id="251" level="10" required-level="30" sp="5700" />
+		<skill name="Stun Mastery" id="100" level="15" required-level="30" sp="5000" />
 		<skill name="Weapon Mastery" id="250" level="7" required-level="30" sp="5700" />
 		<skill name="Heavy Armor Mastery" id="253" level="8" required-level="30" sp="5700" />
-		<skill name="Pa'agrio's Gift" id="1003" level="1" required-level="30" sp="5700">
-			<item id="1519"/>
-		</skill>
-		<skill name="Life Drain" id="1090" level="5" required-level="30" sp="5700" />
+		<skill name="Eagle Spirit" id="1003" level="3" required-level="30" sp="5000" />
+		<skill name="Soul Evasion" id="1005" level="3" required-level="30" sp="5000" />
 		<skill name="Frost Flame" id="1107" level="2" required-level="30" sp="5700" />
-		<skill name="Chant of Life" id="1229" level="3" required-level="30" sp="5700" />
-		<skill name="Chant of Shielding" id="1009" level="2" required-level="30" sp="5700" />
-		<skill name="Chant of Flame" id="1002" level="1" required-level="30" sp="5700">
-			<item id="1518"/>
-		</skill>
 		<skill name="Seal of Binding" id="1208" level="2" required-level="30" sp="5700" />
+		<skill name="Venom Seal" id="1209" level="2" required-level="30" sp="5700" />
 		<skill name="Seal of Chaos" id="1096" level="1" required-level="30" sp="5700" />
- 		<skill name="Seal of Poison" id="1209" level="2" required-level="30" sp="5700" />
 		<skill name="Dreaming Spirit" id="1097" level="5" required-level="30" sp="5700" />
 		<skill name="Life Rescue" id="1610" level="4" required-level="30" sp="5700" />
 		<skill name="Fear" id="1092" level="4" required-level="30" sp="5700" />
 		<skill name="Madness" id="1105" level="3" required-level="30" sp="5700" />
 		<skill name="Boost Mana" id="213" level="2" required-level="30" sp="5700" />
 
+		<!-- Skills Lv32 -->
+		<skill name="Drain Energy" id="1090" level="9" required-level="32" sp="5700" />
+
+		<!-- Skills Lv33 -->
 		<skill name="Anti Magic" id="146" level="11" required-level="33" sp="13000" />
-		<skill name="Shock Attack" id="100" level="10" required-level="33" sp="13000" />
 		<skill name="Light Armor Mastery" id="252" level="11" required-level="33" sp="13000" />
 		<skill name="Robe Mastery" id="251" level="11" required-level="33" sp="13000" />
 		<skill name="Weapon Mastery" id="250" level="8" required-level="33" sp="13000" />
 		<skill name="Heavy Armor Mastery" id="253" level="9" required-level="33" sp="13000" />
-		
-		<skill name="Shock Attack" id="100" level="11" required-level="34" sp="13000" />
+
+		<!-- Skills Lv34 -->
 		<skill name="Life Rescue" id="1610" level="5" required-level="34" sp="13000" />
 
+		<!-- Skills Lv35 -->
 		<skill name="Anti Magic" id="146" level="12" required-level="35" sp="13000" />
-		<skill name="Shock Attack" id="100" level="12" required-level="35" sp="13000" />
-		<skill name="Pa'agrio's Blessing" id="1005" level="1" required-level="35" sp="13000" />
+		<skill name="Battle Cry" id="1001" level="4" required-level="35" sp="13000" />
 		<skill name="Fast HP Recovery" id="212" level="1" required-level="35" sp="13000" />
 		<skill name="Fast Mana Recovery" id="229" level="2" required-level="35" sp="13000" />
 		<skill name="Light Armor Mastery" id="252" level="12" required-level="35" sp="13000" />
 		<skill name="Robe Mastery" id="251" level="12" required-level="35" sp="13000" />
 		<skill name="Weapon Mastery" id="250" level="9" required-level="35" sp="13000" />
 		<skill name="Heavy Armor Mastery" id="253" level="10" required-level="35" sp="13000" />
+		<skill name="Spirit Shield" id="1010" level="3" required-level="35" sp="13000" />
 		<skill name="Blaze Quake" id="1101" level="2" required-level="35" sp="13000" />
-		<skill name="Life Drain" id="1090" level="6" required-level="35" sp="13000" />
-		<skill name="Soul Cry" id="1001" level="4" required-level="35" sp="13000" />
 		<skill name="Chant of Life" id="1229" level="4" required-level="35" sp="13000" />
 		<skill name="Aura Sink" id="1102" level="2" required-level="35" sp="13000" />
+		<skill name="Seal of Slow" id="1099" level="1" required-level="35" sp="13000" />
 		<skill name="Seal of Binding" id="1208" level="3" required-level="35" sp="13000" />
 		<skill name="Seal of Chaos" id="1096" level="2" required-level="35" sp="13000" />
 		<skill name="Dreaming Spirit" id="1097" level="6" required-level="35" sp="13000" />
 		<skill name="Fear" id="1092" level="5" required-level="35" sp="13000" />
 		<skill name="Madness" id="1105" level="4" required-level="35" sp="13000" />
-		<skill name="Soul Shield" id="1010" level="3" required-level="35" sp="13000" />
-		<skill name="Seal of Slow" id="1099" level="1" required-level="35" sp="13000">
-			<item id="1530"/>
-		</skill>
+
+		<!-- Skills Lv36 -->
+		<skill name="Drain Energy" id="1090" level="10" required-level="36" sp="13000" />
+		
 	</skillTree>
 </list>

--- a/data/skillTrees/1stClass/PalusKnight.xml
+++ b/data/skillTrees/1stClass/PalusKnight.xml
@@ -1,113 +1,212 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="32" parentClassId="31">
+
+		<!-- Master Buffs Lv. 20 -->
+		<skill name="Empower" id="45105" level="1" required-level="20" sp="1000" />
+		<skill name="Wind Walk" id="45107" level="1" required-level="20" sp="1000" />
+		<skill name="Might" id="1068" level="2" required-level="20" sp="1000" />
+		<skill name="Acumen" id="45104" level="1" required-level="20" sp="1000" />
+		<skill name="Haste" id="45111" level="1" required-level="20" sp="1000" />
+		<skill name="Focus" id="45109" level="1" required-level="20" sp="1000" />
+		<skill name="Clarity" id="45113" level="1" required-level="20" sp="1000" />
+		<skill name="Death Whisper" id="45110" level="1" required-level="20" sp="1000" />
+		<skill name="Shield" id="1040" level="2" required-level="20" sp="1000" />
+
+
+		<!-- Skills Lv20 -->	
 		<skill name="Ultimate Defense" id="110" level="1" required-level="20" sp="1000" />
-		<skill name="Defense Aura" id="91" level="2" required-level="20" sp="1000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="1" required-level="20" sp="1000" />
+		<skill name="Majesty" id="82" level="1" required-level="20" sp="1000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="1" required-level="20" sp="1000" />
+		<skill name="Stun Mastery" id="100" level="1" required-level="20" sp="1000" />
+		<skill name="Stun Mastery" id="100" level="2" required-level="20" sp="1000" />
+		<skill name="Stun Mastery" id="100" level="3" required-level="20" sp="1000" />
+		<skill name="Stun Mastery" id="100" level="4" required-level="20" sp="1000" />
+		<skill name="Stun Mastery" id="100" level="5" required-level="20" sp="1000" />
 		<skill name="Heavy Armor Mastery" id="232" level="1" required-level="20" sp="1000" />
 		<skill name="Heavy Armor Mastery" id="232" level="2" required-level="20" sp="1000" />
 		<skill name="Heavy Armor Mastery" id="232" level="3" required-level="20" sp="1000" />
 		<skill name="Shield Mastery" id="153" level="1" required-level="20" sp="1000" />
-		<skill name="Drain Energy" id="70" level="3" required-level="20" sp="1000" />
-		<skill name="Drain Energy" id="70" level="4" required-level="20" sp="1000" />
+		<skill name="Recover HP" id="45176" level="1" required-level="20" sp="1000" />
+		<skill name="Recover MP" id="45177" level="1" required-level="20" sp="1000" />
+		<skill name="Dark Elven Spirit" id="129" level="1" required-level="20" sp="1000" />
+		<skill name="Drain Energy" id="45250" level="1" required-level="20" sp="1000" />
+		<skill name="Blood Attack" id="223" level="1" required-level="20" sp="1000" />
 		<skill name="Magic Resistance" id="147" level="1" required-level="20" sp="1000" />
 		<skill name="Magic Resistance" id="147" level="2" required-level="20" sp="1000" />
-		<skill name="Poison" id="129" level="1" required-level="20" sp="1000" />
-		
+		<skill name="Enhanced Weapon" id="255" level="1" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="2" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="3" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="4" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="5" required-level="20" sp="1000" />
+		<skill name="Power Strike" id="3" level="10" required-level="20" sp="1000" />
+		<skill name="Power Strike" id="3" level="11" required-level="20" sp="1000" />
+		<skill name="Power Strike" id="3" level="12" required-level="20" sp="1000" />
+		<skill name="Ability to Protect" id="91" level="2" required-level="20" sp="1000" />
+
+		<skill name="Emergency Rescue" id="70" level="3" required-level="20" sp="1000" />
+
+		<!-- Skills Lv21 -->
+		<skill name="Stun Mastery" id="100" level="6" required-level="21" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="6" required-level="21" sp="1000" />
+
+		<!-- Skills Lv22 -->
 		<skill name="Aggression" id="28" level="1" required-level="22" sp="2800" />
+		<skill name="Stun Mastery" id="100" level="7" required-level="22" sp="2800" />
 		<skill name="Heavy Armor Mastery" id="232" level="4" required-level="22" sp="2800" />
-		<skill name="Sting" id="223" level="1" required-level="22" sp="2800" />
-		<skill name="Drain Energy" id="70" level="5" required-level="22" sp="2800" />
 		<skill name="Magic Resistance" id="147" level="3" required-level="22" sp="2800" />
-		
+		<skill name="Enhanced Weapon" id="255" level="7" required-level="22" sp="2800" />
+		<skill name="Power Strike" id="3" level="13" required-level="22" sp="2800" />
+
+		<!-- Skills Lv23 -->
 		<skill name="Aggression" id="28" level="2" required-level="23" sp="2800" />
+		<skill name="Stun Mastery" id="100" level="8" required-level="23" sp="2800" />
 		<skill name="Heavy Armor Mastery" id="232" level="5" required-level="23" sp="2800" />
-		<skill name="Sting" id="223" level="2" required-level="23" sp="2800" />
-		<skill name="Drain Energy" id="70" level="6" required-level="23" sp="2800" />
+		<skill name="Blood Attack" id="223" level="2" required-level="23" sp="2800" />
 		<skill name="Magic Resistance" id="147" level="4" required-level="23" sp="2800" />
-		
+		<skill name="Enhanced Weapon" id="255" level="8" required-level="23" sp="2800" />
+		<skill name="Power Strike" id="3" level="14" required-level="23" sp="2800" />
+
+		<!-- Skills Lv24 -->
 		<skill name="Aggression" id="28" level="3" required-level="24" sp="2800" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="2" required-level="24" sp="2800" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="2" required-level="24" sp="2800" />
+		<skill name="Stun Mastery" id="100" level="9" required-level="24" sp="2800" />
 		<skill name="Heavy Armor Mastery" id="232" level="6" required-level="24" sp="2800" />
-		<skill name="Sting" id="223" level="3" required-level="24" sp="2800" />
 		<skill name="Confusion" id="2" level="1" required-level="24" sp="2800" />
-		<skill name="Drain Energy" id="70" level="7" required-level="24" sp="2800" />
+		<skill name="Drain Energy" id="45250" level="2" required-level="24" sp="2800" />
 		<skill name="Magic Resistance" id="147" level="5" required-level="24" sp="2800" />
+		<skill name="Enhanced Weapon" id="255" level="9" required-level="24" sp="2800" />
+		<skill name="Power Strike" id="3" level="15" required-level="24" sp="2800" />
 		<skill name="Deflect Arrow" id="112" level="1" required-level="24" sp="2800" />
-		
+
+		<!-- Skills Lv25 -->
+		<skill name="Stun Mastery" id="100" level="10" required-level="25" sp="2800" />
+		<skill name="Enhanced Weapon" id="255" level="10" required-level="25" sp="2800" />
+		<skill name="Ability to Attack" id="77" level="2" required-level="25" sp="2800" />
+		<skill name="Emergency Rescue" id="70" level="4" required-level="25" sp="2800" />
+
+		<!-- Skills Lv26 -->
 		<skill name="Aggression" id="28" level="4" required-level="26" sp="5700" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="3" required-level="26" sp="5700" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="3" required-level="26" sp="5700" />
+		<skill name="Stun Mastery" id="100" level="11" required-level="26" sp="5700" />
 		<skill name="Heavy Armor Mastery" id="232" level="7" required-level="26" sp="5700" />
-		<skill name="Sting" id="223" level="4" required-level="26" sp="5700" />
-		<skill name="Drain Energy" id="70" level="8" required-level="26" sp="5700" />
+		<skill name="Blood Attack" id="223" level="3" required-level="26" sp="5700" />
 		<skill name="Magic Resistance" id="147" level="6" required-level="26" sp="5700" />
-		
+		<skill name="Enhanced Weapon" id="255" level="11" required-level="26" sp="5700" />
+		<skill name="Power Strike" id="3" level="16" required-level="26" sp="5700" />
+
+		<!-- Skills Lv27 -->
 		<skill name="Aggression" id="28" level="5" required-level="27" sp="5700" />
+		<skill name="Stun Mastery" id="100" level="12" required-level="27" sp="5700" />
 		<skill name="Heavy Armor Mastery" id="232" level="8" required-level="27" sp="5700" />
-		<skill name="Sting" id="223" level="5" required-level="27" sp="5700" />
-		<skill name="Drain Energy" id="70" level="9" required-level="27" sp="5700" />
 		<skill name="Magic Resistance" id="147" level="7" required-level="27" sp="5700" />
-		
+		<skill name="Enhanced Weapon" id="255" level="12" required-level="27" sp="5700" />
+		<skill name="Power Strike" id="3" level="17" required-level="27" sp="5700" />
+
+		<!-- Skills Lv28 -->
 		<skill name="Aggression" id="28" level="6" required-level="28" sp="5700" />
-		<skill name="Attack Aura" id="77" level="2" required-level="28" sp="5700" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="4" required-level="28" sp="5700" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="4" required-level="28" sp="5700" />
+		<skill name="Stun Mastery" id="100" level="13" required-level="28" sp="5700" />
 		<skill name="Heavy Armor Mastery" id="232" level="9" required-level="28" sp="5700" />
 		<skill name="Shield Mastery" id="153" level="2" required-level="28" sp="5700" />
-		<skill name="Sting" id="223" level="6" required-level="28" sp="5700" />
 		<skill name="Confusion" id="2" level="2" required-level="28" sp="5700" />
-		<skill name="Drain Energy" id="70" level="10" required-level="28" sp="5700" />
+		<skill name="Drain Energy" id="45250" level="3" required-level="28" sp="5700" />
+		<skill name="Blood Attack" id="223" level="4" required-level="28" sp="5700" />
 		<skill name="Magic Resistance" id="147" level="8" required-level="28" sp="5700" />
-		
+		<skill name="Enhanced Weapon" id="255" level="13" required-level="28" sp="5700" />
+		<skill name="Power Strike" id="3" level="18" required-level="28" sp="5700" />
+
+		<!-- Skills Lv29 -->
+		<skill name="Stun Mastery" id="100" level="14" required-level="29" sp="11000" />
+		<skill name="Enhanced Weapon" id="255" level="14" required-level="29" sp="11000" />
+
+		<!-- Master Buffs Lv. 30 -->
+		<skill name="Empower" id="45105" level="2" required-level="30" sp="11000" />
+		<skill name="Wild Magic" id="45106" level="1" required-level="30" sp="11000" />
+		<skill name="Berserker Spirit" id="45112" level="1" required-level="30" sp="11000" />
+		<skill name="Wind Walk" id="45107" level="2" required-level="30" sp="11000" />
+		<skill name="Magic Barrier" id="45108" level="1" required-level="30" sp="11000" />
+		<skill name="Acumen" id="45104" level="2" required-level="30" sp="11000" />
+		<skill name="Focus" id="45109" level="2" required-level="30" sp="11000" />
+		<skill name="Clarity" id="45113" level="2" required-level="30" sp="11000" />
+		<skill name="Death Whisper" id="45110" level="2" required-level="30" sp="11000" />
+
+		<!-- Skills Lv30 -->
 		<skill name="Aggression" id="28" level="7" required-level="30" sp="11000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="5" required-level="30" sp="11000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="5" required-level="30" sp="11000" />
+		<skill name="Stun Mastery" id="100" level="15" required-level="30" sp="11000" />
 		<skill name="Heavy Armor Mastery" id="232" level="10" required-level="30" sp="11000" />
-		<skill name="Sting" id="223" level="7" required-level="30" sp="11000" />
-		<skill name="Drain Energy" id="70" level="11" required-level="30" sp="11000" />
+		<skill name="Freezing Weapon" id="105" level="1" required-level="30" sp="11000" />
+		<skill name="Blood Attack" id="223" level="5" required-level="30" sp="11000" />
 		<skill name="Magic Resistance" id="147" level="9" required-level="30" sp="11000" />
-		
+		<skill name="Enhanced Weapon" id="255" level="15" required-level="30" sp="11000" />
+		<skill name="Power Strike" id="3" level="19" required-level="30" sp="11000" />
+		<skill name="Emergency Rescue" id="70" level="5" required-level="30" sp="11000" />
+
+		<!-- Skills Lv31 -->
 		<skill name="Aggression" id="28" level="8" required-level="31" sp="11000" />
 		<skill name="Heavy Armor Mastery" id="232" level="11" required-level="31" sp="11000" />
-		<skill name="Sting" id="223" level="8" required-level="31" sp="11000" />
-		<skill name="Drain Energy" id="70" level="12" required-level="31" sp="11000" />
+		<skill name="Blood Attack" id="223" level="6" required-level="31" sp="11000" />
 		<skill name="Magic Resistance" id="147" level="10" required-level="31" sp="11000" />
-		
+		<skill name="Power Strike" id="3" level="20" required-level="31" sp="11000" />
+
+		<!-- Skills Lv32 -->
 		<skill name="Aggression" id="28" level="9" required-level="32" sp="11000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="6" required-level="32" sp="11000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="6" required-level="32" sp="11000" />
 		<skill name="Heavy Armor Mastery" id="232" level="12" required-level="32" sp="11000" />
-		<skill name="Sting" id="223" level="9" required-level="32" sp="11000" />
 		<skill name="Confusion" id="2" level="3" required-level="32" sp="11000" />
-		<skill name="Drain Energy" id="70" level="13" required-level="32" sp="11000" />
+		<skill name="Drain Energy" id="45250" level="4" required-level="32" sp="11000" />
+		<skill name="Blood Attack" id="223" level="7" required-level="32" sp="11000" />
 		<skill name="Magic Resistance" id="147" level="11" required-level="32" sp="11000" />
+		<skill name="Power Strike" id="3" level="21" required-level="32" sp="11000" />
 		<skill name="Deflect Arrow" id="112" level="2" required-level="32" sp="11000" />
-		<skill name="Power Break" id="115" level="1" required-level="32" sp="11000">
-			<item id="1382"/>
-		</skill>
-		
+		<skill name="Power Break" id="115" level="1" required-level="32" sp="10000" />
+		<skill name="Emergency Rescue" id="70" level="6" required-level="32" sp="11000" />
+
+		<!-- Skills Lv33 -->
+		<skill name="Freezing Weapon" id="105" level="2" required-level="33" sp="20000" />
+		<skill name="Blood Attack" id="223" level="8" required-level="33" sp="20000" />
+
+		<!-- Skills Lv34 -->
 		<skill name="Aggression" id="28" level="10" required-level="34" sp="20000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="7" required-level="34" sp="20000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="7" required-level="34" sp="20000" />
 		<skill name="Heavy Armor Mastery" id="232" level="13" required-level="34" sp="20000" />
-		<skill name="Sting" id="223" level="10" required-level="34" sp="20000" />
-		<skill name="Drain Energy" id="70" level="14" required-level="34" sp="20000" />
+		<skill name="Blood Attack" id="223" level="9" required-level="34" sp="20000" />
 		<skill name="Magic Resistance" id="147" level="12" required-level="34" sp="20000" />
-		<skill name="Freezing Strike" id="105" level="1" required-level="34" sp="20000">
-			<item id="1381"/>
-		</skill>
-		
+		<skill name="Power Strike" id="3" level="22" required-level="34" sp="20000" />
+		<skill name="Emergency Rescue" id="70" level="7" required-level="34" sp="20000" />
+
+		<!-- Skills Lv35 -->
 		<skill name="Aggression" id="28" level="11" required-level="35" sp="20000" />
 		<skill name="Heavy Armor Mastery" id="232" level="14" required-level="35" sp="20000" />
-		<skill name="Sting" id="223" level="11" required-level="35" sp="20000" />
-		<skill name="Drain Energy" id="70" level="15" required-level="35" sp="20000" />
+		<skill name="Dark Elven Spirit" id="129" level="2" required-level="35" sp="20000" />
+		<skill name="Blood Attack" id="223" level="10" required-level="35" sp="20000" />
 		<skill name="Magic Resistance" id="147" level="13" required-level="35" sp="20000" />
-		
+		<skill name="Power Strike" id="3" level="23" required-level="35" sp="20000" />
+
+		<!-- Skills Lv36 -->
 		<skill name="Aggression" id="28" level="12" required-level="36" sp="20000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="8" required-level="36" sp="20000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="8" required-level="36" sp="20000" />
 		<skill name="Heavy Armor Mastery" id="232" level="15" required-level="36" sp="20000" />
-		<skill name="Sting" id="223" level="12" required-level="36" sp="20000" />
 		<skill name="Confusion" id="2" level="4" required-level="36" sp="20000" />
-		<skill name="Freezing Strike" id="105" level="2" required-level="36" sp="20000" />
-		<skill name="Drain Energy" id="70" level="16" required-level="36" sp="20000" />
+		<skill name="Freezing Weapon" id="105" level="3" required-level="36" sp="20000" />
+		<skill name="Drain Energy" id="45250" level="5" required-level="36" sp="20000" />
+		<skill name="Blood Attack" id="223" level="11" required-level="36" sp="20000" />
 		<skill name="Magic Resistance" id="147" level="14" required-level="36" sp="20000" />
+		<skill name="Power Strike" id="3" level="24" required-level="36" sp="20000" />
 		<skill name="Power Break" id="115" level="2" required-level="36" sp="20000" />
 		<skill name="Focus Mind" id="191" level="1" required-level="36" sp="20000" />
+		<skill name="Emergency Rescue" id="70" level="8" required-level="36" sp="20000" />
+
+		<!-- Skills Lv37 -->
+		<skill name="Blood Attack" id="223" level="12" required-level="37" sp="20000" />
+
+		<!-- Skills Lv38 -->
+		<skill name="Freezing Weapon" id="105" level="4" required-level="38" sp="20000" />
+		<skill name="Blood Attack" id="223" level="13" required-level="38" sp="20000" />
+		<skill name="Emergency Rescue" id="70" level="9" required-level="38" sp="20000" />
+
+		<!-- Skills Lv39 -->
+		<skill name="Blood Attack" id="223" level="14" required-level="39" sp="20000" />
 	</skillTree>
 </list>

--- a/data/skillTrees/1stClass/Rogue.xml
+++ b/data/skillTrees/1stClass/Rogue.xml
@@ -1,34 +1,54 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="7" parentClassId="0">
+
+		<!-- Master Buffs Lv. 20 -->
+		<skill name="Empower" id="45105" level="1" required-level="20" sp="1000" />
+		<skill name="Wind Walk" id="45107" level="1" required-level="20" sp="1000" />
+		<skill name="Might" id="1068" level="2" required-level="20" sp="1000" />
+		<skill name="Acumen" id="45104" level="1" required-level="20" sp="1000" />
+		<skill name="Haste" id="45111" level="1" required-level="20" sp="1000" />
+		<skill name="Focus" id="45109" level="1" required-level="20" sp="1000" />
+		<skill name="Clarity" id="45113" level="1" required-level="20" sp="1000" />
+		<skill name="Death Whisper" id="45110" level="1" required-level="20" sp="1000" />
+		<skill name="Shield" id="1040" level="2" required-level="20" sp="1000" />
+
+		<!-- Skills Lv20 -->
 		<skill name="Acrobatics" id="173" level="1" required-level="20" sp="1000" />
 		<skill name="Vicious Stance" id="312" level="1" required-level="20" sp="1000" />
+		<skill name="Fast Run" id="4" level="1" required-level="20" sp="1000" />
 		<skill name="Dagger Mastery" id="209" level="1" required-level="20" sp="1000" />
 		<skill name="Light Armor Mastery" id="233" level="1" required-level="20" sp="1000" />
 		<skill name="Light Armor Mastery" id="233" level="2" required-level="20" sp="1000" />
 		<skill name="Bow Mastery" id="208" level="1" required-level="20" sp="1000" />
 		<skill name="Bow Mastery" id="208" level="2" required-level="20" sp="1000" />
 		<skill name="Bow Mastery" id="208" level="3" required-level="20" sp="1000" />
+		<skill name="Recover HP" id="45176" level="1" required-level="20" sp="1000" />
+		<skill name="Recover MP" id="45177" level="1" required-level="20" sp="1000" />
 		<skill name="Boost Breath" id="195" level="1" required-level="20" sp="1000" />
 		<skill name="Long Shot" id="113" level="1" required-level="20" sp="1000" />
 		<skill name="Power Shot" id="56" level="10" required-level="20" sp="1000" />
 		<skill name="Power Shot" id="56" level="11" required-level="20" sp="1000" />
 		<skill name="Power Shot" id="56" level="12" required-level="20" sp="1000" />
 		<skill name="Unlock" id="27" level="1" required-level="20" sp="1000" />
-		<skill name="Dash" id="4" level="1" required-level="20" sp="1000" />
 		<skill name="Mortal Blow" id="16" level="10" required-level="20" sp="1000" />
 		<skill name="Mortal Blow" id="16" level="11" required-level="20" sp="1000" />
 		<skill name="Mortal Blow" id="16" level="12" required-level="20" sp="1000" />
+		<skill name="Ability to Protect" id="91" level="2" required-level="20" sp="1000" />
+		<skill name="Emergency Rescue" id="70" level="3" required-level="20" sp="1000" />
 
+		<!-- Skills Lv22 -->
 		<skill name="Light Armor Mastery" id="233" level="3" required-level="22" sp="2800" />
 		<skill name="Bow Mastery" id="208" level="4" required-level="22" sp="2800" />
 		<skill name="Power Shot" id="56" level="13" required-level="22" sp="2800" />
 		<skill name="Mortal Blow" id="16" level="13" required-level="22" sp="2800" />
-		
+
+		<!-- Skills Lv23 -->
 		<skill name="Bow Mastery" id="208" level="5" required-level="23" sp="2800" />
 		<skill name="Power Shot" id="56" level="14" required-level="23" sp="2800" />
 		<skill name="Mortal Blow" id="16" level="14" required-level="23" sp="2800" />
-		
+
+		<!-- Skills Lv24 -->
 		<skill name="Vicious Stance" id="312" level="2" required-level="24" sp="2800" />
 		<skill name="Dagger Mastery" id="209" level="2" required-level="24" sp="2800" />
 		<skill name="Light Armor Mastery" id="233" level="4" required-level="24" sp="2800" />
@@ -42,16 +62,23 @@
 		<skill name="Accuracy" id="256" level="1" required-level="24" sp="2800" />
 		<skill name="Boost Evasion" id="198" level="1" required-level="24" sp="2800" />
 
+		<!-- Skills Lv25 -->
+		<skill name="Ability to Attack" id="77" level="2" required-level="25" sp="2800" />
+		<skill name="Emergency Rescue" id="70" level="4" required-level="25" sp="2800" />
+
+		<!-- Skills Lv26 -->
 		<skill name="Dagger Mastery" id="209" level="3" required-level="26" sp="5700" />
 		<skill name="Light Armor Mastery" id="233" level="5" required-level="26" sp="5700" />
 		<skill name="Bow Mastery" id="208" level="7" required-level="26" sp="5700" />
 		<skill name="Power Shot" id="56" level="16" required-level="26" sp="5700" />
 		<skill name="Mortal Blow" id="16" level="16" required-level="26" sp="5700" />
 
+		<!-- Skills Lv27 -->
 		<skill name="Bow Mastery" id="208" level="8" required-level="27" sp="5700" />
 		<skill name="Power Shot" id="56" level="17" required-level="27" sp="5700" />
 		<skill name="Mortal Blow" id="16" level="17" required-level="27" sp="5700" />
-		
+
+		<!-- Skills Lv28 -->
 		<skill name="Ultimate Evasion" id="111" level="1" required-level="28" sp="5700" />
 		<skill name="Acrobatic Move" id="225" level="1" required-level="28" sp="5700" />
 		<skill name="Vicious Stance" id="312" level="3" required-level="28" sp="5700" />
@@ -63,17 +90,32 @@
 		<skill name="Unlock" id="27" level="3" required-level="28" sp="5700" />
 		<skill name="Mortal Blow" id="16" level="18" required-level="28" sp="5700" />
 		<skill name="Critical Chance" id="137" level="1" required-level="28" sp="5700" />
-		
+
+		<!-- Master Buffs Lv. 30 -->
+		<skill name="Empower" id="45105" level="2" required-level="30" sp="11000" />
+		<skill name="Wild Magic" id="45106" level="1" required-level="30" sp="11000" />
+		<skill name="Berserker Spirit" id="45112" level="1" required-level="30" sp="11000" />
+		<skill name="Wind Walk" id="45107" level="2" required-level="30" sp="11000" />
+		<skill name="Magic Barrier" id="45108" level="1" required-level="30" sp="11000" />
+		<skill name="Acumen" id="45104" level="2" required-level="30" sp="11000" />
+		<skill name="Focus" id="45109" level="2" required-level="30" sp="11000" />
+		<skill name="Clarity" id="45113" level="2" required-level="30" sp="11000" />
+		<skill name="Death Whisper" id="45110" level="2" required-level="30" sp="11000" />
+
+		<!-- Skills Lv30 -->
 		<skill name="Dagger Mastery" id="209" level="5" required-level="30" sp="11000" />
 		<skill name="Light Armor Mastery" id="233" level="7" required-level="30" sp="11000" />
 		<skill name="Bow Mastery" id="208" level="10" required-level="30" sp="11000" />
 		<skill name="Power Shot" id="56" level="19" required-level="30" sp="11000" />
 		<skill name="Mortal Blow" id="16" level="19" required-level="30" sp="11000" />
-		
+		<skill name="Emergency Rescue" id="70" level="5" required-level="30" sp="11000" />
+
+		<!-- Skills Lv31 -->
 		<skill name="Bow Mastery" id="208" level="11" required-level="31" sp="11000" />
 		<skill name="Power Shot" id="56" level="20" required-level="31" sp="11000" />
 		<skill name="Mortal Blow" id="16" level="20" required-level="31" sp="11000" />
-		
+
+		<!-- Skills Lv32 -->
 		<skill name="Vicious Stance" id="312" level="4" required-level="32" sp="11000" />
 		<skill name="Rapid Shot" id="99" level="1" required-level="32" sp="11000" />
 		<skill name="Dagger Mastery" id="209" level="6" required-level="32" sp="11000" />
@@ -85,19 +127,24 @@
 		<skill name="Power Shot" id="56" level="21" required-level="32" sp="11000" />
 		<skill name="Unlock" id="27" level="4" required-level="32" sp="11000" />
 		<skill name="Mortal Blow" id="16" level="21" required-level="32" sp="11000" />
+		<skill name="Emergency Rescue" id="70" level="6" required-level="32" sp="11000" />
 
+		<!-- Skills Lv34 -->
 		<skill name="Dagger Mastery" id="209" level="7" required-level="34" sp="20000" />
 		<skill name="Light Armor Mastery" id="233" level="9" required-level="34" sp="20000" />
 		<skill name="Bow Mastery" id="208" level="13" required-level="34" sp="20000" />
 		<skill name="Power Shot" id="56" level="22" required-level="34" sp="20000" />
 		<skill name="Stun Shot" id="101" level="1" required-level="34" sp="20000" />
 		<skill name="Mortal Blow" id="16" level="22" required-level="34" sp="20000" />
-		
+		<skill name="Emergency Rescue" id="70" level="7" required-level="34" sp="20000" />
+
+		<!-- Skills Lv35 -->
 		<skill name="Bow Mastery" id="208" level="14" required-level="35" sp="20000" />
 		<skill name="Power Shot" id="56" level="23" required-level="35" sp="20000" />
 		<skill name="Stun Shot" id="101" level="2" required-level="35" sp="20000" />
 		<skill name="Mortal Blow" id="16" level="23" required-level="35" sp="20000" />
-		
+
+		<!-- Skills Lv36 -->
 		<skill name="Vicious Stance" id="312" level="5" required-level="36" sp="20000" />
 		<skill name="Esprit" id="171" level="1" required-level="36" sp="20000" />
 		<skill name="Dagger Mastery" id="209" level="8" required-level="36" sp="20000" />
@@ -107,6 +154,11 @@
 		<skill name="Stun Shot" id="101" level="3" required-level="36" sp="20000" />
 		<skill name="Unlock" id="27" level="5" required-level="36" sp="20000" />
 		<skill name="Mortal Blow" id="16" level="24" required-level="36" sp="20000" />
-		<skill name="Boost Atk. Spd." id="168" level="1" required-level="36" sp="20000" />
+		<skill name="Attack Speed Boost" id="168" level="1" required-level="36" sp="20000" />
+		<skill name="Emergency Rescue" id="70" level="8" required-level="36" sp="20000" />
+
+		<!-- Skills Lv38 -->
+		<skill name="Emergency Rescue" id="70" level="9" required-level="38" sp="20000" />
+		
 	</skillTree>
 </list>

--- a/data/skillTrees/1stClass/Scavenger.xml
+++ b/data/skillTrees/1stClass/Scavenger.xml
@@ -1,106 +1,149 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="54" parentClassId="53">
-		<skill name="Shock Attack" id="100" level="1" required-level="20" sp="1000" />
-		<skill name="Shock Attack" id="100" level="2" required-level="20" sp="1000" />
-		<skill name="Shock Attack" id="100" level="3" required-level="20" sp="1000" />
-		<skill name="Polearm Mastery" id="216" level="1" required-level="20" sp="1000" />
-		<skill name="Light Armor Mastery" id="227" level="1" required-level="20" sp="1000" />
-		<skill name="Light Armor Mastery" id="227" level="2" required-level="20" sp="1000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="1" required-level="20" sp="1000" />
-		<skill name="Heavy Armor Mastery" id="231" level="1" required-level="20" sp="1000" />
-		<skill name="Heavy Armor Mastery" id="231" level="2" required-level="20" sp="1000" />
+
+		<!-- Master Buffs Lv. 20 -->
+		<skill name="Maphr's Empower" id="45131" level="1" required-level="20" sp="1000" />
+		<skill name="Maphr's Wind Walk" id="45117" level="1" required-level="20" sp="1000" />
+		<skill name="Maphr's Might" id="45119" level="2" required-level="20" sp="1000" />
+		<skill name="Maphr's Acumen" id="45130" level="1" required-level="20" sp="1000" />
+		<skill name="Maphr's Haste" id="45116" level="1" required-level="20" sp="1000" />
+		<skill name="Maphr's Focus" id="45114" level="1" required-level="20" sp="1000" />
+		<skill name="Maphr's Clarity" id="45134" level="1" required-level="20" sp="1000" />
+		<skill name="Maphr's Death Whisper" id="45115" level="1" required-level="20" sp="1000" />
+		<skill name="Maphr's Shield" id="45120" level="2" required-level="20" sp="1000" />
+		<skill name="Recover HP" id="45176" level="1" required-level="20" sp="1000" />
+		<skill name="Recover MP" id="45177" level="1" required-level="20" sp="1000" />
+
+		<!-- Skills Lv20 -->
+		<skill name="Power Strike" id="3" level="10" required-level="20" sp="1000" />
+		<skill name="Power Strike" id="3" level="11" required-level="20" sp="1000" />
+		<skill name="Power Strike" id="3" level="12" required-level="20" sp="1000" />
+		<skill name="Bandage" id="34" level="1" required-level="20" sp="1000" />
+		<skill name="Ability to Protect" id="91" level="2" required-level="20" sp="1000" />
+		<skill name="Shock Mastery" id="100" level="1" required-level="20" sp="1000" />
+		<skill name="Shock Mastery" id="100" level="2" required-level="20" sp="1000" />
+		<skill name="Shock Mastery" id="100" level="3" required-level="20" sp="1000" />
+		<skill name="Shock Mastery" id="100" level="4" required-level="20" sp="1000" />
+		<skill name="Shock Mastery" id="100" level="5" required-level="20" sp="1000" />
+		<skill name="Boost HP" id="211" level="1" required-level="20" sp="1000" />
 		<skill name="Wild Sweep" id="245" level="1" required-level="20" sp="1000" />
 		<skill name="Wild Sweep" id="245" level="2" required-level="20" sp="1000" />
 		<skill name="Wild Sweep" id="245" level="3" required-level="20" sp="1000" />
 		<skill name="Crystallize" id="248" level="1" required-level="20" sp="1000" />
 		<skill name="Spoil" id="254" level="2" required-level="20" sp="1000" />
-		<skill name="Bandage" id="34" level="1" required-level="20" sp="1000" />
-		<skill name="Boost HP" id="211" level="1" required-level="20" sp="1000" />
-		
-		<skill name="Shock Attack" id="100" level="4" required-level="22" sp="2800" />
-		<skill name="Light Armor Mastery" id="227" level="3" required-level="22" sp="2800" />
-		<skill name="Heavy Armor Mastery" id="231" level="3" required-level="22" sp="2800" />
+		<skill name="Enhanced Weapon" id="255" level="1" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="2" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="3" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="4" required-level="20" sp="2800" />
+		<skill name="Enhanced Weapon" id="255" level="5" required-level="20" sp="2800" />
+		<skill name="Emergency Rescue" id="70" level="3" required-level="20" sp="1000" />
+		<skill name="Dwarven Armor Mastery" id="47236" level="1" required-level="20" sp="1000" />
+		<skill name="Dwarven Weapon Mastery" id="47235" level="1" required-level="20" sp="1000" />
+
+		<!-- Skills Lv21 -->
+		<skill name="Shock Mastery" id="100" level="6" required-level="21" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="6" required-level="21" sp="2800" />
+
+		<!-- Skills Lv22 -->
+		<skill name="Shock Mastery" id="100" level="7" required-level="22" sp="2800" />
 		<skill name="Wild Sweep" id="245" level="4" required-level="22" sp="2800" />
-		
-		<skill name="Shock Attack" id="100" level="5" required-level="23" sp="2800" />
+		<skill name="Enhanced Weapon" id="255" level="7" required-level="22" sp="5700" />
+		<skill name="Power Strike" id="3" level="13" required-level="22" sp="2800" />
+
+		<!-- Skills Lv23 -->
+		<skill name="Shock Mastery" id="100" level="8" required-level="23" sp="2800" />
 		<skill name="Wild Sweep" id="245" level="5" required-level="23" sp="2800" />
-		
-		<skill name="Shock Attack" id="100" level="6" required-level="24" sp="2800" />
-		<skill name="Fast HP Recovery" id="212" level="1" required-level="24" sp="2800" />
-		<skill name="Polearm Mastery" id="216" level="2" required-level="24" sp="2800" />
-		<skill name="Light Armor Mastery" id="227" level="4" required-level="24" sp="2800" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="2" required-level="24" sp="2800" />
-		<skill name="Heavy Armor Mastery" id="231" level="4" required-level="24" sp="2800" />
+		<skill name="Enhanced Weapon" id="255" level="8" required-level="23" sp="5700" />
+		<skill name="Power Strike" id="3" level="14" required-level="23" sp="2800" />
+
+		<!-- Skills Lv24 -->
+		<skill name="Power Strike" id="3" level="15" required-level="24" sp="2800" />
+		<skill name="Shock Mastery" id="100" level="9" required-level="24" sp="2800" />
 		<skill name="Wild Sweep" id="245" level="6" required-level="24" sp="2800" />
-		<skill name="Vital Force" id="148" level="1" required-level="24" sp="2800" />
+		<skill name="Enhanced Weapon" id="255" level="9" required-level="24" sp="5700" />
 		<skill name="Weight Limit" id="150" level="2" required-level="24" sp="2800" />
-		
-		<skill name="Shock Attack" id="100" level="7" required-level="26" sp="5700" />
-		<skill name="Polearm Mastery" id="216" level="3" required-level="26" sp="5700" />
-		<skill name="Light Armor Mastery" id="227" level="5" required-level="26" sp="5700" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="3" required-level="26" sp="5700" />
-		<skill name="Heavy Armor Mastery" id="231" level="5" required-level="26" sp="5700" />
+
+
+		<!-- Skills Lv25 -->
+		<skill name="Ability to Attack" id="77" level="2" required-level="25" sp="2800" />
+		<skill name="Shock Mastery" id="100" level="10" required-level="25" sp="2800" />
+		<skill name="Enhanced Weapon" id="255" level="10" required-level="25" sp="11000" />
+		<skill name="Emergency Rescue" id="70" level="4" required-level="25" sp="2800" />
+
+		<!-- Skills Lv26 -->
+		<skill name="Power Strike" id="3" level="16" required-level="26" sp="5700" />
+		<skill name="Shock Mastery" id="100" level="11" required-level="26" sp="5700" />
 		<skill name="Wild Sweep" id="245" level="7" required-level="26" sp="5700" />
-		
-		<skill name="Shock Attack" id="100" level="8" required-level="27" sp="5700" />
-		<skill name="Light Armor Mastery" id="227" level="6" required-level="27" sp="5700" />
-		<skill name="Heavy Armor Mastery" id="231" level="6" required-level="27" sp="5700" />
+		<skill name="Enhanced Weapon" id="255" level="11" required-level="26" sp="11000" />
+
+		<!-- Skills Lv27 -->
+		<skill name="Power Strike" id="3" level="17" required-level="27" sp="5700" />
+		<skill name="Shock Mastery" id="100" level="12" required-level="27" sp="5700" />
 		<skill name="Wild Sweep" id="245" level="8" required-level="27" sp="5700" />
-		
-		<skill name="Shock Attack" id="100" level="9" required-level="28" sp="5700" />
-		<skill name="Polearm Mastery" id="216" level="4" required-level="28" sp="5700" />
-		<skill name="Light Armor Mastery" id="227" level="7" required-level="28" sp="5700" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="4" required-level="28" sp="5700" />
-		<skill name="Heavy Armor Mastery" id="231" level="7" required-level="28" sp="5700" />
+		<skill name="Enhanced Weapon" id="255" level="12" required-level="27" sp="11000" />
+
+		<!-- Skills Lv28 -->
+		<skill name="Power Strike" id="3" level="18" required-level="28" sp="5700" />
+		<skill name="Shock Mastery" id="100" level="13" required-level="28" sp="5700" />
+		<skill name="Boost HP" id="211" level="2" required-level="28" sp="5700" />
 		<skill name="Wild Sweep" id="245" level="9" required-level="28" sp="5700" />
+		<skill name="Spoil" id="254" level="3" required-level="28" sp="5700" />
+		<skill name="Enhanced Weapon" id="255" level="13" required-level="28" sp="20000" />
 		<skill name="Spoil Festival" id="302" level="1" required-level="28" sp="5700" />
 		<skill name="Sweeper Festival" id="444" level="1" required-level="28" sp="5700" />
-		<skill name="Spoil" id="254" level="3" required-level="28" sp="5700" />
-		<skill name="Boost HP" id="211" level="2" required-level="28" sp="5700" />
 
-		<skill name="Shock Attack" id="100" level="10" required-level="30" sp="11000" />
-		<skill name="Polearm Mastery" id="216" level="5" required-level="30" sp="11000" />
-		<skill name="Light Armor Mastery" id="227" level="8" required-level="30" sp="11000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="5" required-level="30" sp="11000" />
-		<skill name="Heavy Armor Mastery" id="231" level="8" required-level="30" sp="11000" />
+		<!-- Skills Lv29 -->
+		<skill name="Shock Mastery" id="100" level="14" required-level="29" sp="11000" />
+		<skill name="Enhanced Weapon" id="255" level="14" required-level="29" sp="20000" />
+
+		<!-- Master Buffs Lv. 30 -->
+		<skill name="Maphr's Empower" id="45131" level="2" required-level="30" sp="11000" />
+		<skill name="Maphr's Wild Magic" id="45132" level="1" required-level="30" sp="11000" />
+		<skill name="Maphr's Berserker Spirit" id="45133" level="1" required-level="30" sp="11000" />
+		<skill name="Maphr's Wind Walk" id="45117" level="2" required-level="30" sp="11000" />
+		<skill name="Maphr's Magic Barrier" id="45118" level="1" required-level="30" sp="11000" />
+		<skill name="Maphr's Acumen" id="45130" level="2" required-level="30" sp="11000" />
+		<skill name="Maphr's Focus" id="45114" level="2" required-level="30" sp="11000" />
+		<skill name="Maphr's Clarity" id="45134" level="2" required-level="30" sp="11000" />
+		<skill name="Maphr's Death Whisper" id="45115" level="2" required-level="30" sp="11000" />
+
+		<!-- Skills Lv30 -->
+		<skill name="Power Strike" id="3" level="19" required-level="30" sp="11000" />
+		<skill name="ShockMastery" id="100" level="15" required-level="30" sp="11000" />
 		<skill name="Wild Sweep" id="245" level="10" required-level="30" sp="11000" />
-		
-		<skill name="Shock Attack" id="100" level="11" required-level="31" sp="11000" />
-		<skill name="Light Armor Mastery" id="227" level="9" required-level="31" sp="11000" />
-		<skill name="Heavy Armor Mastery" id="231" level="9" required-level="31" sp="11000" />
+		<skill name="Enhanced Weapon" id="255" level="15" required-level="30" sp="20000" />
+		<skill name="Emergency Rescue" id="70" level="5" required-level="30" sp="11000" />
+
+		<!-- Skills Lv31 -->
+		<skill name="Power Strike" id="3" level="20" required-level="31" sp="11000" />
 		<skill name="Wild Sweep" id="245" level="11" required-level="31" sp="11000" />
-		
-		<skill name="Shock Attack" id="100" level="12" required-level="32" sp="11000" />
-		<skill name="Fast HP Recovery" id="212" level="2" required-level="32" sp="11000" />
-		<skill name="Polearm Mastery" id="216" level="6" required-level="32" sp="11000" />
-		<skill name="Light Armor Mastery" id="227" level="10" required-level="32" sp="11000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="6" required-level="32" sp="11000" />
-		<skill name="Heavy Armor Mastery" id="231" level="10" required-level="32" sp="11000" />
+
+		<!-- Skills Lv32 -->
+		<skill name="Power Strike" id="3" level="21" required-level="32" sp="11000" />
 		<skill name="Wild Sweep" id="245" level="12" required-level="32" sp="11000" />
-		<skill name="Vital Force" id="148" level="2" required-level="32" sp="11000" />
-		
-		<skill name="Shock Attack" id="100" level="13" required-level="34" sp="20000" />
-		<skill name="Polearm Mastery" id="216" level="7" required-level="34" sp="20000" />
-		<skill name="Light Armor Mastery" id="227" level="11" required-level="34" sp="20000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="7" required-level="34" sp="20000" />
-		<skill name="Heavy Armor Mastery" id="231" level="11" required-level="34" sp="20000" />
+		<skill name="Emergency Rescue" id="70" level="6" required-level="32" sp="11000" />
+
+		<!-- Skills Lv34 -->
+		<skill name="Power Strike" id="3" level="22" required-level="34" sp="20000" />
 		<skill name="Wild Sweep" id="245" level="13" required-level="34" sp="20000" />
-		
-		<skill name="Shock Attack" id="100" level="14" required-level="35" sp="20000" />
-		<skill name="Light Armor Mastery" id="227" level="12" required-level="35" sp="20000" />
-		<skill name="Heavy Armor Mastery" id="231" level="12" required-level="35" sp="20000" />
+		<skill name="Emergency Rescue" id="70" level="7" required-level="34" sp="20000" />
+
+		<!-- Skills Lv35 -->
 		<skill name="Wild Sweep" id="245" level="14" required-level="35" sp="20000" />
-		
-		<skill name="Shock Attack" id="100" level="15" required-level="36" sp="20000" />
-		<skill name="Polearm Mastery" id="216" level="8" required-level="36" sp="20000" />
-		<skill name="Light Armor Mastery" id="227" level="13" required-level="36" sp="20000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="8" required-level="36" sp="20000" />
-		<skill name="Heavy Armor Mastery" id="231" level="13" required-level="36" sp="20000" />
+		<skill name="Power Strike" id="3" level="23" required-level="35" sp="20000" />
+
+		<!-- Skills Lv36 -->
+		<skill name="Power Strike" id="3" level="24" required-level="36" sp="20000" />
+		<skill name="Boost HP" id="211" level="3" required-level="36" sp="20000" />
 		<skill name="Wild Sweep" id="245" level="15" required-level="36" sp="20000" />
+		<skill name="Spoil" id="254" level="4" required-level="36" sp="20000" />
 		<skill name="Lionheart" id="287" level="1" required-level="36" sp="20000" />
 		<skill name="Spoil Festival" id="302" level="2" required-level="36" sp="20000" />
-		<skill name="Spoil" id="254" level="4" required-level="36" sp="20000" />
-		<skill name="Boost HP" id="211" level="3" required-level="36" sp="20000" />
+		<skill name="Emergency Rescue" id="70" level="8" required-level="36" sp="20000" />
+
+		<!-- Skills Lv38 -->
+		<skill name="Emergency Rescue" id="70" level="9" required-level="38" sp="20000" />
+		
 	</skillTree>
 </list>

--- a/data/skillTrees/1stClass/ShillienOracle.xml
+++ b/data/skillTrees/1stClass/ShillienOracle.xml
@@ -1,37 +1,57 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="42" parentClassId="38">
+
+		<!-- Master Buffs Lv. 20 -->
+		<skill name="Empower" id="1059" level="1" required-level="20" sp="500" />
+		<skill name="Concentration" id="1078" level="1" required-level="20" sp="600" />
+		<skill name="Wind Walk" id="1204" level="1" required-level="20" sp="500" />
+		<skill name="Might" id="1068" level="2" required-level="20" sp="500" />
+		<skill name="Acumen" id="45104" level="1" required-level="20" sp="500" />
+		<skill name="Haste" id="45111" level="1" required-level="20" sp="500" />
+		<skill name="Focus" id="1077" level="1" required-level="20" sp="500" />
+		<skill name="Clarity" id="45113" level="1" required-level="20" sp="500" />
+		<skill name="Death Whisper" id="1242" level="1" required-level="20" sp="500" />
+		<skill name="Shield" id="1040" level="2" required-level="20" sp="500" />
+
+		<!-- Skills Lv20 -->
 		<skill name="Anti Magic" id="146" level="5" required-level="20" sp="600" />
 		<skill name="Anti Magic" id="146" level="6" required-level="20" sp="600" />
 		<skill name="Battle Heal" id="1015" level="4" required-level="20" sp="600" />
 		<skill name="Battle Heal" id="1015" level="5" required-level="20" sp="600" />
 		<skill name="Battle Heal" id="1015" level="6" required-level="20" sp="600" />
+		<skill name="Divine Strike" id="1031" level="1" required-level="20" sp="600" />
+		<skill name="Divine Strike" id="1031" level="2" required-level="20" sp="600" />
 		<skill name="Quick Recovery" id="164" level="1" required-level="20" sp="600" />
 		<skill name="Light Armor Mastery" id="236" level="1" required-level="20" sp="600" />
 		<skill name="Light Armor Mastery" id="236" level="2" required-level="20" sp="600" />
 		<skill name="Robe Mastery" id="235" level="1" required-level="20" sp="600" />
 		<skill name="Robe Mastery" id="235" level="2" required-level="20" sp="600" />
 		<skill name="Weapon Mastery" id="249" level="3" required-level="20" sp="600" />
+		<skill name="Resurrection" id="1016" level="1" required-level="20" sp="600" />
+		<skill name="Recover HP" id="45176" level="1" required-level="20" sp="500" />
+		<skill name="Recover MP" id="45177" level="1" required-level="20" sp="500" />
 		<skill name="Group Heal" id="1027" level="4" required-level="20" sp="600" />
 		<skill name="Group Heal" id="1027" level="5" required-level="20" sp="600" />
 		<skill name="Group Heal" id="1027" level="6" required-level="20" sp="600" />
-		<skill name="Wind Walk" id="1204" level="1" required-level="20" sp="600" />
+		<skill name="Dryad Root" id="1201" level="1" required-level="20" sp="600" />
 		<skill name="Heal" id="1011" level="7" required-level="20" sp="600" />
 		<skill name="Heal" id="1011" level="8" required-level="20" sp="600" />
 		<skill name="Heal" id="1011" level="9" required-level="20" sp="600" />
-		<skill name="Might" id="1068" level="2" required-level="20" sp="600" />
 		<skill name="Wind Shackle" id="1206" level="2" required-level="20" sp="600" />
-		<skill name="Eva's Kiss" id="1073" level="1" required-level="20" sp="600" />
-		<skill name="Disrupt Undead" id="1031" level="1" required-level="20" sp="600" />
-		<skill name="Disrupt Undead" id="1031" level="2" required-level="20" sp="600" />
+		<skill name="Poison" id="1168" level="2" required-level="20" sp="600" />
+		<skill name="Self Heal" id="1216" level="4" required-level="20" sp="600" />
 		<skill name="Boost Mana" id="213" level="1" required-level="20" sp="600" />
-		<skill name="Resurrection" id="1016" level="1" required-level="20" sp="600">
-			<item id="1514"/>
-		</skill>
-		<skill name="Concentration" id="1078" level="1" required-level="20" sp="600">
-			<item id="1399"/>
-		</skill>
+		<skill name="Increased Power of Magic" id="1073" level="1" required-level="20" sp="600" />
+		<skill name="Sleep" id="1069" level="1" required-level="20" sp="600" />
 
+
+		<!-- Skills Lv22 -->
+		<skill name="Divine Strike" id="1031" level="3" required-level="22" sp="2300" />
+		<skill name="Dryad Root" id="1201" level="2" required-level="22" sp="2300" />
+		<skill name="Sleep" id="1069" level="2" required-level="22" sp="2300" />
+
+		<!-- Skills Lv23 -->
 		<skill name="Anti Magic" id="146" level="7" required-level="23" sp="2300" />
 		<skill name="Battle Heal" id="1015" level="7" required-level="23" sp="2300" />
 		<skill name="Light Armor Mastery" id="236" level="3" required-level="23" sp="2300" />
@@ -39,21 +59,18 @@
 		<skill name="Weapon Mastery" id="249" level="4" required-level="23" sp="2300" />
 		<skill name="Group Heal" id="1027" level="7" required-level="23" sp="2300" />
 		<skill name="Heal" id="1011" level="10" required-level="23" sp="2300" />
-		<skill name="Disrupt Undead" id="1031" level="3" required-level="23" sp="2300" />
-		<skill name="Sleep" id="1069" level="1" required-level="23" sp="2300">
-			<item id="1394"/>
-		</skill>
-		<skill name="Dryad Root" id="1201" level="1" required-level="23" sp="2300">
-			<item id="1415"/>
-		</skill>
-		
-		<skill name="Battle Heal" id="1015" level="8" required-level="24" sp="2300" />
-		<skill name="Group Heal" id="1027" level="8" required-level="24" sp="2300" />
-		<skill name="Dryad Root" id="1201" level="2" required-level="24" sp="2300" />
-		<skill name="Heal" id="1011" level="11" required-level="24" sp="2300" />
-		<skill name="Sleep" id="1069" level="2" required-level="24" sp="2300" />
 
+		<!-- Skills Lv24 -->
+		<skill name="Battle Heal" id="1015" level="8" required-level="24" sp="2300" />
+		<skill name="Divine Strike" id="1031" level="4" required-level="24" sp="2300" />
+		<skill name="Group Heal" id="1027" level="8" required-level="24" sp="2300" />
+		<skill name="Dryad Root" id="1201" level="3" required-level="24" sp="2300" />
+		<skill name="Heal" id="1011" level="11" required-level="24" sp="2300" />
+		<skill name="Sleep" id="1069" level="3" required-level="24" sp="2300" />
+
+		<!-- Skills Lv25 -->
 		<skill name="Anti Magic" id="146" level="8" required-level="25" sp="2300" />
+		<skill name="Mage's Blessing" id="1043" level="1" required-level="25" sp="2300" />
 		<skill name="Battle Heal" id="1015" level="9" required-level="25" sp="2300" />
 		<skill name="Fast Mana Recovery" id="229" level="1" required-level="25" sp="2300" />
 		<skill name="Fast Spell Casting" id="228" level="1" required-level="25" sp="2300" />
@@ -61,79 +78,94 @@
 		<skill name="Robe Mastery" id="235" level="4" required-level="25" sp="2300" />
 		<skill name="Weapon Mastery" id="249" level="5" required-level="25" sp="2300" />
 		<skill name="Group Heal" id="1027" level="9" required-level="25" sp="2300" />
-		<skill name="Dryad Root" id="1201" level="3" required-level="25" sp="2300" />
 		<skill name="Heal" id="1011" level="12" required-level="25" sp="2300" />
+		<skill name="Mental Shield" id="1035" level="1" required-level="25" sp="2300" />
 		<skill name="Wind Shackle" id="1206" level="3" required-level="25" sp="2300" />
-		<skill name="Disrupt Undead" id="1031" level="4" required-level="25" sp="2300" />
-		<skill name="Sleep" id="1069" level="3" required-level="25" sp="2300" />
-		<skill name="Shield" id="1040" level="2" required-level="25" sp="2300" />
-		<skill name="Empower" id="1059" level="1" required-level="25" sp="2300">
-			<item id="1391"/>
-		</skill>
-		<skill name="Focus" id="1077" level="1" required-level="25" sp="2300">
-			<item id="1398"/>
-		</skill>
-		<skill name="Mental Shield" id="1035" level="1" required-level="25" sp="2300">
-			<item id="1388"/>
-		</skill>
+		<skill name="Self Heal" id="1216" level="5" required-level="25" sp="2300" />
 
+		<!-- Skills Lv26 -->
+		<skill name="Divine Strike" id="1031" level="5" required-level="26" sp="2300" />
+		<skill name="Dryad Root" id="1201" level="4" required-level="26" sp="2300" />
+		<skill name="Sleep" id="1069" level="4" required-level="26" sp="2300" />
+
+		<!-- Skills Lv28 -->
 		<skill name="Anti Magic" id="146" level="9" required-level="28" sp="5700" />
 		<skill name="Battle Heal" id="1015" level="10" required-level="28" sp="5700" />
+		<skill name="Divine Strike" id="1031" level="6" required-level="28" sp="5700" />
 		<skill name="Light Armor Mastery" id="236" level="5" required-level="28" sp="5700" />
 		<skill name="Robe Mastery" id="235" level="5" required-level="28" sp="5700" />
 		<skill name="Weapon Mastery" id="249" level="6" required-level="28" sp="5700" />
 		<skill name="Group Heal" id="1027" level="10" required-level="28" sp="5700" />
-		<skill name="Dryad Root" id="1201" level="4" required-level="28" sp="5700" />
+		<skill name="Dryad Root" id="1201" level="5" required-level="28" sp="5700" />
 		<skill name="Heal" id="1011" level="13" required-level="28" sp="5700" />
-		<skill name="Disrupt Undead" id="1031" level="5" required-level="28" sp="5700" />
-		<skill name="Sleep" id="1069" level="4" required-level="28" sp="5700" />
-		<skill name="Recharge" id="1013" level="1" required-level="28" sp="5700">
-			<item id="1385"/>
-		</skill>
-		
+		<skill name="Boost Mana" id="1013" level="1" required-level="28" sp="5700" />
+		<skill name="Sleep" id="1069" level="5" required-level="28" sp="5700" />
+		<skill name="Mana Effect Boost" id="1013" level="1" required-level="28" sp="5700" />
+
+
+		<!-- Skills Lv29 -->
 		<skill name="Battle Heal" id="1015" level="11" required-level="29" sp="5700" />
 		<skill name="Group Heal" id="1027" level="11" required-level="29" sp="5700" />
-		<skill name="Dryad Root" id="1201" level="5" required-level="29" sp="5700" />
 		<skill name="Heal" id="1011" level="14" required-level="29" sp="5700" />
-		<skill name="Sleep" id="1069" level="5" required-level="29" sp="5700" />
 
+		<!-- Master Buffs Lv. 30 -->
+		<skill name="Empower" id="1059" level="2" required-level="30" sp="5000" />
+		<skill name="Vampiric Rage" id="1268" level="1" required-level="30" sp="5700" />
+		<skill name="Wild Magic" id="1303" level="1" required-level="30" sp="5000" />
+		<skill name="Berserker Spirit" id="45112" level="1" required-level="30" sp="5000" />
+		<skill name="Concentration" id="1078" level="2" required-level="30" sp="5700" />
+		<skill name="Wind Walk" id="1204" level="2" required-level="30" sp="5000" />
+		<skill name="Magic Barrier" id="45108" level="1" required-level="30" sp="5000" />
+		<skill name="Focus" id="1077" level="2" required-level="30" sp="5000" />
+		<skill name="Clarity" id="45113" level="2" required-level="30" sp="5000" />
+		<skill name="Death Whisper" id="1242" level="2" required-level="30" sp="5000" />
+
+
+		<!-- Skills Lv30 -->
 		<skill name="Anti Magic" id="146" level="10" required-level="30" sp="5700" />
 		<skill name="Battle Heal" id="1015" level="12" required-level="30" sp="5700" />
+		<skill name="Divine Strike" id="1031" level="7" required-level="30" sp="5700" />
 		<skill name="Quick Recovery" id="164" level="2" required-level="30" sp="5700" />
 		<skill name="Light Armor Mastery" id="236" level="6" required-level="30" sp="5700" />
 		<skill name="Robe Mastery" id="235" level="6" required-level="30" sp="5700" />
 		<skill name="Weapon Mastery" id="249" level="7" required-level="30" sp="5700" />
 		<skill name="Resurrection" id="1016" level="2" required-level="30" sp="5700" />
-		<skill name="Vampiric Rage" id="1268" level="1" required-level="30" sp="5700" />
 		<skill name="Group Heal" id="1027" level="12" required-level="30" sp="5700" />
-		<skill name="Concentration" id="1078" level="2" required-level="30" sp="5700" />
 		<skill name="Dryad Root" id="1201" level="6" required-level="30" sp="5700" />
-		<skill name="Wind Walk" id="1204" level="2" required-level="30" sp="5700" />
 		<skill name="Heal" id="1011" level="15" required-level="30" sp="5700" />
 		<skill name="Wind Shackle" id="1206" level="4" required-level="30" sp="5700" />
-		<skill name="Recharge" id="1013" level="2" required-level="30" sp="5700" />
-		<skill name="Disrupt Undead" id="1031" level="6" required-level="30" sp="5700" />
+		<skill name="Poison" id="1168" level="3" required-level="30" sp="5700" />
+		<skill name="Acumen" id="45104" level="2" required-level="30" sp="5000" />
 		<skill name="Boost Mana" id="213" level="2" required-level="30" sp="5700" />
+		<skill name="Boost Mana" id="1013" level="2" required-level="30" sp="5700" />
 		<skill name="Sleep" id="1069" level="6" required-level="30" sp="5700" />
+		<skill name="Mana Effect Boost" id="1013" level="2" required-level="30" sp="5700" />
 
+		<!-- Skills Lv32 -->
+		<skill name="Divine Strike" id="1031" level="8" required-level="32" sp="5700" />
+		<skill name="Dryad Root" id="1201" level="7" required-level="32" sp="5700" />
+		<skill name="Sleep" id="1069" level="7" required-level="32" sp="5700" />
+
+		<!-- Skills Lv33 -->
 		<skill name="Anti Magic" id="146" level="11" required-level="33" sp="13000" />
 		<skill name="Battle Heal" id="1015" level="13" required-level="33" sp="13000" />
 		<skill name="Light Armor Mastery" id="236" level="7" required-level="33" sp="13000" />
 		<skill name="Robe Mastery" id="235" level="7" required-level="33" sp="13000" />
 		<skill name="Weapon Mastery" id="249" level="8" required-level="33" sp="13000" />
 		<skill name="Group Heal" id="1027" level="13" required-level="33" sp="13000" />
-		<skill name="Dryad Root" id="1201" level="7" required-level="33" sp="13000" />
 		<skill name="Heal" id="1011" level="16" required-level="33" sp="13000" />
-		<skill name="Recharge" id="1013" level="3" required-level="33" sp="13000" />
-		<skill name="Disrupt Undead" id="1031" level="7" required-level="33" sp="13000" />
-		<skill name="Sleep" id="1069" level="7" required-level="33" sp="13000" />
-		
+		<skill name="Boost Mana" id="1013" level="3" required-level="33" sp="13000" />
+		<skill name="Mana Effect Boost" id="1013" level="3" required-level="33" sp="13000" />
+
+		<!-- Skills Lv34 -->
 		<skill name="Battle Heal" id="1015" level="14" required-level="34" sp="13000" />
+		<skill name="Divine Strike" id="1031" level="9" required-level="34" sp="13000" />
 		<skill name="Group Heal" id="1027" level="14" required-level="34" sp="13000" />
 		<skill name="Dryad Root" id="1201" level="8" required-level="34" sp="13000" />
 		<skill name="Heal" id="1011" level="17" required-level="34" sp="13000" />
 		<skill name="Sleep" id="1069" level="8" required-level="34" sp="13000" />
 
+		<!-- Skills Lv35 -->
 		<skill name="Anti Magic" id="146" level="12" required-level="35" sp="13000" />
 		<skill name="Battle Heal" id="1015" level="15" required-level="35" sp="13000" />
 		<skill name="Fast HP Recovery" id="212" level="1" required-level="35" sp="13000" />
@@ -142,12 +174,21 @@
 		<skill name="Robe Mastery" id="235" level="8" required-level="35" sp="13000" />
 		<skill name="Weapon Mastery" id="249" level="9" required-level="35" sp="13000" />
 		<skill name="Group Heal" id="1027" level="15" required-level="35" sp="13000" />
-		<skill name="Cure Poison" id="1012" level="2" required-level="35" sp="13000" />
-		<skill name="Dryad Root" id="1201" level="9" required-level="35" sp="13000" />
+		<skill name="Cure" id="1012" level="2" required-level="35" sp="13000" />
 		<skill name="Heal" id="1011" level="18" required-level="35" sp="13000" />
 		<skill name="Wind Shackle" id="1206" level="5" required-level="35" sp="13000" />
-		<skill name="Recharge" id="1013" level="4" required-level="35" sp="13000" />
-		<skill name="Disrupt Undead" id="1031" level="8" required-level="35" sp="13000" />
-		<skill name="Sleep" id="1069" level="9" required-level="35" sp="13000" />
+		<skill name="Regeneration" id="1044" level="1" required-level="35" sp="13000" />
+		<skill name="Boost Mana" id="1013" level="4" required-level="35" sp="13000" />
+		<skill name="Mana Effect Boost" id="1013" level="4" required-level="35" sp="13000" />
+
+		<!-- Skills Lv36 -->
+		<skill name="Divine Strike" id="1031" level="10" required-level="36" sp="13000" />
+		<skill name="Dryad Root" id="1201" level="9" required-level="36" sp="13000" />
+		<skill name="Sleep" id="1069" level="9" required-level="36" sp="13000" />
+
+		<!-- Skills Lv38 -->
+		<skill name="Dryad Root" id="1201" level="10" required-level="38" sp="13000" />
+		<skill name="Sleep" id="1069" level="10" required-level="38" sp="13000" />
+
 	</skillTree>
 </list>

--- a/data/skillTrees/1stClass/SoulFinder.xml
+++ b/data/skillTrees/1stClass/SoulFinder.xml
@@ -2,25 +2,100 @@
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="193" parentClassId="192">
 
+		<!-- Master Buffs Lv. 20 -->
+		<skill name="Soul Empower" id="45147" level="1" required-level="20" sp="1000" />
+		<skill name="Soul Wind Walk" id="45142" level="1" required-level="20" sp="1000" />
+		<skill name="Soul Might" id="45144" level="2" required-level="20" sp="1000" />
+		<skill name="Soul Acumen" id="45146" level="1" required-level="20" sp="1000" />
+		<skill name="Soul Haste" id="45141" level="1" required-level="20" sp="1000" />
+		<skill name="Soul Focus" id="45139" level="1" required-level="20" sp="1000" />
+		<skill name="Soul Clarity" id="45150" level="1" required-level="20" sp="1000" />
+		<skill name="Soul Death Whisper" id="45140" level="1" required-level="20" sp="1000" />
+		<skill name="Soul Shield" id="45145" level="2" required-level="20" sp="1000" />
+
+		<!-- Skills Lv20 -->
 		<skill name="Armor Mastery" id="464" level="2" required-level="20" sp="1000" />
 		<skill name="Light Armor Mastery" id="465" level="1" required-level="20" sp="1000" />
 		<skill name="Weapon Mastery" id="463" level="2" required-level="20" sp="1000" />
 		<skill name="Rapier Mastery" id="474" level="1" required-level="20" sp="1000" />
-		<skill name="Light Master" id="45178" level="1" required-level="20"  />
-		<skill name="Shine Soul Finding" id="393" level="1" required-level="20" sp="1000" />
+		<skill name="Light Master" id="45178" level="1" required-level="20" auto-learn="true" />
+		<skill name="Recover HP" id="45176" level="1" required-level="20" sp="1000" />
+		<skill name="Recover MP" id="45177" level="1" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="1" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="2" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="3" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="4" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="5" required-level="20" sp="1000" />
+		<skill name="Bandage" id="34" level="1" required-level="20" sp="1000" />
+		<skill name="Absorb Light Souls" id="393" level="1" required-level="20" sp="1000" />
 		<skill name="Soul Slash" id="45160" level="1" required-level="20" sp="1000" />
 		<skill name="Soul Link" id="1378" level="1" required-level="20" sp="1000" />
+		<skill name="Ability to Protect" id="91" level="2" required-level="20" sp="1000" />
 		<skill name="Soul Strike" id="1516" level="1" required-level="20" sp="1000" />
 		<skill name="Soul Sense" id="1379" level="1" required-level="20" sp="1000" />
+		<skill name="Emergency Rescue" id="70" level="3" required-level="20" sp="1000" />
 
+		<!-- Skills Lv21 -->
+		<skill name="Enhanced Weapon" id="255" level="6" required-level="21" sp="2500" />
+
+		<!-- Skills Lv22 -->
+		<skill name="Enhanced Weapon" id="255" level="7" required-level="22" sp="2500" />
+
+		<!-- Skills Lv23 -->
+		<skill name="Enhanced Weapon" id="255" level="8" required-level="23" sp="2500" />
+
+		<!-- Skills Lv24 -->
+		<skill name="Enhanced Weapon" id="255" level="9" required-level="24" sp="2500" />
+
+		<!-- Skills Lv25 -->
 		<skill name="Magic Immunity" id="466" level="1" required-level="25" sp="5500" />
+		<skill name="Enhanced Weapon" id="255" level="10" required-level="25" sp="5500" />
+		<skill name="Ability to Attack" id="77" level="2" required-level="25" sp="5500" />
+		<skill name="Emergency Rescue" id="70" level="4" required-level="25" sp="5500" />
 
+		<!-- Skills Lv26 -->
+		<skill name="Enhanced Weapon" id="255" level="11" required-level="26" sp="5500" />
+
+		<!-- Skills Lv27 -->
+		<skill name="Enhanced Weapon" id="255" level="12" required-level="27" sp="5500" />
+
+		<!-- Skills Lv28 -->
+		<skill name="Enhanced Weapon" id="255" level="13" required-level="28" sp="5500" />
+
+		<!-- Skills Lv29 -->
+		<skill name="Enhanced Weapon" id="255" level="14" required-level="29" sp="10000" />
+
+		<!-- Master Buffs Lv. 30 -->
+		<skill name="Soul Empower" id="45147" level="2" required-level="30" sp="10000" />
+		<skill name="Soul Wild Magic" id="45148" level="1" required-level="30" sp="10000" />
+		<skill name="Soul Berserker Spirit" id="45149" level="1" required-level="30" sp="10000" />
+		<skill name="Soul Wind Walk" id="45142" level="2" required-level="30" sp="10000" />
+		<skill name="Soul Magic Barrier" id="45143" level="1" required-level="30" sp="10000" />
+		<skill name="Soul Acumen" id="45146" level="2" required-level="30" sp="10000" />
+		<skill name="Soul Focus" id="45139" level="2" required-level="30" sp="10000" />
+		<skill name="Soul Clarity" id="45150" level="2" required-level="30" sp="10000" />
+		<skill name="Soul Death Whisper" id="45140" level="2" required-level="30" sp="10000" />
+
+		<!-- Skills Lv30 -->
 		<skill name="Light Armor Mastery" id="465" level="2" required-level="30" sp="10000" />
 		<skill name="Rapier Mastery" id="474" level="2" required-level="30" sp="10000" />
+		<skill name="Enhanced Weapon" id="255" level="15" required-level="30" sp="10000" />
 		<skill name="Soul Slash" id="45160" level="2" required-level="30" sp="10000" />
 		<skill name="Soul Strike" id="1516" level="2" required-level="30" sp="10000" />
+		<skill name="Emergency Rescue" id="70" level="5" required-level="30" sp="10000" />
 
-		<skill name="Death Mark" id="1435" level="2" required-level="32" sp="10000"/>
+		<!-- Skills Lv32 -->
+		<skill name="Death Mark" id="1435" level="2" required-level="32" sp="10000" />
+		<skill name="Emergency Rescue" id="70" level="6" required-level="32" sp="10000" />
+
+		<!-- Skills Lv34 -->
+		<skill name="Emergency Rescue" id="70" level="7" required-level="34" sp="20000" />
+
+		<!-- Skills Lv36 -->
+		<skill name="Emergency Rescue" id="70" level="8" required-level="36" sp="20000" />
+
+		<!-- Skills Lv38 -->
+		<skill name="Emergency Rescue" id="70" level="9" required-level="38" sp="20000" />
 		
 	</skillTree>
 </list>

--- a/data/skillTrees/1stClass/SylphGunner.xml
+++ b/data/skillTrees/1stClass/SylphGunner.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
+	<skillTree type="classSkillTree" classId="209" parentClassId="208">
+
+		<!-- Master Buffs Lv. 20 -->
+		<skill name="Elemental Empower" id="47029" level="1" required-level="20" sp="1000" />
+		<skill name="Elemental Wind Walk" id="47024" level="1" required-level="20" sp="1000" />
+		<skill name="Elemental Might" id="47026" level="2" required-level="20" sp="1000" />
+		<skill name="Elemental Acumen" id="47028" level="1" required-level="20" sp="1000" />
+		<skill name="Elemental Haste" id="47023" level="1" required-level="20" sp="1000" />
+		<skill name="Elemental Focus" id="47021" level="1" required-level="20" sp="1000" />
+		<skill name="Elemental Clarity" id="47032" level="1" required-level="20" sp="1000" />
+		<skill name="Elemental Death Whisper" id="47022" level="1" required-level="20" sp="1000" />
+		<skill name="Elemental Shield" id="47027" level="2" required-level="20" sp="1000" />
+
+		<!-- Skills Lv20 -->
+		<skill name="Light Armor Mastery" id="47082" level="1" required-level="20" sp="1000" />
+		<skill name="Firearms Mastery" id="47081" level="1" required-level="20" sp="1000" />
+		<skill name="Recover HP" id="45176" level="1" required-level="20" sp="1000" />
+		<skill name="Recover MP" id="45177" level="1" required-level="20" sp="1000" />
+		<skill name="Ability to Protect" id="91" level="2" required-level="20" sp="1000" />
+		<skill name="Soul Strike" id="1516" level="1" required-level="20" sp="1000" />
+		<skill name="Dual Blow" id="47002" level="1" required-level="20" sp="1000" />
+		<skill name="Elemental Connection" id="47104" level="2" required-level="40" sp="1000" />
+
+		<!-- Skills Lv21 -->
+		<skill name="Dual Blow" id="47002" level="2" required-level="21" sp="2500" />
+
+		<!-- Skills Lv25 -->
+		<skill name="Ability to Attack" id="77" level="2" required-level="25" sp="5500" />
+
+		<!-- Skills Lv27 -->
+		<skill name="Critical Chance" id="137" level="1" required-level="27" sp="5500" />
+
+		<!-- Skills Lv28 -->
+		<skill name="Dual Blow" id="47002" level="3" required-level="28" sp="5500" />
+
+
+		<!-- Skills Lv30 -->
+		<skill name="Elemental Focus" id="47021" level="1" required-level="2" sp="10000" />
+		<skill name="Elemental Death Whisper" id="47022" level="2" required-level="20" sp="10000" />
+		<skill name="Elemental Wind Walk" id="47024" level="2" required-level="20" sp="1000" />
+		<skill name="Elemental Magic Barrier" id="47025" level="1" required-level="20" sp="10000" />
+		<skill name="Elemental Acumen" id="47028" level="2" required-level="20" sp="10000" />
+		<skill name="Elemental Empower" id="47029" level="2" required-level="20" sp="10000" />
+		<skill name="Elemental Wild Magic" id="47030" level="1" required-level="20" sp="10000" />
+		<skill name="Elemental Berserker Spirit" id="47031" level="1" required-level="30" sp="10000" />
+		<skill name="Elemental Clarity" id="47032" level="2" required-level="30" sp="10000" />
+
+		<!-- Skills Lv32 -->
+		<skill name="Dual Blow" id="47002" level="4" required-level="32" sp="18000" />
+
+		<!-- Skills Lv35 -->
+		<skill name="Long Range Attack" id="47084" level="1" required-level="35" sp="20000" />
+
+		<!-- Skills Lv36 -->
+		<skill name="Dual Blow" id="47002" level="5" required-level="36" sp="20000" />
+		
+	</skillTree>
+</list>

--- a/data/skillTrees/1stClass/Trooper.xml
+++ b/data/skillTrees/1stClass/Trooper.xml
@@ -2,28 +2,103 @@
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
     <skillTree type="classSkillTree" classId="125" parentClassId="192">
 
-        <skill name="Armor Mastery" id="464" level="2" required-level="20" sp="1000" />
-        <skill name="Ancient Sword Mastery" id="472" level="1" required-level="20" sp="1000" />
-        <skill name="Light Armor Mastery" id="465" level="1" required-level="20" sp="1000" />
-        <skill name="Weapon Mastery" id="463" level="2" required-level="20" sp="1000" />
-        <skill name="Light Master" id="45178" level="1" required-level="20"  />
-        <skill name="Heavy Armor Mastery" id="399" level="1" required-level="20" sp="1000" />
-        <skill name="Shine Soul Finding" id="393" level="1" required-level="20" sp="1000" />
-        <skill name="Soul Smash" id="477" level="1" required-level="20" sp="1000" />
+		<!-- Master Buffs Lv. 20 -->
+		<skill name="Soul Empower" id="45147" level="1" required-level="20" sp="1000" />
+		<skill name="Soul Wind Walk" id="45142" level="1" required-level="20" sp="1000" />
+		<skill name="Soul Might" id="45144" level="2" required-level="20" sp="1000" />
+		<skill name="Soul Acumen" id="45146" level="1" required-level="20" sp="1000" />
+		<skill name="Soul Haste" id="45141" level="1" required-level="20" sp="1000" />
+		<skill name="Soul Focus" id="45139" level="1" required-level="20" sp="1000" />
+		<skill name="Soul Clarity" id="45150" level="1" required-level="20" sp="1000" />
+		<skill name="Soul Death Whisper" id="45140" level="1" required-level="20" sp="1000" />
+		<skill name="Soul Shield" id="45145" level="2" required-level="20" sp="1000" />
 
-        <skill name="Magic Immunity" id="466" level="1" required-level="25" sp="5500" />
-        <skill name="Increase Power" id="1432" level="1" required-level="25" sp="5500" />
+		<!-- Skills Lv20 -->
+ 		<skill name="Armor Mastery" id="464" level="2" required-level="20" sp="1000" />
+		<skill name="Ancient Sword Mastery" id="472" level="1" required-level="20" sp="1000" />
+		<skill name="Light Armor Mastery" id="465" level="1" required-level="20" sp="1000" />
+		<skill name="Weapon Mastery" id="463" level="2" required-level="20" sp="1000" />
+		<skill name="Light Master" id="45178" level="1" required-level="20" auto-learn="true" />
+		<skill name="Heavy Armor Mastery" id="399" level="1" required-level="20" sp="1000" />
+		<skill name="Recover HP" id="45176" level="1" required-level="20" sp="1000" />
+		<skill name="Recover MP" id="45177" level="1" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="1" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="2" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="3" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="4" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="5" required-level="20" sp="1000" />
+		<skill name="Bandage" id="34" level="1" required-level="20" sp="1000" />
+		<skill name="Absorb Light Souls" id="393" level="1" required-level="20" sp="1000" />
+		<skill name="Soul Smash" id="477" level="1" required-level="20" sp="1000" />
+		<skill name="Ability to Protect" id="91" level="2" required-level="20" sp="1000" />
+		<skill name="Emergency Rescue" id="70" level="3" required-level="20" sp="1000" />
 
-        <skill name="Soul Roar" id="1441" level="1" required-level="28" sp="5500" />
+		<!-- Skills Lv21 -->
+		<skill name="Enhanced Weapon" id="255" level="6" required-level="21" sp="2500" />
 
-        <skill name="Ancient Sword Mastery" id="472" level="2" required-level="30" sp="10000" />
-        <skill name="Light Armor Mastery" id="465" level="2" required-level="30" sp="10000" />
-        <skill name="Heavy Armor Mastery" id="399" level="2" required-level="30" sp="10000" />
-        <skill name="Soul Smash" id="477" level="2" required-level="30" sp="10000" />
+		<!-- Skills Lv22 -->
+		<skill name="Enhanced Weapon" id="255" level="7" required-level="22" sp="2500" />
 
-        <skill name="Death Mark" id="1435" level="2" required-level="32" sp="10000"/>
+		<!-- Skills Lv23 -->
+		<skill name="Enhanced Weapon" id="255" level="8" required-level="23" sp="2500" />
 
-        <skill name="Courage" id="499" level="1" required-level="35" sp="20000"/>
+		<!-- Skills Lv24 -->
+		<skill name="Enhanced Weapon" id="255" level="9" required-level="24" sp="2500" />
+
+		<!-- Skills Lv25 -->
+		<skill name="Magic Immunity" id="466" level="1" required-level="25" sp="5500" />
+		<skill name="Enhanced Weapon" id="255" level="10" required-level="25" sp="5500" />
+		<skill name="Ability to Attack" id="77" level="2" required-level="25" sp="5500" />
+		<skill name="Increase Power" id="1432" level="1" required-level="25" sp="5500" />
+		<skill name="Emergency Rescue" id="70" level="4" required-level="25" sp="5500" />
+
+		<!-- Skills Lv26 -->
+		<skill name="Enhanced Weapon" id="255" level="11" required-level="26" sp="5500" />
+
+		<!-- Skills Lv27 -->
+		<skill name="Enhanced Weapon" id="255" level="12" required-level="27" sp="5500" />
+
+		<!-- Skills Lv28 -->
+		<skill name="Enhanced Weapon" id="255" level="13" required-level="28" sp="5500" />
+		<skill name="Soul Roar" id="1441" level="1" required-level="28" sp="5500" />
+
+		<!-- Skills Lv29 -->
+		<skill name="Enhanced Weapon" id="255" level="14" required-level="29" sp="10000" />
+
+		<!-- Master Buffs Lv. 30 -->
+		<skill name="Soul Empower" id="45147" level="2" required-level="30" sp="10000" />
+		<skill name="Soul Wild Magic" id="45148" level="1" required-level="30" sp="10000" />
+		<skill name="Soul Berserker Spirit" id="45149" level="1" required-level="30" sp="10000" />
+		<skill name="Soul Wind Walk" id="45142" level="2" required-level="30" sp="10000" />
+		<skill name="Soul Magic Barrier" id="45143" level="1" required-level="30" sp="10000" />
+		<skill name="Soul Acumen" id="45146" level="2" required-level="30" sp="10000" />
+		<skill name="Soul Focus" id="45139" level="2" required-level="30" sp="10000" />
+		<skill name="Soul Clarity" id="45150" level="2" required-level="30" sp="10000" />
+		<skill name="Soul Death Whisper" id="45140" level="2" required-level="30" sp="10000" />
+
+		<!-- Skills Lv30 -->
+		<skill name="Ancient Sword Mastery" id="472" level="2" required-level="30" sp="10000" />
+		<skill name="Light Armor Mastery" id="465" level="2" required-level="30" sp="10000" />
+		<skill name="Heavy Armor Mastery" id="399" level="2" required-level="30" sp="10000" />
+		<skill name="Enhanced Weapon" id="255" level="15" required-level="30" sp="11000" />
+		<skill name="Soul Smash" id="477" level="2" required-level="30" sp="10000" />
+		<skill name="Emergency Rescue" id="70" level="5" required-level="30" sp="10000" />
+
+		<!-- Skills Lv32 -->
+		<skill name="Death Mark" id="1435" level="2" required-level="32" sp="10000" />
+		<skill name="Emergency Rescue" id="70" level="6" required-level="32" sp="10000" />
+
+		<!-- Skills Lv34 -->
+		<skill name="Emergency Rescue" id="70" level="7" required-level="34" sp="20000" />
+
+		<!-- Skills Lv35 -->
+		<skill name="Courage" id="499" level="1" required-level="35" sp="20000" />
+
+		<!-- Skills Lv36 -->
+		<skill name="Emergency Rescue" id="70" level="8" required-level="36" sp="20000" />
+
+		<!-- Skills Lv38 -->
+		<skill name="Emergency Rescue" id="70" level="9" required-level="38" sp="20000" />
 
     </skillTree>
 </list>

--- a/data/skillTrees/1stClass/Warden.xml
+++ b/data/skillTrees/1stClass/Warden.xml
@@ -2,26 +2,69 @@
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
     <skillTree type="classSkillTree" classId="126" parentClassId="192">
 
-        <skill name="Armor Mastery" id="464" level="2" required-level="20" sp="1000" />
-        <skill name="Light Armor Mastery" id="465" level="1" required-level="20" sp="1000" />
-        <skill name="Weapon Mastery" id="463" level="2" required-level="20" sp="1000" />
-        <skill name="Bow Mastery" id="767" level="1" required-level="20" sp="1000" />
-        <skill name="Light Master" id="45178" level="1" required-level="20"  />
-        <skill name="Long Shot" id="113" level="1" required-level="20" sp="1000" />
-        <skill name="Shine Soul Finding" id="393" level="1" required-level="20" sp="1000" />
-        <skill name="Dash" id="4" level="1" required-level="20" sp="1000" />
-        <skill name="Twin Shot" id="45168" level="1" required-level="20" sp="1000" />
+		<!-- Master Buffs Lv. 20 -->
+		<skill name="Soul Empower" id="45147" level="1" required-level="20" sp="1000" />
+		<skill name="Soul Wind Walk" id="45142" level="1" required-level="20" sp="1000" />
+		<skill name="Soul Might" id="45144" level="2" required-level="20" sp="1000" />
+		<skill name="Soul Acumen" id="45146" level="1" required-level="20" sp="1000" />
+		<skill name="Soul Haste" id="45141" level="1" required-level="20" sp="1000" />
+		<skill name="Soul Focus" id="45139" level="1" required-level="20" sp="1000" />
+		<skill name="Soul Clarity" id="45150" level="1" required-level="20" sp="1000" />
+		<skill name="Soul Death Whisper" id="45140" level="1" required-level="20" sp="1000" />
+		<skill name="Soul Shield" id="45145" level="2" required-level="20" sp="1000" />
 
-        <skill name="Magic Immunity" id="466" level="1" required-level="25" sp="5500" />
 
-        <skill name="Ultimate Escape" id="622" level="1" required-level="28" sp="5500" />
+		<!-- Skills Lv20 -->
+		<skill name="Fast Run" id="4" level="1" required-level="20" sp="1000" />
+		<skill name="Armor Mastery" id="464" level="2" required-level="20" sp="1000" />
+		<skill name="Light Armor Mastery" id="465" level="1" required-level="20" sp="1000" />
+		<skill name="Bow Mastery" id="767" level="1" required-level="20" sp="1000" />
+		<skill name="Weapon Mastery" id="463" level="2" required-level="20" sp="1000" />
+		<skill name="Light Master" id="45178" level="1" required-level="20" auto-learn="true" />
+		<skill name="Recover HP" id="45176" level="1" required-level="20" sp="1000" />
+		<skill name="Recover MP" id="45177" level="1" required-level="20" sp="1000" />
+		<skill name="Long Shot" id="113" level="1" required-level="20" sp="1000" />
+		<skill name="Absorb Light Souls" id="393" level="1" required-level="20" sp="1000" />
+		<skill name="Twin Shot" id="45168" level="1" required-level="20" sp="1000" />
+		<skill name="Ability to Protect" id="91" level="2" required-level="20" sp="1000" />
+		<skill name="Emergency Rescue" id="70" level="3" required-level="20" sp="1000" />
 
-        <skill name="Light Armor Mastery" id="465" level="2" required-level="30" sp="10000" />
-        <skill name="Bow Mastery" id="767" level="2" required-level="30" sp="10000" />
-        <skill name="Twin Shot" id="45168" level="2" required-level="30" sp="10000" />
+		<!-- Skills Lv25 -->
+		<skill name="Magic Immunity" id="466" level="1" required-level="25" sp="5500" />
+		<skill name="Ability to Attack" id="77" level="2" required-level="25" sp="5500" />
+		<skill name="Emergency Rescue" id="70" level="4" required-level="25" sp="5500" />
 
-        <skill name="Rapid Shot" id="99" level="1" required-level="32" sp="10000"/>
-        <skill name="Death Mark" id="1435" level="2" required-level="32" sp="10000"/>
+		<!-- Skills Lv28 -->
+		<skill name="Ultimate Escape" id="622" level="1" required-level="28" sp="5500" />
+
+		<!-- Skills Lv30 -->
+		<skill name="Light Armor Mastery" id="465" level="2" required-level="30" sp="10000" />
+		<skill name="Bow Mastery" id="767" level="2" required-level="30" sp="10000" />
+		<skill name="Soul Empower" id="45147" level="2" required-level="30" sp="10000" />
+		<skill name="Soul Wild Magic" id="45148" level="1" required-level="30" sp="10000" />
+		<skill name="Soul Berserker Spirit" id="45149" level="1" required-level="30" sp="10000" />
+		<skill name="Soul Wind Walk" id="45142" level="2" required-level="30" sp="10000" />
+		<skill name="Soul Magic Barrier" id="45143" level="1" required-level="30" sp="10000" />
+		<skill name="Soul Acumen" id="45146" level="2" required-level="30" sp="10000" />
+		<skill name="Twin Shot" id="45168" level="2" required-level="30" sp="10000" />
+		<skill name="Soul Focus" id="45139" level="2" required-level="30" sp="10000" />
+		<skill name="Soul Clarity" id="45150" level="2" required-level="30" sp="10000" />
+		<skill name="Soul Death Whisper" id="45140" level="2" required-level="30" sp="10000" />
+		<skill name="Emergency Rescue" id="70" level="5" required-level="30" sp="10000" />
+
+		<!-- Skills Lv32 -->
+		<skill name="Rapid Shot" id="99" level="1" required-level="32" sp="10000" />
+		<skill name="Death Mark" id="1435" level="2" required-level="32" sp="10000" />
+		<skill name="Emergency Rescue" id="70" level="6" required-level="32" sp="10000" />
+
+		<!-- Skills Lv34 -->
+		<skill name="Emergency Rescue" id="70" level="7" required-level="34" sp="20000" />
+
+		<!-- Skills Lv36 -->
+		<skill name="Emergency Rescue" id="70" level="8" required-level="36" sp="20000" />
+
+		<!-- Skills Lv38 -->
+		<skill name="Emergency Rescue" id="70" level="9" required-level="38" sp="20000" />
 
     </skillTree>
 </list>

--- a/data/skillTrees/1stClass/Warrior.xml
+++ b/data/skillTrees/1stClass/Warrior.xml
@@ -1,121 +1,196 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="1" parentClassId="0">
-		<skill name="Shock Attack" id="100" level="1" required-level="20" sp="1000" />
-		<skill name="Shock Attack" id="100" level="2" required-level="20" sp="1000" />
-		<skill name="Shock Attack" id="100" level="3" required-level="20" sp="1000" />
-		<skill name="Vicious Stance" id="312" level="1" required-level="20" sp="1000" />
-		<skill name="Polearm Mastery" id="216" level="1" required-level="20" sp="1000" />
+
+		<!-- Master Buffs Lv. 20 -->
+		<skill name="Empower" id="45105" level="1" required-level="20" sp="1000" />
+		<skill name="Wind Walk" id="45107" level="1" required-level="20" sp="1000" />
+		<skill name="Might" id="1068" level="2" required-level="20" sp="1000" />
+		<skill name="Acumen" id="45104" level="1" required-level="20" sp="1000" />
+		<skill name="Haste" id="45111" level="1" required-level="20" sp="1000" />
+		<skill name="Focus" id="45109" level="1" required-level="20" sp="1000" />
+		<skill name="Clarity" id="45113" level="1" required-level="20" sp="1000" />
+		<skill name="Death Whisper" id="45110" level="1" required-level="20" sp="1000" />
+		<skill name="Shield" id="1040" level="2" required-level="20" sp="1000" />
+		<skill name="Recover HP" id="45176" level="1" required-level="20" sp="1000" />
+		<skill name="Recover MP" id="45177" level="1" required-level="20" sp="1000" />
+
+		<!-- Skills Lv20 -->
+		<skill name="Power Strike" id="3" level="10" required-level="20" sp="1000" />
+		<skill name="Power Strike" id="3" level="11" required-level="20" sp="1000" />
+		<skill name="Power Strike" id="3" level="12" required-level="20" sp="1000" />
+		<skill name="Bandage" id="34" level="1" required-level="20" sp="1000" />
+		<skill name="Emergency Rescue" id="70" level="3" required-level="20" sp="1000" />
+		<skill name="Detect Weakness" id="75" level="1" required-level="20" sp="1000" />
+		<skill name="War Cry" id="78" level="1" required-level="20" sp="1000" />
+		<skill name="Belief" id="80" level="1" required-level="20" sp="1000" />
+		<skill name="Ability to Protect" id="91" level="2" required-level="20" sp="1000" />
+		<skill name="Shock Mastery" id="100" level="1" required-level="20" sp="1000" />
+		<skill name="Shock Mastery" id="100" level="2" required-level="20" sp="1000" />
+		<skill name="Shock Mastery" id="100" level="3" required-level="20" sp="1000" />
+		<skill name="Shock Mastery" id="100" level="4" required-level="20" sp="1000" />
+		<skill name="Shock Mastery" id="100" level="5" required-level="20" sp="1000" />
+		<skill name="Boost HP" id="211" level="1" required-level="20" sp="1000" />
 		<skill name="Light Armor Mastery" id="227" level="1" required-level="20" sp="1000" />
 		<skill name="Light Armor Mastery" id="227" level="2" required-level="20" sp="1000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="1" required-level="20" sp="1000" />
+		<skill name="Polearm Mastery" id="216" level="1" required-level="20" sp="1000" />
 		<skill name="Heavy Armor Mastery" id="231" level="1" required-level="20" sp="1000" />
 		<skill name="Heavy Armor Mastery" id="231" level="2" required-level="20" sp="1000" />
 		<skill name="Wild Sweep" id="245" level="1" required-level="20" sp="1000" />
 		<skill name="Wild Sweep" id="245" level="2" required-level="20" sp="1000" />
 		<skill name="Wild Sweep" id="245" level="3" required-level="20" sp="1000" />
-		<skill name="War Cry" id="78" level="1" required-level="20" sp="1000" />
-		<skill name="Power Smash" id="255" level="1" required-level="20" sp="1000" />
-		<skill name="Power Smash" id="255" level="2" required-level="20" sp="1000" />
-		<skill name="Power Smash" id="255" level="3" required-level="20" sp="1000" />
-		<skill name="Boost HP" id="211" level="1" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="1" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="2" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="3" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="4" required-level="20" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="5" required-level="20" sp="1000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="1" required-level="20" sp="1000" />
+		<skill name="Vicious Stance" id="312" level="1" required-level="20" sp="1000" />
 
-		<skill name="Shock Attack" id="100" level="4" required-level="22" sp="2800" />
+
+		<!-- Skills Lv21 -->
+		<skill name="Shock Mastery" id="100" level="6" required-level="21" sp="1000" />
+		<skill name="Enhanced Weapon" id="255" level="6" required-level="21" sp="1000" />
+
+		<!-- Skills Lv22 -->
 		<skill name="Light Armor Mastery" id="227" level="3" required-level="22" sp="2800" />
+		<skill name="Shock Mastery" id="100" level="7" required-level="22" sp="2800" />
 		<skill name="Heavy Armor Mastery" id="231" level="3" required-level="22" sp="2800" />
 		<skill name="Wild Sweep" id="245" level="4" required-level="22" sp="2800" />
-		<skill name="Power Smash" id="255" level="4" required-level="22" sp="2800" />
-		
-		<skill name="Shock Attack" id="100" level="5" required-level="23" sp="2800" />
+		<skill name="Enhanced Weapon" id="255" level="7" required-level="22" sp="2800" />
+		<skill name="Power Strike" id="3" level="13" required-level="22" sp="2800" />
+
+		<!-- Skills Lv23 -->
+		<skill name="Power Strike" id="3" level="14" required-level="23" sp="2800" />
+		<skill name="Shock Mastery" id="100" level="8" required-level="23" sp="2800" />
 		<skill name="Wild Sweep" id="245" level="5" required-level="23" sp="2800" />
-		<skill name="Power Smash" id="255" level="5" required-level="23" sp="2800" />
-		
-		<skill name="Shock Attack" id="100" level="6" required-level="24" sp="2800" />
+		<skill name="Enhanced Weapon" id="255" level="8" required-level="23" sp="2800" />
+
+		<!-- Skills Lv24 -->
 		<skill name="Vicious Stance" id="312" level="2" required-level="24" sp="2800" />
 		<skill name="Fast HP Recovery" id="212" level="1" required-level="24" sp="2800" />
 		<skill name="Polearm Mastery" id="216" level="2" required-level="24" sp="2800" />
 		<skill name="Light Armor Mastery" id="227" level="4" required-level="24" sp="2800" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="2" required-level="24" sp="2800" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="2" required-level="24" sp="2800" />
+		<skill name="Shock Mastery" id="100" level="9" required-level="24" sp="2800" />
 		<skill name="Heavy Armor Mastery" id="231" level="4" required-level="24" sp="2800" />
 		<skill name="Wild Sweep" id="245" level="6" required-level="24" sp="2800" />
 		<skill name="Vital Force" id="148" level="1" required-level="24" sp="2800" />
-		<skill name="Power Smash" id="255" level="6" required-level="24" sp="2800" />
+		<skill name="Enhanced Weapon" id="255" level="9" required-level="24" sp="2800" />
+		<skill name="Power Strike" id="3" level="15" required-level="24" sp="2800" />
 		<skill name="Accuracy" id="256" level="1" required-level="24" sp="2800" />
-		
-		<skill name="Shock Attack" id="100" level="7" required-level="26" sp="5700" />
+
+		<!-- Skills Lv25 -->
+		<skill name="Shock Mastery" id="100" level="10" required-level="25" sp="2800" />
+		<skill name="Enhanced Weapon" id="255" level="10" required-level="25" sp="2800" />
+		<skill name="Ability to Attack" id="77" level="2" required-level="25" sp="2800" />
+		<skill name="Emergency Rescue" id="70" level="4" required-level="25" sp="2800" />
+
+		<!-- Skills Lv26 -->
 		<skill name="Polearm Mastery" id="216" level="3" required-level="26" sp="5700" />
 		<skill name="Light Armor Mastery" id="227" level="5" required-level="26" sp="5700" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="3" required-level="26" sp="5700" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="3" required-level="26" sp="5700" />
+		<skill name="Shock Mastery" id="100" level="11" required-level="26" sp="5700" />
 		<skill name="Heavy Armor Mastery" id="231" level="5" required-level="26" sp="5700" />
 		<skill name="Wild Sweep" id="245" level="7" required-level="26" sp="5700" />
-		<skill name="Power Smash" id="255" level="7" required-level="26" sp="5700" />
-		
-		<skill name="Shock Attack" id="100" level="8" required-level="27" sp="5700" />
+		<skill name="Enhanced Weapon" id="255" level="11" required-level="26" sp="5700" />
+		<skill name="Power Strike" id="3" level="16" required-level="26" sp="5700" />
+
+		<!-- Skills Lv27 -->
 		<skill name="Light Armor Mastery" id="227" level="6" required-level="27" sp="5700" />
+		<skill name="Shock Mastery" id="100" level="12" required-level="27" sp="5700" />
 		<skill name="Heavy Armor Mastery" id="231" level="6" required-level="27" sp="5700" />
 		<skill name="Wild Sweep" id="245" level="8" required-level="27" sp="5700" />
-		<skill name="Power Smash" id="255" level="8" required-level="27" sp="5700" />
-		
-		<skill name="Shock Attack" id="100" level="9" required-level="28" sp="5700" />
+		<skill name="Enhanced Weapon" id="255" level="12" required-level="27" sp="5700" />
+		<skill name="Power Strike" id="3" level="17" required-level="27" sp="5700" />
+
+		<!-- Skills Lv28 -->
 		<skill name="Vicious Stance" id="312" level="3" required-level="28" sp="5700" />
 		<skill name="Battle Roar" id="121" level="1" required-level="28" sp="5700" />
 		<skill name="Polearm Mastery" id="216" level="4" required-level="28" sp="5700" />
 		<skill name="Light Armor Mastery" id="227" level="7" required-level="28" sp="5700" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="4" required-level="28" sp="5700" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="4" required-level="28" sp="5700" />
+		<skill name="Shock Mastery" id="100" level="13" required-level="28" sp="5700" />
 		<skill name="Heavy Armor Mastery" id="231" level="7" required-level="28" sp="5700" />
 		<skill name="Wild Sweep" id="245" level="9" required-level="28" sp="5700" />
-		<skill name="Power Smash" id="255" level="9" required-level="28" sp="5700" />
+		<skill name="Enhanced Weapon" id="255" level="13" required-level="28" sp="5700" />
+		<skill name="Power Strike" id="3" level="18" required-level="28" sp="5700" />
 		<skill name="Boost HP" id="211" level="2" required-level="28" sp="5700" />
-		
-		<skill name="Shock Attack" id="100" level="10" required-level="30" sp="11000" />
+
+		<!-- Skills Lv29 -->
+		<skill name="Shock Mastery" id="100" level="14" required-level="29" sp="11000" />
+		<skill name="Enhanced Weapon" id="255" level="14" required-level="29" sp="11000" />
+
+		<!-- Master Buffs Lv. 30 -->
+		<skill name="Empower" id="45105" level="2" required-level="30" sp="11000" />
+		<skill name="Wild Magic" id="45106" level="1" required-level="30" sp="11000" />
+		<skill name="Berserker Spirit" id="45112" level="1" required-level="30" sp="11000" />
+		<skill name="Wind Walk" id="45107" level="2" required-level="30" sp="11000" />
+		<skill name="Magic Barrier" id="45108" level="1" required-level="30" sp="11000" />
+		<skill name="Acumen" id="45104" level="2" required-level="30" sp="11000" />
+		<skill name="Focus" id="45109" level="2" required-level="30" sp="11000" />
+		<skill name="Clarity" id="45113" level="2" required-level="30" sp="11000" />
+		<skill name="Death Whisper" id="45110" level="2" required-level="30" sp="11000" />
+
+		<!-- Skills Lv30 -->
 		<skill name="Polearm Mastery" id="216" level="5" required-level="30" sp="11000" />
 		<skill name="Light Armor Mastery" id="227" level="8" required-level="30" sp="11000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="5" required-level="30" sp="11000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="5" required-level="30" sp="11000" />
+		<skill name="Shock Mastery" id="100" level="15" required-level="30" sp="11000" />
 		<skill name="Heavy Armor Mastery" id="231" level="8" required-level="30" sp="11000" />
 		<skill name="Wild Sweep" id="245" level="10" required-level="30" sp="11000" />
-		<skill name="Power Smash" id="255" level="10" required-level="30" sp="11000" />
-		
-		<skill name="Shock Attack" id="100" level="11" required-level="31" sp="11000" />
+		<skill name="Enhanced Weapon" id="255" level="15" required-level="30" sp="11000" />
+		<skill name="Power Strike" id="3" level="19" required-level="30" sp="11000" />
+		<skill name="Struggle" id="87" level="1" required-level="30" sp="11000" />
+		<skill name="Emergency Rescue" id="70" level="5" required-level="30" sp="11000" />
+
+		<!-- Skills Lv31 -->
 		<skill name="Light Armor Mastery" id="227" level="9" required-level="31" sp="11000" />
 		<skill name="Heavy Armor Mastery" id="231" level="9" required-level="31" sp="11000" />
 		<skill name="Wild Sweep" id="245" level="11" required-level="31" sp="11000" />
-		<skill name="Power Smash" id="255" level="11" required-level="31" sp="11000" />
-		
-		<skill name="Shock Attack" id="100" level="12" required-level="32" sp="11000" />
+		<skill name="Power Strike" id="3" level="20" required-level="31" sp="11000" />
+
+		<!-- Skills Lv32 -->
 		<skill name="Vicious Stance" id="312" level="4" required-level="32" sp="11000" />
 		<skill name="Fast HP Recovery" id="212" level="2" required-level="32" sp="11000" />
 		<skill name="Polearm Mastery" id="216" level="6" required-level="32" sp="11000" />
 		<skill name="Light Armor Mastery" id="227" level="10" required-level="32" sp="11000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="6" required-level="32" sp="11000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="6" required-level="32" sp="11000" />
 		<skill name="Heavy Armor Mastery" id="231" level="10" required-level="32" sp="11000" />
 		<skill name="Wild Sweep" id="245" level="12" required-level="32" sp="11000" />
 		<skill name="Vital Force" id="148" level="2" required-level="32" sp="11000" />
-		<skill name="Power Smash" id="255" level="12" required-level="32" sp="11000" />
-		<skill name="Detect Insect Weakness" id="75" level="1" required-level="32" sp="11000" />
-		
-		<skill name="Shock Attack" id="100" level="13" required-level="34" sp="20000" />
+		<skill name="Power Strike" id="3" level="21" required-level="32" sp="11000" />
+		<skill name="Emergency Rescue" id="70" level="6" required-level="32" sp="11000" />
+
+		<!-- Skills Lv34 -->
 		<skill name="Polearm Mastery" id="216" level="7" required-level="34" sp="20000" />
 		<skill name="Light Armor Mastery" id="227" level="11" required-level="34" sp="20000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="7" required-level="34" sp="20000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="7" required-level="34" sp="20000" />
 		<skill name="Heavy Armor Mastery" id="231" level="11" required-level="34" sp="20000" />
 		<skill name="Wild Sweep" id="245" level="13" required-level="34" sp="20000" />
-		<skill name="Power Smash" id="255" level="13" required-level="34" sp="20000" />
-		
-		<skill name="Shock Attack" id="100" level="14" required-level="35" sp="20000" />
+		<skill name="Power Strike" id="3" level="22" required-level="34" sp="20000" />
+		<skill name="Emergency Rescue" id="70" level="7" required-level="34" sp="20000" />
+
+		<!-- Skills Lv35 -->
 		<skill name="Light Armor Mastery" id="227" level="12" required-level="35" sp="20000" />
 		<skill name="Heavy Armor Mastery" id="231" level="12" required-level="35" sp="20000" />
 		<skill name="Wild Sweep" id="245" level="14" required-level="35" sp="20000" />
-		<skill name="Power Smash" id="255" level="14" required-level="35" sp="20000" />
-		
-		<skill name="Shock Attack" id="100" level="15" required-level="36" sp="20000" />
+		<skill name="Power Strike" id="3" level="23" required-level="35" sp="20000" />
+
+		<!-- Skills Lv36 -->
 		<skill name="Vicious Stance" id="312" level="5" required-level="36" sp="20000" />
 		<skill name="Polearm Mastery" id="216" level="8" required-level="36" sp="20000" />
 		<skill name="Light Armor Mastery" id="227" level="13" required-level="36" sp="20000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="8" required-level="36" sp="20000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="8" required-level="36" sp="20000" />
 		<skill name="Heavy Armor Mastery" id="231" level="13" required-level="36" sp="20000" />
 		<skill name="Wild Sweep" id="245" level="15" required-level="36" sp="20000" />
 		<skill name="Lionheart" id="287" level="1" required-level="36" sp="20000" />
-		<skill name="Power Smash" id="255" level="15" required-level="36" sp="20000" />
+		<skill name="Power Strike" id="3" level="24" required-level="36" sp="20000" />
 		<skill name="Boost HP" id="211" level="3" required-level="36" sp="20000" />
+		<skill name="Emergency Rescue" id="70" level="8" required-level="36" sp="20000" />
+
+		<!-- Skills Lv38 -->
+		<skill name="Emergency Rescue" id="70" level="9" required-level="38" sp="20000" />
+		
 	</skillTree>
 </list>

--- a/data/skillTrees/2ndClass/AbyssWalker.xml
+++ b/data/skillTrees/2ndClass/AbyssWalker.xml
@@ -1,191 +1,231 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="36" parentClassId="35">
-		<skill name="Pirate" id="1800" level="1" required-level="45" auto-learn="true" />
-		<skill name="Dark Assassin" id="1801" level="1" required-level="60" auto-learn="true" />
-		<skill name="White Assassin" id="1802" level="1" required-level="70" auto-learn="true" />
+
+		<!-- Skills Lv40 -->
 		<skill name="Silent Move" id="221" level="1" required-level="40" sp="65000" />
 		<skill name="Vicious Stance" id="312" level="6" required-level="40" sp="65000" />
+		<skill name="Potion Mastery" id="45184" level="1" required-level="40">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Dagger Mastery" id="209" level="9" required-level="40" sp="65000" />
 		<skill name="Dagger Mastery" id="209" level="10" required-level="40" sp="65000" />
 		<skill name="Dagger Mastery" id="209" level="11" required-level="40" sp="65000" />
 		<skill name="Light Armor Mastery" id="233" level="11" required-level="40" sp="65000" />
 		<skill name="Light Armor Mastery" id="233" level="12" required-level="40" sp="65000" />
 		<skill name="Light Armor Mastery" id="233" level="13" required-level="40" sp="65000" />
-		<skill name="Sting" id="223" level="13" required-level="40" sp="65000" />
-		<skill name="Sting" id="223" level="14" required-level="40" sp="65000" />
-		<skill name="Sting" id="223" level="15" required-level="40" sp="65000" />
+		<skill name="Weapon Mastery" id="141" level="4" required-level="40" sp="65000" />
 		<skill name="Confusion" id="2" level="5" required-level="40" sp="65000" />
-		<skill name="Freezing Strike" id="105" level="3" required-level="40" sp="65000" />
-		<skill name="Freezing Strike" id="105" level="4" required-level="40" sp="65000" />
-		<skill name="Drain Energy" id="70" level="17" required-level="40" sp="65000" />
-		<skill name="Drain Energy" id="70" level="18" required-level="40" sp="65000" />
-		<skill name="Drain Energy" id="70" level="19" required-level="40" sp="65000" />
+		<skill name="Freezing Weapon" id="105" level="5" required-level="40" sp="65000" />
+		<skill name="Drain Energy" id="45250" level="6" required-level="40" sp="65000" />
 		<skill name="Critical Damage" id="193" level="3" required-level="40" sp="65000" />
+		<skill name="Blood Attack" id="223" level="15" required-level="40" sp="65000" />
+		<skill name="Sharpness" id="53009" level="1" required-level="40" sp="65000" />
 		<skill name="Unlock" id="27" level="6" required-level="40" sp="65000" />
+		<skill name="Hex" id="122" level="1" required-level="40" sp="65000" />
+		<skill name="Power Break" id="115" level="3" required-level="40" sp="65000" />
 		<skill name="Deadly Blow" id="263" level="1" required-level="40" sp="65000" />
 		<skill name="Deadly Blow" id="263" level="2" required-level="40" sp="65000" />
 		<skill name="Deadly Blow" id="263" level="3" required-level="40" sp="65000" />
-		<skill name="Power Break" id="115" level="3" required-level="40" sp="65000" />
+		<skill name="Deadly Blow" id="263" level="4" required-level="40" sp="65000" />
+		<skill name="Deadly Blow" id="263" level="5" required-level="40" sp="65000" />
+		<skill name="Accuracy" id="256" level="2" required-level="40" sp="110000" />
 		<skill name="Backstab" id="30" level="1" required-level="40" sp="65000" />
 		<skill name="Backstab" id="30" level="2" required-level="40" sp="65000" />
 		<skill name="Backstab" id="30" level="3" required-level="40" sp="65000" />
-		<skill name="Potion Mastery" id="45184" level="1" required-level="40">
-			<item id="57" count="1000000"/> <!-- Adena -->
-		</skill>
-		<skill name="Hex" id="122" level="1" required-level="40" sp="65000">
-			<item id="3050"/>
-		</skill>
+		<skill name="Emergency Rescue" id="70" level="10" required-level="40" sp="65000" />
 
+		<!-- Master Buffs Lv. 40 -->
+		<skill name="Might" id="1068" level="3" required-level="40" sp="80000" />
+		<skill name="Shield" id="1040" level="3" required-level="40" sp="80000" />
+		<skill name="Acumen" id="45104" level="3" required-level="40" sp="80000" />
+		<skill name="Empower" id="45105" level="3" required-level="40" sp="80000" />
+		<skill name="Wild Magic" id="45106" level="2" required-level="40" sp="80000" />
+		<skill name="Magic Barrier" id="45108" level="2" required-level="40" sp="80000" />
+		<skill name="Focus" id="45109" level="3" required-level="40" sp="80000" />
+		<skill name="Death Whisper" id="45110" level="3" required-level="40" sp="80000" />
+		<skill name="Haste" id="45111" level="2" required-level="40" sp="80000" />
+		<skill name="Berserker Spirit" id="45112" level="2" required-level="40" sp="80000" />
+		<skill name="Clarity" id="45113" level="3" required-level="40" sp="80000" />
+
+
+		<!-- Skills Lv41 -->
 		<skill name="Dagger Mastery" id="209" level="12" required-level="41" sp="76000" />
 		<skill name="Light Armor Mastery" id="233" level="14" required-level="41" sp="76000" />
-		<skill name="Sting" id="223" level="16" required-level="41" sp="76000" />
-		<skill name="Drain Energy" id="70" level="20" required-level="41" sp="76000" />
-		<skill name="Deadly Blow" id="263" level="4" required-level="41" sp="76000" />
+		<skill name="Blood Attack" id="223" level="16" required-level="41" sp="76000" />
+		<skill name="Deadly Blow" id="263" level="6" required-level="41" sp="76000" />
 		<skill name="Backstab" id="30" level="4" required-level="41" sp="76000" />
-		
+		<skill name="Emergency Rescue" id="70" level="11" required-level="41" sp="76000" />
+
+		<!-- Skills Lv42 -->
 		<skill name="Dagger Mastery" id="209" level="13" required-level="42" sp="76000" />
 		<skill name="Light Armor Mastery" id="233" level="15" required-level="42" sp="76000" />
-		<skill name="Sting" id="223" level="17" required-level="42" sp="76000" />
-		<skill name="Freezing Strike" id="105" level="5" required-level="42" sp="76000" />
-		<skill name="Drain Energy" id="70" level="21" required-level="42" sp="76000" />
-		<skill name="Deadly Blow" id="263" level="5" required-level="42" sp="76000" />
+		<skill name="Freezing Weapon" id="105" level="6" required-level="42" sp="76000" />
+		<skill name="Drain Energy" id="45250" level="7" required-level="42" sp="76000" />
+		<skill name="Blood Attack" id="223" level="17" required-level="42" sp="76000" />
+		<skill name="Deadly Blow" id="263" level="7" required-level="42" sp="76000" />
 		<skill name="Backstab" id="30" level="5" required-level="42" sp="76000" />
-		
+		<skill name="Emergency Rescue" id="70" level="12" required-level="42" sp="76000" />
+
+		<!-- Skills Lv43 -->
 		<skill name="Acrobatic Move" id="225" level="2" required-level="43" sp="76000" />
 		<skill name="Vicious Stance" id="312" level="7" required-level="43" sp="76000" />
 		<skill name="Esprit" id="171" level="2" required-level="43" sp="76000" />
 		<skill name="Quick Step" id="169" level="2" required-level="43" sp="76000" />
 		<skill name="Dagger Mastery" id="209" level="14" required-level="43" sp="76000" />
 		<skill name="Light Armor Mastery" id="233" level="16" required-level="43" sp="76000" />
-		<skill name="Sting" id="223" level="18" required-level="43" sp="76000" />
 		<skill name="Confusion" id="2" level="6" required-level="43" sp="76000" />
-		<skill name="Freezing Strike" id="105" level="6" required-level="43" sp="76000" />
-		<skill name="Drain Energy" id="70" level="22" required-level="43" sp="76000" />
+		<skill name="Blood Attack" id="223" level="18" required-level="43" sp="76000" />
 		<skill name="Unlock" id="27" level="7" required-level="43" sp="76000" />
 		<skill name="Hex" id="122" level="2" required-level="43" sp="76000" />
-		<skill name="Deadly Blow" id="263" level="6" required-level="43" sp="76000" />
 		<skill name="Power Break" id="115" level="4" required-level="43" sp="76000" />
+		<skill name="Deadly Blow" id="263" level="8" required-level="43" sp="76000" />
 		<skill name="Backstab" id="30" level="6" required-level="43" sp="76000" />
+		<skill name="Emergency Rescue" id="70" level="13" required-level="43" sp="76000" />
 
+		<!-- Skills Lv44 -->
 		<skill name="Dagger Mastery" id="209" level="15" required-level="44" sp="110000" />
 		<skill name="Light Armor Mastery" id="233" level="17" required-level="44" sp="110000" />
-		<skill name="Sting" id="223" level="19" required-level="44" sp="110000" />
-		<skill name="Drain Energy" id="70" level="23" required-level="44" sp="110000" />
-		<skill name="Deadly Blow" id="263" level="7" required-level="44" sp="110000" />
+		<skill name="Freezing Weapon" id="105" level="7" required-level="44" sp="110000" />
+		<skill name="Drain Energy" id="45250" level="8" required-level="44" sp="110000" />
+		<skill name="Blood Attack" id="223" level="19" required-level="44" sp="110000" />
+		<skill name="Deadly Blow" id="263" level="9" required-level="44" sp="110000" />
 		<skill name="Backstab" id="30" level="7" required-level="44" sp="110000" />
-		
+		<skill name="Emergency Rescue" id="70" level="14" required-level="44" sp="110000" />
+
+		<!-- Skills Lv45 -->
 		<skill name="Dagger Mastery" id="209" level="16" required-level="45" sp="110000" />
 		<skill name="Light Armor Mastery" id="233" level="18" required-level="45" sp="110000" />
-		<skill name="Sting" id="223" level="20" required-level="45" sp="110000" />
-		<skill name="Freezing Strike" id="105" level="7" required-level="45" sp="110000" />
-		<skill name="Drain Energy" id="70" level="24" required-level="45" sp="110000" />
-		<skill name="Deadly Blow" id="263" level="8" required-level="45" sp="110000" />
+		<skill name="Blood Attack" id="223" level="20" required-level="45" sp="110000" />
+		<skill name="Deadly Blow" id="263" level="10" required-level="45" sp="110000" />
+		<skill name="Pirate Transformation" id="1800" level="1" required-level="45" auto-learn="true" />
 		<skill name="Backstab" id="30" level="8" required-level="45" sp="110000" />
-		
+		<skill name="Emergency Rescue" id="70" level="15" required-level="45" sp="110000" />
+
+		<!-- Skills Lv46 -->
 		<skill name="Vicious Stance" id="312" level="8" required-level="46" sp="110000" />
 		<skill name="Esprit" id="171" level="3" required-level="46" sp="110000" />
+		<skill name="Fast Run" id="4" level="2" required-level="46" sp="110000" />
 		<skill name="Dagger Mastery" id="209" level="17" required-level="46" sp="110000" />
 		<skill name="Light Armor Mastery" id="233" level="19" required-level="46" sp="110000" />
-		<skill name="Sting" id="223" level="21" required-level="46" sp="110000" />
 		<skill name="Confusion" id="2" level="7" required-level="46" sp="110000" />
-		<skill name="Freezing Strike" id="105" level="8" required-level="46" sp="110000" />
-		<skill name="Drain Energy" id="70" level="25" required-level="46" sp="110000" />
+		<skill name="Freezing Weapon" id="105" level="8" required-level="46" sp="110000" />
+		<skill name="Drain Energy" id="45250" level="9" required-level="46" sp="110000" />
+		<skill name="Blood Attack" id="223" level="21" required-level="46" sp="110000" />
 		<skill name="Unlock" id="27" level="8" required-level="46" sp="110000" />
 		<skill name="Hex" id="122" level="3" required-level="46" sp="110000" />
-		<skill name="Deadly Blow" id="263" level="9" required-level="46" sp="110000" />
 		<skill name="Power Break" id="115" level="5" required-level="46" sp="110000" />
+		<skill name="Deadly Blow" id="263" level="11" required-level="46" sp="110000" />
 		<skill name="Boost Evasion" id="198" level="2" required-level="46" sp="110000" />
 		<skill name="Backstab" id="30" level="9" required-level="46" sp="110000" />
+		<skill name="Emergency Rescue" id="70" level="16" required-level="46" sp="110000" />
 
+		<!-- Skills Lv47 -->
 		<skill name="Dagger Mastery" id="209" level="18" required-level="47" sp="160000" />
 		<skill name="Light Armor Mastery" id="233" level="20" required-level="47" sp="160000" />
-		<skill name="Sting" id="223" level="22" required-level="47" sp="160000" />
-		<skill name="Drain Energy" id="70" level="26" required-level="47" sp="160000" />
-		<skill name="Deadly Blow" id="263" level="10" required-level="47" sp="160000" />
+		<skill name="Blood Attack" id="223" level="22" required-level="47" sp="160000" />
+		<skill name="Deadly Blow" id="263" level="12" required-level="47" sp="160000" />
 		<skill name="Backstab" id="30" level="10" required-level="47" sp="160000" />
-		
+		<skill name="Emergency Rescue" id="70" level="17" required-level="47" sp="160000" />
+
+		<!-- Skills Lv48 -->
 		<skill name="Dagger Mastery" id="209" level="19" required-level="48" sp="160000" />
 		<skill name="Light Armor Mastery" id="233" level="21" required-level="48" sp="160000" />
-		<skill name="Sting" id="223" level="23" required-level="48" sp="160000" />
-		<skill name="Freezing Strike" id="105" level="9" required-level="48" sp="160000" />
-		<skill name="Drain Energy" id="70" level="27" required-level="48" sp="160000" />
-		<skill name="Deadly Blow" id="263" level="11" required-level="48" sp="160000" />
+		<skill name="Freezing Weapon" id="105" level="9" required-level="48" sp="160000" />
+		<skill name="Drain Energy" id="45250" level="10" required-level="48" sp="160000" />
+		<skill name="Blood Attack" id="223" level="23" required-level="48" sp="160000" />
+		<skill name="Deadly Blow" id="263" level="13" required-level="48" sp="160000" />
 		<skill name="Backstab" id="30" level="11" required-level="48" sp="160000" />
-		
+		<skill name="Emergency Rescue" id="70" level="18" required-level="48" sp="160000" />
+
+		<!-- Skills Lv49 -->
 		<skill name="Vicious Stance" id="312" level="9" required-level="49" sp="160000" />
 		<skill name="Esprit" id="171" level="4" required-level="49" sp="160000" />
 		<skill name="Dagger Mastery" id="209" level="20" required-level="49" sp="160000" />
 		<skill name="Light Armor Mastery" id="233" level="22" required-level="49" sp="160000" />
-		<skill name="Sting" id="223" level="24" required-level="49" sp="160000" />
 		<skill name="Confusion" id="2" level="8" required-level="49" sp="160000" />
-		<skill name="Freezing Strike" id="105" level="10" required-level="49" sp="160000" />
-		<skill name="Drain Energy" id="70" level="28" required-level="49" sp="160000" />
+		<skill name="Blood Attack" id="223" level="24" required-level="49" sp="160000" />
 		<skill name="Bleed" id="96" level="3" required-level="49" sp="160000" />
-		<skill name="Poison" id="129" level="2" required-level="49" sp="160000" />
 		<skill name="Hex" id="122" level="4" required-level="49" sp="160000" />
-		<skill name="Deadly Blow" id="263" level="12" required-level="49" sp="160000" />
 		<skill name="Power Break" id="115" level="6" required-level="49" sp="160000" />
+		<skill name="Deadly Blow" id="263" level="14" required-level="49" sp="160000" />
 		<skill name="Trick" id="11" level="1" required-level="49" sp="160000" />
 		<skill name="Backstab" id="30" level="12" required-level="49" sp="160000" />
+		<skill name="Emergency Rescue" id="70" level="19" required-level="49" sp="160000" />
 
+		<!-- Skills Lv50 -->
+		<skill name="Potion Mastery" id="45184" level="2" required-level="50">
+			<item id="57" count="3000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Dagger Mastery" id="209" level="21" required-level="50" sp="230000" />
 		<skill name="Light Armor Mastery" id="233" level="23" required-level="50" sp="230000" />
-		<skill name="Sting" id="223" level="25" required-level="50" sp="230000" />
-		<skill name="Drain Energy" id="70" level="29" required-level="50" sp="230000" />
-		<skill name="Deadly Blow" id="263" level="13" required-level="50" sp="230000" />
+		<skill name="Recover HP" id="45176" level="2" required-level="50" sp="300000" >
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Recover MP" id="45177" level="2" required-level="50" sp="300000" >
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Dark Elven Spirit" id="129" level="3" required-level="50" sp="230000" />
+		<skill name="Freezing Weapon" id="105" level="10" required-level="50" sp="230000" />
+		<skill name="Drain Energy" id="45250" level="11" required-level="50" sp="230000" />
+		<skill name="Blood Attack" id="223" level="25" required-level="50" sp="230000" />
+		<skill name="Deadly Blow" id="263" level="15" required-level="50" sp="230000" />
 		<skill name="Backstab" id="30" level="13" required-level="50" sp="230000" />
 		<skill name="Shadow Step" id="821" level="1" required-level="50" sp="230000" />
-		<skill name="Potion Mastery" id="45184" level="2" required-level="50">
-			<item id="57" count="3000000"/> <!-- Adena -->
-		</skill>
-		
+		<skill name="Emergency Rescue" id="70" level="20" required-level="50" sp="230000" />
+
+		<!-- Skills Lv51 -->
 		<skill name="Dagger Mastery" id="209" level="22" required-level="51" sp="230000" />
 		<skill name="Light Armor Mastery" id="233" level="24" required-level="51" sp="230000" />
-		<skill name="Sting" id="223" level="26" required-level="51" sp="230000" />
-		<skill name="Freezing Strike" id="105" level="11" required-level="51" sp="230000" />
-		<skill name="Drain Energy" id="70" level="30" required-level="51" sp="230000" />
-		<skill name="Deadly Blow" id="263" level="14" required-level="51" sp="230000" />
+		<skill name="Freezing Weapon" id="105" level="11" required-level="51" sp="230000" />
+		<skill name="Blood Attack" id="223" level="26" required-level="51" sp="230000" />
+		<skill name="Deadly Blow" id="263" level="16" required-level="51" sp="230000" />
+		<skill name="Hide" id="922" level="1" required-level="51" sp="230000" />
 		<skill name="Backstab" id="30" level="14" required-level="51" sp="230000" />
-		<skill name="Hide" id="922" level="1" required-level="51" sp="230000" >
-			<item id="49429"/>
-		</skill>
+		<skill name="Emergency Rescue" id="70" level="21" required-level="51" sp="230000" />
 
+		<!-- Skills Lv52 -->
 		<skill name="Vicious Stance" id="312" level="10" required-level="52" sp="230000" />
 		<skill name="Esprit" id="171" level="5" required-level="52" sp="230000" />
+		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="230000" >
+			<item id="8618" count="1" /> <!-- Ancient Book: Divine Inspiration (Modern Language Version) Lv 1 -->
+		</skill>
 		<skill name="Dagger Mastery" id="209" level="23" required-level="52" sp="230000" />
 		<skill name="Light Armor Mastery" id="233" level="25" required-level="52" sp="230000" />
-		<skill name="Sting" id="223" level="27" required-level="52" sp="230000" />
 		<skill name="Confusion" id="2" level="9" required-level="52" sp="230000" />
-		<skill name="Freezing Strike" id="105" level="12" required-level="52" sp="230000" />
-		<skill name="Drain Energy" id="70" level="31" required-level="52" sp="230000" />
+		<skill name="Freezing Weapon" id="105" level="12" required-level="52" sp="230000" />
+		<skill name="Drain Energy" id="45250" level="12" required-level="52" sp="230000" />
 		<skill name="Critical Damage" id="193" level="4" required-level="52" sp="230000" />
+		<skill name="Blood Attack" id="223" level="27" required-level="52" sp="230000" />
 		<skill name="Unlock" id="27" level="9" required-level="52" sp="230000" />
 		<skill name="Hex" id="122" level="5" required-level="52" sp="230000" />
-		<skill name="Deadly Blow" id="263" level="15" required-level="52" sp="230000" />
 		<skill name="Power Break" id="115" level="7" required-level="52" sp="230000" />
+		<skill name="Deadly Blow" id="263" level="17" required-level="52" sp="230000" />
 		<skill name="Trick" id="11" level="2" required-level="52" sp="230000" />
 		<skill name="Backstab" id="30" level="15" required-level="52" sp="230000" />
-		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="230000" >
-			<item id="8618"/> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
-		</skill>
-		
+		<skill name="Emergency Rescue" id="70" level="22" required-level="52" sp="230000" />
+
+		<!-- Skills Lv53 -->
 		<skill name="Dagger Mastery" id="209" level="24" required-level="53" sp="320000" />
 		<skill name="Light Armor Mastery" id="233" level="26" required-level="53" sp="320000" />
-		<skill name="Sting" id="223" level="28" required-level="53" sp="320000" />
-		<skill name="Drain Energy" id="70" level="32" required-level="53" sp="320000" />
-		<skill name="Deadly Blow" id="263" level="16" required-level="53" sp="320000" />
+		<skill name="Freezing Weapon" id="105" level="13" required-level="53" sp="320000" />
+		<skill name="Blood Attack" id="223" level="28" required-level="53" sp="320000" />
+		<skill name="Deadly Blow" id="263" level="18" required-level="53" sp="320000" />
 		<skill name="Backstab" id="30" level="16" required-level="53" sp="320000" />
-		
+		<skill name="Emergency Rescue" id="70" level="23" required-level="53" sp="320000" />
+
+		<!-- Skills Lv54 -->
 		<skill name="Dagger Mastery" id="209" level="25" required-level="54" sp="320000" />
 		<skill name="Light Armor Mastery" id="233" level="27" required-level="54" sp="320000" />
-		<skill name="Sting" id="223" level="29" required-level="54" sp="320000" />
-		<skill name="Freezing Strike" id="105" level="13" required-level="54" sp="320000" />
-		<skill name="Drain Energy" id="70" level="33" required-level="54" sp="320000" />
-		<skill name="Deadly Blow" id="263" level="17" required-level="54" sp="320000" />
+		<skill name="Freezing Weapon" id="105" level="14" required-level="54" sp="320000" />
+		<skill name="Drain Energy" id="45250" level="13" required-level="54" sp="320000" />
+		<skill name="Blood Attack" id="223" level="29" required-level="54" sp="320000" />
+		<skill name="Deadly Blow" id="263" level="19" required-level="54" sp="320000" />
 		<skill name="Backstab" id="30" level="17" required-level="54" sp="320000" />
 		<skill name="Shadow Step" id="821" level="2" required-level="54" sp="320000" />
-		
+		<skill name="Emergency Rescue" id="70" level="24" required-level="54" sp="320000" />
+
+		<!-- Skills Lv55 -->
 		<skill name="Ultimate Evasion" id="111" level="2" required-level="55" sp="320000" />
 		<skill name="Acrobatics" id="173" level="2" required-level="55" sp="320000" />
 		<skill name="Acrobatic Move" id="225" level="3" required-level="55" sp="320000" />
@@ -193,242 +233,287 @@
 		<skill name="Dagger Mastery" id="209" level="26" required-level="55" sp="320000" />
 		<skill name="Light Armor Mastery" id="233" level="28" required-level="55" sp="320000" />
 		<skill name="Boost Breath" id="195" level="2" required-level="55" sp="320000" />
-		<skill name="Sting" id="223" level="30" required-level="55" sp="320000" />
 		<skill name="Confusion" id="2" level="10" required-level="55" sp="320000" />
-		<skill name="Freezing Strike" id="105" level="14" required-level="55" sp="320000" />
-		<skill name="Drain Energy" id="70" level="34" required-level="55" sp="320000" />
+		<skill name="Freezing Weapon" id="105" level="15" required-level="55" sp="320000" />
+		<skill name="Blood Attack" id="223" level="30" required-level="55" sp="320000" />
+		<skill name="Sharpness" id="53009" level="2" required-level="55" sp="320000" />
 		<skill name="Unlock" id="27" level="10" required-level="55" sp="320000" />
+		<skill name="Sand Bomb" id="412" level="1" required-level="55" sp="320000" />
 		<skill name="Hex" id="122" level="6" required-level="55" sp="320000" />
-		<skill name="Deadly Blow" id="263" level="18" required-level="55" sp="320000" />
 		<skill name="Power Break" id="115" level="8" required-level="55" sp="320000" />
+		<skill name="Deadly Blow" id="263" level="20" required-level="55" sp="320000" />
 		<skill name="Trick" id="11" level="3" required-level="55" sp="320000" />
 		<skill name="Backstab" id="30" level="18" required-level="55" sp="320000" />
-		<skill name="Sand Bomb" id="412" level="1" required-level="55" sp="320000" >
-			<item id="49569"/>
-		</skill>
+		<skill name="Emergency Rescue" id="70" level="25" required-level="55" sp="320000" />
 
+		<!-- Skills Lv56 -->
 		<skill name="Dagger Mastery" id="209" level="27" required-level="56" sp="440000" />
 		<skill name="Light Armor Mastery" id="233" level="29" required-level="56" sp="440000" />
-		<skill name="Sting" id="223" level="31" required-level="56" sp="440000" />
-		<skill name="Drain Energy" id="70" level="35" required-level="56" sp="440000" />
-		<skill name="Deadly Blow" id="263" level="19" required-level="56" sp="440000" />
+		<skill name="Freezing Weapon" id="105" level="16" required-level="56" sp="440000" />
+		<skill name="Drain Energy" id="45250" level="14" required-level="56" sp="440000" />
+		<skill name="Blood Attack" id="223" level="31" required-level="56" sp="440000" />
+		<skill name="Deadly Blow" id="263" level="21" required-level="56" sp="440000" />
 		<skill name="Backstab" id="30" level="19" required-level="56" sp="440000" />
-		
+		<skill name="Emergency Rescue" id="70" level="26" required-level="56" sp="440000" />
+
+		<!-- Skills Lv57 -->
 		<skill name="Dagger Mastery" id="209" level="28" required-level="57" sp="440000" />
 		<skill name="Light Armor Mastery" id="233" level="30" required-level="57" sp="440000" />
-		<skill name="Sting" id="223" level="32" required-level="57" sp="440000" />
-		<skill name="Freezing Strike" id="105" level="15" required-level="57" sp="440000" />
-		<skill name="Drain Energy" id="70" level="36" required-level="57" sp="440000" />
-		<skill name="Deadly Blow" id="263" level="20" required-level="57" sp="440000" />
+		<skill name="Freezing Weapon" id="105" level="17" required-level="57" sp="440000" />
+		<skill name="Blood Attack" id="223" level="32" required-level="57" sp="440000" />
+		<skill name="Deadly Blow" id="263" level="22" required-level="57" sp="440000" />
 		<skill name="Backstab" id="30" level="20" required-level="57" sp="440000" />
-		
+		<skill name="Emergency Rescue" id="70" level="27" required-level="57" sp="440000" />
+
+		<!-- Skills Lv58 -->
 		<skill name="Vicious Stance" id="312" level="12" required-level="58" sp="440000" />
 		<skill name="Dagger Mastery" id="209" level="29" required-level="58" sp="440000" />
 		<skill name="Light Armor Mastery" id="233" level="31" required-level="58" sp="440000" />
-		<skill name="Sting" id="223" level="33" required-level="58" sp="440000" />
 		<skill name="Confusion" id="2" level="11" required-level="58" sp="440000" />
-		<skill name="Freezing Strike" id="105" level="16" required-level="58" sp="440000" />
-		<skill name="Drain Energy" id="70" level="37" required-level="58" sp="440000" />
+		<skill name="Freezing Weapon" id="105" level="18" required-level="58" sp="440000" />
+		<skill name="Drain Energy" id="45250" level="15" required-level="58" sp="440000" />
+		<skill name="Blood Attack" id="223" level="33" required-level="58" sp="440000" />
 		<skill name="Bleed" id="96" level="4" required-level="58" sp="440000" />
-		<skill name="Poison" id="129" level="3" required-level="58" sp="440000" />
 		<skill name="Sand Bomb" id="412" level="2" required-level="58" sp="440000" />
 		<skill name="Hex" id="122" level="7" required-level="58" sp="440000" />
-		<skill name="Deadly Blow" id="263" level="21" required-level="58" sp="440000" />
 		<skill name="Power Break" id="115" level="9" required-level="58" sp="440000" />
+		<skill name="Deadly Blow" id="263" level="23" required-level="58" sp="440000" />
 		<skill name="Trick" id="11" level="4" required-level="58" sp="440000" />
 		<skill name="Boost Evasion" id="198" level="3" required-level="58" sp="440000" />
 		<skill name="Backstab" id="30" level="21" required-level="58" sp="440000" />
 		<skill name="Shadow Step" id="821" level="3" required-level="58" sp="440000" />
+		<skill name="Emergency Rescue" id="70" level="28" required-level="58" sp="440000" />
 
+		<!-- Skills Lv59 -->
 		<skill name="Dagger Mastery" id="209" level="30" required-level="59" sp="640000" />
 		<skill name="Light Armor Mastery" id="233" level="32" required-level="59" sp="640000" />
-		<skill name="Sting" id="223" level="34" required-level="59" sp="640000" />
-		<skill name="Drain Energy" id="70" level="38" required-level="59" sp="640000" />
-		<skill name="Deadly Blow" id="263" level="22" required-level="59" sp="640000" />
+		<skill name="Freezing Weapon" id="105" level="19" required-level="59" sp="640000" />
+		<skill name="Blood Attack" id="223" level="34" required-level="59" sp="640000" />
+		<skill name="Deadly Blow" id="263" level="24" required-level="59" sp="640000" />
 		<skill name="Backstab" id="30" level="22" required-level="59" sp="640000" />
-		
+		<skill name="Emergency Rescue" id="70" level="29" required-level="59" sp="640000" />
+
+		<!-- Skills Lv60 -->
 		<skill name="Vicious Stance" id="312" level="13" required-level="60" sp="640000" />
+		<skill name="Potion Mastery" id="45184" level="3" required-level="60">
+			<item id="57" count="6000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Dagger Mastery" id="209" level="31" required-level="60" sp="640000" />
 		<skill name="Light Armor Mastery" id="233" level="33" required-level="60" sp="640000" />
-		<skill name="Sting" id="223" level="35" required-level="60" sp="640000" />
+		<skill name="Dark Elven Spirit" id="129" level="4" required-level="60" sp="640000" />
 		<skill name="Confusion" id="2" level="12" required-level="60" sp="640000" />
-		<skill name="Freezing Strike" id="105" level="17" required-level="60" sp="640000" />
-		<skill name="Drain Energy" id="70" level="39" required-level="60" sp="640000" />
+		<skill name="Freezing Weapon" id="105" level="20" required-level="60" sp="640000" />
+		<skill name="Drain Energy" id="45250" level="16" required-level="60" sp="640000" />
+		<skill name="Blood Attack" id="223" level="35" required-level="60" sp="640000" />
 		<skill name="Unlock" id="27" level="11" required-level="60" sp="640000" />
 		<skill name="Sand Bomb" id="412" level="3" required-level="60" sp="640000" />
 		<skill name="Hex" id="122" level="8" required-level="60" sp="640000" />
-		<skill name="Deadly Blow" id="263" level="23" required-level="60" sp="640000" />
 		<skill name="Power Break" id="115" level="10" required-level="60" sp="640000" />
+		<skill name="Deadly Blow" id="263" level="25" required-level="60" sp="640000" />
+		<skill name="Ability to Attack" id="77" level="3" required-level="60" sp="640000" />
+		<skill name="Dark Assassin Transformation" id="1801" level="1" required-level="60" auto-learn="true" />
 		<skill name="Trick" id="11" level="5" required-level="60" sp="640000" />
 		<skill name="Backstab" id="30" level="23" required-level="60" sp="640000" />
+		<skill name="Emergency Rescue" id="70" level="30" required-level="60" sp="640000" />
 
+		<!-- Skills Lv61 -->
+		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="640000" >
+			<item id="8619" count="1" /> <!-- Ancient Book: Divine Inspiration (Modern Language Version) Lv 2 -->
+		</skill>
 		<skill name="Dagger Mastery" id="209" level="32" required-level="61" sp="640000" />
 		<skill name="Light Armor Mastery" id="233" level="34" required-level="61" sp="640000" />
-		<skill name="Sting" id="223" level="36" required-level="61" sp="640000" />
-		<skill name="Drain Energy" id="70" level="40" required-level="61" sp="640000" />
-		<skill name="Deadly Blow" id="263" level="24" required-level="61" sp="640000" />
+		<skill name="Blood Attack" id="223" level="36" required-level="61" sp="640000" />
+		<skill name="Deadly Blow" id="263" level="26" required-level="61" sp="640000" />
 		<skill name="Hide" id="922" level="2" required-level="61" sp="640000" />
 		<skill name="Backstab" id="30" level="24" required-level="61" sp="640000" />
-		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="640000" >
-			<item id="8619"/> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
-		</skill>
-		
+		<skill name="Emergency Rescue" id="70" level="31" required-level="61" sp="640000" />
+
+		<!-- Skills Lv62 -->
 		<skill name="Vicious Stance" id="312" level="14" required-level="62" sp="790000" />
 		<skill name="Esprit" id="171" level="6" required-level="62" sp="790000" />
 		<skill name="Dagger Mastery" id="209" level="33" required-level="62" sp="790000" />
 		<skill name="Light Armor Mastery" id="233" level="35" required-level="62" sp="790000" />
-		<skill name="Sting" id="223" level="37" required-level="62" sp="790000" />
 		<skill name="Confusion" id="2" level="13" required-level="62" sp="790000" />
-		<skill name="Freezing Strike" id="105" level="18" required-level="62" sp="790000" />
-		<skill name="Drain Energy" id="70" level="41" required-level="62" sp="790000" />
+		<skill name="Freezing Weapon" id="105" level="21" required-level="62" sp="790000" />
+		<skill name="Drain Energy" id="45250" level="17" required-level="62" sp="790000" />
+		<skill name="Blood Attack" id="223" level="37" required-level="62" sp="790000" />
 		<skill name="Sand Bomb" id="412" level="4" required-level="62" sp="790000" />
 		<skill name="Hex" id="122" level="9" required-level="62" sp="790000" />
-		<skill name="Deadly Blow" id="263" level="25" required-level="62" sp="790000" />
 		<skill name="Power Break" id="115" level="11" required-level="62" sp="790000" />
+		<skill name="Deadly Blow" id="263" level="27" required-level="62" sp="790000" />
 		<skill name="Trick" id="11" level="6" required-level="62" sp="790000" />
 		<skill name="Backstab" id="30" level="25" required-level="62" sp="790000" />
 		<skill name="Shadow Step" id="821" level="4" required-level="62" sp="790000" />
+		<skill name="Emergency Rescue" id="70" level="32" required-level="62" sp="790000" />
 
+		<!-- Skills Lv63 -->
 		<skill name="Dagger Mastery" id="209" level="34" required-level="63" sp="790000" />
 		<skill name="Light Armor Mastery" id="233" level="36" required-level="63" sp="790000" />
-		<skill name="Sting" id="223" level="38" required-level="63" sp="790000" />
-		<skill name="Drain Energy" id="70" level="42" required-level="63" sp="790000" />
-		<skill name="Deadly Blow" id="263" level="26" required-level="63" sp="790000" />
+		<skill name="Blood Attack" id="223" level="38" required-level="63" sp="790000" />
+		<skill name="Deadly Blow" id="263" level="28" required-level="63" sp="790000" />
 		<skill name="Backstab" id="30" level="26" required-level="63" sp="790000" />
-			
+		<skill name="Emergency Rescue" id="70" level="33" required-level="63" sp="790000" />
+
+		<!-- Skills Lv64 -->
 		<skill name="Vicious Stance" id="312" level="15" required-level="64" sp="990000" />
 		<skill name="Dagger Mastery" id="209" level="35" required-level="64" sp="990000" />
 		<skill name="Light Armor Mastery" id="233" level="37" required-level="64" sp="990000" />
-		<skill name="Sting" id="223" level="39" required-level="64" sp="990000" />
 		<skill name="Confusion" id="2" level="14" required-level="64" sp="990000" />
-		<skill name="Freezing Strike" id="105" level="19" required-level="64" sp="990000" />
-		<skill name="Drain Energy" id="70" level="43" required-level="64" sp="990000" />
+		<skill name="Freezing Weapon" id="105" level="22" required-level="64" sp="990000" />
+		<skill name="Drain Energy" id="45250" level="18" required-level="64" sp="990000" />
 		<skill name="Critical Damage" id="193" level="5" required-level="64" sp="990000" />
+		<skill name="Blood Attack" id="223" level="39" required-level="64" sp="990000" />
 		<skill name="Unlock" id="27" level="12" required-level="64" sp="990000" />
 		<skill name="Sand Bomb" id="412" level="5" required-level="64" sp="990000" />
 		<skill name="Hex" id="122" level="10" required-level="64" sp="990000" />
-		<skill name="Deadly Blow" id="263" level="27" required-level="64" sp="990000" />
 		<skill name="Power Break" id="115" level="12" required-level="64" sp="990000" />
+		<skill name="Deadly Blow" id="263" level="29" required-level="64" sp="990000" />
 		<skill name="Trick" id="11" level="7" required-level="64" sp="990000" />
 		<skill name="Backstab" id="30" level="27" required-level="64" sp="990000" />
+		<skill name="Emergency Rescue" id="70" level="34" required-level="64" sp="990000" />
 
+		<!-- Skills Lv65 -->
 		<skill name="Dagger Mastery" id="209" level="36" required-level="65" sp="990000" />
 		<skill name="Light Armor Mastery" id="233" level="38" required-level="65" sp="990000" />
-		<skill name="Sting" id="223" level="40" required-level="65" sp="990000" />
-		<skill name="Drain Energy" id="70" level="44" required-level="65" sp="990000" />
-		<skill name="Deadly Blow" id="263" level="28" required-level="65" sp="990000" />
+		<skill name="Blood Attack" id="223" level="40" required-level="65" sp="990000" />
+		<skill name="Deadly Blow" id="263" level="30" required-level="65" sp="990000" />
 		<skill name="Backstab" id="30" level="28" required-level="65" sp="990000" />
-		
+		<skill name="Emergency Rescue" id="70" level="35" required-level="65" sp="990000" />
+
+		<!-- Skills Lv66 -->
 		<skill name="Vicious Stance" id="312" level="16" required-level="66" sp="1100000" />
 		<skill name="Dagger Mastery" id="209" level="37" required-level="66" sp="1100000" />
 		<skill name="Light Armor Mastery" id="233" level="39" required-level="66" sp="1100000" />
-		<skill name="Sting" id="223" level="41" required-level="66" sp="1100000" />
 		<skill name="Confusion" id="2" level="15" required-level="66" sp="1100000" />
-		<skill name="Freezing Strike" id="105" level="20" required-level="66" sp="1100000" />
-		<skill name="Drain Energy" id="70" level="45" required-level="66" sp="1100000" />
+		<skill name="Freezing Weapon" id="105" level="23" required-level="66" sp="1100000" />
+		<skill name="Drain Energy" id="45250" level="19" required-level="66" sp="1100000" />
+		<skill name="Blood Attack" id="223" level="41" required-level="66" sp="1100000" />
 		<skill name="Bleed" id="96" level="5" required-level="66" sp="1100000" />
-		<skill name="Poison" id="129" level="4" required-level="66" sp="1100000" />
 		<skill name="Sand Bomb" id="412" level="6" required-level="66" sp="1100000" />
 		<skill name="Hex" id="122" level="11" required-level="66" sp="1100000" />
-		<skill name="Deadly Blow" id="263" level="29" required-level="66" sp="1100000" />
 		<skill name="Power Break" id="115" level="13" required-level="66" sp="1100000" />
+		<skill name="Deadly Blow" id="263" level="31" required-level="66" sp="1100000" />
 		<skill name="Trick" id="11" level="8" required-level="66" sp="1100000" />
 		<skill name="Backstab" id="30" level="29" required-level="66" sp="1100000" />
 		<skill name="Shadow Step" id="821" level="5" required-level="66" sp="1100000" />
+		<skill name="Emergency Rescue" id="70" level="36" required-level="66" sp="1100000" />
 
+		<!-- Skills Lv67 -->
 		<skill name="Dagger Mastery" id="209" level="38" required-level="67" sp="1100000" />
 		<skill name="Light Armor Mastery" id="233" level="40" required-level="67" sp="1100000" />
-		<skill name="Sting" id="223" level="42" required-level="67" sp="1100000" />
-		<skill name="Drain Energy" id="70" level="46" required-level="67" sp="1100000" />
-		<skill name="Deadly Blow" id="263" level="30" required-level="67" sp="1100000" />
+		<skill name="Blood Attack" id="223" level="42" required-level="67" sp="1100000" />
+		<skill name="Deadly Blow" id="263" level="32" required-level="67" sp="1100000" />
 		<skill name="Backstab" id="30" level="30" required-level="67" sp="1100000" />
-		
+		<skill name="Emergency Rescue" id="70" level="37" required-level="67" sp="1100000" />
+
+		<!-- Skills Lv68 -->
 		<skill name="Vicious Stance" id="312" level="17" required-level="68" sp="1500000" />
 		<skill name="Esprit" id="171" level="7" required-level="68" sp="1500000" />
 		<skill name="Dagger Mastery" id="209" level="39" required-level="68" sp="1500000" />
 		<skill name="Light Armor Mastery" id="233" level="41" required-level="68" sp="1500000" />
-		<skill name="Sting" id="223" level="43" required-level="68" sp="1500000" />
 		<skill name="Confusion" id="2" level="16" required-level="68" sp="1500000" />
-		<skill name="Freezing Strike" id="105" level="21" required-level="68" sp="1500000" />
-		<skill name="Drain Energy" id="70" level="47" required-level="68" sp="1500000" />
+		<skill name="Freezing Weapon" id="105" level="24" required-level="68" sp="1500000" />
+		<skill name="Drain Energy" id="45250" level="20" required-level="68" sp="1500000" />
+		<skill name="Blood Attack" id="223" level="43" required-level="68" sp="1500000" />
 		<skill name="Unlock" id="27" level="13" required-level="68" sp="1500000" />
 		<skill name="Sand Bomb" id="412" level="7" required-level="68" sp="1500000" />
 		<skill name="Hex" id="122" level="12" required-level="68" sp="1500000" />
-		<skill name="Deadly Blow" id="263" level="31" required-level="68" sp="1500000" />
 		<skill name="Power Break" id="115" level="14" required-level="68" sp="1500000" />
+		<skill name="Deadly Blow" id="263" level="33" required-level="68" sp="1500000" />
 		<skill name="Trick" id="11" level="9" required-level="68" sp="1500000" />
 		<skill name="Backstab" id="30" level="31" required-level="68" sp="1500000" />
+		<skill name="Emergency Rescue" id="70" level="38" required-level="68" sp="1500000" />
 
+		<!-- Skills Lv69 -->
 		<skill name="Dagger Mastery" id="209" level="40" required-level="69" sp="1500000" />
 		<skill name="Light Armor Mastery" id="233" level="42" required-level="69" sp="1500000" />
-		<skill name="Sting" id="223" level="44" required-level="69" sp="1500000" />
-		<skill name="Drain Energy" id="70" level="48" required-level="69" sp="1500000" />
-		<skill name="Deadly Blow" id="263" level="32" required-level="69" sp="1500000" />
+		<skill name="Blood Attack" id="223" level="44" required-level="69" sp="1500000" />
+		<skill name="Deadly Blow" id="263" level="34" required-level="69" sp="1500000" />
 		<skill name="Backstab" id="30" level="32" required-level="69" sp="1500000" />
-		
+		<skill name="Emergency Rescue" id="70" level="39" required-level="69" sp="1500000" />
+
+		<!-- Skills Lv70 -->
 		<skill name="Vicious Stance" id="312" level="18" required-level="70" sp="1900000" />
 		<skill name="Dagger Mastery" id="209" level="41" required-level="70" sp="1900000" />
 		<skill name="Light Armor Mastery" id="233" level="43" required-level="70" sp="1900000" />
-		<skill name="Sting" id="223" level="45" required-level="70" sp="1900000" />
+		<skill name="Dark Elven Spirit" id="129" level="5" required-level="70" sp="1900000" />
 		<skill name="Confusion" id="2" level="17" required-level="70" sp="1900000" />
-		<skill name="Freezing Strike" id="105" level="22" required-level="70" sp="1900000" />
-		<skill name="Drain Energy" id="70" level="49" required-level="70" sp="1900000" />
+		<skill name="Freezing Weapon" id="105" level="25" required-level="70" sp="1900000" />
+		<skill name="Drain Energy" id="45250" level="21" required-level="70" sp="1900000" />
+		<skill name="Blood Attack" id="223" level="45" required-level="70" sp="1900000" />
 		<skill name="Bleed" id="96" level="6" required-level="70" sp="1900000" />
+		<skill name="Sharpness" id="53009" level="3" required-level="70" sp="1900000" />
 		<skill name="Sand Bomb" id="412" level="8" required-level="70" sp="1900000" />
 		<skill name="Hex" id="122" level="13" required-level="70" sp="1900000" />
-		<skill name="Deadly Blow" id="263" level="33" required-level="70" sp="1900000" />
 		<skill name="Power Break" id="115" level="15" required-level="70" sp="1900000" />
+		<skill name="Deadly Blow" id="263" level="35" required-level="70" sp="1900000" />
+		<skill name="White Assassin Transformation" id="1802" level="1" required-level="70" auto-learn="true" />
 		<skill name="Trick" id="11" level="10" required-level="70" sp="1900000" />
 		<skill name="Backstab" id="30" level="33" required-level="70" sp="1900000" />
 		<skill name="Shadow Step" id="821" level="6" required-level="70" sp="1900000" />
-		
+		<skill name="Emergency Rescue" id="70" level="40" required-level="70" sp="1900000" />
+
+		<!-- Skills Lv71 -->
 		<skill name="Dagger Mastery" id="209" level="42" required-level="71" sp="1900000" />
 		<skill name="Light Armor Mastery" id="233" level="44" required-level="71" sp="1900000" />
-		<skill name="Sting" id="223" level="46" required-level="71" sp="1900000" />
-		<skill name="Drain Energy" id="70" level="50" required-level="71" sp="1900000" />
-		<skill name="Deadly Blow" id="263" level="34" required-level="71" sp="1900000" />
+		<skill name="Blood Attack" id="223" level="46" required-level="71" sp="1900000" />
+		<skill name="Deadly Blow" id="263" level="36" required-level="71" sp="1900000" />
 		<skill name="Hide" id="922" level="3" required-level="71" sp="1900000" />
 		<skill name="Backstab" id="30" level="34" required-level="71" sp="1900000" />
+		<skill name="Emergency Rescue" id="70" level="41" required-level="71" sp="1900000" />
 
+		<!-- Skills Lv72 -->
 		<skill name="Vicious Stance" id="312" level="19" required-level="72" sp="2100000" />
 		<skill name="Dagger Mastery" id="209" level="43" required-level="72" sp="2100000" />
 		<skill name="Light Armor Mastery" id="233" level="45" required-level="72" sp="2100000" />
-		<skill name="Sting" id="223" level="47" required-level="72" sp="2100000" />
 		<skill name="Confusion" id="2" level="18" required-level="72" sp="2100000" />
-		<skill name="Freezing Strike" id="105" level="23" required-level="72" sp="2100000" />
-		<skill name="Drain Energy" id="70" level="51" required-level="72" sp="2100000" />
+		<skill name="Freezing Weapon" id="105" level="26" required-level="72" sp="2100000" />
+		<skill name="Drain Energy" id="45250" level="22" required-level="72" sp="2100000" />
 		<skill name="Critical Damage" id="193" level="6" required-level="72" sp="2100000" />
+		<skill name="Blood Attack" id="223" level="47" required-level="72" sp="2100000" />
 		<skill name="Unlock" id="27" level="14" required-level="72" sp="2100000" />
 		<skill name="Sand Bomb" id="412" level="9" required-level="72" sp="2100000" />
 		<skill name="Hex" id="122" level="14" required-level="72" sp="2100000" />
-		<skill name="Deadly Blow" id="263" level="35" required-level="72" sp="2100000" />
 		<skill name="Power Break" id="115" level="16" required-level="72" sp="2100000" />
+		<skill name="Deadly Blow" id="263" level="37" required-level="72" sp="2100000" />
 		<skill name="Trick" id="11" level="11" required-level="72" sp="2100000" />
 		<skill name="Backstab" id="30" level="35" required-level="72" sp="2100000" />
+		<skill name="Emergency Rescue" id="70" level="42" required-level="72" sp="2100000" />
 
+		<!-- Skills Lv73 -->
 		<skill name="Dagger Mastery" id="209" level="44" required-level="73" sp="2100000" />
 		<skill name="Light Armor Mastery" id="233" level="46" required-level="73" sp="2100000" />
-		<skill name="Sting" id="223" level="48" required-level="73" sp="2100000" />
-		<skill name="Drain Energy" id="70" level="52" required-level="73" sp="2100000" />
-		<skill name="Deadly Blow" id="263" level="36" required-level="73" sp="2100000" />
+		<skill name="Drain Energy" id="45250" level="23" required-level="73" sp="2100000" />
+		<skill name="Blood Attack" id="223" level="48" required-level="73" sp="2100000" />
+		<skill name="Deadly Blow" id="263" level="38" required-level="73" sp="2100000" />
 		<skill name="Backstab" id="30" level="36" required-level="73" sp="2100000" />
-		
+		<skill name="Emergency Rescue" id="70" level="43" required-level="73" sp="2100000" />
+
+		<!-- Skills Lv74 -->
 		<skill name="Vicious Stance" id="312" level="20" required-level="74" sp="2100000" />
 		<skill name="Esprit" id="171" level="8" required-level="74" sp="2100000" />
 		<skill name="Dagger Mastery" id="209" level="45" required-level="74" sp="2100000" />
 		<skill name="Light Armor Mastery" id="233" level="47" required-level="74" sp="2100000" />
-		<skill name="Sting" id="223" level="49" required-level="74" sp="2100000" />
 		<skill name="Confusion" id="2" level="19" required-level="74" sp="2100000" />
-		<skill name="Freezing Strike" id="105" level="24" required-level="74" sp="2100000" />
-		<skill name="Drain Energy" id="70" level="53" required-level="74" sp="2100000" />
+		<skill name="Freezing Weapon" id="105" level="27" required-level="74" sp="2100000" />
+		<skill name="Drain Energy" id="45250" level="24" required-level="74" sp="2100000" />
 		<skill name="Critical Damage" id="193" level="7" required-level="74" sp="2100000" />
-		<skill name="Poison" id="129" level="5" required-level="74" sp="2100000" />
+		<skill name="Blood Attack" id="223" level="49" required-level="74" sp="2100000" />
 		<skill name="Sand Bomb" id="412" level="10" required-level="74" sp="2100000" />
 		<skill name="Hex" id="122" level="15" required-level="74" sp="2100000" />
-		<skill name="Deadly Blow" id="263" level="37" required-level="74" sp="2100000" />
 		<skill name="Power Break" id="115" level="17" required-level="74" sp="2100000" />
+		<skill name="Deadly Blow" id="263" level="39" required-level="74" sp="2100000" />
 		<skill name="Trick" id="11" level="12" required-level="74" sp="2100000" />
 		<skill name="Backstab" id="30" level="37" required-level="74" sp="2100000" />
 		<skill name="Shadow Step" id="821" level="7" required-level="74" sp="2100000" />
+		<skill name="Emergency Rescue" id="70" level="44" required-level="74" sp="2100000" />
+
+		<!-- Skills Lv75 -->
+		<skill name="Confusion" id="2" level="20" required-level="75" sp="2100000" />
+		<skill name="Drain Energy" id="45250" level="25" required-level="75" sp="2100000" />
+		<skill name="Blood Attack" id="223" level="50" required-level="75" sp="2100000" />
+		<skill name="Deadly Blow" id="263" level="40" required-level="75" sp="2100000" />
+		<skill name="Emergency Rescue" id="70" level="45" required-level="75" sp="2100000" />
+
 	</skillTree>
 </list>

--- a/data/skillTrees/2ndClass/Arbalester.xml
+++ b/data/skillTrees/2ndClass/Arbalester.xml
@@ -2,6 +2,20 @@
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
     <skillTree type="classSkillTree" classId="130" parentClassId="126">
 
+        <!-- Lv. 40 Master Buffs -->
+        <skill name="Soul Empower" id="45147" level="3" required-level="40" sp="80000" />
+        <skill name="Soul Wild Magic" id="45148" level="2" required-level="40" sp="80000" />
+        <skill name="Soul Berserker Spirit" id="45149" level="2" required-level="40" sp="80000" />
+        <skill name="Soul Magic Barrier" id="45143" level="2" required-level="40" sp="80000" />
+        <skill name="Soul Might" id="45144" level="3" required-level="40" sp="80000" />
+        <skill name="Soul Acumen" id="45146" level="3" required-level="40" sp="80000" />
+        <skill name="Soul Haste" id="45141" level="2" required-level="40" sp="80000" />
+        <skill name="Soul Focus" id="45139" level="3" required-level="40" sp="80000" />
+        <skill name="Soul Clarity" id="45150" level="3" required-level="40" sp="80000" />
+        <skill name="Soul Death Whisper" id="45140" level="3" required-level="40" sp="80000" />
+        <skill name="Soul Shield" id="45145" level="3" required-level="40" sp="80000" />
+
+
         <skill name="Armor Mastery" id="464" level="3" required-level="40" sp="80000"/>
         <skill name="Light Armor Mastery" id="465" level="3" required-level="40" sp="80000"/>
         <skill name="Bow Mastery" id="767" level="3" required-level="40" sp="80000" />
@@ -23,7 +37,7 @@
         <skill name="Twin Shot" id="45168" level="4" required-level="50" sp="200000" />
 
         <skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="200000">
-            <item id="8618"/> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
+            <item id="8618" count="1"/> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
         </skill>
         <skill name="Ultimate Escape" id="622" level="2" required-level="52" sp="200000" />
         <skill name="Critical Shot" id="790" level="1" required-level="52" sp="200000" />
@@ -37,14 +51,14 @@
         <skill name="Light Armor Mastery" id="465" level="5" required-level="60" sp="800000" />
         <skill name="Bow Mastery" id="767" level="5" required-level="60" sp="800000" />
         <skill name="Light Master" id="45178" level="2" required-level="60" sp="800000">
-            <item id="91944"/> <!-- Book of Light -->
+            <item id="91944" count="1"/> <!-- Book of Light -->
         </skill>
         <skill name="Multiple Shot" id="45170" level="3" required-level="60" sp="800000"/>
         <skill name="Twin Shot" id="45168" level="5" required-level="60" sp="8000000" />
         <skill name="Sharp Aiming" id="45172" level="1" required-level="60" sp="8000000" />
 
         <skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="900000">
-            <item id="8619"/> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
+            <item id="8619" count="1"/> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
         </skill>
 
         <skill name="Sharp Aiming" id="45172" level="2" required-level="62" sp="1000000" />
@@ -61,7 +75,7 @@
         <skill name="Light Armor Mastery" id="465" level="6" required-level="70" sp="1800000" />
         <skill name="Bow Mastery" id="767" level="6" required-level="70" sp="1800000" />
         <skill name="Shadow Master" id="45179" level="2" required-level="70" sp="1800000">
-            <item id="91945"/> <!-- Book of Darkness -->
+            <item id="91945" count="1"/> <!-- Book of Darkness -->
         </skill>
         <skill name="Multiple Shot" id="45170" level="4" required-level="70" sp="1800000"/>
         <skill name="Twin Shot" id="45168" level="6" required-level="70" sp="1800000" />

--- a/data/skillTrees/2ndClass/Berserker.xml
+++ b/data/skillTrees/2ndClass/Berserker.xml
@@ -2,79 +2,179 @@
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
     <skillTree type="classSkillTree" classId="127" parentClassId="125">
 
-        <skill name="Armor Mastery" id="464" level="3" required-level="40" sp="80000"/>
-        <skill name="Ancient Sword Mastery" id="472" level="3" required-level="40" sp="80000"/>
-        <skill name="Light Armor Mastery" id="465" level="3" required-level="40" sp="80000"/>
-        <skill name="Weapon Mastery" id="463" level="3" required-level="40" sp="80000"/>
-        <skill name="Shadow Master" id="45179" level="1" required-level="40" />
-        <skill name="Heavy Armor Mastery" id="399" level="3" required-level="40" sp="80000"/>
-        <skill name="Magic Immunity" id="466" level="2" required-level="40" sp="80000"/>
-        <skill name="Soul Impulse" id="45155" level="1" required-level="40" sp="80000" />
-        <skill name="Shadow Soul Finding" id="394" level="1" required-level="40" sp="80000" />
-        <skill name="Soul Smash" id="477" level="3" required-level="40" sp="80000"/>
-        <skill name="Rush" id="994" level="1" required-level="40" sp="80000" />
+        <!-- Lv. 40 Master Buffs -->
+        <skill name="Soul Empower" id="45147" level="3" required-level="40" sp="80000" />
+        <skill name="Soul Wild Magic" id="45148" level="2" required-level="40" sp="80000" />
+        <skill name="Soul Berserker Spirit" id="45149" level="2" required-level="40" sp="80000" />
+        <skill name="Soul Magic Barrier" id="45143" level="2" required-level="40" sp="80000" />
+        <skill name="Soul Might" id="45144" level="3" required-level="40" sp="80000" />
+        <skill name="Soul Acumen" id="45146" level="3" required-level="40" sp="80000" />
+        <skill name="Soul Haste" id="45141" level="2" required-level="40" sp="80000" />
+        <skill name="Soul Focus" id="45139" level="3" required-level="40" sp="80000" />
+        <skill name="Soul Clarity" id="45150" level="3" required-level="40" sp="80000" />
+        <skill name="Soul Death Whisper" id="45140" level="3" required-level="40" sp="80000" />
+        <skill name="Soul Shield" id="45145" level="3" required-level="40" sp="80000" />
+
+        <!-- Skills Lv40 -->
+        <skill name="Armor Mastery" id="464" level="3" required-level="40" sp="80000" />
+        <skill name="Ancient Sword Mastery" id="472" level="3" required-level="40" sp="80000" />
         <skill name="Potion Mastery" id="45184" level="1" required-level="40">
-            <item id="57" count="1000000"/> <!-- Adena -->
+            <item id="57" count="1000000" /> <!-- Adena -->
         </skill>
+        <skill name="Light Armor Mastery" id="465" level="3" required-level="40" sp="80000" />
+        <skill name="Weapon Mastery" id="463" level="3" required-level="40" sp="80000" />
+        <skill name="Shadow Master" id="45179" level="1" required-level="40" auto-learn="true" />
+        <skill name="Heavy Armor Mastery" id="399" level="3" required-level="40" sp="80000" />
+        <skill name="Magic Immunity" id="466" level="2" required-level="40" sp="80000" />
+        <skill name="Soul Impulse" id="45155" level="1" required-level="40" sp="80000" />
+        <skill name="Absorb Shadow Souls" id="394" level="1" required-level="40" sp="80000" />
+        <skill name="Soul Smash" id="477" level="3" required-level="40" sp="80000" />
+        <skill name="Rush" id="994" level="1" required-level="40" sp="80000" />
+        <skill name="Emergency Rescue" id="70" level="10" required-level="40" sp="80000" />
 
+        <!-- Skills Lv41 -->
+        <skill name="Emergency Rescue" id="70" level="11" required-level="41" sp="80000" />
+
+        <!-- Skills Lv42 -->
+        <skill name="Emergency Rescue" id="70" level="12" required-level="42" sp="80000" />
+
+        <!-- Skills Lv43 -->
         <skill name="Scorn" id="503" level="1" required-level="43" sp="80000" />
+        <skill name="Emergency Rescue" id="70" level="13" required-level="43" sp="80000" />
 
+        <!-- Skills Lv44 -->
+        <skill name="Emergency Rescue" id="70" level="14" required-level="44" sp="120000" />
+
+        <!-- Skills Lv45 -->
         <skill name="Critical Sense" id="626" level="1" required-level="45" sp="120000" />
+        <skill name="Bandage" id="34" level="2" required-level="45" sp="120000" />
+        <skill name="Emergency Rescue" id="70" level="15" required-level="45" sp="120000" />
 
-        <skill name="Soul Roar" id="1441" level="2" required-level="48" sp="120000"/>
+        <!-- Skills Lv46 -->
+        <skill name="Emergency Rescue" id="70" level="16" required-level="46" sp="120000" />
 
-        <skill name="Ancient Sword Mastery" id="472" level="4" required-level="50" sp="200000"/>
+        <!-- Skills Lv47 -->
+        <skill name="Emergency Rescue" id="70" level="17" required-level="47" sp="120000" />
+
+        <!-- Skills Lv48 -->
+        <skill name="Soul Roar" id="1441" level="2" required-level="48" sp="120000" />
+        <skill name="Emergency Rescue" id="70" level="18" required-level="48" sp="120000" />
+
+        <!-- Skills Lv49 -->
+        <skill name="Emergency Rescue" id="70" level="19" required-level="49" sp="200000" />
+
+        <!-- Skills Lv50 -->
+        <skill name="Ancient Sword Mastery" id="472" level="4" required-level="50" sp="200000" />
         <skill name="Potion Mastery" id="45184" level="2" required-level="50">
-            <item id="57" count="3000000"/> <!-- Adena -->
+            <item id="57" count="3000000" /> <!-- Adena -->
         </skill>
         <skill name="Light Armor Mastery" id="465" level="4" required-level="50" sp="200000" />
         <skill name="Heavy Armor Mastery" id="399" level="4" required-level="50" sp="200000" />
+        <skill name="Recover HP" id="45176" level="2" required-level="50" sp="300000" >
+            <item id="57" count="1000000" /> <!-- Adena -->
+        </skill>
+        <skill name="Recover MP" id="45177" level="2" required-level="50" sp="300000" >
+            <item id="57" count="1000000" /> <!-- Adena -->
+        </skill>
         <skill name="Soul Impulse" id="45155" level="2" required-level="50" sp="200000" />
-        <skill name="Courage" id="499" level="2" required-level="50" sp="200000"/>
-        <skill name="Collect Light Souls" id="45151" level="1" required-level="50" sp="200000"/>
-        <skill name="Collect Shadow Souls" id="45152" level="1" required-level="50" sp="200000"/>
+        <skill name="Courage" id="499" level="2" required-level="50" sp="200000" />
+        <skill name="Collect Light Souls" id="45151" level="1" required-level="50" sp="200000" />
+        <skill name="Collect Shadow Souls" id="45152" level="1" required-level="50" sp="200000" />
         <skill name="Soul Smash" id="477" level="4" required-level="50" sp="200000" />
         <skill name="Increase Power" id="1432" level="2" required-level="50" sp="200000" />
+        <skill name="Emergency Rescue" id="70" level="20" required-level="50" sp="200000" />
 
-        <skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="200000">
-            <item id="8618"/> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
+        <!-- Skills Lv51 -->
+        <skill name="Emergency Rescue" id="70" level="21" required-level="51" sp="200000" />
+
+        <!-- Skills Lv52 -->
+        <skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="200000" >
+            <item id="8618" count="1" /> <!-- Ancient Book: Divine Inspiration Lv 1 -->
         </skill>
+        <skill name="Emergency Rescue" id="70" level="22" required-level="52" sp="200000" />
 
+        <!-- Skills Lv53 -->
+        <skill name="Emergency Rescue" id="70" level="23" required-level="53" sp="400000" />
+
+        <!-- Skills Lv54 -->
+        <skill name="Emergency Rescue" id="70" level="24" required-level="54" sp="400000" />
+
+        <!-- Skills Lv55 -->
         <skill name="Magic Immunity" id="466" level="3" required-level="55" sp="450000" />
         <skill name="Critical Sense" id="626" level="2" required-level="55" sp="450000" />
+        <skill name="Emergency Rescue" id="70" level="25" required-level="55" sp="450000" />
 
-        <skill name="Death Mark" id="1435" level="3" required-level="56" sp="500000"/>
+        <!-- Skills Lv56 -->
+        <skill name="Death Mark" id="1435" level="3" required-level="56" sp="500000" />
         <skill name="Scorn" id="503" level="2" required-level="56" sp="500000" />
+        <skill name="Emergency Rescue" id="70" level="26" required-level="56" sp="500000" />
 
+        <!-- Skills Lv57 -->
+        <skill name="Emergency Rescue" id="70" level="27" required-level="57" sp="550000" />
+
+        <!-- Skills Lv58 -->
         <skill name="Soul Barrier" id="1514" level="1" required-level="58" sp="600000" />
+        <skill name="Emergency Rescue" id="70" level="28" required-level="58" sp="600000" />
 
+        <!-- Skills Lv59 -->
+        <skill name="Emergency Rescue" id="70" level="29" required-level="59" sp="700000" />
+
+        <!-- Skills Lv60 -->
         <skill name="Ancient Sword Mastery" id="472" level="5" required-level="60" sp="800000" />
         <skill name="Potion Mastery" id="45184" level="3" required-level="60">
-            <item id="57" count="6000000"/> <!-- Adena -->
+            <item id="57" count="6000000" /> <!-- Adena -->
         </skill>
         <skill name="Light Armor Mastery" id="465" level="5" required-level="60" sp="800000" />
-        <skill name="Light Master" id="45178" level="2" required-level="60" sp="800000">
-            <item id="91944"/> <!-- Book of Light -->
+        <skill name="Light Master" id="45178" level="2" required-level="60" sp="800000" >
+            <item id="91944" count="1" /> <!-- Book of Light -->
         </skill>
         <skill name="Heavy Armor Mastery" id="399" level="5" required-level="60" sp="800000" />
         <skill name="Soul Impulse" id="45155" level="3" required-level="60" sp="800000" />
+        <skill name="Bandage" id="34" level="3" required-level="60" sp="800000" />
         <skill name="Soul Smash" id="477" level="5" required-level="60" sp="800000" />
+        <skill name="Ability to Attack" id="77" level="3" required-level="60" sp="800000" />
         <skill name="Rush" id="994" level="2" required-level="60" sp="800000" />
         <skill name="Rush Impact" id="45159" level="1" required-level="60" sp="800000" />
+        <skill name="Emergency Rescue" id="70" level="30" required-level="60" sp="800000" />
         <skill name="Enuma Elish" id="45157" level="1" required-level="60" sp="800000" />
 
-        <skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="900000">
-            <item id="8619"/> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
+        <!-- Skills Lv61 -->
+        <skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="900000" >
+            <item id="8619" count="1" /> <!-- Ancient Book: Divine Inspiration Lv 2 -->
         </skill>
+        <skill name="Emergency Rescue" id="70" level="31" required-level="61" sp="900000" />
 
-        <skill name="Courage" id="499" level="3" required-level="65" sp="1300000"/>
+        <!-- Skills Lv62 -->
+        <skill name="Emergency Rescue" id="70" level="32" required-level="62" sp="1000000" />
 
+        <!-- Skills Lv63 -->
+        <skill name="Emergency Rescue" id="70" level="33" required-level="63" sp="1100000" />
+
+        <!-- Skills Lv64 -->
+        <skill name="Emergency Rescue" id="70" level="34" required-level="64" sp="1200000" />
+
+        <!-- Skills Lv65 -->
+        <skill name="Courage" id="499" level="3" required-level="65" sp="1300000" />
+        <skill name="Emergency Rescue" id="70" level="35" required-level="65" sp="1300000" />
+
+        <!-- Skills Lv66 -->
+        <skill name="Emergency Rescue" id="70" level="36" required-level="66" sp="1400000" />
+
+        <!-- Skills Lv67 -->
         <skill name="Critical Sense" id="626" level="3" required-level="67" sp="1500000" />
+        <skill name="Emergency Rescue" id="70" level="37" required-level="67" sp="1500000" />
 
+        <!-- Skills Lv68 -->
+        <skill name="Emergency Rescue" id="70" level="38" required-level="68" sp="1600000" />
+
+        <!-- Skills Lv69 -->
+        <skill name="Emergency Rescue" id="70" level="39" required-level="69" sp="1700000" />
+
+        <!-- Skills Lv70 -->
         <skill name="Ancient Sword Mastery" id="472" level="6" required-level="70" sp="1800000" />
         <skill name="Light Armor Mastery" id="465" level="6" required-level="70" sp="1800000" />
-        <skill name="Shadow Master" id="45179" level="2" required-level="70" sp="1800000">
-            <item id="91945"/> <!-- Book of Darkness -->
+        <skill name="Shadow Master" id="45179" level="2" required-level="70" sp="1800000" >
+            <item id="91945" count="1" /> <!-- Book of Darkness -->
         </skill>
         <skill name="Heavy Armor Mastery" id="399" level="6" required-level="70" sp="1800000" />
         <skill name="Soul Impulse" id="45155" level="4" required-level="70" sp="1800000" />
@@ -82,15 +182,30 @@
         <skill name="Soul Roar" id="1441" level="3" required-level="70" sp="1800000" />
         <skill name="Soul Smash" id="477" level="6" required-level="70" sp="1800000" />
         <skill name="Rush Impact" id="45159" level="2" required-level="70" sp="1800000" />
+        <skill name="Emergency Rescue" id="70" level="40" required-level="70" sp="1800000" />
         <skill name="Enuma Elish" id="45157" level="2" required-level="70" sp="1800000" />
 
+        <!-- Skills Lv71 -->
+        <skill name="Emergency Rescue" id="70" level="41" required-level="71" sp="1900000" />
+
+        <!-- Skills Lv72 -->
+        <skill name="Emergency Rescue" id="70" level="42" required-level="72" sp="2000000" />
+
+        <!-- Skills Lv73 -->
+        <skill name="Emergency Rescue" id="70" level="43" required-level="73" sp="2100000" />
+
+        <!-- Skills Lv74 -->
+        <skill name="Emergency Rescue" id="70" level="44" required-level="74" sp="2200000" />
+
+        <!-- Skills Lv75 -->
         <skill name="Ancient Sword Mastery" id="472" level="7" required-level="75" sp="2300000" />
         <skill name="Light Armor Mastery" id="465" level="7" required-level="75" sp="2300000" />
         <skill name="Heavy Armor Mastery" id="399" level="7" required-level="75" sp="2300000" />
         <skill name="Soul Impulse" id="45155" level="5" required-level="75" sp="2300000" />
         <skill name="Soul Smash" id="477" level="7" required-level="75" sp="2300000" />
+        <skill name="Emergency Rescue" id="70" level="45" required-level="75" sp="2300000" />
         <skill name="Enuma Elish" id="45157" level="3" required-level="75" sp="2300000" />
 
-        
+
     </skillTree>
 </list>

--- a/data/skillTrees/2ndClass/Bishop.xml
+++ b/data/skillTrees/2ndClass/Bishop.xml
@@ -1,9 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="16" parentClassId="15">
-		<skill name="Pirate" id="1800" level="1" required-level="45" auto-learn="true" />
-		<skill name="Dark Assassin" id="1801" level="1" required-level="60" auto-learn="true" />
-		<skill name="White Assassin" id="1802" level="1" required-level="70" auto-learn="true" />
+
+		<!-- Master Buffs Lv. 40 -->
+		<skill name="Might" id="1068" level="3" required-level="40" sp="80000" />
+		<skill name="Shield" id="1040" level="3" required-level="40" sp="80000" />
+		<skill name="Acumen" id="45104" level="3" required-level="40" sp="80000" />
+		<skill name="Empower" id="45105" level="3" required-level="40" sp="80000" />
+		<skill name="Wild Magic" id="45106" level="2" required-level="40" sp="80000" />
+		<skill name="Magic Barrier" id="45108" level="2" required-level="40" sp="80000" />
+		<skill name="Focus" id="45109" level="3" required-level="40" sp="80000" />
+		<skill name="Death Whisper" id="45110" level="3" required-level="40" sp="80000" />
+		<skill name="Haste" id="45111" level="2" required-level="40" sp="80000" />
+		<skill name="Berserker Spirit" id="45112" level="2" required-level="40" sp="80000" />
+		<skill name="Clarity" id="45113" level="3" required-level="40" sp="80000" />
+
+		<!-- Skills Lv40 -->
 		<skill name="Anti Magic" id="146" level="13" required-level="40" sp="69000" />
 		<skill name="Anti Magic" id="146" level="14" required-level="40" sp="69000" />
 		<skill name="Anti Magic" id="146" level="15" required-level="40" sp="69000" />
@@ -27,17 +39,26 @@
 		<skill name="Weapon Mastery" id="249" level="11" required-level="40" sp="69000" />
 		<skill name="Weapon Mastery" id="249" level="12" required-level="40" sp="69000" />
 		<skill name="Resurrection" id="1016" level="3" required-level="40" sp="69000" />
+		<skill name="Swap Defense" id="1392" level="1" required-level="40" sp="80000" />
 		<skill name="Mass Resurrection" id="1254" level="1" required-level="40" sp="69000" />
 		<skill name="Spell Master" id="1829" level="1" required-level="40" auto-learn="true" />
+		<skill name="Poison" id="1168" level="4" required-level="40" sp="69000" />
+		<skill name="Convert" id="1393" level="1" required-level="40" sp="80000" />
 		<skill name="Peace" id="1075" level="2" required-level="40" sp="69000" />
 		<skill name="Requiem" id="1049" level="1" required-level="40" sp="69000" />
 		<skill name="Might of Heaven" id="1028" level="1" required-level="40" sp="69000" />
 		<skill name="Might of Heaven" id="1028" level="2" required-level="40" sp="69000" />
+		<skill name="Weakness" id="1164" level="6" required-level="40" sp="69000" />
 		<skill name="Boost Mana" id="213" level="3" required-level="40" sp="69000" />
-		<skill name="Sleep" id="1069" level="10" required-level="40" sp="69000" />
-		<skill name="Sleep" id="1069" level="11" required-level="40" sp="69000" />
-		<skill name="Sleep" id="1069" level="12" required-level="40" sp="69000" />
-		
+
+		<skill name="Mana Effect Boost" id="1013" level="5" required-level="40" sp="69000" />
+		<skill name="Mana Effect Boost" id="1013" level="6" required-level="40" sp="69000" />
+
+		<!-- Skills Lv41 -->
+		<skill name="Dryad Root" id="1201" level="11" required-level="41" sp="98000" />
+		<skill name="Sleep" id="1069" level="11" required-level="41" sp="98000" />
+
+		<!-- Skills Lv42 -->
 		<skill name="Anti Magic" id="146" level="16" required-level="42" sp="98000" />
 		<skill name="Greater Battle Heal" id="1218" level="4" required-level="42" sp="98000" />
 		<skill name="Greater Group Heal" id="1219" level="4" required-level="42" sp="98000" />
@@ -45,9 +66,12 @@
 		<skill name="Light Armor Mastery" id="236" level="12" required-level="42" sp="98000" />
 		<skill name="Robe Mastery" id="235" level="12" required-level="42" sp="98000" />
 		<skill name="Weapon Mastery" id="249" level="13" required-level="42" sp="98000" />
+		<skill name="Dryad Root" id="1201" level="12" required-level="42" sp="98000" />
 		<skill name="Might of Heaven" id="1028" level="3" required-level="42" sp="98000" />
-		<skill name="Sleep" id="1069" level="13" required-level="42" sp="98000" />
-		
+		<skill name="Sleep" id="1069" level="12" required-level="42" sp="98000" />
+		<skill name="Mana Effect Boost" id="1013" level="7" required-level="42" sp="98000" />
+
+		<!-- Skills Lv43 -->
 		<skill name="Anti Magic" id="146" level="17" required-level="43" sp="98000" />
 		<skill name="Greater Battle Heal" id="1218" level="5" required-level="43" sp="98000" />
 		<skill name="Greater Group Heal" id="1219" level="5" required-level="43" sp="98000" />
@@ -55,8 +79,10 @@
 		<skill name="Light Armor Mastery" id="236" level="13" required-level="43" sp="98000" />
 		<skill name="Robe Mastery" id="235" level="13" required-level="43" sp="98000" />
 		<skill name="Weapon Mastery" id="249" level="14" required-level="43" sp="98000" />
-		<skill name="Sleep" id="1069" level="14" required-level="43" sp="98000" />
-		
+		<skill name="Dryad Root" id="1201" level="13" required-level="43" sp="98000" />
+		<skill name="Sleep" id="1069" level="13" required-level="43" sp="98000" />
+
+		<!-- Skills Lv44 -->
 		<skill name="Anti Magic" id="146" level="18" required-level="44" sp="98000" />
 		<skill name="Fast HP Recovery" id="212" level="2" required-level="44" sp="98000" />
 		<skill name="Fast Mana Recovery" id="229" level="3" required-level="44" sp="98000" />
@@ -66,17 +92,25 @@
 		<skill name="Light Armor Mastery" id="236" level="14" required-level="44" sp="98000" />
 		<skill name="Robe Mastery" id="235" level="14" required-level="44" sp="98000" />
 		<skill name="Weapon Mastery" id="249" level="15" required-level="44" sp="98000" />
+		<skill name="Concentration" id="1078" level="3" required-level="44" sp="98000" />
+		<skill name="Dryad Root" id="1201" level="14" required-level="44" sp="98000" />
 		<skill name="Mass Resurrection" id="1254" level="2" required-level="44" sp="98000" />
+		<skill name="Purify" id="1018" level="1" required-level="44" sp="98000" />
 		<skill name="Peace" id="1075" level="3" required-level="44" sp="98000" />
 		<skill name="Restore Life" id="1258" level="1" required-level="44" sp="98000" />
 		<skill name="Requiem" id="1049" level="2" required-level="44" sp="98000" />
 		<skill name="Might of Heaven" id="1028" level="4" required-level="44" sp="98000" />
+		<skill name="Weakness" id="1164" level="7" required-level="44" sp="98000" />
 		<skill name="Repose" id="1034" level="1" required-level="44" sp="98000" />
-		<skill name="Sleep" id="1069" level="15" required-level="44" sp="98000" />
-		<skill name="Purify" id="1018" level="1" required-level="44" sp="98000" >
-			<item id="3072"/>
-		</skill>
-		
+		<skill name="Sleep" id="1069" level="14" required-level="44" sp="98000" />
+		<skill name="Mana Effect Boost" id="1013" level="8" required-level="44" sp="98000" />
+
+		<!-- Skills Lv45 -->
+		<skill name="Dryad Root" id="1201" level="15" required-level="45" sp="98000" />
+		<skill name="Pirate Transformation" id="1800" level="1" required-level="45" auto-learn="true" />
+		<skill name="Sleep" id="1069" level="15" required-level="45" sp="98000" />
+
+		<!-- Skills Lv46 -->
 		<skill name="Anti Magic" id="146" level="19" required-level="46" sp="160000" />
 		<skill name="Greater Battle Heal" id="1218" level="7" required-level="46" sp="160000" />
 		<skill name="Greater Group Heal" id="1219" level="7" required-level="46" sp="160000" />
@@ -84,10 +118,13 @@
 		<skill name="Light Armor Mastery" id="236" level="15" required-level="46" sp="160000" />
 		<skill name="Robe Mastery" id="235" level="15" required-level="46" sp="160000" />
 		<skill name="Weapon Mastery" id="249" level="16" required-level="46" sp="160000" />
+		<skill name="Dryad Root" id="1201" level="16" required-level="46" sp="160000" />
 		<skill name="Vitalize" id="1020" level="1" required-level="46" sp="160000" />
 		<skill name="Might of Heaven" id="1028" level="5" required-level="46" sp="160000" />
 		<skill name="Sleep" id="1069" level="16" required-level="46" sp="160000" />
-		
+		<skill name="Mana Effect Boost" id="1013" level="9" required-level="46" sp="160000" />
+
+		<!-- Skills Lv47 -->
 		<skill name="Anti Magic" id="146" level="20" required-level="47" sp="160000" />
 		<skill name="Greater Battle Heal" id="1218" level="8" required-level="47" sp="160000" />
 		<skill name="Greater Group Heal" id="1219" level="8" required-level="47" sp="160000" />
@@ -95,9 +132,11 @@
 		<skill name="Light Armor Mastery" id="236" level="16" required-level="47" sp="160000" />
 		<skill name="Robe Mastery" id="235" level="16" required-level="47" sp="160000" />
 		<skill name="Weapon Mastery" id="249" level="17" required-level="47" sp="160000" />
+		<skill name="Dryad Root" id="1201" level="17" required-level="47" sp="160000" />
 		<skill name="Vitalize" id="1020" level="2" required-level="47" sp="160000" />
 		<skill name="Sleep" id="1069" level="17" required-level="47" sp="160000" />
-		
+
+		<!-- Skills Lv48 -->
 		<skill name="Anti Magic" id="146" level="21" required-level="48" sp="160000" />
 		<skill name="Quick Recovery" id="164" level="3" required-level="48" sp="160000" />
 		<skill name="Greater Battle Heal" id="1218" level="9" required-level="48" sp="160000" />
@@ -107,19 +146,26 @@
 		<skill name="Robe Mastery" id="235" level="17" required-level="48" sp="160000" />
 		<skill name="Weapon Mastery" id="249" level="18" required-level="48" sp="160000" />
 		<skill name="Resurrection" id="1016" level="4" required-level="48" sp="160000" />
+		<skill name="Body of Avatar" id="1311" level="1" required-level="48" sp="160000" />
+		<skill name="Dryad Root" id="1201" level="18" required-level="48" sp="160000" />
 		<skill name="Vitalize" id="1020" level="3" required-level="48" sp="160000" />
-		<skill name="Hold Undead" id="1042" level="1" required-level="48" sp="160000" />
+		<skill name="Paralysis" id="1042" level="1" required-level="48" sp="160000" />
 		<skill name="Peace" id="1075" level="4" required-level="48" sp="160000" />
 		<skill name="Restore Life" id="1258" level="2" required-level="48" sp="160000" />
 		<skill name="Requiem" id="1049" level="3" required-level="48" sp="160000" />
 		<skill name="Might of Heaven" id="1028" level="6" required-level="48" sp="160000" />
+		<skill name="Weakness" id="1164" level="8" required-level="48" sp="160000" />
 		<skill name="Boost Mana" id="213" level="4" required-level="48" sp="160000" />
 		<skill name="Repose" id="1034" level="2" required-level="48" sp="160000" />
 		<skill name="Sleep" id="1069" level="18" required-level="48" sp="160000" />
-		<skill name="Body of Avatar" id="1311" level="1" required-level="48" sp="160000" >
-			<item id="6398"/>
-		</skill>
-		
+		<skill name="Mana Effect Boost" id="1013" level="10" required-level="48" sp="160000" />
+
+		<!-- Skills Lv49 -->
+		<skill name="Dryad Root" id="1201" level="19" required-level="49" sp="160000" />
+		<skill name="Vitalize" id="1020" level="4" required-level="49" sp="160000" />
+		<skill name="Sleep" id="1069" level="19" required-level="49" sp="160000" />
+
+		<!-- Skills Lv50 -->
 		<skill name="Anti Magic" id="146" level="22" required-level="50" sp="250000" />
 		<skill name="Greater Battle Heal" id="1218" level="10" required-level="50" sp="250000" />
 		<skill name="Greater Group Heal" id="1219" level="10" required-level="50" sp="250000" />
@@ -127,10 +173,21 @@
 		<skill name="Light Armor Mastery" id="236" level="18" required-level="50" sp="250000" />
 		<skill name="Robe Mastery" id="235" level="18" required-level="50" sp="250000" />
 		<skill name="Weapon Mastery" id="249" level="19" required-level="50" sp="250000" />
-		<skill name="Vitalize" id="1020" level="4" required-level="50" sp="250000" />
+		<skill name="Recover HP" id="45176" level="2" required-level="50" sp="300000" >
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Recover MP" id="45177" level="2" required-level="50" sp="300000" >
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Dryad Root" id="1201" level="20" required-level="50" sp="250000" />
+		<skill name="Vitalize" id="1020" level="5" required-level="50" sp="250000" />
+		<skill name="Poison" id="1168" level="5" required-level="50" sp="250000" />
 		<skill name="Might of Heaven" id="1028" level="7" required-level="50" sp="250000" />
-		<skill name="Sleep" id="1069" level="19" required-level="50" sp="250000" />
-		
+		<skill name="Increased Power of Magic" id="1073" level="2" required-level="50" sp="250000" />
+		<skill name="Sleep" id="1069" level="20" required-level="50" sp="250000" />
+		<skill name="Mana Effect Boost" id="1013" level="11" required-level="50" sp="250000" />
+
+		<!-- Skills Lv51 -->
 		<skill name="Anti Magic" id="146" level="23" required-level="51" sp="250000" />
 		<skill name="Divine Power" id="1459" level="1" required-level="51" sp="250000" />
 		<skill name="Greater Battle Heal" id="1218" level="11" required-level="51" sp="250000" />
@@ -139,10 +196,14 @@
 		<skill name="Light Armor Mastery" id="236" level="19" required-level="51" sp="250000" />
 		<skill name="Robe Mastery" id="235" level="19" required-level="51" sp="250000" />
 		<skill name="Weapon Mastery" id="249" level="20" required-level="51" sp="250000" />
-		<skill name="Vitalize" id="1020" level="5" required-level="51" sp="250000" />
-		<skill name="Sleep" id="1069" level="20" required-level="51" sp="250000" />
-		
+		<skill name="Vitalize" id="1020" level="6" required-level="51" sp="250000" />
+		<skill name="Sleep" id="1069" level="21" required-level="51" sp="250000" />
+
+		<!-- Skills Lv52 -->
 		<skill name="Anti Magic" id="146" level="24" required-level="52" sp="250000" />
+		<skill name="Divine Inspiration" id="1405" level="1" required-level="51" sp="250000" >
+			<item id="8618" count="1" /> <!-- Ancient Book: Divine Inspiration Lv 1 -->
+		</skill>
 		<skill name="Fast HP Recovery" id="212" level="3" required-level="52" sp="250000" />
 		<skill name="Fast Mana Recovery" id="229" level="4" required-level="52" sp="250000" />
 		<skill name="Greater Battle Heal" id="1218" level="12" required-level="52" sp="250000" />
@@ -151,20 +212,26 @@
 		<skill name="Light Armor Mastery" id="236" level="20" required-level="52" sp="250000" />
 		<skill name="Robe Mastery" id="235" level="20" required-level="52" sp="250000" />
 		<skill name="Weapon Mastery" id="249" level="21" required-level="52" sp="250000" />
+		<skill name="Concentration" id="1078" level="4" required-level="52" sp="250000" />
+		<skill name="Dryad Root" id="1201" level="21" required-level="52" sp="250000" />
 		<skill name="Mass Resurrection" id="1254" level="3" required-level="52" sp="250000" />
-		<skill name="Vitalize" id="1020" level="6" required-level="52" sp="250000" />
-		<skill name="Hold Undead" id="1042" level="2" required-level="52" sp="250000" />
+		<skill name="Vitalize" id="1020" level="7" required-level="52" sp="250000" />
 		<skill name="Purify" id="1018" level="2" required-level="52" sp="250000" />
+		<skill name="Paralysis" id="1042" level="2" required-level="52" sp="250000" />
 		<skill name="Peace" id="1075" level="5" required-level="52" sp="250000" />
 		<skill name="Restore Life" id="1258" level="3" required-level="52" sp="250000" />
 		<skill name="Requiem" id="1049" level="4" required-level="52" sp="250000" />
 		<skill name="Might of Heaven" id="1028" level="8" required-level="52" sp="250000" />
+		<skill name="Weakness" id="1164" level="9" required-level="52" sp="250000" />
 		<skill name="Repose" id="1034" level="3" required-level="52" sp="250000" />
-		<skill name="Sleep" id="1069" level="21" required-level="52" sp="250000" />
-		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="250000" >
-			<item id="8618"/> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
-		</skill>
-		
+		<skill name="Sleep" id="1069" level="22" required-level="52" sp="250000" />
+		<skill name="Mana Effect Boost" id="1013" level="12" required-level="52" sp="250000" />
+
+		<!-- Skills Lv53 -->
+		<skill name="Vitalize" id="1020" level="8" required-level="53" sp="250000" />
+		<skill name="Sleep" id="1069" level="23" required-level="53" sp="250000" />
+
+		<!-- Skills Lv54 -->
 		<skill name="Anti Magic" id="146" level="25" required-level="54" sp="400000" />
 		<skill name="Greater Battle Heal" id="1218" level="13" required-level="54" sp="400000" />
 		<skill name="Greater Group Heal" id="1219" level="13" required-level="54" sp="400000" />
@@ -172,10 +239,13 @@
 		<skill name="Light Armor Mastery" id="236" level="21" required-level="54" sp="400000" />
 		<skill name="Robe Mastery" id="235" level="21" required-level="54" sp="400000" />
 		<skill name="Weapon Mastery" id="249" level="22" required-level="54" sp="400000" />
-		<skill name="Vitalize" id="1020" level="7" required-level="54" sp="400000" />
+		<skill name="Dryad Root" id="1201" level="22" required-level="54" sp="400000" />
+		<skill name="Vitalize" id="1020" level="9" required-level="54" sp="400000" />
 		<skill name="Might of Heaven" id="1028" level="9" required-level="54" sp="400000" />
-		<skill name="Sleep" id="1069" level="22" required-level="54" sp="400000" />
-		
+		<skill name="Sleep" id="1069" level="24" required-level="54" sp="400000" />
+		<skill name="Mana Effect Boost" id="1013" level="13" required-level="54" sp="400000" />
+
+		<!-- Skills Lv55 -->
 		<skill name="Anti Magic" id="146" level="26" required-level="55" sp="400000" />
 		<skill name="Greater Battle Heal" id="1218" level="14" required-level="55" sp="400000" />
 		<skill name="Greater Group Heal" id="1219" level="14" required-level="55" sp="400000" />
@@ -183,9 +253,10 @@
 		<skill name="Light Armor Mastery" id="236" level="22" required-level="55" sp="400000" />
 		<skill name="Robe Mastery" id="235" level="22" required-level="55" sp="400000" />
 		<skill name="Weapon Mastery" id="249" level="23" required-level="55" sp="400000" />
-		<skill name="Vitalize" id="1020" level="8" required-level="55" sp="400000" />
-		<skill name="Sleep" id="1069" level="23" required-level="55" sp="400000" />
-		
+		<skill name="Vitalize" id="1020" level="10" required-level="55" sp="400000" />
+		<skill name="Sleep" id="1069" level="25" required-level="55" sp="400000" />
+
+		<!-- Skills Lv56 -->
 		<skill name="Anti Magic" id="146" level="27" required-level="56" sp="400000" />
 		<skill name="Fast Spell Casting" id="228" level="3" required-level="56" sp="400000" />
 		<skill name="Greater Battle Heal" id="1218" level="15" required-level="56" sp="400000" />
@@ -196,18 +267,22 @@
 		<skill name="Weapon Mastery" id="249" level="24" required-level="56" sp="400000" />
 		<skill name="Resurrection" id="1016" level="5" required-level="56" sp="400000" />
 		<skill name="Body of Avatar" id="1311" level="2" required-level="56" sp="400000" />
+		<skill name="Dryad Root" id="1201" level="23" required-level="56" sp="400000" />
 		<skill name="Magical Backfire" id="1396" level="1" required-level="56" sp="400000" />
 		<skill name="Mass Resurrection" id="1254" level="4" required-level="56" sp="400000" />
-		<skill name="Vitalize" id="1020" level="9" required-level="56" sp="400000" />
-		<skill name="Hold Undead" id="1042" level="3" required-level="56" sp="400000" />
+		<skill name="Vitalize" id="1020" level="11" required-level="56" sp="400000" />
+		<skill name="Paralysis" id="1042" level="3" required-level="56" sp="400000" />
 		<skill name="Peace" id="1075" level="6" required-level="56" sp="400000" />
 		<skill name="Restore Life" id="1258" level="4" required-level="56" sp="400000" />
 		<skill name="Requiem" id="1049" level="5" required-level="56" sp="400000" />
 		<skill name="Might of Heaven" id="1028" level="10" required-level="56" sp="400000" />
+		<skill name="Weakness" id="1164" level="10" required-level="56" sp="400000" />
 		<skill name="Boost Mana" id="213" level="5" required-level="56" sp="400000" />
 		<skill name="Repose" id="1034" level="4" required-level="56" sp="400000" />
-		<skill name="Sleep" id="1069" level="24" required-level="56" sp="400000" />
+		<skill name="Sleep" id="1069" level="26" required-level="56" sp="400000" />
+		<skill name="Mana Effect Boost" id="1013" level="14" required-level="56" sp="400000" />
 
+		<!-- Skills Lv57 -->
 		<skill name="Anti Magic" id="146" level="28" required-level="57" sp="410000" />
 		<skill name="Greater Battle Heal" id="1218" level="16" required-level="57" sp="410000" />
 		<skill name="Greater Group Heal" id="1219" level="16" required-level="57" sp="410000" />
@@ -215,9 +290,11 @@
 		<skill name="Light Armor Mastery" id="236" level="24" required-level="57" sp="410000" />
 		<skill name="Robe Mastery" id="235" level="24" required-level="57" sp="410000" />
 		<skill name="Weapon Mastery" id="249" level="25" required-level="57" sp="410000" />
-		<skill name="Vitalize" id="1020" level="10" required-level="57" sp="410000" />
-		<skill name="Sleep" id="1069" level="25" required-level="57" sp="410000" />
-		
+		<skill name="Vitalize" id="1020" level="12" required-level="57" sp="410000" />
+		<skill name="Sleep" id="1069" level="27" required-level="57" sp="410000" />
+		<skill name="Mana Effect Boost" id="1013" level="15" required-level="57" sp="410000" />
+
+		<!-- Skills Lv58 -->
 		<skill name="Anti Magic" id="146" level="29" required-level="58" sp="410000" />
 		<skill name="Fast HP Recovery" id="212" level="4" required-level="58" sp="410000" />
 		<skill name="Greater Battle Heal" id="1218" level="17" required-level="58" sp="410000" />
@@ -226,17 +303,21 @@
 		<skill name="Light Armor Mastery" id="236" level="25" required-level="58" sp="410000" />
 		<skill name="Robe Mastery" id="235" level="25" required-level="58" sp="410000" />
 		<skill name="Weapon Mastery" id="249" level="26" required-level="58" sp="410000" />
-		<skill name="Cure Poison" id="1012" level="3" required-level="58" sp="410000" />
+		<skill name="Cure" id="1012" level="3" required-level="58" sp="410000" />
+		<skill name="Dryad Root" id="1201" level="24" required-level="58" sp="410000" />
 		<skill name="Magical Backfire" id="1396" level="2" required-level="58" sp="410000" />
 		<skill name="Mass Resurrection" id="1254" level="5" required-level="58" sp="410000" />
-		<skill name="Vitalize" id="1020" level="11" required-level="58" sp="410000" />
-		<skill name="Hold Undead" id="1042" level="4" required-level="58" sp="410000" />
+		<skill name="Vitalize" id="1020" level="13" required-level="58" sp="410000" />
+		<skill name="Paralysis" id="1042" level="4" required-level="58" sp="410000" />
 		<skill name="Peace" id="1075" level="7" required-level="58" sp="410000" />
 		<skill name="Requiem" id="1049" level="6" required-level="58" sp="410000" />
 		<skill name="Might of Heaven" id="1028" level="11" required-level="58" sp="410000" />
+		<skill name="Weakness" id="1164" level="11" required-level="58" sp="410000" />
 		<skill name="Repose" id="1034" level="5" required-level="58" sp="410000" />
-		<skill name="Sleep" id="1069" level="26" required-level="58" sp="410000" />
+		<skill name="Sleep" id="1069" level="28" required-level="58" sp="410000" />
+		<skill name="Mana Effect Boost" id="1013" level="16" required-level="58" sp="410000" />
 
+		<!-- Skills Lv59 -->
 		<skill name="Anti Magic" id="146" level="30" required-level="59" sp="490000" />
 		<skill name="Greater Battle Heal" id="1218" level="18" required-level="59" sp="490000" />
 		<skill name="Greater Group Heal" id="1219" level="18" required-level="59" sp="490000" />
@@ -244,9 +325,11 @@
 		<skill name="Light Armor Mastery" id="236" level="26" required-level="59" sp="490000" />
 		<skill name="Robe Mastery" id="235" level="26" required-level="59" sp="490000" />
 		<skill name="Weapon Mastery" id="249" level="27" required-level="59" sp="490000" />
-		<skill name="Vitalize" id="1020" level="12" required-level="59" sp="490000" />
-		<skill name="Sleep" id="1069" level="27" required-level="59" sp="490000" />
-		
+		<skill name="Vitalize" id="1020" level="14" required-level="59" sp="490000" />
+		<skill name="Sleep" id="1069" level="29" required-level="59" sp="490000" />
+		<skill name="Mana Effect Boost" id="1013" level="17" required-level="59" sp="490000" />
+
+		<!-- Skills Lv60 -->
 		<skill name="Anti Magic" id="146" level="31" required-level="60" sp="490000" />
 		<skill name="Divine Power" id="1459" level="2" required-level="60" sp="490000" />
 		<skill name="Fast Mana Recovery" id="229" level="5" required-level="60" sp="490000" />
@@ -257,30 +340,44 @@
 		<skill name="Robe Mastery" id="235" level="27" required-level="60" sp="490000" />
 		<skill name="Weapon Mastery" id="249" level="28" required-level="60" sp="490000" />
 		<skill name="Resurrection" id="1016" level="6" required-level="60" sp="490000" />
+		<skill name="Swap Defense" id="1392" level="2" required-level="60" sp="500000" />
 		<skill name="Body of Avatar" id="1311" level="3" required-level="60" sp="490000" />
+		<skill name="Concentration" id="1078" level="5" required-level="60" sp="490000" />
+		<skill name="Dryad Root" id="1201" level="25" required-level="60" sp="490000" />
 		<skill name="Magical Backfire" id="1396" level="3" required-level="60" sp="490000" />
-		<skill name="Vitalize" id="1020" level="13" required-level="60" sp="490000" />
-		<skill name="Hold Undead" id="1042" level="5" required-level="60" sp="490000" />
+		<skill name="Spell Master" id="1829" level="2" required-level="60" sp="500000" >
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Vitalize" id="1020" level="15" required-level="60" sp="490000" />
+		<skill name="Poison" id="1168" level="6" required-level="60" sp="490000" />
+		<skill name="Paralysis" id="1042" level="5" required-level="60" sp="490000" />
+		<skill name="Convert" id="1393" level="2" required-level="60" sp="500000" />
 		<skill name="Peace" id="1075" level="8" required-level="60" sp="490000" />
 		<skill name="Requiem" id="1049" level="7" required-level="60" sp="490000" />
 		<skill name="Might of Heaven" id="1028" level="12" required-level="60" sp="490000" />
+		<skill name="Weakness" id="1164" level="12" required-level="60" sp="490000" />
+		<skill name="Dark Assassin Transformation" id="1801" level="1" required-level="60" auto-learn="true" />
 		<skill name="Boost Mana" id="213" level="6" required-level="60" sp="490000" />
 		<skill name="Repose" id="1034" level="6" required-level="60" sp="490000" />
-		<skill name="Sleep" id="1069" level="28" required-level="60" sp="490000" />
-		
+		<skill name="Sleep" id="1069" level="30" required-level="60" sp="490000" />
+		<skill name="Mana Effect Boost" id="1013" level="18" required-level="60" sp="490000" />
+
+		<!-- Skills Lv61 -->
 		<skill name="Anti Magic" id="146" level="32" required-level="61" sp="590000" />
+		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="590000" >
+			<item id="8619" count="1" /> <!-- Ancient Book: Divine Inspiration Lv 2 -->
+		</skill>
 		<skill name="Greater Battle Heal" id="1218" level="20" required-level="61" sp="590000" />
 		<skill name="Greater Group Heal" id="1219" level="20" required-level="61" sp="590000" />
 		<skill name="Greater Heal" id="1217" level="20" required-level="61" sp="590000" />
 		<skill name="Light Armor Mastery" id="236" level="28" required-level="61" sp="590000" />
 		<skill name="Robe Mastery" id="235" level="28" required-level="61" sp="590000" />
 		<skill name="Weapon Mastery" id="249" level="29" required-level="61" sp="590000" />
-		<skill name="Vitalize" id="1020" level="14" required-level="61" sp="590000" />
-		<skill name="Sleep" id="1069" level="29" required-level="61" sp="590000" />
-		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="590000" >
-			<item id="8619"/> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
-		</skill>
-		
+		<skill name="Vitalize" id="1020" level="16" required-level="61" sp="590000" />
+		<skill name="Sleep" id="1069" level="31" required-level="61" sp="590000" />
+		<skill name="Mana Effect Boost" id="1013" level="19" required-level="61" sp="590000" />
+
+		<!-- Skills Lv62 -->
 		<skill name="Anti Magic" id="146" level="33" required-level="62" sp="590000" />
 		<skill name="Greater Battle Heal" id="1218" level="21" required-level="62" sp="590000" />
 		<skill name="Greater Group Heal" id="1219" level="21" required-level="62" sp="590000" />
@@ -288,16 +385,20 @@
 		<skill name="Light Armor Mastery" id="236" level="29" required-level="62" sp="590000" />
 		<skill name="Robe Mastery" id="235" level="29" required-level="62" sp="590000" />
 		<skill name="Weapon Mastery" id="249" level="30" required-level="62" sp="590000" />
+		<skill name="Dryad Root" id="1201" level="26" required-level="62" sp="590000" />
 		<skill name="Magical Backfire" id="1396" level="4" required-level="62" sp="590000" />
-		<skill name="Vitalize" id="1020" level="15" required-level="62" sp="590000" />
-		<skill name="Hold Undead" id="1042" level="6" required-level="62" sp="590000" />
+		<skill name="Vitalize" id="1020" level="17" required-level="62" sp="590000" />
 		<skill name="Purify" id="1018" level="3" required-level="62" sp="590000" />
+		<skill name="Paralysis" id="1042" level="6" required-level="62" sp="590000" />
 		<skill name="Peace" id="1075" level="9" required-level="62" sp="590000" />
 		<skill name="Requiem" id="1049" level="8" required-level="62" sp="590000" />
 		<skill name="Might of Heaven" id="1028" level="13" required-level="62" sp="590000" />
+		<skill name="Weakness" id="1164" level="13" required-level="62" sp="590000" />
 		<skill name="Repose" id="1034" level="7" required-level="62" sp="590000" />
-		<skill name="Sleep" id="1069" level="30" required-level="62" sp="590000" />
-		
+		<skill name="Sleep" id="1069" level="32" required-level="62" sp="590000" />
+		<skill name="Mana Effect Boost" id="1013" level="20" required-level="62" sp="590000" />
+
+		<!-- Skills Lv63 -->
 		<skill name="Anti Magic" id="146" level="34" required-level="63" sp="740000" />
 		<skill name="Greater Battle Heal" id="1218" level="22" required-level="63" sp="740000" />
 		<skill name="Greater Group Heal" id="1219" level="22" required-level="63" sp="740000" />
@@ -305,9 +406,11 @@
 		<skill name="Light Armor Mastery" id="236" level="30" required-level="63" sp="740000" />
 		<skill name="Robe Mastery" id="235" level="30" required-level="63" sp="740000" />
 		<skill name="Weapon Mastery" id="249" level="31" required-level="63" sp="740000" />
-		<skill name="Vitalize" id="1020" level="16" required-level="63" sp="740000" />
-		<skill name="Sleep" id="1069" level="31" required-level="63" sp="740000" />
-		
+		<skill name="Vitalize" id="1020" level="18" required-level="63" sp="740000" />
+		<skill name="Sleep" id="1069" level="33" required-level="63" sp="740000" />
+		<skill name="Mana Effect Boost" id="1013" level="21" required-level="63" sp="740000" />
+
+		<!-- Skills Lv64 -->
 		<skill name="Anti Magic" id="146" level="35" required-level="64" sp="740000" />
 		<skill name="Fast HP Recovery" id="212" level="5" required-level="64" sp="740000" />
 		<skill name="Greater Battle Heal" id="1218" level="23" required-level="64" sp="740000" />
@@ -318,15 +421,19 @@
 		<skill name="Weapon Mastery" id="249" level="32" required-level="64" sp="740000" />
 		<skill name="Resurrection" id="1016" level="7" required-level="64" sp="740000" />
 		<skill name="Body of Avatar" id="1311" level="4" required-level="64" sp="740000" />
+		<skill name="Dryad Root" id="1201" level="27" required-level="64" sp="740000" />
 		<skill name="Magical Backfire" id="1396" level="5" required-level="64" sp="740000" />
-		<skill name="Vitalize" id="1020" level="17" required-level="64" sp="740000" />
-		<skill name="Hold Undead" id="1042" level="7" required-level="64" sp="740000" />
+		<skill name="Vitalize" id="1020" level="19" required-level="64" sp="740000" />
+		<skill name="Paralysis" id="1042" level="7" required-level="64" sp="740000" />
 		<skill name="Peace" id="1075" level="10" required-level="64" sp="740000" />
 		<skill name="Requiem" id="1049" level="9" required-level="64" sp="740000" />
 		<skill name="Might of Heaven" id="1028" level="14" required-level="64" sp="740000" />
+		<skill name="Weakness" id="1164" level="14" required-level="64" sp="740000" />
 		<skill name="Repose" id="1034" level="8" required-level="64" sp="740000" />
-		<skill name="Sleep" id="1069" level="32" required-level="64" sp="740000" />
+		<skill name="Sleep" id="1069" level="34" required-level="64" sp="740000" />
+		<skill name="Mana Effect Boost" id="1013" level="22" required-level="64" sp="740000" />
 
+		<!-- Skills Lv65 -->
 		<skill name="Anti Magic" id="146" level="36" required-level="65" sp="920000" />
 		<skill name="Greater Battle Heal" id="1218" level="24" required-level="65" sp="920000" />
 		<skill name="Greater Group Heal" id="1219" level="24" required-level="65" sp="920000" />
@@ -334,29 +441,33 @@
 		<skill name="Light Armor Mastery" id="236" level="32" required-level="65" sp="920000" />
 		<skill name="Robe Mastery" id="235" level="32" required-level="65" sp="920000" />
 		<skill name="Weapon Mastery" id="249" level="33" required-level="65" sp="920000" />
-		<skill name="Vitalize" id="1020" level="18" required-level="65" sp="920000" />
-		<skill name="Sleep" id="1069" level="33" required-level="65" sp="920000" />
-		
+		<skill name="Vitalize" id="1020" level="20" required-level="65" sp="920000" />
+		<skill name="Sleep" id="1069" level="35" required-level="65" sp="920000" />
+		<skill name="Mana Effect Boost" id="1013" level="23" required-level="65" sp="920000" />
+
+		<!-- Skills Lv66 -->
 		<skill name="Anti Magic" id="146" level="37" required-level="66" sp="920000" />
+		<skill name="Benediction" id="1271" level="1" required-level="66" sp="920000" />
 		<skill name="Greater Battle Heal" id="1218" level="25" required-level="66" sp="920000" />
 		<skill name="Greater Group Heal" id="1219" level="25" required-level="66" sp="920000" />
 		<skill name="Greater Heal" id="1217" level="25" required-level="66" sp="920000" />
 		<skill name="Light Armor Mastery" id="236" level="33" required-level="66" sp="920000" />
 		<skill name="Robe Mastery" id="235" level="33" required-level="66" sp="920000" />
 		<skill name="Weapon Mastery" id="249" level="34" required-level="66" sp="920000" />
+		<skill name="Dryad Root" id="1201" level="28" required-level="66" sp="920000" />
 		<skill name="Magical Backfire" id="1396" level="6" required-level="66" sp="920000" />
-		<skill name="Vitalize" id="1020" level="19" required-level="66" sp="920000" />
-		<skill name="Hold Undead" id="1042" level="8" required-level="66" sp="920000" />
+		<skill name="Vitalize" id="1020" level="21" required-level="66" sp="920000" />
+		<skill name="Paralysis" id="1042" level="8" required-level="66" sp="920000" />
 		<skill name="Peace" id="1075" level="11" required-level="66" sp="920000" />
 		<skill name="Requiem" id="1049" level="10" required-level="66" sp="920000" />
 		<skill name="Might of Heaven" id="1028" level="15" required-level="66" sp="920000" />
+		<skill name="Weakness" id="1164" level="15" required-level="66" sp="920000" />
 		<skill name="Boost Mana" id="213" level="7" required-level="66" sp="920000" />
 		<skill name="Repose" id="1034" level="9" required-level="66" sp="920000" />
-		<skill name="Sleep" id="1069" level="34" required-level="66" sp="920000" />
-		<skill name="Benediction" id="1271" level="1" required-level="66" sp="920000" >
-			<item id="4912"/>
-		</skill>
-		
+		<skill name="Sleep" id="1069" level="36" required-level="66" sp="920000" />
+		<skill name="Mana Effect Boost" id="1013" level="24" required-level="66" sp="920000" />
+
+		<!-- Skills Lv67 -->
 		<skill name="Anti Magic" id="146" level="38" required-level="67" sp="1200000" />
 		<skill name="Greater Battle Heal" id="1218" level="26" required-level="67" sp="1200000" />
 		<skill name="Greater Group Heal" id="1219" level="26" required-level="67" sp="1200000" />
@@ -364,9 +475,11 @@
 		<skill name="Light Armor Mastery" id="236" level="34" required-level="67" sp="1200000" />
 		<skill name="Robe Mastery" id="235" level="34" required-level="67" sp="1200000" />
 		<skill name="Weapon Mastery" id="249" level="35" required-level="67" sp="1200000" />
-		<skill name="Vitalize" id="1020" level="20" required-level="67" sp="1200000" />
-		<skill name="Sleep" id="1069" level="35" required-level="67" sp="1200000" />
-		
+		<skill name="Vitalize" id="1020" level="22" required-level="67" sp="1200000" />
+		<skill name="Sleep" id="1069" level="37" required-level="67" sp="1200000" />
+		<skill name="Mana Effect Boost" id="1013" level="25" required-level="67" sp="1200000" />
+
+		<!-- Skills Lv68 -->
 		<skill name="Anti Magic" id="146" level="39" required-level="68" sp="1200000" />
 		<skill name="Fast Mana Recovery" id="229" level="6" required-level="68" sp="1200000" />
 		<skill name="Greater Battle Heal" id="1218" level="27" required-level="68" sp="1200000" />
@@ -376,16 +489,21 @@
 		<skill name="Robe Mastery" id="235" level="35" required-level="68" sp="1200000" />
 		<skill name="Weapon Mastery" id="249" level="36" required-level="68" sp="1200000" />
 		<skill name="Body of Avatar" id="1311" level="5" required-level="68" sp="1200000" />
+		<skill name="Concentration" id="1078" level="6" required-level="68" sp="1200000" />
+		<skill name="Dryad Root" id="1201" level="29" required-level="68" sp="1200000" />
 		<skill name="Magical Backfire" id="1396" level="7" required-level="68" sp="1200000" />
 		<skill name="Mass Resurrection" id="1254" level="6" required-level="68" sp="1200000" />
-		<skill name="Vitalize" id="1020" level="21" required-level="68" sp="1200000" />
-		<skill name="Hold Undead" id="1042" level="9" required-level="68" sp="1200000" />
+		<skill name="Vitalize" id="1020" level="23" required-level="68" sp="1200000" />
+		<skill name="Paralysis" id="1042" level="9" required-level="68" sp="1200000" />
 		<skill name="Peace" id="1075" level="12" required-level="68" sp="1200000" />
 		<skill name="Requiem" id="1049" level="11" required-level="68" sp="1200000" />
 		<skill name="Might of Heaven" id="1028" level="16" required-level="68" sp="1200000" />
+		<skill name="Weakness" id="1164" level="16" required-level="68" sp="1200000" />
 		<skill name="Repose" id="1034" level="10" required-level="68" sp="1200000" />
-		<skill name="Sleep" id="1069" level="36" required-level="68" sp="1200000" />
+		<skill name="Sleep" id="1069" level="38" required-level="68" sp="1200000" />
+		<skill name="Mana Effect Boost" id="1013" level="26" required-level="68" sp="1200000" />
 
+		<!-- Skills Lv69 -->
 		<skill name="Anti Magic" id="146" level="40" required-level="69" sp="1400000" />
 		<skill name="Divine Power" id="1459" level="3" required-level="69" sp="1400000" />
 		<skill name="Greater Battle Heal" id="1218" level="28" required-level="69" sp="1400000" />
@@ -394,9 +512,11 @@
 		<skill name="Light Armor Mastery" id="236" level="36" required-level="69" sp="1400000" />
 		<skill name="Robe Mastery" id="235" level="36" required-level="69" sp="1400000" />
 		<skill name="Weapon Mastery" id="249" level="37" required-level="69" sp="1400000" />
-		<skill name="Vitalize" id="1020" level="22" required-level="69" sp="1400000" />
-		<skill name="Sleep" id="1069" level="37" required-level="69" sp="1400000" />
-		
+		<skill name="Vitalize" id="1020" level="24" required-level="69" sp="1400000" />
+		<skill name="Sleep" id="1069" level="39" required-level="69" sp="1400000" />
+		<skill name="Mana Effect Boost" id="1013" level="27" required-level="69" sp="1400000" />
+
+		<!-- Skills Lv70 -->
 		<skill name="Anti Magic" id="146" level="41" required-level="70" sp="1400000" />
 		<skill name="Greater Battle Heal" id="1218" level="29" required-level="70" sp="1400000" />
 		<skill name="Greater Group Heal" id="1219" level="29" required-level="70" sp="1400000" />
@@ -405,15 +525,26 @@
 		<skill name="Robe Mastery" id="235" level="37" required-level="70" sp="1400000" />
 		<skill name="Weapon Mastery" id="249" level="38" required-level="70" sp="1400000" />
 		<skill name="Resurrection" id="1016" level="8" required-level="70" sp="1400000" />
+		<skill name="Swap Defense" id="1392" level="3" required-level="70" sp="2000000" />
+		<skill name="Dryad Root" id="1201" level="30" required-level="70" sp="1400000" />
 		<skill name="Magical Backfire" id="1396" level="8" required-level="70" sp="1400000" />
-		<skill name="Vitalize" id="1020" level="23" required-level="70" sp="1400000" />
-		<skill name="Hold Undead" id="1042" level="10" required-level="70" sp="1400000" />
+		<skill name="Spell Master" id="1829" level="3" required-level="70" sp="1200000" >
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Vitalize" id="1020" level="25" required-level="70" sp="1400000" />
+		<skill name="Poison" id="1168" level="7" required-level="70" sp="1400000" />
+		<skill name="Paralysis" id="1042" level="10" required-level="70" sp="1400000" />
+		<skill name="Convert" id="1393" level="3" required-level="70" sp="2000000" />
 		<skill name="Peace" id="1075" level="13" required-level="70" sp="1400000" />
 		<skill name="Requiem" id="1049" level="12" required-level="70" sp="1400000" />
 		<skill name="Might of Heaven" id="1028" level="17" required-level="70" sp="1400000" />
+		<skill name="Weakness" id="1164" level="17" required-level="70" sp="1400000" />
+		<skill name="White Assassin Transformation" id="1802" level="1" required-level="70" auto-learn="true" />
 		<skill name="Repose" id="1034" level="11" required-level="70" sp="1400000" />
-		<skill name="Sleep" id="1069" level="38" required-level="70" sp="1400000" />
-		
+		<skill name="Sleep" id="1069" level="40" required-level="70" sp="1400000" />
+		<skill name="Mana Effect Boost" id="1013" level="28" required-level="70" sp="1400000" />
+
+		<!-- Skills Lv71 -->
 		<skill name="Anti Magic" id="146" level="42" required-level="71" sp="1700000" />
 		<skill name="Greater Battle Heal" id="1218" level="30" required-level="71" sp="1700000" />
 		<skill name="Greater Group Heal" id="1219" level="30" required-level="71" sp="1700000" />
@@ -421,9 +552,11 @@
 		<skill name="Light Armor Mastery" id="236" level="38" required-level="71" sp="1700000" />
 		<skill name="Robe Mastery" id="235" level="38" required-level="71" sp="1700000" />
 		<skill name="Weapon Mastery" id="249" level="39" required-level="71" sp="1700000" />
-		<skill name="Vitalize" id="1020" level="24" required-level="71" sp="1700000" />
-		<skill name="Sleep" id="1069" level="39" required-level="71" sp="1700000" />
-		
+		<skill name="Vitalize" id="1020" level="26" required-level="71" sp="1700000" />
+		<skill name="Sleep" id="1069" level="41" required-level="71" sp="1700000" />
+		<skill name="Mana Effect Boost" id="1013" level="29" required-level="71" sp="1700000" />
+
+		<!-- Skills Lv72 -->
 		<skill name="Anti Magic" id="146" level="43" required-level="72" sp="1700000" />
 		<skill name="Greater Battle Heal" id="1218" level="31" required-level="72" sp="1700000" />
 		<skill name="Greater Group Heal" id="1219" level="31" required-level="72" sp="1700000" />
@@ -432,16 +565,20 @@
 		<skill name="Robe Mastery" id="235" level="39" required-level="72" sp="1700000" />
 		<skill name="Weapon Mastery" id="249" level="40" required-level="72" sp="1700000" />
 		<skill name="Body of Avatar" id="1311" level="6" required-level="72" sp="1700000" />
+		<skill name="Dryad Root" id="1201" level="31" required-level="72" sp="1700000" />
 		<skill name="Magical Backfire" id="1396" level="9" required-level="72" sp="1700000" />
-		<skill name="Vitalize" id="1020" level="25" required-level="72" sp="1700000" />
-		<skill name="Hold Undead" id="1042" level="11" required-level="72" sp="1700000" />
+		<skill name="Vitalize" id="1020" level="27" required-level="72" sp="1700000" />
+		<skill name="Paralysis" id="1042" level="11" required-level="72" sp="1700000" />
 		<skill name="Peace" id="1075" level="14" required-level="72" sp="1700000" />
 		<skill name="Requiem" id="1049" level="13" required-level="72" sp="1700000" />
 		<skill name="Might of Heaven" id="1028" level="18" required-level="72" sp="1700000" />
+		<skill name="Weakness" id="1164" level="18" required-level="72" sp="1700000" />
 		<skill name="Boost Mana" id="213" level="8" required-level="72" sp="1700000" />
 		<skill name="Repose" id="1034" level="12" required-level="72" sp="1700000" />
-		<skill name="Sleep" id="1069" level="40" required-level="72" sp="1700000" />
-		
+		<skill name="Sleep" id="1069" level="42" required-level="72" sp="1700000" />
+		<skill name="Mana Effect Boost" id="1013" level="30" required-level="72" sp="1700000" />
+
+		<!-- Skills Lv73 -->
 		<skill name="Anti Magic" id="146" level="44" required-level="73" sp="2000000" />
 		<skill name="Greater Battle Heal" id="1218" level="32" required-level="73" sp="2000000" />
 		<skill name="Greater Group Heal" id="1219" level="32" required-level="73" sp="2000000" />
@@ -449,9 +586,11 @@
 		<skill name="Light Armor Mastery" id="236" level="40" required-level="73" sp="2000000" />
 		<skill name="Robe Mastery" id="235" level="40" required-level="73" sp="2000000" />
 		<skill name="Weapon Mastery" id="249" level="41" required-level="73" sp="2000000" />
-		<skill name="Vitalize" id="1020" level="26" required-level="73" sp="2000000" />
-		<skill name="Sleep" id="1069" level="41" required-level="73" sp="2000000" />
-		
+		<skill name="Vitalize" id="1020" level="28" required-level="73" sp="2000000" />
+		<skill name="Sleep" id="1069" level="43" required-level="73" sp="2000000" />
+		<skill name="Mana Effect Boost" id="1013" level="31" required-level="73" sp="2000000" />
+
+		<!-- Skills Lv74 -->
 		<skill name="Anti Magic" id="146" level="45" required-level="74" sp="2000000" />
 		<skill name="Fast HP Recovery" id="212" level="6" required-level="74" sp="2000000" />
 		<skill name="Fast Mana Recovery" id="229" level="7" required-level="74" sp="2000000" />
@@ -462,13 +601,22 @@
 		<skill name="Robe Mastery" id="235" level="41" required-level="74" sp="2000000" />
 		<skill name="Weapon Mastery" id="249" level="42" required-level="74" sp="2000000" />
 		<skill name="Resurrection" id="1016" level="9" required-level="74" sp="2000000" />
+		<skill name="Dryad Root" id="1201" level="32" required-level="74" sp="2000000" />
 		<skill name="Magical Backfire" id="1396" level="10" required-level="74" sp="2000000" />
-		<skill name="Vitalize" id="1020" level="27" required-level="74" sp="2000000" />
-		<skill name="Hold Undead" id="1042" level="12" required-level="74" sp="2000000" />
+		<skill name="Vitalize" id="1020" level="29" required-level="74" sp="2000000" />
+		<skill name="Paralysis" id="1042" level="12" required-level="74" sp="2000000" />
 		<skill name="Peace" id="1075" level="15" required-level="74" sp="2000000" />
 		<skill name="Requiem" id="1049" level="14" required-level="74" sp="2000000" />
 		<skill name="Might of Heaven" id="1028" level="19" required-level="74" sp="2000000" />
+		<skill name="Weakness" id="1164" level="19" required-level="74" sp="2000000" />
 		<skill name="Repose" id="1034" level="13" required-level="74" sp="2000000" />
-		<skill name="Sleep" id="1069" level="42" required-level="74" sp="2000000" />
+		<skill name="Sleep" id="1069" level="44" required-level="74" sp="2000000" />
+		<skill name="Mana Effect Boost" id="1013" level="32" required-level="74" sp="2000000" />
+
+		<!-- Skills Lv75 -->
+		<skill name="Vitalize" id="1020" level="30" required-level="75" sp="2000000" />
+		<skill name="Might of Heaven" id="1028" level="20" required-level="75" sp="2000000" />
+		<skill name="Sleep" id="1069" level="45" required-level="75" sp="2000000" />
+
 	</skillTree>
 </list>

--- a/data/skillTrees/2ndClass/BladeDancer.xml
+++ b/data/skillTrees/2ndClass/BladeDancer.xml
@@ -1,343 +1,442 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="34" parentClassId="32">
-		<skill name="Pirate" id="1800" level="1" required-level="45" auto-learn="true" />
-		<skill name="Dark Assassin" id="1801" level="1" required-level="60" auto-learn="true" />
-		<skill name="White Assassin" id="1802" level="1" required-level="70" auto-learn="true" />
-		<skill name="Dual Weapon Mastery" id="144" level="1" required-level="40" sp="87000" />
-		<skill name="Dual Weapon Mastery" id="144" level="2" required-level="40" sp="87000" />
-		<skill name="Dual Weapon Mastery" id="144" level="3" required-level="40" sp="87000" />
+
+		<!-- Master Buffs Lv. 40 -->
+		<skill name="Might" id="1068" level="3" required-level="40" sp="80000" />
+		<skill name="Shield" id="1040" level="3" required-level="40" sp="80000" />
+		<skill name="Acumen" id="45104" level="3" required-level="40" sp="80000" />
+		<skill name="Empower" id="45105" level="3" required-level="40" sp="80000" />
+		<skill name="Wild Magic" id="45106" level="2" required-level="40" sp="80000" />
+		<skill name="Magic Barrier" id="45108" level="2" required-level="40" sp="80000" />
+		<skill name="Focus" id="45109" level="3" required-level="40" sp="80000" />
+		<skill name="Death Whisper" id="45110" level="3" required-level="40" sp="80000" />
+		<skill name="Haste" id="45111" level="2" required-level="40" sp="80000" />
+		<skill name="Berserker Spirit" id="45112" level="2" required-level="40" sp="80000" />
+		<skill name="Clarity" id="45113" level="3" required-level="40" sp="80000" />
+
+		<!-- Skills Lv40 -->
+		<skill name="Majesty" id="82" level="2" required-level="40" sp="87000" />
+		<skill name="Potion Mastery" id="45184" level="1" required-level="40">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Weapon Mastery" id="141" level="4" required-level="40" sp="87000" />
+		<skill name="Dual Sword Mastery" id="144" level="1" required-level="40" sp="87000" />
+		<skill name="Dual Sword Mastery" id="144" level="2" required-level="40" sp="87000" />
+		<skill name="Dual Sword Mastery" id="144" level="3" required-level="40" sp="87000" />
 		<skill name="Heavy Armor Mastery" id="232" level="16" required-level="40" sp="87000" />
 		<skill name="Heavy Armor Mastery" id="232" level="17" required-level="40" sp="87000" />
 		<skill name="Heavy Armor Mastery" id="232" level="18" required-level="40" sp="87000" />
-		<skill name="Sting" id="223" level="13" required-level="40" sp="87000" />
-		<skill name="Sting" id="223" level="14" required-level="40" sp="87000" />
-		<skill name="Sting" id="223" level="15" required-level="40" sp="87000" />
+		<skill name="Dignity" id="196" level="1" required-level="40" sp="87000" />
 		<skill name="Confusion" id="2" level="5" required-level="40" sp="87000" />
-		<skill name="Freezing Strike" id="105" level="3" required-level="40" sp="87000" />
-		<skill name="Freezing Strike" id="105" level="4" required-level="40" sp="87000" />
-		<skill name="Drain Energy" id="70" level="17" required-level="40" sp="87000" />
-		<skill name="Drain Energy" id="70" level="18" required-level="40" sp="87000" />
-		<skill name="Drain Energy" id="70" level="19" required-level="40" sp="87000" />
+		<skill name="Freezing Weapon" id="105" level="5" required-level="40" sp="87000" />
+		<skill name="Drain Energy" id="45250" level="6" required-level="40" sp="87000" />
+		<skill name="Blood Attack" id="223" level="15" required-level="40" sp="87000" />
 		<skill name="Magic Resistance" id="147" level="15" required-level="40" sp="87000" />
 		<skill name="Magic Resistance" id="147" level="16" required-level="40" sp="87000" />
 		<skill name="Magic Resistance" id="147" level="17" required-level="40" sp="87000" />
+		<skill name="Hex" id="122" level="1" required-level="40" sp="87000" />
 		<skill name="Power Break" id="115" level="3" required-level="40" sp="87000" />
-		<skill name="Dance of Fire" id="274" level="1" required-level="40" sp="87000" />
-		<skill name="Potion Mastery" id="45184" level="1" required-level="40">
-			<item id="57" count="1000000"/> <!-- Adena -->
+		<skill name="Guard Crush" id="45187" level="1" required-level="40" sp="87000" />
+		<skill name="Fatal Slasher" id="45185" level="1" required-level="40" sp="87000" />
+		<skill name="Honor" id="197" level="1" required-level="40" sp="87000" />
+		<skill name="Emergency Rescue" id="70" level="10" required-level="40" sp="87000" />
+		<skill name="Intoxicating Dance" id="45395" level="1" required-level="40" sp="87000" >
+			<item id="94320" count="1" /> <!-- Spellbook: Intoxicating Dance -->
 		</skill>
-		<skill name="Hex" id="122" level="1" required-level="40" sp="87000" >
-			<item id="3050"/>
+		<skill name="Warrior's Dance" id="274" level="1" required-level="40" sp="87000" />
+		<skill name="Warrior's Dance" id="274" level="2" required-level="40" sp="87000" >
+			<item id="94326" count="1" /> <!-- Spellbook: Dance of Warrior -->
 		</skill>
-		
-		<skill name="Dual Weapon Mastery" id="144" level="4" required-level="41" sp="100000" />
+		<skill name="Dance of Fire" id="271" level="1" required-level="40" sp="87000" />
+		<skill name="Dance of Fire" id="271" level="2" required-level="40" sp="87000" >
+			<item id="94327" count="1" /> <!-- Spellbook: Dance of Fire -->
+		</skill>
+		<skill name="Dance of Fury" id="310" level="1" required-level="40" sp="87000" />
+		<skill name="Dance of Fury" id="310" level="2" required-level="40" sp="87000" >
+			<item id="95349" count="1" /> <!-- Spellbook: Dance of Fury -->
+		</skill>
+
+		<!-- Skills Lv41 -->
+		<skill name="Dual Sword Mastery" id="144" level="4" required-level="41" sp="100000" />
 		<skill name="Heavy Armor Mastery" id="232" level="19" required-level="41" sp="100000" />
-		<skill name="Sting" id="223" level="16" required-level="41" sp="100000" />
-		<skill name="Drain Energy" id="70" level="20" required-level="41" sp="100000" />
+		<skill name="Blood Attack" id="223" level="16" required-level="41" sp="100000" />
 		<skill name="Magic Resistance" id="147" level="18" required-level="41" sp="100000" />
-		
-		<skill name="Dual Weapon Mastery" id="144" level="5" required-level="42" sp="100000" />
+		<skill name="Emergency Rescue" id="70" level="11" required-level="41" sp="100000" />
+
+		<!-- Skills Lv42 -->
+		<skill name="Dual Sword Mastery" id="144" level="5" required-level="42" sp="100000" />
 		<skill name="Heavy Armor Mastery" id="232" level="20" required-level="42" sp="100000" />
-		<skill name="Sting" id="223" level="17" required-level="42" sp="100000" />
-		<skill name="Freezing Strike" id="105" level="5" required-level="42" sp="100000" />
-		<skill name="Drain Energy" id="70" level="21" required-level="42" sp="100000" />
+		<skill name="Freezing Weapon" id="105" level="6" required-level="42" sp="100000" />
+		<skill name="Drain Energy" id="45250" level="7" required-level="42" sp="100000" />
+		<skill name="Blood Attack" id="223" level="17" required-level="42" sp="100000" />
 		<skill name="Magic Resistance" id="147" level="19" required-level="42" sp="100000" />
-		
-		<skill name="Dual Weapon Mastery" id="144" level="6" required-level="43" sp="100000" />
+		<skill name="Dance of Protection" id="277" level="1" required-level="42" sp="100000" />
+		<skill name="Emergency Rescue" id="70" level="12" required-level="42" sp="100000" />
+
+		<!-- Skills Lv43 -->
+		<skill name="Dual Sword Mastery" id="144" level="6" required-level="43" sp="100000" />
 		<skill name="Heavy Armor Mastery" id="232" level="21" required-level="43" sp="100000" />
-		<skill name="Sting" id="223" level="18" required-level="43" sp="100000" />
 		<skill name="Confusion" id="2" level="6" required-level="43" sp="100000" />
-		<skill name="Freezing Strike" id="105" level="6" required-level="43" sp="100000" />
-		<skill name="Drain Energy" id="70" level="22" required-level="43" sp="100000" />
+		<skill name="Blood Attack" id="223" level="18" required-level="43" sp="100000" />
 		<skill name="Magic Resistance" id="147" level="20" required-level="43" sp="100000" />
 		<skill name="Hex" id="122" level="2" required-level="43" sp="100000" />
 		<skill name="Power Break" id="115" level="4" required-level="43" sp="100000" />
-		<skill name="Dance of Light" id="277" level="1" required-level="43" sp="100000" />
 		<skill name="Focus Mind" id="191" level="2" required-level="43" sp="100000" />
-		
-		<skill name="Dual Weapon Mastery" id="144" level="7" required-level="44" sp="150000" />
+		<skill name="Emergency Rescue" id="70" level="13" required-level="43" sp="100000" />
+
+		<!-- Skills Lv44 -->
+		<skill name="Dual Sword Mastery" id="144" level="7" required-level="44" sp="150000" />
 		<skill name="Heavy Armor Mastery" id="232" level="22" required-level="44" sp="150000" />
-		<skill name="Sting" id="223" level="19" required-level="44" sp="150000" />
-		<skill name="Drain Energy" id="70" level="23" required-level="44" sp="150000" />
+		<skill name="Freezing Weapon" id="105" level="7" required-level="44" sp="150000" />
+		<skill name="Drain Energy" id="45250" level="8" required-level="44" sp="150000" />
+		<skill name="Blood Attack" id="223" level="19" required-level="44" sp="150000" />
 		<skill name="Magic Resistance" id="147" level="21" required-level="44" sp="150000" />
-		<skill name="Dance of Protection" id="311" level="1" required-level="44" sp="150000" />
-		
-		<skill name="Dual Weapon Mastery" id="144" level="8" required-level="45" sp="150000" />
+		<skill name="Dark Elven Buff Cancel Resistance" id="311" level="1" required-level="44" sp="150000" />
+		<skill name="Emergency Rescue" id="70" level="14" required-level="44" sp="150000" />
+
+		<!-- Skills Lv45 -->
+		<skill name="Dual Sword Mastery" id="144" level="8" required-level="45" sp="150000" />
 		<skill name="Heavy Armor Mastery" id="232" level="23" required-level="45" sp="150000" />
-		<skill name="Sting" id="223" level="20" required-level="45" sp="150000" />
-		<skill name="Freezing Strike" id="105" level="7" required-level="45" sp="150000" />
-		<skill name="Drain Energy" id="70" level="24" required-level="45" sp="150000" />
+		<skill name="Blood Attack" id="223" level="20" required-level="45" sp="150000" />
 		<skill name="Magic Resistance" id="147" level="22" required-level="45" sp="150000" />
-		
-		<skill name="Dual Weapon Mastery" id="144" level="9" required-level="46" sp="150000" />
+		<skill name="Pirate Transformation" id="1800" level="1" required-level="45" auto-learn="true" />
+		<skill name="Emergency Rescue" id="70" level="15" required-level="45" sp="150000" />
+
+		<!-- Skills Lv46 -->
+		<skill name="Dual Sword Mastery" id="144" level="9" required-level="46" sp="150000" />
 		<skill name="Heavy Armor Mastery" id="232" level="24" required-level="46" sp="150000" />
-		<skill name="Sting" id="223" level="21" required-level="46" sp="150000" />
 		<skill name="Confusion" id="2" level="7" required-level="46" sp="150000" />
-		<skill name="Freezing Strike" id="105" level="8" required-level="46" sp="150000" />
-		<skill name="Drain Energy" id="70" level="25" required-level="46" sp="150000" />
+		<skill name="Freezing Weapon" id="105" level="8" required-level="46" sp="150000" />
+		<skill name="Drain Energy" id="45250" level="9" required-level="46" sp="150000" />
+		<skill name="Blood Attack" id="223" level="21" required-level="46" sp="150000" />
 		<skill name="Magic Resistance" id="147" level="23" required-level="46" sp="150000" />
 		<skill name="Hex" id="122" level="3" required-level="46" sp="150000" />
 		<skill name="Power Break" id="115" level="5" required-level="46" sp="150000" />
-		<skill name="Dance of Inspiration" id="272" level="1" required-level="46" sp="150000" />
-		
-		<skill name="Dual Weapon Mastery" id="144" level="10" required-level="47" sp="210000" />
+		<skill name="Emergency Rescue" id="70" level="16" required-level="46" sp="150000" />
+
+		<!-- Skills Lv47 -->
+		<skill name="Dual Sword Mastery" id="144" level="10" required-level="47" sp="210000" />
 		<skill name="Heavy Armor Mastery" id="232" level="25" required-level="47" sp="210000" />
-		<skill name="Sting" id="223" level="22" required-level="47" sp="210000" />
-		<skill name="Drain Energy" id="70" level="26" required-level="47" sp="210000" />
+		<skill name="Blood Attack" id="223" level="22" required-level="47" sp="210000" />
 		<skill name="Magic Resistance" id="147" level="24" required-level="47" sp="210000" />
-		
-		<skill name="Dual Weapon Mastery" id="144" level="11" required-level="48" sp="210000" />
+		<skill name="Emergency Rescue" id="70" level="17" required-level="47" sp="210000" />
+
+		<!-- Skills Lv48 -->
+		<skill name="Dark Elven Absorption" id="272" level="1" required-level="48" sp="210000" />
+		<skill name="Dual Sword Mastery" id="144" level="11" required-level="48" sp="210000" />
 		<skill name="Heavy Armor Mastery" id="232" level="26" required-level="48" sp="210000" />
-		<skill name="Sting" id="223" level="23" required-level="48" sp="210000" />
-		<skill name="Freezing Strike" id="105" level="9" required-level="48" sp="210000" />
-		<skill name="Drain Energy" id="70" level="27" required-level="48" sp="210000" />
+		<skill name="Freezing Weapon" id="105" level="9" required-level="48" sp="210000" />
+		<skill name="Drain Energy" id="45250" level="10" required-level="48" sp="210000" />
+		<skill name="Blood Attack" id="223" level="23" required-level="48" sp="210000" />
 		<skill name="Magic Resistance" id="147" level="25" required-level="48" sp="210000" />
-		
-		<skill name="Dual Weapon Mastery" id="144" level="12" required-level="49" sp="210000" />
+		<skill name="Emergency Rescue" id="70" level="18" required-level="48" sp="210000" />
+
+		<!-- Skills Lv49 -->
+		<skill name="Dual Sword Mastery" id="144" level="12" required-level="49" sp="210000" />
 		<skill name="Heavy Armor Mastery" id="232" level="27" required-level="49" sp="210000" />
-		<skill name="Sting" id="223" level="24" required-level="49" sp="210000" />
 		<skill name="Confusion" id="2" level="8" required-level="49" sp="210000" />
-		<skill name="Freezing Strike" id="105" level="10" required-level="49" sp="210000" />
-		<skill name="Drain Energy" id="70" level="28" required-level="49" sp="210000" />
+		<skill name="Blood Attack" id="223" level="24" required-level="49" sp="210000" />
 		<skill name="Magic Resistance" id="147" level="26" required-level="49" sp="210000" />
-		<skill name="Poison" id="129" level="2" required-level="49" sp="210000" />
 		<skill name="Hex" id="122" level="4" required-level="49" sp="210000" />
 		<skill name="Power Break" id="115" level="6" required-level="49" sp="210000" />
-		<skill name="Dance of the Mystic" id="273" level="1" required-level="49" sp="210000" />
 		<skill name="Focus Mind" id="191" level="3" required-level="49" sp="210000" />
-		
-		<skill name="Dual Weapon Mastery" id="144" level="13" required-level="50" sp="300000" />
-		<skill name="Heavy Armor Mastery" id="232" level="28" required-level="50" sp="300000" />
-		<skill name="Sting" id="223" level="25" required-level="50" sp="300000" />
-		<skill name="Drain Energy" id="70" level="29" required-level="50" sp="300000" />
-		<skill name="Magic Resistance" id="147" level="27" required-level="50" sp="300000" />
+		<skill name="Emergency Rescue" id="70" level="19" required-level="49" sp="210000" />
+
+		<!-- Skills Lv50 -->
 		<skill name="Potion Mastery" id="45184" level="2" required-level="50">
-			<item id="57" count="3000000"/> <!-- Adena -->
+			<item id="57" count="3000000" /> <!-- Adena -->
 		</skill>
-		
-		<skill name="Dual Weapon Mastery" id="144" level="14" required-level="51" sp="300000" />
+		<skill name="Dual Sword Mastery" id="144" level="13" required-level="50" sp="300000" />
+		<skill name="Heavy Armor Mastery" id="232" level="28" required-level="50" sp="300000" />
+		<skill name="Recover HP" id="45176" level="2" required-level="50" sp="300000" >
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Recover MP" id="45177" level="2" required-level="50" sp="300000" >
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Dark Elven Spirit" id="129" level="3" required-level="50" sp="300000" />
+		<skill name="Freezing Weapon" id="105" level="10" required-level="50" sp="300000" />
+		<skill name="Shackle" id="402" level="1" required-level="50" sp="300000" />
+		<skill name="Drain Energy" id="45250" level="11" required-level="50" sp="300000" />
+		<skill name="Blood Attack" id="223" level="25" required-level="50" sp="300000" />
+		<skill name="Magic Resistance" id="147" level="27" required-level="50" sp="300000" />
+		<skill name="Guard Crush" id="45187" level="2" required-level="50" sp="300000" />
+		<skill name="Emergency Rescue" id="70" level="20" required-level="50" sp="300000" />
+
+		<!-- Skills Lv51 -->
+		<skill name="Dual Sword Mastery" id="144" level="14" required-level="51" sp="300000" />
 		<skill name="Heavy Armor Mastery" id="232" level="29" required-level="51" sp="300000" />
-		<skill name="Sting" id="223" level="26" required-level="51" sp="300000" />
-		<skill name="Freezing Strike" id="105" level="11" required-level="51" sp="300000" />
-		<skill name="Drain Energy" id="70" level="30" required-level="51" sp="300000" />
+		<skill name="Freezing Weapon" id="105" level="11" required-level="51" sp="300000" />
+		<skill name="Blood Attack" id="223" level="26" required-level="51" sp="300000" />
 		<skill name="Magic Resistance" id="147" level="28" required-level="51" sp="300000" />
-		
-		<skill name="Dual Weapon Mastery" id="144" level="15" required-level="52" sp="300000" />
+		<skill name="Emergency Rescue" id="70" level="21" required-level="51" sp="300000" />
+
+		<!-- Skills Lv52 -->
+		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="300000" >
+			<item id="8618" count="1" /> <!-- Ancient Book: Divine Inspiration (Modern Language Version) Lv 1 -->
+		</skill>
+		<skill name="Dual Sword Mastery" id="144" level="15" required-level="52" sp="300000" />
 		<skill name="Heavy Armor Mastery" id="232" level="30" required-level="52" sp="300000" />
-		<skill name="Sting" id="223" level="27" required-level="52" sp="300000" />
 		<skill name="Confusion" id="2" level="9" required-level="52" sp="300000" />
-		<skill name="Freezing Strike" id="105" level="12" required-level="52" sp="300000" />
-		<skill name="Drain Energy" id="70" level="31" required-level="52" sp="300000" />
+		<skill name="Freezing Weapon" id="105" level="12" required-level="52" sp="300000" />
+		<skill name="Drain Energy" id="45250" level="12" required-level="52" sp="300000" />
+		<skill name="Blood Attack" id="223" level="27" required-level="52" sp="300000" />
 		<skill name="Magic Resistance" id="147" level="29" required-level="52" sp="300000" />
 		<skill name="Hex" id="122" level="5" required-level="52" sp="300000" />
 		<skill name="Power Break" id="115" level="7" required-level="52" sp="300000" />
-		<skill name="Dance of Concentration" id="276" level="1" required-level="52" sp="300000" />
-		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="300000" >
-			<item id="8618"/> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
-		</skill>
-		
-		<skill name="Dual Weapon Mastery" id="144" level="16" required-level="53" sp="420000" />
+		<skill name="Dark Elven Damage Decrease" id="273" level="1" required-level="52" sp="300000" />
+		<skill name="Emergency Rescue" id="70" level="22" required-level="52" sp="300000" />
+
+		<!-- Skills Lv53 -->
+		<skill name="Dual Sword Mastery" id="144" level="16" required-level="53" sp="420000" />
 		<skill name="Heavy Armor Mastery" id="232" level="31" required-level="53" sp="420000" />
-		<skill name="Sting" id="223" level="28" required-level="53" sp="420000" />
-		<skill name="Drain Energy" id="70" level="32" required-level="53" sp="420000" />
+		<skill name="Freezing Weapon" id="105" level="13" required-level="53" sp="420000" />
+		<skill name="Blood Attack" id="223" level="28" required-level="53" sp="420000" />
 		<skill name="Magic Resistance" id="147" level="30" required-level="53" sp="420000" />
-		
-		<skill name="Dual Weapon Mastery" id="144" level="17" required-level="54" sp="420000" />
+		<skill name="Emergency Rescue" id="70" level="23" required-level="53" sp="420000" />
+
+		<!-- Skills Lv54 -->
+		<skill name="Dual Sword Mastery" id="144" level="17" required-level="54" sp="420000" />
 		<skill name="Heavy Armor Mastery" id="232" level="32" required-level="54" sp="420000" />
-		<skill name="Sting" id="223" level="29" required-level="54" sp="420000" />
-		<skill name="Freezing Strike" id="105" level="13" required-level="54" sp="420000" />
-		<skill name="Drain Energy" id="70" level="33" required-level="54" sp="420000" />
+		<skill name="Freezing Weapon" id="105" level="14" required-level="54" sp="420000" />
+		<skill name="Drain Energy" id="45250" level="13" required-level="54" sp="420000" />
+		<skill name="Blood Attack" id="223" level="29" required-level="54" sp="420000" />
 		<skill name="Magic Resistance" id="147" level="31" required-level="54" sp="420000" />
-		
-		<skill name="Arrest" id="402" level="1" required-level="55" sp="420000" />
-		<skill name="Dual Weapon Mastery" id="144" level="18" required-level="55" sp="420000" />
+		<skill name="Emergency Rescue" id="70" level="24" required-level="54" sp="420000" />
+
+		<!-- Skills Lv55 -->
+		<skill name="Dual Sword Mastery" id="144" level="18" required-level="55" sp="420000" />
 		<skill name="Heavy Armor Mastery" id="232" level="33" required-level="55" sp="420000" />
-		<skill name="Sting" id="223" level="30" required-level="55" sp="420000" />
 		<skill name="Confusion" id="2" level="10" required-level="55" sp="420000" />
-		<skill name="Freezing Strike" id="105" level="14" required-level="55" sp="420000" />
-		<skill name="Drain Energy" id="70" level="34" required-level="55" sp="420000" />
+		<skill name="Freezing Weapon" id="105" level="15" required-level="55" sp="420000" />
+		<skill name="Shackle" id="402" level="2" required-level="55" sp="420000" />
+		<skill name="Blood Attack" id="223" level="30" required-level="55" sp="420000" />
 		<skill name="Magic Resistance" id="147" level="32" required-level="55" sp="420000" />
 		<skill name="Hex" id="122" level="6" required-level="55" sp="420000" />
 		<skill name="Power Break" id="115" level="8" required-level="55" sp="420000" />
-		<skill name="Dance of the Warrior" id="271" level="1" required-level="55" sp="420000" />
+		<skill name="Dark Elven Magic Resistance" id="276" level="1" required-level="55" sp="420000" />
 		<skill name="Poison Blade Dance" id="84" level="1" required-level="55" sp="420000" />
 		<skill name="Focus Mind" id="191" level="4" required-level="55" sp="420000" />
-		
-		<skill name="Dual Weapon Mastery" id="144" level="19" required-level="56" sp="580000" />
+		<skill name="Emergency Rescue" id="70" level="25" required-level="55" sp="420000" />
+
+		<!-- Skills Lv56 -->
+		<skill name="Dual Sword Mastery" id="144" level="19" required-level="56" sp="580000" />
 		<skill name="Heavy Armor Mastery" id="232" level="34" required-level="56" sp="580000" />
-		<skill name="Sting" id="223" level="31" required-level="56" sp="580000" />
-		<skill name="Drain Energy" id="70" level="35" required-level="56" sp="580000" />
+		<skill name="Freezing Weapon" id="105" level="16" required-level="56" sp="580000" />
+		<skill name="Drain Energy" id="45250" level="14" required-level="56" sp="580000" />
+		<skill name="Blood Attack" id="223" level="31" required-level="56" sp="580000" />
 		<skill name="Magic Resistance" id="147" level="33" required-level="56" sp="580000" />
-		
-		<skill name="Dual Weapon Mastery" id="144" level="20" required-level="57" sp="580000" />
+		<skill name="Emergency Rescue" id="70" level="26" required-level="56" sp="580000" />
+
+		<!-- Skills Lv57 -->
+		<skill name="Dual Sword Mastery" id="144" level="20" required-level="57" sp="580000" />
 		<skill name="Heavy Armor Mastery" id="232" level="35" required-level="57" sp="580000" />
-		<skill name="Sting" id="223" level="32" required-level="57" sp="580000" />
-		<skill name="Freezing Strike" id="105" level="15" required-level="57" sp="580000" />
-		<skill name="Drain Energy" id="70" level="36" required-level="57" sp="580000" />
+		<skill name="Freezing Weapon" id="105" level="17" required-level="57" sp="580000" />
+		<skill name="Blood Attack" id="223" level="32" required-level="57" sp="580000" />
 		<skill name="Magic Resistance" id="147" level="34" required-level="57" sp="580000" />
-		
-		<skill name="Arrest" id="402" level="2" required-level="58" sp="580000" />
-		<skill name="Dual Weapon Mastery" id="144" level="21" required-level="58" sp="580000" />
+		<skill name="Emergency Rescue" id="70" level="27" required-level="57" sp="580000" />
+
+		<!-- Skills Lv58 -->
+		<skill name="Majesty" id="82" level="3" required-level="58" sp="580000" />
+		<skill name="Dual Sword Mastery" id="144" level="21" required-level="58" sp="580000" />
 		<skill name="Heavy Armor Mastery" id="232" level="36" required-level="58" sp="580000" />
-		<skill name="Sting" id="223" level="33" required-level="58" sp="580000" />
 		<skill name="Confusion" id="2" level="11" required-level="58" sp="580000" />
-		<skill name="Freezing Strike" id="105" level="16" required-level="58" sp="580000" />
-		<skill name="Drain Energy" id="70" level="37" required-level="58" sp="580000" />
+		<skill name="Freezing Weapon" id="105" level="18" required-level="58" sp="580000" />
+		<skill name="Drain Energy" id="45250" level="15" required-level="58" sp="580000" />
+		<skill name="Blood Attack" id="223" level="33" required-level="58" sp="580000" />
 		<skill name="Magic Resistance" id="147" level="35" required-level="58" sp="580000" />
-		<skill name="Poison" id="129" level="3" required-level="58" sp="580000" />
 		<skill name="Hex" id="122" level="7" required-level="58" sp="580000" />
 		<skill name="Power Break" id="115" level="9" required-level="58" sp="580000" />
-		<skill name="Dance of Fury" id="275" level="1" required-level="58" sp="580000" />
-		
-		<skill name="Dual Weapon Mastery" id="144" level="22" required-level="59" sp="850000" />
+		<skill name="Emergency Rescue" id="70" level="28" required-level="58" sp="580000" />
+
+		<!-- Skills Lv59 -->
+		<skill name="Dual Sword Mastery" id="144" level="22" required-level="59" sp="850000" />
 		<skill name="Heavy Armor Mastery" id="232" level="37" required-level="59" sp="850000" />
-		<skill name="Sting" id="223" level="34" required-level="59" sp="850000" />
-		<skill name="Drain Energy" id="70" level="38" required-level="59" sp="850000" />
+		<skill name="Freezing Weapon" id="105" level="19" required-level="59" sp="850000" />
+		<skill name="Blood Attack" id="223" level="34" required-level="59" sp="850000" />
 		<skill name="Magic Resistance" id="147" level="36" required-level="59" sp="850000" />
-		
-		<skill name="Arrest" id="402" level="3" required-level="60" sp="850000" />
-		<skill name="Dual Weapon Mastery" id="144" level="23" required-level="60" sp="850000" />
+		<skill name="Emergency Rescue" id="70" level="29" required-level="59" sp="850000" />
+
+		<!-- Skills Lv60 -->
+		<skill name="Dual Sword Mastery" id="144" level="23" required-level="60" sp="850000" />
 		<skill name="Heavy Armor Mastery" id="232" level="38" required-level="60" sp="850000" />
-		<skill name="Sting" id="223" level="35" required-level="60" sp="850000" />
+		<skill name="Dark Elven Spirit" id="129" level="4" required-level="60" sp="850000" />
 		<skill name="Confusion" id="2" level="12" required-level="60" sp="850000" />
-		<skill name="Freezing Strike" id="105" level="17" required-level="60" sp="850000" />
-		<skill name="Drain Energy" id="70" level="39" required-level="60" sp="850000" />
+		<skill name="Freezing Weapon" id="105" level="20" required-level="60" sp="850000" />
+		<skill name="Shackle" id="402" level="3" required-level="60" sp="850000" />
+		<skill name="Drain Energy" id="45250" level="16" required-level="60" sp="850000" />
+		<skill name="Blood Attack" id="223" level="35" required-level="60" sp="850000" />
 		<skill name="Magic Resistance" id="147" level="37" required-level="60" sp="850000" />
 		<skill name="Hex" id="122" level="8" required-level="60" sp="850000" />
 		<skill name="Power Break" id="115" level="10" required-level="60" sp="850000" />
+		<skill name="Guard Crush" id="45187" level="3" required-level="60" sp="850000" />
+		<skill name="Ability to Attack" id="77" level="3" required-level="60" sp="850000" />
 		<skill name="Poison Blade Dance" id="84" level="2" required-level="60" sp="850000" />
-		
-		<skill name="Dual Weapon Mastery" id="144" level="24" required-level="61" sp="850000" />
-		<skill name="Heavy Armor Mastery" id="232" level="39" required-level="61" sp="850000" />
-		<skill name="Sting" id="223" level="36" required-level="61" sp="850000" />
-		<skill name="Drain Energy" id="70" level="40" required-level="61" sp="850000" />
-		<skill name="Magic Resistance" id="147" level="38" required-level="61" sp="850000" />
-		<skill name="Dance of Fire" id="274" level="2" required-level="61" sp="850000" />
+		<skill name="Dark Assassin Transformation" id="1801" level="1" required-level="60" auto-learn="true" />
+		<skill name="Emergency Rescue" id="70" level="30" required-level="60" sp="850000" />
+
+		<!-- Skills Lv61 -->
 		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="850000" >
-			<item id="8619"/> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
+			<item id="8619" count="1" /> <!-- Ancient Book: Divine Inspiration (Modern Language Version) Lv 2 -->
 		</skill>
-		
-		<skill name="Arrest" id="402" level="4" required-level="62" sp="1100000" />
-		<skill name="Dual Weapon Mastery" id="144" level="25" required-level="62" sp="1100000" />
+		<skill name="Dual Sword Mastery" id="144" level="24" required-level="61" sp="850000" />
+		<skill name="Heavy Armor Mastery" id="232" level="39" required-level="61" sp="850000" />
+		<skill name="Blood Attack" id="223" level="36" required-level="61" sp="850000" />
+		<skill name="Magic Resistance" id="147" level="38" required-level="61" sp="850000" />
+		<skill name="Emergency Rescue" id="70" level="31" required-level="61" sp="850000" />
+
+		<!-- Skills Lv62 -->
+		<skill name="Dual Sword Mastery" id="144" level="25" required-level="62" sp="1100000" />
 		<skill name="Heavy Armor Mastery" id="232" level="40" required-level="62" sp="1100000" />
-		<skill name="Sting" id="223" level="37" required-level="62" sp="1100000" />
 		<skill name="Confusion" id="2" level="13" required-level="62" sp="1100000" />
-		<skill name="Freezing Strike" id="105" level="18" required-level="62" sp="1100000" />
-		<skill name="Drain Energy" id="70" level="41" required-level="62" sp="1100000" />
+		<skill name="Freezing Weapon" id="105" level="21" required-level="62" sp="1100000" />
+		<skill name="Shackle" id="402" level="4" required-level="62" sp="1100000" />
+		<skill name="Drain Energy" id="45250" level="17" required-level="62" sp="1100000" />
+		<skill name="Blood Attack" id="223" level="37" required-level="62" sp="1100000" />
 		<skill name="Magic Resistance" id="147" level="39" required-level="62" sp="1100000" />
 		<skill name="Hex" id="122" level="9" required-level="62" sp="1100000" />
 		<skill name="Power Break" id="115" level="11" required-level="62" sp="1100000" />
-		
-		<skill name="Dual Weapon Mastery" id="144" level="26" required-level="63" sp="1100000" />
+		<skill name="Emergency Rescue" id="70" level="32" required-level="62" sp="1100000" />
+		<skill name="Moving Shadows" id="915" level="1" required-level="62" sp="1100000" />
+
+		<!-- Skills Lv63 -->
+		<skill name="Dual Sword Mastery" id="144" level="26" required-level="63" sp="1100000" />
 		<skill name="Heavy Armor Mastery" id="232" level="41" required-level="63" sp="1100000" />
-		<skill name="Sting" id="223" level="38" required-level="63" sp="1100000" />
-		<skill name="Drain Energy" id="70" level="42" required-level="63" sp="1100000" />
+		<skill name="Blood Attack" id="223" level="38" required-level="63" sp="1100000" />
 		<skill name="Magic Resistance" id="147" level="40" required-level="63" sp="1100000" />
-		
-		<skill name="Arrest" id="402" level="5" required-level="64" sp="1300000" />
-		<skill name="Dual Weapon Mastery" id="144" level="27" required-level="64" sp="1300000" />
+		<skill name="Emergency Rescue" id="70" level="33" required-level="63" sp="1100000" />
+
+		<!-- Skills Lv64 -->
+		<skill name="Dual Sword Mastery" id="144" level="27" required-level="64" sp="1300000" />
 		<skill name="Heavy Armor Mastery" id="232" level="42" required-level="64" sp="1300000" />
-		<skill name="Sting" id="223" level="39" required-level="64" sp="1300000" />
 		<skill name="Confusion" id="2" level="14" required-level="64" sp="1300000" />
-		<skill name="Freezing Strike" id="105" level="19" required-level="64" sp="1300000" />
-		<skill name="Drain Energy" id="70" level="43" required-level="64" sp="1300000" />
+		<skill name="Freezing Weapon" id="105" level="22" required-level="64" sp="1300000" />
+		<skill name="Shackle" id="402" level="5" required-level="64" sp="1300000" />
+		<skill name="Drain Energy" id="45250" level="18" required-level="64" sp="1300000" />
+		<skill name="Blood Attack" id="223" level="39" required-level="64" sp="1300000" />
 		<skill name="Magic Resistance" id="147" level="41" required-level="64" sp="1300000" />
 		<skill name="Hex" id="122" level="10" required-level="64" sp="1300000" />
 		<skill name="Power Break" id="115" level="12" required-level="64" sp="1300000" />
 		<skill name="Focus Mind" id="191" level="5" required-level="64" sp="1300000" />
-		
-		<skill name="Dual Weapon Mastery" id="144" level="28" required-level="65" sp="1300000" />
-		<skill name="Heavy Armor Mastery" id="232" level="43" required-level="65" sp="1300000" />
-		<skill name="Sting" id="223" level="40" required-level="65" sp="1300000" />
-		<skill name="Drain Energy" id="70" level="44" required-level="65" sp="1300000" />
-		<skill name="Magic Resistance" id="147" level="42" required-level="65" sp="1300000" />
+		<skill name="Emergency Rescue" id="70" level="34" required-level="64" sp="1300000" />
 
-		<skill name="Arrest" id="402" level="6" required-level="66" sp="1500000" />
-		<skill name="Dual Weapon Mastery" id="144" level="29" required-level="66" sp="1500000" />
+		<!-- Skills Lv65 -->
+		<skill name="Dual Sword Mastery" id="144" level="28" required-level="65" sp="1300000" />
+		<skill name="Heavy Armor Mastery" id="232" level="43" required-level="65" sp="1300000" />
+		<skill name="Dignity" id="196" level="2" required-level="65" sp="1300000" />
+		<skill name="Blood Attack" id="223" level="40" required-level="65" sp="1300000" />
+		<skill name="Magic Resistance" id="147" level="42" required-level="65" sp="1300000" />
+		<skill name="Honor" id="197" level="2" required-level="65" sp="1300000" />
+		<skill name="Emergency Rescue" id="70" level="35" required-level="65" sp="1300000" />
+
+		<!-- Skills Lv66 -->
+		<skill name="Dual Sword Mastery" id="144" level="29" required-level="66" sp="1500000" />
 		<skill name="Heavy Armor Mastery" id="232" level="44" required-level="66" sp="1500000" />
-		<skill name="Sting" id="223" level="41" required-level="66" sp="1500000" />
 		<skill name="Confusion" id="2" level="15" required-level="66" sp="1500000" />
-		<skill name="Freezing Strike" id="105" level="20" required-level="66" sp="1500000" />
-		<skill name="Drain Energy" id="70" level="45" required-level="66" sp="1500000" />
+		<skill name="Freezing Weapon" id="105" level="23" required-level="66" sp="1500000" />
+		<skill name="Shackle" id="402" level="6" required-level="66" sp="1500000" />
+		<skill name="Drain Energy" id="45250" level="19" required-level="66" sp="1500000" />
+		<skill name="Blood Attack" id="223" level="41" required-level="66" sp="1500000" />
 		<skill name="Magic Resistance" id="147" level="43" required-level="66" sp="1500000" />
-		<skill name="Poison" id="129" level="4" required-level="66" sp="1500000" />
 		<skill name="Hex" id="122" level="11" required-level="66" sp="1500000" />
 		<skill name="Power Break" id="115" level="13" required-level="66" sp="1500000" />
-		<skill name="Dance of Protection" id="311" level="2" required-level="66" sp="1500000" />
-		
-		<skill name="Dual Weapon Mastery" id="144" level="30" required-level="67" sp="1500000" />
+		<skill name="Emergency Rescue" id="70" level="36" required-level="66" sp="1500000" />
+
+		<!-- Skills Lv67 -->
+		<skill name="Dual Sword Mastery" id="144" level="30" required-level="67" sp="1500000" />
 		<skill name="Heavy Armor Mastery" id="232" level="45" required-level="67" sp="1500000" />
-		<skill name="Sting" id="223" level="42" required-level="67" sp="1500000" />
-		<skill name="Drain Energy" id="70" level="46" required-level="67" sp="1500000" />
+		<skill name="Blood Attack" id="223" level="42" required-level="67" sp="1500000" />
 		<skill name="Magic Resistance" id="147" level="44" required-level="67" sp="1500000" />
-		
-		<skill name="Arrest" id="402" level="7" required-level="68" sp="2000000" />
-		<skill name="Dual Weapon Mastery" id="144" level="31" required-level="68" sp="2000000" />
+		<skill name="Emergency Rescue" id="70" level="37" required-level="67" sp="1500000" />
+
+		<!-- Skills Lv68 -->
+		<skill name="Dual Sword Mastery" id="144" level="31" required-level="68" sp="2000000" />
 		<skill name="Heavy Armor Mastery" id="232" level="46" required-level="68" sp="2000000" />
-		<skill name="Sting" id="223" level="43" required-level="68" sp="2000000" />
 		<skill name="Confusion" id="2" level="16" required-level="68" sp="2000000" />
-		<skill name="Freezing Strike" id="105" level="21" required-level="68" sp="2000000" />
-		<skill name="Drain Energy" id="70" level="47" required-level="68" sp="2000000" />
+		<skill name="Freezing Weapon" id="105" level="24" required-level="68" sp="2000000" />
+		<skill name="Shackle" id="402" level="7" required-level="68" sp="2000000" />
+		<skill name="Drain Energy" id="45250" level="20" required-level="68" sp="2000000" />
+		<skill name="Blood Attack" id="223" level="43" required-level="68" sp="2000000" />
 		<skill name="Magic Resistance" id="147" level="45" required-level="68" sp="2000000" />
 		<skill name="Hex" id="122" level="12" required-level="68" sp="2000000" />
 		<skill name="Power Break" id="115" level="14" required-level="68" sp="2000000" />
-		
-		<skill name="Dual Weapon Mastery" id="144" level="32" required-level="69" sp="2000000" />
+		<skill name="Dance of Berserker" id="366" level="1" required-level="68" sp="2000000" />
+		<skill name="Emergency Rescue" id="70" level="38" required-level="68" sp="2000000" />
+
+		<!-- Skills Lv69 -->
+		<skill name="Dual Sword Mastery" id="144" level="32" required-level="69" sp="2000000" />
 		<skill name="Heavy Armor Mastery" id="232" level="47" required-level="69" sp="2000000" />
-		<skill name="Sting" id="223" level="44" required-level="69" sp="2000000" />
-		<skill name="Drain Energy" id="70" level="48" required-level="69" sp="2000000" />
+		<skill name="Blood Attack" id="223" level="44" required-level="69" sp="2000000" />
 		<skill name="Magic Resistance" id="147" level="46" required-level="69" sp="2000000" />
-		<skill name="Dance of the Mystic" id="273" level="2" required-level="69" sp="2000000" />
-		
-		<skill name="Arrest" id="402" level="8" required-level="70" sp="2500000" />
-		<skill name="Dual Weapon Mastery" id="144" level="33" required-level="70" sp="2500000" />
+		<skill name="Emergency Rescue" id="70" level="39" required-level="69" sp="2000000" />
+
+		<!-- Skills Lv70 -->
+		<skill name="Dual Sword Mastery" id="144" level="33" required-level="70" sp="2500000" />
 		<skill name="Heavy Armor Mastery" id="232" level="48" required-level="70" sp="2500000" />
-		<skill name="Sting" id="223" level="45" required-level="70" sp="2500000" />
+		<skill name="Dark Elven Spirit" id="129" level="5" required-level="70" sp="2500000" />
 		<skill name="Confusion" id="2" level="17" required-level="70" sp="2500000" />
-		<skill name="Freezing Strike" id="105" level="22" required-level="70" sp="2500000" />
-		<skill name="Drain Energy" id="70" level="49" required-level="70" sp="2500000" />
+		<skill name="Freezing Weapon" id="105" level="25" required-level="70" sp="2500000" />
+		<skill name="Shackle" id="402" level="8" required-level="70" sp="2500000" />
+		<skill name="Drain Energy" id="45250" level="21" required-level="70" sp="2500000" />
+		<skill name="Blood Attack" id="223" level="45" required-level="70" sp="2500000" />
 		<skill name="Magic Resistance" id="147" level="47" required-level="70" sp="2500000" />
 		<skill name="Hex" id="122" level="13" required-level="70" sp="2500000" />
 		<skill name="Power Break" id="115" level="15" required-level="70" sp="2500000" />
-		
-		<skill name="Dual Weapon Mastery" id="144" level="34" required-level="71" sp="2500000" />
+		<skill name="Guard Crush" id="45187" level="4" required-level="70" sp="2500000" />
+		<skill name="White Assassin Transformation" id="1802" level="1" required-level="70" auto-learn="true" />
+		<skill name="Emergency Rescue" id="70" level="40" required-level="70" sp="2500000" />
+
+		<!-- Skills Lv71 -->
+		<skill name="Dual Sword Mastery" id="144" level="34" required-level="71" sp="2500000" />
 		<skill name="Heavy Armor Mastery" id="232" level="49" required-level="71" sp="2500000" />
-		<skill name="Sting" id="223" level="46" required-level="71" sp="2500000" />
-		<skill name="Drain Energy" id="70" level="50" required-level="71" sp="2500000" />
+		<skill name="Blood Attack" id="223" level="46" required-level="71" sp="2500000" />
 		<skill name="Magic Resistance" id="147" level="48" required-level="71" sp="2500000" />
-		<skill name="Dance of the Warrior" id="271" level="2" required-level="71" sp="2500000" />
-		
-		<skill name="Arrest" id="402" level="9" required-level="72" sp="2800000" />
-		<skill name="Dual Weapon Mastery" id="144" level="35" required-level="72" sp="2800000" />
+		<skill name="Dark Elven Magic Affinity" id="365" level="1" required-level="71" sp="2500000" />
+		<skill name="Emergency Rescue" id="70" level="41" required-level="71" sp="2500000" />
+
+		<!-- Skills Lv72 -->
+		<skill name="Dual Sword Mastery" id="144" level="35" required-level="72" sp="2800000" />
 		<skill name="Heavy Armor Mastery" id="232" level="50" required-level="72" sp="2800000" />
-		<skill name="Sting" id="223" level="47" required-level="72" sp="2800000" />
 		<skill name="Confusion" id="2" level="18" required-level="72" sp="2800000" />
-		<skill name="Freezing Strike" id="105" level="23" required-level="72" sp="2800000" />
-		<skill name="Drain Energy" id="70" level="51" required-level="72" sp="2800000" />
+		<skill name="Freezing Weapon" id="105" level="26" required-level="72" sp="2800000" />
+		<skill name="Shackle" id="402" level="9" required-level="72" sp="2800000" />
+		<skill name="Drain Energy" id="45250" level="22" required-level="72" sp="2800000" />
+		<skill name="Blood Attack" id="223" level="47" required-level="72" sp="2800000" />
 		<skill name="Magic Resistance" id="147" level="49" required-level="72" sp="2800000" />
 		<skill name="Hex" id="122" level="14" required-level="72" sp="2800000" />
 		<skill name="Power Break" id="115" level="16" required-level="72" sp="2800000" />
 		<skill name="Poison Blade Dance" id="84" level="3" required-level="72" sp="2800000" />
 		<skill name="Focus Mind" id="191" level="6" required-level="72" sp="2800000" />
-		
-		<skill name="Dual Weapon Mastery" id="144" level="36" required-level="73" sp="2800000" />
+		<skill name="Emergency Rescue" id="70" level="42" required-level="72" sp="2800000" />
+
+		<!-- Skills Lv73 -->
+		<skill name="Dual Sword Mastery" id="144" level="36" required-level="73" sp="2800000" />
 		<skill name="Heavy Armor Mastery" id="232" level="51" required-level="73" sp="2800000" />
-		<skill name="Sting" id="223" level="48" required-level="73" sp="2800000" />
-		<skill name="Drain Energy" id="70" level="52" required-level="73" sp="2800000" />
+		<skill name="Drain Energy" id="45250" level="23" required-level="73" sp="2800000" />
+		<skill name="Blood Attack" id="223" level="48" required-level="73" sp="2800000" />
 		<skill name="Magic Resistance" id="147" level="50" required-level="73" sp="2800000" />
-		
-		<skill name="Arrest" id="402" level="10" required-level="74" sp="2800000" />
-		<skill name="Dual Weapon Mastery" id="144" level="37" required-level="74" sp="2800000" />
+		<skill name="Emergency Rescue" id="70" level="43" required-level="73" sp="2800000" />
+
+		<!-- Skills Lv74 -->
+		<skill name="Dual Sword Mastery" id="144" level="37" required-level="74" sp="2800000" />
 		<skill name="Heavy Armor Mastery" id="232" level="52" required-level="74" sp="2800000" />
-		<skill name="Sting" id="223" level="49" required-level="74" sp="2800000" />
 		<skill name="Confusion" id="2" level="19" required-level="74" sp="2800000" />
-		<skill name="Freezing Strike" id="105" level="24" required-level="74" sp="2800000" />
-		<skill name="Drain Energy" id="70" level="53" required-level="74" sp="2800000" />
+		<skill name="Freezing Weapon" id="105" level="27" required-level="74" sp="2800000" />
+		<skill name="Shackle" id="402" level="10" required-level="74" sp="2800000" />
+		<skill name="Drain Energy" id="45250" level="24" required-level="74" sp="2800000" />
+		<skill name="Blood Attack" id="223" level="49" required-level="74" sp="2800000" />
 		<skill name="Magic Resistance" id="147" level="51" required-level="74" sp="2800000" />
-		<skill name="Poison" id="129" level="5" required-level="74" sp="2800000" />
 		<skill name="Hex" id="122" level="15" required-level="74" sp="2800000" />
 		<skill name="Power Break" id="115" level="17" required-level="74" sp="2800000" />
-		<skill name="Dance of the Vampire" id="310" level="1" required-level="74" sp="2800000" />
+		<skill name="Emergency Rescue" id="70" level="44" required-level="74" sp="2800000" />
+		<skill name="Dance of the Mystic" id="275" level="1" required-level="74" sp="2800000" />
+
+		<!-- Skills Lv75 -->
+		<skill name="Confusion" id="2" level="20" required-level="75" sp="2800000" />
+		<skill name="Drain Energy" id="45250" level="25" required-level="75" sp="2800000" />
+		<skill name="Blood Attack" id="223" level="50" required-level="75" sp="2800000" />
+		<skill name="Guard Crush" id="45187" level="5" required-level="75" sp="2800000" />
+		<skill name="Emergency Rescue" id="70" level="45" required-level="75" sp="2800000" />
 	</skillTree>
 </list>

--- a/data/skillTrees/2ndClass/BountyHunter.xml
+++ b/data/skillTrees/2ndClass/BountyHunter.xml
@@ -1,344 +1,357 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="55" parentClassId="54">
-		<skill name="Pirate" id="1800" level="1" required-level="45" auto-learn="true" />
-		<skill name="Dark Assassin" id="1801" level="1" required-level="60" auto-learn="true" />
-		<skill name="White Assassin" id="1802" level="1" required-level="70" auto-learn="true" />
-		<skill name="Fast HP Recovery" id="212" level="3" required-level="40" sp="82000" />
+
+		<!-- Master Buffs Lv. 40 -->
+		<skill name="Maphr's Shield" id="45120" level="3" required-level="40" sp="80000" />
+		<skill name="Maphr's Might" id="45119" level="3" required-level="40" sp="80000" />
+		<skill name="Maphr's Acumen" id="45130" level="3" required-level="40" sp="80000" />
+		<skill name="Maphr's Empower" id="45131" level="3" required-level="40" sp="80000" />
+		<skill name="Maphr's Wild Magic" id="45132" level="2" required-level="40" sp="80000" />
+		<skill name="Maphr's Magic Barrier" id="45118" level="2" required-level="40" sp="80000" />
+		<skill name="Maphr's Focus" id="45114" level="3" required-level="40" sp="80000" />
+		<skill name="Maphr's Death Whisper" id="45115" level="3" required-level="40" sp="80000" />
+		<skill name="Maphr's Haste" id="45116" level="2" required-level="40" sp="80000" />
+		<skill name="Maphr's Berserker Spirit" id="45133" level="2" required-level="40" sp="80000" />
+		<skill name="Maphr's Clarity" id="45134" level="3" required-level="40" sp="80000" />
+
+		<!-- Skills Lv40 -->
 		<skill name="Spinning Slasher" id="36" level="1" required-level="40" sp="82000" />
 		<skill name="Spinning Slasher" id="36" level="2" required-level="40" sp="82000" />
 		<skill name="Spinning Slasher" id="36" level="3" required-level="40" sp="82000" />
-		<skill name="Polearm Mastery" id="216" level="9" required-level="40" sp="82000" />
-		<skill name="Polearm Mastery" id="216" level="10" required-level="40" sp="82000" />
-		<skill name="Polearm Mastery" id="216" level="11" required-level="40" sp="82000" />
-		<skill name="Light Armor Mastery" id="227" level="14" required-level="40" sp="82000" />
-		<skill name="Light Armor Mastery" id="227" level="15" required-level="40" sp="82000" />
-		<skill name="Light Armor Mastery" id="227" level="16" required-level="40" sp="82000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="9" required-level="40" sp="82000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="10" required-level="40" sp="82000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="11" required-level="40" sp="82000" />
-		<skill name="Heavy Armor Mastery" id="231" level="14" required-level="40" sp="82000" />
-		<skill name="Heavy Armor Mastery" id="231" level="15" required-level="40" sp="82000" />
-		<skill name="Heavy Armor Mastery" id="231" level="16" required-level="40" sp="82000" />
-		<skill name="Vital Force" id="148" level="3" required-level="40" sp="82000" />
+		<skill name="Spinning Slasher" id="36" level="4" required-level="40" sp="82000" />
+		<skill name="Spinning Slasher" id="36" level="5" required-level="40" sp="82000" />
 		<skill name="Fake Death" id="60" level="1" required-level="40" sp="82000" />
-		<skill name="Power Crush" id="260" level="1" required-level="40" sp="82000" />
-		<skill name="Power Crush" id="260" level="2" required-level="40" sp="82000" />
-		<skill name="Power Crush" id="260" level="3" required-level="40" sp="82000" />
+		<skill name="Weapon Mastery" id="141" level="4" required-level="40" sp="82000" />
+		<skill name="Fatal Strike" id="190" level="1" required-level="40" sp="82000" />
+		<skill name="Fatal Strike" id="190" level="2" required-level="40" sp="82000" />
+		<skill name="Fatal Strike" id="190" level="3" required-level="40" sp="82000" />
+		<skill name="Fatal Strike" id="190" level="4" required-level="40" sp="82000" />
+		<skill name="Fatal Strike" id="190" level="5" required-level="40" sp="82000" />
+		<skill name="Power Break" id="260" level="1" required-level="40" sp="82000" />
+		<skill name="Power Break" id="260" level="2" required-level="40" sp="82000" />
+		<skill name="Power Break" id="260" level="3" required-level="40" sp="82000" />
+		<skill name="Rush" id="994" level="1" required-level="40" sp="82000" />
 		<skill name="Potion Mastery" id="45184" level="1" required-level="40">
-			<item id="57" count="1000000"/> <!-- Adena -->
+			<item id="57" count="1000000" /> <!-- Adena -->
 		</skill>
-		<skill name="Collecting Mastery" id="45248" level="2" required-level="40" sp="82000" />
+		<skill name="Collecting Mastery" id="45248" level="1" required-level="40" sp="82000" />
+		<skill name="Fast HP Recovery" id="212" level="3" required-level="40" sp="82000" />
+		<skill name="Dwarven Armor Mastery" id="47236" level="2" required-level="40" sp="82000" />
+		<skill name="Dwarven Weapon Mastery" id="47235" level="2" required-level="40" sp="82000" />
+		<skill name="Dwarven Restore Mastery" id="47237" level="1" required-level="40" sp="82000" />
+		<skill name="Emergency Rescue" id="70" level="10" required-level="40" sp="82000" />
 
-		<skill name="Spinning Slasher" id="36" level="4" required-level="41" sp="96000" />
-		<skill name="Polearm Mastery" id="216" level="12" required-level="41" sp="96000" />
-		<skill name="Light Armor Mastery" id="227" level="17" required-level="41" sp="96000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="12" required-level="41" sp="96000" />
-		<skill name="Heavy Armor Mastery" id="231" level="17" required-level="41" sp="96000" />
-		<skill name="Power Crush" id="260" level="4" required-level="41" sp="96000" />
+		<!-- Skills Lv41 -->
+		<skill name="Spinning Slasher" id="36" level="6" required-level="41" sp="96000" />
+		<skill name="Fatal Strike" id="190" level="6" required-level="41" sp="96000" />
+		<skill name="Power Break" id="260" level="4" required-level="41" sp="96000" />
+		<skill name="Emergency Rescue" id="70" level="11" required-level="41" sp="96000" />
 
-		<skill name="Spinning Slasher" id="36" level="5" required-level="42" sp="96000" />
-		<skill name="Polearm Mastery" id="216" level="13" required-level="42" sp="96000" />
-		<skill name="Light Armor Mastery" id="227" level="18" required-level="42" sp="96000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="13" required-level="42" sp="96000" />
-		<skill name="Heavy Armor Mastery" id="231" level="18" required-level="42" sp="96000" />
-		<skill name="Power Crush" id="260" level="5" required-level="42" sp="96000" />
-		<skill name="Body Impale" id="1613" level="1" required-level="42" sp="96000" />
+		<!-- Skills Lv42 -->
+		<skill name="Spinning Slasher" id="36" level="7" required-level="42" sp="96000" />
+		<skill name="Fatal Strike" id="190" level="7" required-level="42" sp="96000" />
+		<skill name="Power Break" id="260" level="5" required-level="42" sp="96000" />
+		<skill name="Body Crush" id="1613" level="1" required-level="42" sp="96000" />
 		<skill name="Weapon Reinforcement" id="1615" level="1" required-level="42" sp="96000" />
-		
-		<skill name="Fast HP Recovery" id="212" level="4" required-level="43" sp="96000" />
-		<skill name="Spinning Slasher" id="36" level="6" required-level="43" sp="96000" />
-		<skill name="Polearm Mastery" id="216" level="14" required-level="43" sp="96000" />
-		<skill name="Light Armor Mastery" id="227" level="19" required-level="43" sp="96000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="14" required-level="43" sp="96000" />
-		<skill name="Heavy Armor Mastery" id="231" level="19" required-level="43" sp="96000" />
-		<skill name="Spoil Festival" id="302" level="3" required-level="43" sp="96000" />
-		<skill name="Spoil" id="254" level="5" required-level="43" sp="96000" />
-		<skill name="Provoke" id="286" level="1" required-level="43" sp="96000" />
-		<skill name="Power Crush" id="260" level="6" required-level="43" sp="96000" />
+		<skill name="Emergency Rescue" id="70" level="12" required-level="42" sp="96000" />
+
+		<!-- Skills Lv43 -->
+		<skill name="Spinning Slasher" id="36" level="8" required-level="43" sp="96000" />
+		<skill name="Fatal Strike" id="190" level="8" required-level="43" sp="96000" />
 		<skill name="Boost HP" id="211" level="4" required-level="43" sp="96000" />
+		<skill name="Spoil" id="254" level="5" required-level="43" sp="96000" />
+		<skill name="Power Break" id="260" level="6" required-level="43" sp="96000" />
+		<skill name="Provoke" id="286" level="1" required-level="43" sp="96000" />
+		<skill name="Final Frenzy" id="290" level="1" required-level="43" sp="96000" />
+		<skill name="Spoil Festival" id="302" level="3" required-level="43" sp="96000" />
+		<skill name="Emergency Rescue" id="70" level="13" required-level="43" sp="96000" />
 
-		<skill name="Spinning Slasher" id="36" level="7" required-level="44" sp="140000" />
-		<skill name="Polearm Mastery" id="216" level="15" required-level="44" sp="140000" />
-		<skill name="Light Armor Mastery" id="227" level="20" required-level="44" sp="140000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="15" required-level="44" sp="140000" />
-		<skill name="Heavy Armor Mastery" id="231" level="20" required-level="44" sp="140000" />
+		<!-- Skills Lv44 -->
+		<skill name="Spinning Slasher" id="36" level="9" required-level="44" sp="140000" />
+		<skill name="Fatal Strike" id="190" level="9" required-level="44" sp="140000" />
+		<skill name="Power Break" id="260" level="7" required-level="44" sp="140000" />
 		<skill name="Tenacity" id="1617" level="1" required-level="44" sp="140000" />
-		<skill name="Power Crush" id="260" level="7" required-level="44" sp="140000" />
-		
-		<skill name="Spinning Slasher" id="36" level="8" required-level="45" sp="140000" />
-		<skill name="Polearm Mastery" id="216" level="16" required-level="45" sp="140000" />
-		<skill name="Light Armor Mastery" id="227" level="21" required-level="45" sp="140000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="16" required-level="45" sp="140000" />
-		<skill name="Heavy Armor Mastery" id="231" level="21" required-level="45" sp="140000" />
-		<skill name="Power Crush" id="260" level="8" required-level="45" sp="140000" />
-		
-		<skill name="Spinning Slasher" id="36" level="9" required-level="46" sp="140000" />
-		<skill name="Polearm Mastery" id="216" level="17" required-level="46" sp="140000" />
-		<skill name="Light Armor Mastery" id="227" level="22" required-level="46" sp="140000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="17" required-level="46" sp="140000" />
-		<skill name="Heavy Armor Mastery" id="231" level="22" required-level="46" sp="140000" />
-		<skill name="Vital Force" id="148" level="4" required-level="46" sp="140000" />
-		<skill name="Encase Armor" id="828" level="1" required-level="46" sp="140000" />
-		<skill name="Weight Limit" id="150" level="3" required-level="46" sp="140000" />
-		<skill name="Bandage" id="34" level="2" required-level="46" sp="140000" />
-		<skill name="Power Crush" id="260" level="9" required-level="46" sp="140000" />
-		<skill name="Body Impale" id="1613" level="2" required-level="46" sp="140000" />
-		
-		<skill name="Spinning Slasher" id="36" level="10" required-level="47" sp="200000" />
-		<skill name="Polearm Mastery" id="216" level="18" required-level="47" sp="200000" />
-		<skill name="Light Armor Mastery" id="227" level="23" required-level="47" sp="200000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="18" required-level="47" sp="200000" />
-		<skill name="Heavy Armor Mastery" id="231" level="23" required-level="47" sp="200000" />
-		<skill name="Power Crush" id="260" level="10" required-level="47" sp="200000" />
-		
-		<skill name="Spinning Slasher" id="36" level="11" required-level="48" sp="200000" />
-		<skill name="Polearm Mastery" id="216" level="19" required-level="48" sp="200000" />
-		<skill name="Light Armor Mastery" id="227" level="24" required-level="48" sp="200000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="19" required-level="48" sp="200000" />
-		<skill name="Heavy Armor Mastery" id="231" level="24" required-level="48" sp="200000" />
-		<skill name="Power Crush" id="260" level="11" required-level="48" sp="200000" />
-		
-		<skill name="Spinning Slasher" id="36" level="12" required-level="49" sp="200000" />
-		<skill name="Polearm Mastery" id="216" level="20" required-level="49" sp="200000" />
-		<skill name="Light Armor Mastery" id="227" level="25" required-level="49" sp="200000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="20" required-level="49" sp="200000" />
-		<skill name="Heavy Armor Mastery" id="231" level="25" required-level="49" sp="200000" />
-		<skill name="Lionheart" id="287" level="2" required-level="49" sp="200000" />
-		<skill name="Spoil Festival" id="302" level="4" required-level="49" sp="200000" />
-		<skill name="Spoil" id="254" level="6" required-level="49" sp="200000" />
-		<skill name="Power Crush" id="260" level="12" required-level="49" sp="200000" />
-		<skill name="Boost HP" id="211" level="5" required-level="49" sp="200000" />
-		<skill name="Spike" id="826" level="1" required-level="49" sp="200000" />
-		
-		<skill name="Spinning Slasher" id="36" level="13" required-level="50" sp="290000" />
-		<skill name="Polearm Mastery" id="216" level="21" required-level="50" sp="290000" />
-		<skill name="Light Armor Mastery" id="227" level="26" required-level="50" sp="290000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="21" required-level="50" sp="290000" />
-		<skill name="Heavy Armor Mastery" id="231" level="26" required-level="50" sp="290000" />
-		<skill name="Power Crush" id="260" level="13" required-level="50" sp="290000" />
-		<skill name="Body Impale" id="1613" level="3" required-level="50" sp="290000" />
-		<skill name="Potion Mastery" id="45184" level="2" required-level="50">
-			<item id="57" count="3000000"/> <!-- Adena -->
-		</skill>
-		
-		<skill name="Spinning Slasher" id="36" level="14" required-level="51" sp="290000" />
-		<skill name="Polearm Mastery" id="216" level="22" required-level="51" sp="290000" />
-		<skill name="Light Armor Mastery" id="227" level="27" required-level="51" sp="290000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="22" required-level="51" sp="290000" />
-		<skill name="Heavy Armor Mastery" id="231" level="27" required-level="51" sp="290000" />
-		<skill name="Power Crush" id="260" level="14" required-level="51" sp="290000" />
-		
-		<skill name="Fast HP Recovery" id="212" level="5" required-level="52" sp="290000" />
-		<skill name="Spinning Slasher" id="36" level="15" required-level="52" sp="290000" />
-		<skill name="Polearm Mastery" id="216" level="23" required-level="52" sp="290000" />
-		<skill name="Light Armor Mastery" id="227" level="28" required-level="52" sp="290000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="23" required-level="52" sp="290000" />
-		<skill name="Heavy Armor Mastery" id="231" level="28" required-level="52" sp="290000" />
-		<skill name="Vital Force" id="148" level="5" required-level="52" sp="290000" />
-		<skill name="Power Crush" id="260" level="15" required-level="52" sp="290000" />
-		<skill name="Weapon Reinforcement" id="1615" level="2" required-level="52" sp="290000" />
-		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="290000" >
-			<item id="8618"/> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
-		</skill>
-		
-		<skill name="Spinning Slasher" id="36" level="16" required-level="53" sp="400000" />
-		<skill name="Polearm Mastery" id="216" level="24" required-level="53" sp="400000" />
-		<skill name="Light Armor Mastery" id="227" level="29" required-level="53" sp="400000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="24" required-level="53" sp="400000" />
-		<skill name="Heavy Armor Mastery" id="231" level="29" required-level="53" sp="400000" />
-		<skill name="Power Crush" id="260" level="16" required-level="53" sp="400000" />
-		
-		<skill name="Spinning Slasher" id="36" level="17" required-level="54" sp="400000" />
-		<skill name="Polearm Mastery" id="216" level="25" required-level="54" sp="400000" />
-		<skill name="Light Armor Mastery" id="227" level="30" required-level="54" sp="400000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="25" required-level="54" sp="400000" />
-		<skill name="Heavy Armor Mastery" id="231" level="30" required-level="54" sp="400000" />
-		<skill name="Power Crush" id="260" level="17" required-level="54" sp="400000" />
-		<skill name="Body Impale" id="1613" level="4" required-level="54" sp="400000" />
-		
-		<skill name="Spinning Slasher" id="36" level="18" required-level="55" sp="400000" />
-		<skill name="Polearm Mastery" id="216" level="26" required-level="55" sp="400000" />
-		<skill name="Light Armor Mastery" id="227" level="31" required-level="55" sp="400000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="26" required-level="55" sp="400000" />
-		<skill name="Heavy Armor Mastery" id="231" level="31" required-level="55" sp="400000" />
-		<skill name="Spoil Festival" id="302" level="5" required-level="55" sp="400000" />
-		<skill name="Spoil" id="254" level="7" required-level="55" sp="400000" />
-		<skill name="Provoke" id="286" level="2" required-level="55" sp="400000" />
-		<skill name="Power Crush" id="260" level="18" required-level="55" sp="400000" />
-		<skill name="Boost HP" id="211" level="6" required-level="55" sp="400000" />
-		
-		<skill name="Spinning Slasher" id="36" level="19" required-level="56" sp="550000" />
-		<skill name="Polearm Mastery" id="216" level="27" required-level="56" sp="550000" />
-		<skill name="Light Armor Mastery" id="227" level="32" required-level="56" sp="550000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="27" required-level="56" sp="550000" />
-		<skill name="Heavy Armor Mastery" id="231" level="32" required-level="56" sp="550000" />
-		<skill name="Tenacity" id="1617" level="2" required-level="56" sp="550000" />
-		<skill name="Power Crush" id="260" level="19" required-level="56" sp="550000" />
-		
-		<skill name="Spinning Slasher" id="36" level="20" required-level="57" sp="550000" />
-		<skill name="Polearm Mastery" id="216" level="28" required-level="57" sp="550000" />
-		<skill name="Light Armor Mastery" id="227" level="33" required-level="57" sp="550000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="28" required-level="57" sp="550000" />
-		<skill name="Heavy Armor Mastery" id="231" level="33" required-level="57" sp="550000" />
-		<skill name="Power Crush" id="260" level="20" required-level="57" sp="550000" />
-		
-		<skill name="Fast HP Recovery" id="212" level="6" required-level="58" sp="550000" />
-		<skill name="Spinning Slasher" id="36" level="21" required-level="58" sp="550000" />
-		<skill name="Polearm Mastery" id="216" level="29" required-level="58" sp="550000" />
-		<skill name="Light Armor Mastery" id="227" level="34" required-level="58" sp="550000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="29" required-level="58" sp="550000" />
-		<skill name="Heavy Armor Mastery" id="231" level="34" required-level="58" sp="550000" />
-		<skill name="Vital Force" id="148" level="6" required-level="58" sp="550000" />
-		<skill name="Power Crush" id="260" level="21" required-level="58" sp="550000" />
-		<skill name="Body Impale" id="1613" level="5" required-level="58" sp="550000" />
-		
-		<skill name="Spinning Slasher" id="36" level="22" required-level="59" sp="800000" />
-		<skill name="Polearm Mastery" id="216" level="30" required-level="59" sp="800000" />
-		<skill name="Light Armor Mastery" id="227" level="35" required-level="59" sp="800000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="30" required-level="59" sp="800000" />
-		<skill name="Heavy Armor Mastery" id="231" level="35" required-level="59" sp="800000" />
-		<skill name="Power Crush" id="260" level="22" required-level="59" sp="800000" />
-		
-		<skill name="Spinning Slasher" id="36" level="23" required-level="60" sp="800000" />
-		<skill name="Polearm Mastery" id="216" level="31" required-level="60" sp="800000" />
-		<skill name="Light Armor Mastery" id="227" level="36" required-level="60" sp="800000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="31" required-level="60" sp="800000" />
-		<skill name="Heavy Armor Mastery" id="231" level="36" required-level="60" sp="800000" />
-		<skill name="Spoil" id="254" level="8" required-level="60" sp="800000" />
-		<skill name="Provoke" id="286" level="3" required-level="60" sp="800000" />
-		<skill name="Power Crush" id="260" level="23" required-level="60" sp="800000" />
-		<skill name="Potion Mastery" id="45184" level="3" required-level="60">
-			<item id="57" count="6000000"/> <!-- Adena -->
-		</skill>
-		
-		<skill name="Spinning Slasher" id="36" level="24" required-level="61" sp="800000" />
-		<skill name="Polearm Mastery" id="216" level="32" required-level="61" sp="800000" />
-		<skill name="Light Armor Mastery" id="227" level="37" required-level="61" sp="800000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="32" required-level="61" sp="800000" />
-		<skill name="Heavy Armor Mastery" id="231" level="37" required-level="61" sp="800000" />
-		<skill name="Power Crush" id="260" level="24" required-level="61" sp="800000" />
-		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="800000" >
-			<item id="8619"/> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
-		</skill>
-		
-		<skill name="Spinning Slasher" id="36" level="25" required-level="62" sp="1000000" />
-		<skill name="Polearm Mastery" id="216" level="33" required-level="62" sp="1000000" />
-		<skill name="Light Armor Mastery" id="227" level="38" required-level="62" sp="1000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="33" required-level="62" sp="1000000" />
-		<skill name="Heavy Armor Mastery" id="231" level="38" required-level="62" sp="1000000" />
-		<skill name="Lionheart" id="287" level="3" required-level="62" sp="1000000" />
-		<skill name="Spoil Festival" id="302" level="6" required-level="62" sp="1000000" />
-		<skill name="Bandage" id="34" level="3" required-level="62" sp="1000000" />
-		<skill name="Power Crush" id="260" level="25" required-level="62" sp="1000000" />
-		<skill name="Body Impale" id="1613" level="6" required-level="62" sp="1000000" />
-		<skill name="Boost HP" id="211" level="7" required-level="62" sp="1000000" />
-		<skill name="Weapon Reinforcement" id="1615" level="3" required-level="62" sp="1000000" />
-		
-		<skill name="Spinning Slasher" id="36" level="26" required-level="63" sp="1000000" />
-		<skill name="Polearm Mastery" id="216" level="34" required-level="63" sp="1000000" />
-		<skill name="Light Armor Mastery" id="227" level="39" required-level="63" sp="1000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="34" required-level="63" sp="1000000" />
-		<skill name="Heavy Armor Mastery" id="231" level="39" required-level="63" sp="1000000" />
-		<skill name="Power Crush" id="260" level="26" required-level="63" sp="1000000" />
-		
-		<skill name="Spinning Slasher" id="36" level="27" required-level="64" sp="1200000" />
-		<skill name="Polearm Mastery" id="216" level="35" required-level="64" sp="1200000" />
-		<skill name="Light Armor Mastery" id="227" level="40" required-level="64" sp="1200000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="35" required-level="64" sp="1200000" />
-		<skill name="Heavy Armor Mastery" id="231" level="40" required-level="64" sp="1200000" />
-		<skill name="Vital Force" id="148" level="7" required-level="64" sp="1200000" />
-		<skill name="Tenacity" id="1617" level="3" required-level="64" sp="1200000" />
-		<skill name="Spoil" id="254" level="9" required-level="64" sp="1200000" />
-		<skill name="Provoke" id="286" level="4" required-level="64" sp="1200000" />
-		<skill name="Power Crush" id="260" level="27" required-level="64" sp="1200000" />
-		
-		<skill name="Spinning Slasher" id="36" level="28" required-level="65" sp="1200000" />
-		<skill name="Polearm Mastery" id="216" level="36" required-level="65" sp="1200000" />
-		<skill name="Light Armor Mastery" id="227" level="41" required-level="65" sp="1200000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="36" required-level="65" sp="1200000" />
-		<skill name="Heavy Armor Mastery" id="231" level="41" required-level="65" sp="1200000" />
-		<skill name="Power Crush" id="260" level="28" required-level="65" sp="1200000" />
-		
-		<skill name="Spinning Slasher" id="36" level="29" required-level="66" sp="1400000" />
-		<skill name="Polearm Mastery" id="216" level="37" required-level="66" sp="1400000" />
-		<skill name="Light Armor Mastery" id="227" level="42" required-level="66" sp="1400000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="37" required-level="66" sp="1400000" />
-		<skill name="Heavy Armor Mastery" id="231" level="42" required-level="66" sp="1400000" />
-		<skill name="Spoil Festival" id="302" level="7" required-level="66" sp="1400000" />
-		<skill name="Power Crush" id="260" level="29" required-level="66" sp="1400000" />
-		<skill name="Body Impale" id="1613" level="7" required-level="66" sp="1400000" />
-		<skill name="Boost HP" id="211" level="8" required-level="66" sp="1400000" />
-		
-		<skill name="Spinning Slasher" id="36" level="30" required-level="67" sp="1400000" />
-		<skill name="Polearm Mastery" id="216" level="38" required-level="67" sp="1400000" />
-		<skill name="Light Armor Mastery" id="227" level="43" required-level="67" sp="1400000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="38" required-level="67" sp="1400000" />
-		<skill name="Heavy Armor Mastery" id="231" level="43" required-level="67" sp="1400000" />
-		<skill name="Power Crush" id="260" level="30" required-level="67" sp="1400000" />
-		
-		<skill name="Fast HP Recovery" id="212" level="7" required-level="68" sp="1900000" />
-		<skill name="Spinning Slasher" id="36" level="31" required-level="68" sp="1900000" />
-		<skill name="Polearm Mastery" id="216" level="39" required-level="68" sp="1900000" />
-		<skill name="Light Armor Mastery" id="227" level="44" required-level="68" sp="1900000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="39" required-level="68" sp="1900000" />
-		<skill name="Heavy Armor Mastery" id="231" level="44" required-level="68" sp="1900000" />
-		<skill name="Spoil" id="254" level="10" required-level="68" sp="1900000" />
-		<skill name="Provoke" id="286" level="5" required-level="68" sp="1900000" />
-		<skill name="Power Crush" id="260" level="31" required-level="68" sp="1900000" />
-		
-		<skill name="Spinning Slasher" id="36" level="32" required-level="69" sp="1900000" />
-		<skill name="Polearm Mastery" id="216" level="40" required-level="69" sp="1900000" />
-		<skill name="Light Armor Mastery" id="227" level="45" required-level="69" sp="1900000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="40" required-level="69" sp="1900000" />
-		<skill name="Heavy Armor Mastery" id="231" level="45" required-level="69" sp="1900000" />
-		<skill name="Power Crush" id="260" level="32" required-level="69" sp="1900000" />
-		
-		<skill name="Spinning Slasher" id="36" level="33" required-level="70" sp="2400000" />
-		<skill name="Polearm Mastery" id="216" level="41" required-level="70" sp="2400000" />
-		<skill name="Light Armor Mastery" id="227" level="46" required-level="70" sp="2400000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="41" required-level="70" sp="2400000" />
-		<skill name="Heavy Armor Mastery" id="231" level="46" required-level="70" sp="2400000" />
-		<skill name="Spoil Festival" id="302" level="8" required-level="70" sp="2400000" />
-		<skill name="Power Crush" id="260" level="33" required-level="70" sp="2400000" />
-		<skill name="Body Impale" id="1613" level="8" required-level="70" sp="2400000" />
-		<skill name="Boost HP" id="211" level="9" required-level="70" sp="2400000" />
-		
-		<skill name="Spinning Slasher" id="36" level="34" required-level="71" sp="2400000" />
-		<skill name="Polearm Mastery" id="216" level="42" required-level="71" sp="2400000" />
-		<skill name="Light Armor Mastery" id="227" level="47" required-level="71" sp="2400000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="42" required-level="71" sp="2400000" />
-		<skill name="Heavy Armor Mastery" id="231" level="47" required-level="71" sp="2400000" />
-		<skill name="Power Crush" id="260" level="34" required-level="71" sp="2400000" />
-		
-		<skill name="Spinning Slasher" id="36" level="35" required-level="72" sp="2700000" />
-		<skill name="Polearm Mastery" id="216" level="43" required-level="72" sp="2700000" />
-		<skill name="Light Armor Mastery" id="227" level="48" required-level="72" sp="2700000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="43" required-level="72" sp="2700000" />
-		<skill name="Heavy Armor Mastery" id="231" level="48" required-level="72" sp="2700000" />
-		<skill name="Vital Force" id="148" level="8" required-level="72" sp="2700000" />
-		<skill name="Spoil" id="254" level="11" required-level="72" sp="2700000" />
-		<skill name="Provoke" id="286" level="6" required-level="72" sp="2700000" />
-		<skill name="Power Crush" id="260" level="35" required-level="72" sp="2700000" />
+		<skill name="Emergency Rescue" id="70" level="14" required-level="44" sp="140000" />
 
-		<skill name="Spinning Slasher" id="36" level="36" required-level="73" sp="2700000" />
-		<skill name="Polearm Mastery" id="216" level="44" required-level="73" sp="2700000" />
-		<skill name="Light Armor Mastery" id="227" level="49" required-level="73" sp="2700000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="44" required-level="73" sp="2700000" />
-		<skill name="Heavy Armor Mastery" id="231" level="49" required-level="73" sp="2700000" />
-		<skill name="Power Crush" id="260" level="36" required-level="73" sp="2700000" />
-		
-		<skill name="Fast HP Recovery" id="212" level="8" required-level="74" sp="2700000" />
-		<skill name="Spinning Slasher" id="36" level="37" required-level="74" sp="2700000" />
-		<skill name="Polearm Mastery" id="216" level="45" required-level="74" sp="2700000" />
-		<skill name="Light Armor Mastery" id="227" level="50" required-level="74" sp="2700000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="45" required-level="74" sp="2700000" />
-		<skill name="Heavy Armor Mastery" id="231" level="50" required-level="74" sp="2700000" />
-		<skill name="Spoil Festival" id="302" level="9" required-level="74" sp="2700000" />
-		<skill name="Spoil" id="254" level="12" required-level="74" sp="2700000" />
-		<skill name="Provoke" id="286" level="7" required-level="74" sp="2700000" />
-		<skill name="Power Crush" id="260" level="37" required-level="74" sp="2700000" />
-		<skill name="Body Impale" id="1613" level="9" required-level="74" sp="2700000" />
+		<!-- Skills Lv45 -->
+		<skill name="Bandage" id="34" level="2" required-level="45" sp="140000" />
+		<skill name="Spinning Slasher" id="36" level="10" required-level="45" sp="140000" />
+		<skill name="Fatal Strike" id="190" level="10" required-level="45" sp="140000" />
+		<skill name="Power Break" id="260" level="8" required-level="45" sp="140000" />
+		<skill name="Pirate Transformation" id="1800" level="1" required-level="45" auto-learn="true" />
+		<skill name="Emergency Rescue" id="70" level="15" required-level="45" sp="140000" />
+
+		<!-- Skills Lv46 -->
+		<skill name="Spinning Slasher" id="36" level="11" required-level="46" sp="140000" />
+		<skill name="Weight Limit" id="150" level="3" required-level="46" sp="140000" />
+		<skill name="Fatal Strike" id="190" level="11" required-level="46" sp="140000" />
+		<skill name="Power Break" id="260" level="9" required-level="46" sp="140000" />
+		<skill name="Final Frenzy" id="290" level="2" required-level="46" sp="140000" />
+		<skill name="Encase Armor" id="828" level="1" required-level="46" sp="140000" />
+		<skill name="Body Crush" id="1613" level="2" required-level="46" sp="140000" />
+		<skill name="Emergency Rescue" id="70" level="16" required-level="46" sp="140000" />
+
+		<!-- Skills Lv47 -->
+		<skill name="Spinning Slasher" id="36" level="12" required-level="47" sp="200000" />
+		<skill name="Fatal Strike" id="190" level="12" required-level="47" sp="200000" />
+		<skill name="Power Break" id="260" level="10" required-level="47" sp="200000" />
+		<skill name="Emergency Rescue" id="70" level="17" required-level="47" sp="200000" />
+		<skill name="Dwarven Armor Mastery" id="47236" level="3" required-level="47" sp="200000" />
+
+
+		<!-- Skills Lv48 -->
+		<skill name="Spinning Slasher" id="36" level="13" required-level="48" sp="200000" />
+		<skill name="Fatal Strike" id="190" level="13" required-level="48" sp="200000" />
+		<skill name="Power Break" id="260" level="11" required-level="48" sp="200000" />
+		<skill name="Emergency Rescue" id="70" level="18" required-level="48" sp="200000" />
+		<skill name="Dwarven Weapon Mastery" id="47235" level="3" required-level="48" sp="200000" />
+
+
+		<!-- Skills Lv49 -->
+		<skill name="Spinning Slasher" id="36" level="14" required-level="49" sp="200000" />
+		<skill name="Fatal Strike" id="190" level="14" required-level="49" sp="200000" />
+		<skill name="Boost HP" id="211" level="5" required-level="49" sp="200000" />
+		<skill name="Spoil" id="254" level="6" required-level="49" sp="200000" />
+		<skill name="Power Break" id="260" level="12" required-level="49" sp="200000" />
+		<skill name="Lionheart" id="287" level="2" required-level="49" sp="200000" />
+		<skill name="Final Frenzy" id="290" level="3" required-level="49" sp="200000" />
+		<skill name="Spoil Festival" id="302" level="4" required-level="49" sp="200000" />
+		<skill name="Spike" id="826" level="1" required-level="49" sp="200000" />
+		<skill name="Emergency Rescue" id="70" level="19" required-level="49" sp="200000" />
+
+		<!-- Skills Lv50 -->
+		<skill name="Spinning Slasher" id="36" level="15" required-level="50" sp="290000" />
+		<skill name="Fatal Strike" id="190" level="15" required-level="50" sp="290000" />
+		<skill name="Power Break" id="260" level="13" required-level="50" sp="290000" />
+		<skill name="Body Crush" id="1613" level="3" required-level="50" sp="290000" />
+		<skill name="Recover HP" id="45176" level="2" required-level="50" sp="300000" >
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Recover MP" id="45177" level="2" required-level="50" sp="300000" >
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Potion Mastery" id="45184" level="2" required-level="50">
+			<item id="57" count="3000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="20" required-level="50" sp="290000" />
+
+		<!-- Skills Lv51 -->
+		<skill name="Spinning Slasher" id="36" level="16" required-level="51" sp="290000" />
+		<skill name="Power Break" id="260" level="14" required-level="51" sp="290000" />
+		<skill name="Fatal Strike" id="190" level="16" required-level="51" sp="290000" />
+		<skill name="Emergency Rescue" id="70" level="21" required-level="51" sp="290000" />
+
+		<!-- Skills Lv52 -->
+		<skill name="Spinning Slasher" id="36" level="17" required-level="52" sp="290000" />
+		<skill name="Fatal Strike" id="190" level="17" required-level="52" sp="290000" />
+		<skill name="Power Break" id="260" level="15" required-level="52" sp="290000" />
+		<skill name="Final Frenzy" id="290" level="4" required-level="52" sp="290000" />
+		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="290000" >
+			<item id="8618" count="1" /> <!-- Ancient Book: Divine Inspiration Lv 1 -->
+		</skill>
+		<skill name="Weapon Reinforcement" id="1615" level="2" required-level="52" sp="290000" />
+		<skill name="Dwarven Restore Mastery" id="47237" level="2" required-level="52" sp="290000" />
+		<skill name="Emergency Rescue" id="70" level="22" required-level="52" sp="290000" />
+
+		<!-- Skills Lv53 -->
+		<skill name="Spinning Slasher" id="36" level="18" required-level="53" sp="400000" />
+		<skill name="Fatal Strike" id="190" level="18" required-level="53" sp="400000" />
+		<skill name="Power Break" id="260" level="16" required-level="53" sp="400000" />
+		<skill name="Emergency Rescue" id="70" level="23" required-level="53" sp="400000" />
+		<skill name="Dwarven Armor Mastery" id="47236" level="4" required-level="53" sp="400000" />
+
+		<!-- Skills Lv54 -->
+		<skill name="Spinning Slasher" id="36" level="19" required-level="54" sp="400000" />
+		<skill name="Fatal Strike" id="190" level="19" required-level="54" sp="400000" />
+		<skill name="Power Break" id="260" level="17" required-level="54" sp="400000" />
+		<skill name="Body Crush" id="1613" level="4" required-level="54" sp="400000" />
+		<skill name="Emergency Rescue" id="70" level="24" required-level="54" sp="400000" />
+		<skill name="Dwarven Weapon Mastery" id="47235" level="4" required-level="54" sp="400000" />
+
+		<!-- Skills Lv55 -->
+		<skill name="Spinning Slasher" id="36" level="20" required-level="55" sp="400000" />
+		<skill name="Fatal Strike" id="190" level="20" required-level="55" sp="400000" />
+		<skill name="Boost HP" id="211" level="6" required-level="55" sp="400000" />
+		<skill name="Spoil" id="254" level="7" required-level="55" sp="400000" />
+		<skill name="Power Break" id="260" level="18" required-level="55" sp="400000" />
+		<skill name="Provoke" id="286" level="2" required-level="55" sp="400000" />
+		<skill name="Final Frenzy" id="290" level="5" required-level="55" sp="400000" />
+		<skill name="Spoil Festival" id="302" level="5" required-level="55" sp="400000" />
+		<skill name="Emergency Rescue" id="70" level="25" required-level="55" sp="400000" />
+
+		<!-- Skills Lv56 -->
+		<skill name="Spinning Slasher" id="36" level="21" required-level="56" sp="550000" />
+		<skill name="Fatal Strike" id="190" level="21" required-level="56" sp="550000" />
+		<skill name="Power Break" id="260" level="19" required-level="56" sp="550000" />
+		<skill name="Tenacity" id="1617" level="2" required-level="56" sp="550000" />
+		<skill name="Emergency Rescue" id="70" level="26" required-level="56" sp="550000" />
+
+		<!-- Skills Lv57 -->
+		<skill name="Spinning Slasher" id="36" level="22" required-level="57" sp="550000" />
+		<skill name="Fatal Strike" id="190" level="22" required-level="57" sp="550000" />
+		<skill name="Power Break" id="260" level="20" required-level="57" sp="550000" />
+		<skill name="Emergency Rescue" id="70" level="27" required-level="57" sp="550000" />
+
+		<!-- Skills Lv58 -->
+		<skill name="Spinning Slasher" id="36" level="23" required-level="58" sp="550000" />
+		<skill name="Fatal Strike" id="190" level="23" required-level="58" sp="550000" />
+		<skill name="Power Break" id="260" level="21" required-level="58" sp="550000" />
+		<skill name="Final Frenzy" id="290" level="6" required-level="58" sp="550000" />
+		<skill name="Body Crush" id="1613" level="5" required-level="58" sp="550000" />
+		<skill name="Emergency Rescue" id="70" level="28" required-level="58" sp="550000" />
+
+		<!-- Skills Lv59 -->
+		<skill name="Spinning Slasher" id="36" level="24" required-level="59" sp="800000" />
+		<skill name="Fatal Strike" id="190" level="24" required-level="59" sp="800000" />
+		<skill name="Power Break" id="260" level="22" required-level="59" sp="800000" />
+		<skill name="Emergency Rescue" id="70" level="29" required-level="59" sp="800000" />
+		<skill name="Dwarven Armor Mastery" id="47236" level="5" required-level="59" sp="800000" />
+
+		<!-- Skills Lv60 -->
+		<skill name="Bandage" id="34" level="3" required-level="60" sp="800000" />
+		<skill name="Spinning Slasher" id="36" level="25" required-level="60" sp="800000" />
+		<skill name="Ability to Attack" id="77" level="3" required-level="60" sp="800000" />
+		<skill name="Fatal Strike" id="190" level="25" required-level="60" sp="800000" />
+		<skill name="Spoil" id="254" level="8" required-level="60" sp="800000" />
+		<skill name="Power Break" id="260" level="23" required-level="60" sp="800000" />
+		<skill name="Provoke" id="286" level="3" required-level="60" sp="800000" />
+		<skill name="Final Frenzy" id="290" level="7" required-level="60" sp="800000" />
+		<skill name="Rush" id="994" level="2" required-level="60" sp="800000" />
+		<skill name="Dark Assassin Transformation" id="1801" level="1" required-level="60" auto-learn="true" />
+		<skill name="Potion Mastery" id="45184" level="3" required-level="60">
+			<item id="57" count="6000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="30" required-level="60" sp="800000" />
+		<skill name="Dwarven Weapon Mastery" id="47235" level="5" required-level="60" sp="800000" />
+
+		<!-- Skills Lv61 -->
+		<skill name="Spinning Slasher" id="36" level="26" required-level="61" sp="800000" />
+		<skill name="Fatal Strike" id="190" level="26" required-level="61" sp="800000" />
+		<skill name="Power Break" id="260" level="24" required-level="61" sp="800000" />
+		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="800000" >
+			<item id="8619" count="1" /> <!-- Ancient Book: Divine Inspiration Lv 2 -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="31" required-level="61" sp="800000" />
+
+		<!-- Skills Lv62 -->
+		<skill name="Spinning Slasher" id="36" level="27" required-level="62" sp="1000000" />
+		<skill name="Fatal Strike" id="190" level="27" required-level="62" sp="1000000" />
+		<skill name="Boost HP" id="211" level="7" required-level="62" sp="1000000" />
+		<skill name="Power Break" id="260" level="25" required-level="62" sp="1000000" />
+		<skill name="Lionheart" id="287" level="3" required-level="62" sp="1000000" />
+		<skill name="Final Frenzy" id="290" level="8" required-level="62" sp="1000000" />
+		<skill name="Spoil Festival" id="302" level="6" required-level="62" sp="1000000" />
+		<skill name="Body Crush" id="1613" level="6" required-level="62" sp="1000000" />
+		<skill name="Weapon Reinforcement" id="1615" level="3" required-level="62" sp="1000000" />
+		<skill name="Emergency Rescue" id="70" level="32" required-level="62" sp="1000000" />
+
+		<!-- Skills Lv63 -->
+		<skill name="Spinning Slasher" id="36" level="28" required-level="63" sp="1000000" />
+		<skill name="Fatal Strike" id="190" level="28" required-level="63" sp="1000000" />
+		<skill name="Power Break" id="260" level="26" required-level="63" sp="1000000" />
+		<skill name="Emergency Rescue" id="70" level="33" required-level="63" sp="1000000" />
+
+		<!-- Skills Lv64 -->
+		<skill name="Spinning Slasher" id="36" level="29" required-level="64" sp="1200000" />
+		<skill name="Fatal Strike" id="190" level="29" required-level="64" sp="1200000" />
+		<skill name="Spoil" id="254" level="9" required-level="64" sp="1200000" />
+		<skill name="Power Break" id="260" level="27" required-level="64" sp="1200000" />
+		<skill name="Provoke" id="286" level="4" required-level="64" sp="1200000" />
+		<skill name="Final Frenzy" id="290" level="9" required-level="64" sp="1200000" />
+		<skill name="Tenacity" id="1617" level="3" required-level="64" sp="1200000" />
+		<skill name="Emergency Rescue" id="70" level="34" required-level="64" sp="1200000" />
+		<skill name="Dwarven Restore Mastery" id="47237" level="3" required-level="64" sp="1200000" />
+
+		<!-- Skills Lv65 -->
+		<skill name="Spinning Slasher" id="36" level="30" required-level="65" sp="1200000" />
+		<skill name="Power Break" id="260" level="28" required-level="65" sp="1200000" />
+		<skill name="Fatal Strike" id="190" level="30" required-level="65" sp="1200000" />
+		<skill name="Emergency Rescue" id="70" level="35" required-level="65" sp="1200000" />
+		<skill name="Dwarven Armor Mastery" id="47236" level="6" required-level="65" sp="1200000" />
+
+		<!-- Skills Lv66 -->
+		<skill name="Spinning Slasher" id="36" level="31" required-level="66" sp="1400000" />
+		<skill name="Fatal Strike" id="190" level="31" required-level="66" sp="1400000" />
+		<skill name="Boost HP" id="211" level="8" required-level="66" sp="1400000" />
+		<skill name="Power Break" id="260" level="29" required-level="66" sp="1400000" />
+		<skill name="Final Frenzy" id="290" level="10" required-level="66" sp="1400000" />
+		<skill name="Body Crush" id="1613" level="7" required-level="66" sp="1400000" />
+		<skill name="Spoil Festival" id="302" level="7" required-level="66" sp="1400000" />
+		<skill name="Emergency Rescue" id="70" level="36" required-level="66" sp="1400000" />
+		<skill name="Dwarven Weapon Mastery" id="47235" level="6" required-level="66" sp="1400000" />
+
+		<!-- Skills Lv67 -->
+		<skill name="Spinning Slasher" id="36" level="32" required-level="67" sp="1400000" />
+		<skill name="Fatal Strike" id="190" level="32" required-level="67" sp="1400000" />
+		<skill name="Power Break" id="260" level="30" required-level="67" sp="1400000" />
+		<skill name="Emergency Rescue" id="70" level="37" required-level="67" sp="1400000" />
+
+		<!-- Skills Lv68 -->
+		<skill name="Spinning Slasher" id="36" level="33" required-level="68" sp="1900000" />
+		<skill name="Fatal Strike" id="190" level="33" required-level="68" sp="1900000" />
+		<skill name="Spoil" id="254" level="10" required-level="68" sp="1900000" />
+		<skill name="Power Break" id="260" level="31" required-level="68" sp="1900000" />
+		<skill name="Final Frenzy" id="290" level="11" required-level="68" sp="1900000" />
+		<skill name="Provoke" id="286" level="5" required-level="68" sp="1900000" />
+		<skill name="Emergency Rescue" id="70" level="38" required-level="68" sp="1900000" />
+
+		<!-- Skills Lv69 -->
+		<skill name="Spinning Slasher" id="36" level="34" required-level="69" sp="1900000" />
+		<skill name="Power Break" id="260" level="32" required-level="69" sp="1900000" />
+		<skill name="Fatal Strike" id="190" level="34" required-level="69" sp="1900000" />
+		<skill name="Emergency Rescue" id="70" level="39" required-level="69" sp="1900000" />
+
+		<!-- Skills Lv70 -->
+		<skill name="Spinning Slasher" id="36" level="35" required-level="70" sp="2400000" />
+		<skill name="Fatal Strike" id="190" level="35" required-level="70" sp="2400000" />
+		<skill name="Boost HP" id="211" level="9" required-level="70" sp="2400000" />
+		<skill name="Power Break" id="260" level="33" required-level="70" sp="2400000" />
+		<skill name="Final Frenzy" id="290" level="12" required-level="70" sp="2400000" />
+		<skill name="Spoil Festival" id="302" level="8" required-level="70" sp="2400000" />
+		<skill name="Body Crush" id="1613" level="8" required-level="70" sp="2400000" />
+		<skill name="White Assassin Transformation" id="1802" level="1" required-level="70" auto-learn="true" />
+		<skill name="Emergency Rescue" id="70" level="40" required-level="70" sp="2400000" />
+		<skill name="Dwarven Restore Mastery" id="47237" level="4" required-level="70" sp="2400000" />
+
+		<!-- Skills Lv71 -->
+		<skill name="Spinning Slasher" id="36" level="36" required-level="71" sp="2400000" />
+		<skill name="Fatal Strike" id="190" level="36" required-level="71" sp="2400000" />
+		<skill name="Power Break" id="260" level="34" required-level="71" sp="2400000" />
+		<skill name="Dwarven Armor Mastery" id="47236" level="7" required-level="71" sp="2400000" />
+		<skill name="Emergency Rescue" id="70" level="41" required-level="71" sp="2400000" />
+
+		<!-- Skills Lv72 -->
+		<skill name="Spinning Slasher" id="36" level="37" required-level="72" sp="2700000" />
+		<skill name="Fatal Strike" id="190" level="37" required-level="72" sp="2700000" />
+		<skill name="Spoil" id="254" level="11" required-level="72" sp="2700000" />
+		<skill name="Power Break" id="260" level="35" required-level="72" sp="2700000" />
+		<skill name="Provoke" id="286" level="6" required-level="72" sp="2700000" />
+		<skill name="Final Frenzy" id="290" level="13" required-level="72" sp="2700000" />
+		<skill name="Emergency Rescue" id="70" level="42" required-level="72" sp="2700000" />
+		<skill name="Dwarven Weapon Mastery" id="47235" level="72" required-level="72" sp="2700000" />
+
+		<!-- Skills Lv73 -->
+		<skill name="Spinning Slasher" id="36" level="38" required-level="73" sp="2700000" />
+		<skill name="Power Break" id="260" level="36" required-level="73" sp="2700000" />
+		<skill name="Fatal Strike" id="190" level="38" required-level="73" sp="2700000" />
+		<skill name="Emergency Rescue" id="70" level="43" required-level="73" sp="2700000" />
+
+		<!-- Skills Lv74 -->
+		<skill name="Spinning Slasher" id="36" level="39" required-level="74" sp="2700000" />
+		<skill name="Fatal Strike" id="190" level="39" required-level="74" sp="2700000" />
 		<skill name="Boost HP" id="211" level="10" required-level="74" sp="2700000" />
+		<skill name="Spoil" id="254" level="12" required-level="74" sp="2700000" />
+		<skill name="Power Break" id="260" level="37" required-level="74" sp="2700000" />
+		<skill name="Provoke" id="286" level="7" required-level="74" sp="2700000" />
+		<skill name="Final Frenzy" id="290" level="14" required-level="74" sp="2700000" />
+		<skill name="Spoil Festival" id="302" level="9" required-level="74" sp="2700000" />
+		<skill name="Body Crush" id="1613" level="9" required-level="74" sp="2700000" />
+		<skill name="Emergency Rescue" id="70" level="44" required-level="74" sp="2700000" />
+
+		<!-- Skills Lv75 -->
+		<skill name="Spinning Slasher" id="36" level="40" required-level="75" sp="2700000" />
+		<skill name="Fatal Strike" id="190" level="40" required-level="75" sp="2700000" />
+		<skill name="Emergency Rescue" id="70" level="45" required-level="75" sp="2700000" />
 	</skillTree>
 </list>

--- a/data/skillTrees/2ndClass/DarkAvenger.xml
+++ b/data/skillTrees/2ndClass/DarkAvenger.xml
@@ -1,9 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="6" parentClassId="4">
-		<skill name="Pirate" id="1800" level="1" required-level="45" auto-learn="true" />
-		<skill name="Dark Assassin" id="1801" level="1" required-level="60" auto-learn="true" />
-		<skill name="White Assassin" id="1802" level="1" required-level="70" auto-learn="true" />
+
+		<!-- Master Buffs Lv. 40 -->
+		<skill name="Might" id="1068" level="3" required-level="40" sp="80000" />
+		<skill name="Shield" id="1040" level="3" required-level="40" sp="80000" />
+		<skill name="Acumen" id="45104" level="3" required-level="40" sp="80000" />
+		<skill name="Empower" id="45105" level="3" required-level="40" sp="80000" />
+		<skill name="Wild Magic" id="45106" level="2" required-level="40" sp="80000" />
+		<skill name="Magic Barrier" id="45108" level="2" required-level="40" sp="80000" />
+		<skill name="Focus" id="45109" level="3" required-level="40" sp="80000" />
+		<skill name="Death Whisper" id="45110" level="3" required-level="40" sp="80000" />
+		<skill name="Haste" id="45111" level="2" required-level="40" sp="80000" />
+		<skill name="Berserker Spirit" id="45112" level="2" required-level="40" sp="80000" />
+		<skill name="Clarity" id="45113" level="3" required-level="40" sp="80000" />
+
+		<!-- Skills Lv40 -->
 		<skill name="Aggression" id="28" level="13" required-level="40" sp="62000" />
 		<skill name="Aggression" id="28" level="14" required-level="40" sp="62000" />
 		<skill name="Aggression" id="28" level="15" required-level="40" sp="62000" />
@@ -11,20 +23,20 @@
 		<skill name="Aggression Aura" id="18" level="1" required-level="40" sp="62000" />
 		<skill name="Aggression Aura" id="18" level="2" required-level="40" sp="62000" />
 		<skill name="Aggression Aura" id="18" level="3" required-level="40" sp="62000" />
+		<skill name="Quick Heal" id="45" level="10" required-level="40" sp="62000" />
 		<skill name="Majesty" id="82" level="2" required-level="40" sp="62000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="9" required-level="40" sp="62000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="10" required-level="40" sp="62000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="11" required-level="40" sp="62000" />
+		<skill name="Potion Mastery" id="45184" level="1" required-level="40">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="9" required-level="40" sp="62000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="10" required-level="40" sp="62000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="11" required-level="40" sp="62000" />
+		<skill name="Weapon Mastery" id="141" level="4" required-level="40" sp="62000" />
 		<skill name="Heavy Armor Mastery" id="232" level="16" required-level="40" sp="62000" />
 		<skill name="Heavy Armor Mastery" id="232" level="17" required-level="40" sp="62000" />
 		<skill name="Heavy Armor Mastery" id="232" level="18" required-level="40" sp="62000" />
 		<skill name="Shield Mastery" id="153" level="3" required-level="40" sp="62000" />
-		<skill name="Drain Energy" id="70" level="14" required-level="40" sp="62000" />
-		<skill name="Drain Energy" id="70" level="15" required-level="40" sp="62000" />
-		<skill name="Drain Energy" id="70" level="16" required-level="40" sp="62000" />
-		<skill name="Drain Energy" id="70" level="17" required-level="40" sp="62000" />
-		<skill name="Drain Energy" id="70" level="18" required-level="40" sp="62000" />
-		<skill name="Drain Energy" id="70" level="19" required-level="40" sp="62000" />
+		<skill name="Dignity" id="196" level="1" required-level="40" sp="62000" />
 		<skill name="Magic Resistance" id="147" level="15" required-level="40" sp="62000" />
 		<skill name="Magic Resistance" id="147" level="16" required-level="40" sp="62000" />
 		<skill name="Magic Resistance" id="147" level="17" required-level="40" sp="62000" />
@@ -34,101 +46,110 @@
 		<skill name="Life Scavenge" id="46" level="1" required-level="40" sp="62000" />
 		<skill name="Reflect Damage" id="86" level="1" required-level="40" sp="62000" />
 		<skill name="Summon Dark Panther" id="283" level="1" required-level="40" sp="62000" />
-		<skill name="Potion Mastery" id="45184" level="1" required-level="40">
-			<item id="57" count="1000000"/> <!-- Adena -->
-		</skill>
-		
+		<skill name="Dark Strike" id="45257" level="1" required-level="40" sp="62000" />
+		<skill name="Honor" id="197" level="1" required-level="40" sp="62000" />
+		<skill name="Emergency Rescue" id="70" level="10" required-level="40" sp="62000" />
+
+		<!-- Skills Lv41 -->
 		<skill name="Aggression" id="28" level="16" required-level="41" sp="72000" />
 		<skill name="Aggression Aura" id="18" level="4" required-level="41" sp="72000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="12" required-level="41" sp="72000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="12" required-level="41" sp="72000" />
 		<skill name="Heavy Armor Mastery" id="232" level="19" required-level="41" sp="72000" />
-		<skill name="Drain Energy" id="70" level="20" required-level="41" sp="72000" />
 		<skill name="Magic Resistance" id="147" level="18" required-level="41" sp="72000" />
 		<skill name="Shield Stun" id="92" level="19" required-level="41" sp="72000" />
-		
+		<skill name="Emergency Rescue" id="70" level="11" required-level="41" sp="72000" />
+
+		<!-- Skills Lv42 -->
 		<skill name="Aggression" id="28" level="17" required-level="42" sp="72000" />
 		<skill name="Aggression Aura" id="18" level="5" required-level="42" sp="72000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="13" required-level="42" sp="72000" />
+		<skill name="Quick Heal" id="45" level="11" required-level="42" sp="72000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="13" required-level="42" sp="72000" />
 		<skill name="Heavy Armor Mastery" id="232" level="20" required-level="42" sp="72000" />
-		<skill name="Drain Energy" id="70" level="21" required-level="42" sp="72000" />
 		<skill name="Magic Resistance" id="147" level="19" required-level="42" sp="72000" />
 		<skill name="Shield Stun" id="92" level="20" required-level="42" sp="72000" />
-			
+		<skill name="Emergency Rescue" id="70" level="12" required-level="42" sp="72000" />
+
+		<!-- Skills Lv43 -->
 		<skill name="Aggression" id="28" level="18" required-level="43" sp="72000" />
 		<skill name="Shield Strike" id="984" level="2" required-level="43" sp="72000" />
 		<skill name="Aggression Aura" id="18" level="6" required-level="43" sp="72000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="14" required-level="43" sp="72000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="14" required-level="43" sp="72000" />
 		<skill name="Heavy Armor Mastery" id="232" level="21" required-level="43" sp="72000" />
 		<skill name="Iron Will" id="72" level="1" required-level="43" sp="72000" />
-		<skill name="Drain Energy" id="70" level="22" required-level="43" sp="72000" />
 		<skill name="Magic Resistance" id="147" level="20" required-level="43" sp="72000" />
 		<skill name="Shield Stun" id="92" level="21" required-level="43" sp="72000" />
 		<skill name="Life Scavenge" id="46" level="2" required-level="43" sp="72000" />
 		<skill name="Deflect Arrow" id="112" level="3" required-level="43" sp="72000" />
+		<skill name="Hamstring" id="127" level="1" required-level="43" sp="72000" />
+		<skill name="Dark Strike" id="45257" level="2" required-level="43" sp="72000" />
 		<skill name="Focus Mind" id="191" level="2" required-level="43" sp="72000" />
-		<skill name="Hamstring" id="127" level="1" required-level="43" sp="72000" >
-			<item id="3052"/>
-		</skill>
-		<skill name="Iron Will" id="72" level="1" required-level="43" sp="72000" >
-			<item id="3047"/>
-		</skill>
-		
+		<skill name="Emergency Rescue" id="70" level="13" required-level="43" sp="72000" />
+
+		<!-- Skills Lv44 -->
 		<skill name="Aggression" id="28" level="19" required-level="44" sp="110000" />
 		<skill name="Aggression Aura" id="18" level="7" required-level="44" sp="110000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="15" required-level="44" sp="110000" />
+		<skill name="Quick Heal" id="45" level="12" required-level="44" sp="110000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="15" required-level="44" sp="110000" />
 		<skill name="Heavy Armor Mastery" id="232" level="22" required-level="44" sp="110000" />
-		<skill name="Drain Energy" id="70" level="23" required-level="44" sp="110000" />
 		<skill name="Magic Resistance" id="147" level="21" required-level="44" sp="110000" />
 		<skill name="Shield Stun" id="92" level="22" required-level="44" sp="110000" />
-		
+		<skill name="Emergency Rescue" id="70" level="14" required-level="44" sp="110000" />
+
+		<!-- Skills Lv45 -->
 		<skill name="Aggression" id="28" level="20" required-level="45" sp="110000" />
 		<skill name="Aggression Aura" id="18" level="8" required-level="45" sp="110000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="16" required-level="45" sp="110000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="16" required-level="45" sp="110000" />
 		<skill name="Heavy Armor Mastery" id="232" level="23" required-level="45" sp="110000" />
-		<skill name="Drain Energy" id="70" level="24" required-level="45" sp="110000" />
 		<skill name="Magic Resistance" id="147" level="22" required-level="45" sp="110000" />
 		<skill name="Shield Stun" id="92" level="23" required-level="45" sp="110000" />
-		
+		<skill name="Pirate Transformation" id="1800" level="1" required-level="45" auto-learn="true" />
+		<skill name="Emergency Rescue" id="70" level="15" required-level="45" sp="110000" />
+
+		<!-- Skills Lv46 -->
 		<skill name="Ultimate Defense" id="110" level="2" required-level="46" sp="110000" />
 		<skill name="Aggression" id="28" level="21" required-level="46" sp="110000" />
 		<skill name="Shield Strike" id="984" level="3" required-level="46" sp="110000" />
 		<skill name="Aggression Aura" id="18" level="9" required-level="46" sp="110000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="17" required-level="46" sp="110000" />
+		<skill name="Quick Heal" id="45" level="13" required-level="46" sp="110000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="17" required-level="46" sp="110000" />
 		<skill name="Heavy Armor Mastery" id="232" level="24" required-level="46" sp="110000" />
-		<skill name="Drain Energy" id="70" level="25" required-level="46" sp="110000" />
 		<skill name="Magic Resistance" id="147" level="23" required-level="46" sp="110000" />
 		<skill name="Shield Stun" id="92" level="24" required-level="46" sp="110000" />
 		<skill name="Life Scavenge" id="46" level="3" required-level="46" sp="110000" />
 		<skill name="Reflect Damage" id="86" level="2" required-level="46" sp="110000" />
 		<skill name="Corpse Plague" id="103" level="1" required-level="46" sp="110000" />
 		<skill name="Hamstring" id="127" level="2" required-level="46" sp="110000" />
-		<skill name="Horror" id="65" level="1" required-level="46" sp="110000" >
-			<item id="3044"/>
-		</skill>
-		
+		<skill name="Dark Strike" id="45257" level="3" required-level="46" sp="110000" />
+		<skill name="Horror" id="65" level="1" required-level="46" sp="110000" />
+		<skill name="Emergency Rescue" id="70" level="16" required-level="46" sp="110000" />
+
+		<!-- Skills Lv47 -->
 		<skill name="Aggression" id="28" level="22" required-level="47" sp="150000" />
 		<skill name="Aggression Aura" id="18" level="10" required-level="47" sp="150000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="18" required-level="47" sp="150000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="18" required-level="47" sp="150000" />
 		<skill name="Heavy Armor Mastery" id="232" level="25" required-level="47" sp="150000" />
-		<skill name="Drain Energy" id="70" level="26" required-level="47" sp="150000" />
 		<skill name="Magic Resistance" id="147" level="24" required-level="47" sp="150000" />
 		<skill name="Shield Stun" id="92" level="25" required-level="47" sp="150000" />
-		
+		<skill name="Emergency Rescue" id="70" level="17" required-level="47" sp="150000" />
+
+		<!-- Skills Lv48 -->
 		<skill name="Aggression" id="28" level="23" required-level="48" sp="150000" />
 		<skill name="Aggression Aura" id="18" level="11" required-level="48" sp="150000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="19" required-level="48" sp="150000" />
+		<skill name="Quick Heal" id="45" level="14" required-level="48" sp="150000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="19" required-level="48" sp="150000" />
 		<skill name="Heavy Armor Mastery" id="232" level="26" required-level="48" sp="150000" />
-		<skill name="Drain Energy" id="70" level="27" required-level="48" sp="150000" />
 		<skill name="Magic Resistance" id="147" level="25" required-level="48" sp="150000" />
 		<skill name="Shield Stun" id="92" level="26" required-level="48" sp="150000" />
-		
+		<skill name="Dark Strike" id="45257" level="4" required-level="48" sp="150000" />
+		<skill name="Emergency Rescue" id="70" level="18" required-level="48" sp="150000" />
+
+		<!-- Skills Lv49 -->
 		<skill name="Aggression" id="28" level="24" required-level="49" sp="150000" />
 		<skill name="Shield Strike" id="984" level="4" required-level="49" sp="150000" />
 		<skill name="Aggression Aura" id="18" level="12" required-level="49" sp="150000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="20" required-level="49" sp="150000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="20" required-level="49" sp="150000" />
 		<skill name="Heavy Armor Mastery" id="232" level="27" required-level="49" sp="150000" />
 		<skill name="Iron Will" id="72" level="2" required-level="49" sp="150000" />
-		<skill name="Drain Energy" id="70" level="28" required-level="49" sp="150000" />
 		<skill name="Magic Resistance" id="147" level="26" required-level="49" sp="150000" />
 		<skill name="Shield Stun" id="92" level="27" required-level="49" sp="150000" />
 		<skill name="Life Scavenge" id="46" level="4" required-level="49" sp="150000" />
@@ -137,64 +158,77 @@
 		<skill name="Hamstring" id="127" level="3" required-level="49" sp="150000" />
 		<skill name="Horror" id="65" level="2" required-level="49" sp="150000" />
 		<skill name="Focus Mind" id="191" level="3" required-level="49" sp="150000" />
-		
+		<skill name="Emergency Rescue" id="70" level="19" required-level="49" sp="150000" />
+
+		<!-- Skills Lv50 -->
 		<skill name="Aggression" id="28" level="25" required-level="50" sp="210000" />
 		<skill name="Aggression Aura" id="18" level="13" required-level="50" sp="210000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="21" required-level="50" sp="210000" />
+		<skill name="Quick Heal" id="45" level="15" required-level="50" sp="210000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="21" required-level="50" sp="210000" />
 		<skill name="Heavy Armor Mastery" id="232" level="28" required-level="50" sp="210000" />
-		<skill name="Drain Energy" id="70" level="29" required-level="50" sp="210000" />
+		<skill name="Recover HP" id="45176" level="2" required-level="50" sp="300000" />
+		<skill name="Recover MP" id="45177" level="2" required-level="50" sp="300000" />
+		<skill name="Knight's Protection" id="53010" level="1" required-level="50" sp="210000" />
 		<skill name="Magic Resistance" id="147" level="27" required-level="50" sp="210000" />
 		<skill name="Shield Stun" id="92" level="28" required-level="50" sp="210000" />
-		
+		<skill name="Dark Strike" id="45257" level="5" required-level="50" sp="210000" />
+		<skill name="Emergency Rescue" id="70" level="20" required-level="50" sp="210000" />
+
+		<!-- Skills Lv51 -->
 		<skill name="Aggression" id="28" level="26" required-level="51" sp="210000" />
 		<skill name="Aggression Aura" id="18" level="14" required-level="51" sp="210000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="22" required-level="51" sp="210000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="22" required-level="51" sp="210000" />
 		<skill name="Heavy Armor Mastery" id="232" level="29" required-level="51" sp="210000" />
-		<skill name="Drain Energy" id="70" level="30" required-level="51" sp="210000" />
 		<skill name="Magic Resistance" id="147" level="28" required-level="51" sp="210000" />
 		<skill name="Shield Stun" id="92" level="29" required-level="51" sp="210000" />
-		
+		<skill name="Emergency Rescue" id="70" level="21" required-level="51" sp="210000" />
+
+		<!-- Skills Lv52 -->
 		<skill name="Aggression" id="28" level="27" required-level="52" sp="210000" />
 		<skill name="Shield Strike" id="984" level="5" required-level="52" sp="210000" />
 		<skill name="Aggression Aura" id="18" level="15" required-level="52" sp="210000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="23" required-level="52" sp="210000" />
+		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="210000" >
+			<item id="8618" count="1" /> <!-- Ancient Book: Divine Inspiration Lv 1 -->
+		</skill>
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="23" required-level="52" sp="210000" />
 		<skill name="Heavy Armor Mastery" id="232" level="30" required-level="52" sp="210000" />
 		<skill name="Shield Mastery" id="153" level="4" required-level="52" sp="210000" />
-		<skill name="Drain Energy" id="70" level="31" required-level="52" sp="210000" />
 		<skill name="Magic Resistance" id="147" level="29" required-level="52" sp="210000" />
 		<skill name="Shield Stun" id="92" level="30" required-level="52" sp="210000" />
 		<skill name="Life Scavenge" id="46" level="5" required-level="52" sp="210000" />
 		<skill name="Reflect Damage" id="86" level="3" required-level="52" sp="210000" />
 		<skill name="Final Fortress" id="291" level="1" required-level="52" sp="210000" />
 		<skill name="Hamstring" id="127" level="4" required-level="52" sp="210000" />
+		<skill name="Dark Strike" id="45257" level="6" required-level="52" sp="210000" />
 		<skill name="Horror" id="65" level="3" required-level="52" sp="210000" />
-		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="210000" >
-			<item id="8618"/> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
-		</skill>
-		
+		<skill name="Emergency Rescue" id="70" level="22" required-level="52" sp="210000" />
+
+		<!-- Skills Lv53 -->
 		<skill name="Aggression" id="28" level="28" required-level="53" sp="300000" />
 		<skill name="Aggression Aura" id="18" level="16" required-level="53" sp="300000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="24" required-level="53" sp="300000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="24" required-level="53" sp="300000" />
 		<skill name="Heavy Armor Mastery" id="232" level="31" required-level="53" sp="300000" />
-		<skill name="Drain Energy" id="70" level="32" required-level="53" sp="300000" />
 		<skill name="Magic Resistance" id="147" level="30" required-level="53" sp="300000" />
 		<skill name="Shield Stun" id="92" level="31" required-level="53" sp="300000" />
-		
+		<skill name="Emergency Rescue" id="70" level="23" required-level="53" sp="300000" />
+
+		<!-- Skills Lv54 -->
 		<skill name="Aggression" id="28" level="29" required-level="54" sp="300000" />
 		<skill name="Aggression Aura" id="18" level="17" required-level="54" sp="300000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="25" required-level="54" sp="300000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="25" required-level="54" sp="300000" />
 		<skill name="Heavy Armor Mastery" id="232" level="32" required-level="54" sp="300000" />
-		<skill name="Drain Energy" id="70" level="33" required-level="54" sp="300000" />
 		<skill name="Magic Resistance" id="147" level="31" required-level="54" sp="300000" />
 		<skill name="Shield Stun" id="92" level="32" required-level="54" sp="300000" />
-		
+		<skill name="Dark Strike" id="45257" level="7" required-level="54" sp="300000" />
+		<skill name="Emergency Rescue" id="70" level="24" required-level="54" sp="300000" />
+
+		<!-- Skills Lv55 -->
 		<skill name="Aggression" id="28" level="30" required-level="55" sp="300000" />
 		<skill name="Shield Strike" id="984" level="6" required-level="55" sp="300000" />
 		<skill name="Aggression Aura" id="18" level="18" required-level="55" sp="300000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="26" required-level="55" sp="300000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="26" required-level="55" sp="300000" />
 		<skill name="Heavy Armor Mastery" id="232" level="33" required-level="55" sp="300000" />
 		<skill name="Iron Will" id="72" level="3" required-level="55" sp="300000" />
-		<skill name="Drain Energy" id="70" level="34" required-level="55" sp="300000" />
 		<skill name="Magic Resistance" id="147" level="32" required-level="55" sp="300000" />
 		<skill name="Shield Stun" id="92" level="33" required-level="55" sp="300000" />
 		<skill name="Life Scavenge" id="46" level="6" required-level="55" sp="300000" />
@@ -202,30 +236,34 @@
 		<skill name="Hamstring" id="127" level="5" required-level="55" sp="300000" />
 		<skill name="Horror" id="65" level="4" required-level="55" sp="300000" />
 		<skill name="Focus Mind" id="191" level="4" required-level="55" sp="300000" />
-		
+		<skill name="Emergency Rescue" id="70" level="25" required-level="55" sp="300000" />
+
+		<!-- Skills Lv56 -->
 		<skill name="Aggression" id="28" level="31" required-level="56" sp="410000" />
 		<skill name="Aggression Aura" id="18" level="19" required-level="56" sp="410000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="27" required-level="56" sp="410000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="27" required-level="56" sp="410000" />
 		<skill name="Heavy Armor Mastery" id="232" level="34" required-level="56" sp="410000" />
-		<skill name="Drain Energy" id="70" level="35" required-level="56" sp="410000" />
 		<skill name="Magic Resistance" id="147" level="33" required-level="56" sp="410000" />
 		<skill name="Shield Stun" id="92" level="34" required-level="56" sp="410000" />
-		
+		<skill name="Dark Strike" id="45257" level="8" required-level="56" sp="410000" />
+		<skill name="Emergency Rescue" id="70" level="26" required-level="56" sp="410000" />
+
+		<!-- Skills Lv57 -->
 		<skill name="Aggression" id="28" level="32" required-level="57" sp="410000" />
 		<skill name="Aggression Aura" id="18" level="20" required-level="57" sp="410000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="28" required-level="57" sp="410000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="28" required-level="57" sp="410000" />
 		<skill name="Heavy Armor Mastery" id="232" level="35" required-level="57" sp="410000" />
-		<skill name="Drain Energy" id="70" level="36" required-level="57" sp="410000" />
 		<skill name="Magic Resistance" id="147" level="34" required-level="57" sp="410000" />
 		<skill name="Shield Stun" id="92" level="35" required-level="57" sp="410000" />
-		
+		<skill name="Emergency Rescue" id="70" level="27" required-level="57" sp="410000" />
+
+		<!-- Skills Lv58 -->
 		<skill name="Aggression" id="28" level="33" required-level="58" sp="410000" />
 		<skill name="Shield Strike" id="984" level="7" required-level="58" sp="410000" />
 		<skill name="Aggression Aura" id="18" level="21" required-level="58" sp="410000" />
 		<skill name="Majesty" id="82" level="3" required-level="58" sp="410000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="29" required-level="58" sp="410000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="29" required-level="58" sp="410000" />
 		<skill name="Heavy Armor Mastery" id="232" level="36" required-level="58" sp="410000" />
-		<skill name="Drain Energy" id="70" level="37" required-level="58" sp="410000" />
 		<skill name="Magic Resistance" id="147" level="35" required-level="58" sp="410000" />
 		<skill name="Shield Stun" id="92" level="36" required-level="58" sp="410000" />
 		<skill name="Life Scavenge" id="46" level="7" required-level="58" sp="410000" />
@@ -233,49 +271,57 @@
 		<skill name="Summon Dark Panther" id="283" level="3" required-level="58" sp="410000" />
 		<skill name="Corpse Plague" id="103" level="2" required-level="58" sp="410000" />
 		<skill name="Hamstring" id="127" level="6" required-level="58" sp="410000" />
+		<skill name="Dark Strike" id="45257" level="9" required-level="58" sp="410000" />
 		<skill name="Horror" id="65" level="5" required-level="58" sp="410000" />
-		
+		<skill name="Emergency Rescue" id="70" level="28" required-level="58" sp="410000" />
+
+		<!-- Skills Lv59 -->
 		<skill name="Aggression" id="28" level="34" required-level="59" sp="600000" />
 		<skill name="Aggression Aura" id="18" level="22" required-level="59" sp="600000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="30" required-level="59" sp="600000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="30" required-level="59" sp="600000" />
 		<skill name="Heavy Armor Mastery" id="232" level="37" required-level="59" sp="600000" />
-		<skill name="Drain Energy" id="70" level="38" required-level="59" sp="600000" />
 		<skill name="Magic Resistance" id="147" level="36" required-level="59" sp="600000" />
 		<skill name="Shield Stun" id="92" level="37" required-level="59" sp="600000" />
-		
+		<skill name="Emergency Rescue" id="70" level="29" required-level="59" sp="600000" />
+
+		<!-- Skills Lv60 -->
 		<skill name="Aggression" id="28" level="35" required-level="60" sp="600000" />
 		<skill name="Shield Strike" id="984" level="8" required-level="60" sp="600000" />
 		<skill name="Aggression Aura" id="18" level="23" required-level="60" sp="600000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="31" required-level="60" sp="600000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="31" required-level="60" sp="600000" />
 		<skill name="Heavy Armor Mastery" id="232" level="38" required-level="60" sp="600000" />
-		<skill name="Drain Energy" id="70" level="39" required-level="60" sp="600000" />
+		<skill name="Knight's Protection" id="53010" level="2" required-level="60" sp="600000" />
 		<skill name="Magic Resistance" id="147" level="37" required-level="60" sp="600000" />
 		<skill name="Shield Stun" id="92" level="38" required-level="60" sp="600000" />
 		<skill name="Life Scavenge" id="46" level="8" required-level="60" sp="600000" />
 		<skill name="Final Fortress" id="291" level="4" required-level="60" sp="600000" />
+		<skill name="Ability to Attack" id="77" level="3" required-level="60" sp="600000" />
+		<skill name="Dark Assassin Transformation" id="1801" level="1" required-level="60" auto-learn="true" />
 		<skill name="Hamstring" id="127" level="7" required-level="60" sp="600000" />
+		<skill name="Dark Strike" id="45257" level="10" required-level="60" sp="600000" />
 		<skill name="Horror" id="65" level="6" required-level="60" sp="600000" />
-		<skill name="Shield Deflect Magic" id="916" level="1" required-level="60" sp="600000" >
-			<item id="49427"/>
-		</skill>
-		
+		<skill name="Shield Deflect Magic" id="916" level="1" required-level="60" sp="600000" />
+		<skill name="Emergency Rescue" id="70" level="30" required-level="60" sp="600000" />
+
+		<!-- Skills Lv61 -->
 		<skill name="Aggression" id="28" level="36" required-level="61" sp="600000" />
 		<skill name="Aggression Aura" id="18" level="24" required-level="61" sp="600000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="32" required-level="61" sp="600000" />
+		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="600000" >
+			<item id="8619" count="1" /> <!-- Ancient Book: Divine Inspiration Lv 2 -->
+		</skill>
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="32" required-level="61" sp="600000" />
 		<skill name="Heavy Armor Mastery" id="232" level="39" required-level="61" sp="600000" />
-		<skill name="Drain Energy" id="70" level="40" required-level="61" sp="600000" />
 		<skill name="Magic Resistance" id="147" level="38" required-level="61" sp="600000" />
 		<skill name="Shield Stun" id="92" level="39" required-level="61" sp="600000" />
-		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="600000" >
-			<item id="8619"/> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
-		</skill>
-		
+		<skill name="Dark Strike" id="45257" level="11" required-level="61" sp="600000" />
+		<skill name="Emergency Rescue" id="70" level="31" required-level="61" sp="600000" />
+
+		<!-- Skills Lv62 -->
 		<skill name="Aggression" id="28" level="37" required-level="62" sp="740000" />
 		<skill name="Shield Strike" id="984" level="9" required-level="62" sp="740000" />
 		<skill name="Aggression Aura" id="18" level="25" required-level="62" sp="740000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="33" required-level="62" sp="740000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="33" required-level="62" sp="740000" />
 		<skill name="Heavy Armor Mastery" id="232" level="40" required-level="62" sp="740000" />
-		<skill name="Drain Energy" id="70" level="41" required-level="62" sp="740000" />
 		<skill name="Magic Resistance" id="147" level="39" required-level="62" sp="740000" />
 		<skill name="Shield Stun" id="92" level="40" required-level="62" sp="740000" />
 		<skill name="Life Scavenge" id="46" level="9" required-level="62" sp="740000" />
@@ -283,147 +329,181 @@
 		<skill name="Summon Dark Panther" id="283" level="4" required-level="62" sp="740000" />
 		<skill name="Corpse Plague" id="103" level="3" required-level="62" sp="740000" />
 		<skill name="Hamstring" id="127" level="8" required-level="62" sp="740000" />
+		<skill name="Dark Strike" id="45257" level="12" required-level="62" sp="740000" />
 		<skill name="Horror" id="65" level="7" required-level="62" sp="740000" />
-		
+		<skill name="Emergency Rescue" id="70" level="32" required-level="62" sp="740000" />
+
+		<!-- Skills Lv63 -->
 		<skill name="Aggression" id="28" level="38" required-level="63" sp="740000" />
 		<skill name="Aggression Aura" id="18" level="26" required-level="63" sp="740000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="34" required-level="63" sp="740000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="34" required-level="63" sp="740000" />
 		<skill name="Heavy Armor Mastery" id="232" level="41" required-level="63" sp="740000" />
-		<skill name="Drain Energy" id="70" level="42" required-level="63" sp="740000" />
 		<skill name="Magic Resistance" id="147" level="40" required-level="63" sp="740000" />
 		<skill name="Shield Stun" id="92" level="41" required-level="63" sp="740000" />
-		
+		<skill name="Dark Strike" id="45257" level="13" required-level="63" sp="740000" />
+		<skill name="Emergency Rescue" id="70" level="33" required-level="63" sp="740000" />
+
+		<!-- Skills Lv64 -->
 		<skill name="Aggression" id="28" level="39" required-level="64" sp="930000" />
 		<skill name="Shield Strike" id="984" level="10" required-level="64" sp="930000" />
 		<skill name="Aggression Aura" id="18" level="27" required-level="64" sp="930000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="35" required-level="64" sp="930000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="35" required-level="64" sp="930000" />
 		<skill name="Heavy Armor Mastery" id="232" level="42" required-level="64" sp="930000" />
-		<skill name="Drain Energy" id="70" level="43" required-level="64" sp="930000" />
 		<skill name="Magic Resistance" id="147" level="41" required-level="64" sp="930000" />
 		<skill name="Shield Stun" id="92" level="42" required-level="64" sp="930000" />
 		<skill name="Life Scavenge" id="46" level="10" required-level="64" sp="930000" />
 		<skill name="Final Fortress" id="291" level="6" required-level="64" sp="930000" />
 		<skill name="Hamstring" id="127" level="9" required-level="64" sp="930000" />
+		<skill name="Dark Strike" id="45257" level="14" required-level="64" sp="930000" />
 		<skill name="Horror" id="65" level="8" required-level="64" sp="930000" />
 		<skill name="Focus Mind" id="191" level="5" required-level="64" sp="930000" />
 		<skill name="Shield Deflect Magic" id="916" level="2" required-level="64" sp="930000" />
 		<skill name="Ultimate Shield" id="322" level="1" required-level="64" sp="930000" />
-		
+		<skill name="Emergency Rescue" id="70" level="34" required-level="64" sp="930000" />
+
+		<!-- Skills Lv65 -->
 		<skill name="Aggression" id="28" level="40" required-level="65" sp="930000" />
 		<skill name="Aggression Aura" id="18" level="28" required-level="65" sp="930000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="36" required-level="65" sp="930000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="36" required-level="65" sp="930000" />
 		<skill name="Heavy Armor Mastery" id="232" level="43" required-level="65" sp="930000" />
-		<skill name="Drain Energy" id="70" level="44" required-level="65" sp="930000" />
+		<skill name="Knight's Protection" id="53010" level="3" required-level="65" sp="930000" />
 		<skill name="Magic Resistance" id="147" level="42" required-level="65" sp="930000" />
 		<skill name="Shield Stun" id="92" level="43" required-level="65" sp="930000" />
-			
+		<skill name="Dark Strike" id="45257" level="15" required-level="65" sp="930000" />
+		<skill name="Emergency Rescue" id="70" level="35" required-level="65" sp="930000" />
+
+		<!-- Skills Lv66 -->
 		<skill name="Aggression" id="28" level="41" required-level="66" sp="1000000" />
 		<skill name="Shield Strike" id="984" level="11" required-level="66" sp="1000000" />
 		<skill name="Aggression Aura" id="18" level="29" required-level="66" sp="1000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="37" required-level="66" sp="1000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="37" required-level="66" sp="1000000" />
 		<skill name="Heavy Armor Mastery" id="232" level="44" required-level="66" sp="1000000" />
-		<skill name="Drain Energy" id="70" level="45" required-level="66" sp="1000000" />
 		<skill name="Magic Resistance" id="147" level="43" required-level="66" sp="1000000" />
 		<skill name="Shield Stun" id="92" level="44" required-level="66" sp="1000000" />
 		<skill name="Life Scavenge" id="46" level="11" required-level="66" sp="1000000" />
 		<skill name="Final Fortress" id="291" level="7" required-level="66" sp="1000000" />
 		<skill name="Summon Dark Panther" id="283" level="5" required-level="66" sp="1000000" />
 		<skill name="Hamstring" id="127" level="10" required-level="66" sp="1000000" />
+		<skill name="Dark Strike" id="45257" level="16" required-level="66" sp="1000000" />
 		<skill name="Horror" id="65" level="9" required-level="66" sp="1000000" />
 		<skill name="Ultimate Shield" id="322" level="2" required-level="66" sp="1000000" />
-		
+		<skill name="Emergency Rescue" id="70" level="36" required-level="66" sp="1000000" />
+
+		<!-- Skills Lv67 -->
 		<skill name="Aggression" id="28" level="42" required-level="67" sp="1000000" />
 		<skill name="Aggression Aura" id="18" level="30" required-level="67" sp="1000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="38" required-level="67" sp="1000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="38" required-level="67" sp="1000000" />
 		<skill name="Heavy Armor Mastery" id="232" level="45" required-level="67" sp="1000000" />
-		<skill name="Drain Energy" id="70" level="46" required-level="67" sp="1000000" />
 		<skill name="Magic Resistance" id="147" level="44" required-level="67" sp="1000000" />
 		<skill name="Shield Stun" id="92" level="45" required-level="67" sp="1000000" />
-		
+		<skill name="Dark Strike" id="45257" level="17" required-level="67" sp="1000000" />
+		<skill name="Emergency Rescue" id="70" level="37" required-level="67" sp="1000000" />
+
+		<!-- Skills Lv68 -->
 		<skill name="Aggression" id="28" level="43" required-level="68" sp="1400000" />
 		<skill name="Shield Strike" id="984" level="12" required-level="68" sp="1400000" />
 		<skill name="Aggression Aura" id="18" level="31" required-level="68" sp="1400000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="39" required-level="68" sp="1400000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="39" required-level="68" sp="1400000" />
 		<skill name="Heavy Armor Mastery" id="232" level="46" required-level="68" sp="1400000" />
-		<skill name="Drain Energy" id="70" level="47" required-level="68" sp="1400000" />
 		<skill name="Magic Resistance" id="147" level="45" required-level="68" sp="1400000" />
 		<skill name="Shield Stun" id="92" level="46" required-level="68" sp="1400000" />
 		<skill name="Life Scavenge" id="46" level="12" required-level="68" sp="1400000" />
 		<skill name="Final Fortress" id="291" level="8" required-level="68" sp="1400000" />
 		<skill name="Hamstring" id="127" level="11" required-level="68" sp="1400000" />
+		<skill name="Dark Strike" id="45257" level="18" required-level="68" sp="1400000" />
 		<skill name="Horror" id="65" level="10" required-level="68" sp="1400000" />
 		<skill name="Shield Deflect Magic" id="916" level="3" required-level="68" sp="1400000" />
 		<skill name="Ultimate Shield" id="322" level="3" required-level="68" sp="1400000" />
-		
+		<skill name="Emergency Rescue" id="70" level="38" required-level="68" sp="1400000" />
+
+		<!-- Skills Lv69 -->
 		<skill name="Aggression" id="28" level="44" required-level="69" sp="1400000" />
 		<skill name="Aggression Aura" id="18" level="32" required-level="69" sp="1400000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="40" required-level="69" sp="1400000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="40" required-level="69" sp="1400000" />
 		<skill name="Heavy Armor Mastery" id="232" level="47" required-level="69" sp="1400000" />
-		<skill name="Drain Energy" id="70" level="48" required-level="69" sp="1400000" />
 		<skill name="Magic Resistance" id="147" level="46" required-level="69" sp="1400000" />
 		<skill name="Shield Stun" id="92" level="47" required-level="69" sp="1400000" />
-		
+		<skill name="Dark Strike" id="45257" level="19" required-level="69" sp="1400000" />
+		<skill name="Emergency Rescue" id="70" level="39" required-level="69" sp="1400000" />
+
+		<!-- Skills Lv70 -->
 		<skill name="Aggression" id="28" level="45" required-level="70" sp="1800000" />
 		<skill name="Shield Strike" id="984" level="13" required-level="70" sp="1800000" />
 		<skill name="Aggression Aura" id="18" level="33" required-level="70" sp="1800000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="41" required-level="70" sp="1800000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="41" required-level="70" sp="1800000" />
 		<skill name="Heavy Armor Mastery" id="232" level="48" required-level="70" sp="1800000" />
-		<skill name="Drain Energy" id="70" level="49" required-level="70" sp="1800000" />
+		<skill name="Knight's Protection" id="53010" level="4" required-level="70" sp="1800000" />
 		<skill name="Magic Resistance" id="147" level="47" required-level="70" sp="1800000" />
 		<skill name="Shield Stun" id="92" level="48" required-level="70" sp="1800000" />
 		<skill name="Life Scavenge" id="46" level="13" required-level="70" sp="1800000" />
 		<skill name="Final Fortress" id="291" level="9" required-level="70" sp="1800000" />
 		<skill name="Summon Dark Panther" id="283" level="6" required-level="70" sp="1800000" />
+		<skill name="White Assassin Transformation" id="1802" level="1" required-level="70" auto-learn="true" />
 		<skill name="Corpse Plague" id="103" level="4" required-level="70" sp="1800000" />
 		<skill name="Hamstring" id="127" level="12" required-level="70" sp="1800000" />
+		<skill name="Dark Strike" id="45257" level="20" required-level="70" sp="1800000" />
 		<skill name="Horror" id="65" level="11" required-level="70" sp="1800000" />
 		<skill name="Ultimate Shield" id="322" level="4" required-level="70" sp="1800000" />
-		
+		<skill name="Emergency Rescue" id="70" level="40" required-level="70" sp="1800000" />
+
+		<!-- Skills Lv71 -->
 		<skill name="Aggression" id="28" level="46" required-level="71" sp="1800000" />
 		<skill name="Aggression Aura" id="18" level="34" required-level="71" sp="1800000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="42" required-level="71" sp="1800000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="42" required-level="71" sp="1800000" />
 		<skill name="Heavy Armor Mastery" id="232" level="49" required-level="71" sp="1800000" />
-		<skill name="Drain Energy" id="70" level="50" required-level="71" sp="1800000" />
 		<skill name="Magic Resistance" id="147" level="48" required-level="71" sp="1800000" />
 		<skill name="Shield Stun" id="92" level="49" required-level="71" sp="1800000" />
-		
+		<skill name="Dark Strike" id="45257" level="21" required-level="71" sp="1800000" />
+		<skill name="Emergency Rescue" id="70" level="41" required-level="71" sp="1800000" />
+
+		<!-- Skills Lv72 -->
 		<skill name="Aggression" id="28" level="47" required-level="72" sp="2000000" />
 		<skill name="Shield Strike" id="984" level="14" required-level="72" sp="2000000" />
 		<skill name="Aggression Aura" id="18" level="35" required-level="72" sp="2000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="43" required-level="72" sp="2000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="43" required-level="72" sp="2000000" />
 		<skill name="Heavy Armor Mastery" id="232" level="50" required-level="72" sp="2000000" />
-		<skill name="Drain Energy" id="70" level="51" required-level="72" sp="2000000" />
 		<skill name="Magic Resistance" id="147" level="49" required-level="72" sp="2000000" />
 		<skill name="Shield Stun" id="92" level="50" required-level="72" sp="2000000" />
 		<skill name="Life Scavenge" id="46" level="14" required-level="72" sp="2000000" />
 		<skill name="Final Fortress" id="291" level="10" required-level="72" sp="2000000" />
 		<skill name="Hamstring" id="127" level="13" required-level="72" sp="2000000" />
+		<skill name="Dark Strike" id="45257" level="22" required-level="72" sp="2000000" />
 		<skill name="Horror" id="65" level="12" required-level="72" sp="2000000" />
 		<skill name="Focus Mind" id="191" level="6" required-level="72" sp="2000000" />
 		<skill name="Shield Deflect Magic" id="916" level="4" required-level="72" sp="2000000" />
 		<skill name="Ultimate Shield" id="322" level="5" required-level="72" sp="2000000" />
-		
+		<skill name="Emergency Rescue" id="70" level="42" required-level="72" sp="2000000" />
+
+		<!-- Skills Lv73 -->
 		<skill name="Aggression" id="28" level="48" required-level="73" sp="2000000" />
 		<skill name="Aggression Aura" id="18" level="36" required-level="73" sp="2000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="44" required-level="73" sp="2000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="44" required-level="73" sp="2000000" />
 		<skill name="Heavy Armor Mastery" id="232" level="51" required-level="73" sp="2000000" />
-		<skill name="Drain Energy" id="70" level="52" required-level="73" sp="2000000" />
 		<skill name="Magic Resistance" id="147" level="50" required-level="73" sp="2000000" />
 		<skill name="Shield Stun" id="92" level="51" required-level="73" sp="2000000" />
-		
+		<skill name="Dark Strike" id="45257" level="23" required-level="73" sp="2000000" />
+		<skill name="Emergency Rescue" id="70" level="43" required-level="73" sp="2000000" />
+
+		<!-- Skills Lv74 -->
 		<skill name="Aggression" id="28" level="49" required-level="74" sp="2000000" />
 		<skill name="Shield Strike" id="984" level="15" required-level="74" sp="2000000" />
 		<skill name="Aggression Aura" id="18" level="37" required-level="74" sp="2000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="45" required-level="74" sp="2000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="45" required-level="74" sp="2000000" />
 		<skill name="Heavy Armor Mastery" id="232" level="52" required-level="74" sp="2000000" />
-		<skill name="Drain Energy" id="70" level="53" required-level="74" sp="2000000" />
 		<skill name="Magic Resistance" id="147" level="51" required-level="74" sp="2000000" />
 		<skill name="Shield Stun" id="92" level="52" required-level="74" sp="2000000" />
 		<skill name="Life Scavenge" id="46" level="15" required-level="74" sp="2000000" />
 		<skill name="Final Fortress" id="291" level="11" required-level="74" sp="2000000" />
 		<skill name="Summon Dark Panther" id="283" level="7" required-level="74" sp="2000000" />
 		<skill name="Hamstring" id="127" level="14" required-level="74" sp="2000000" />
+		<skill name="Dark Strike" id="45257" level="24" required-level="74" sp="2000000" />
 		<skill name="Horror" id="65" level="13" required-level="74" sp="2000000" />
 		<skill name="Ultimate Shield" id="322" level="6" required-level="74" sp="2000000" />
+		<skill name="Emergency Rescue" id="70" level="44" required-level="74" sp="2000000" />
+
+		<!-- Skills Lv75 -->
+		<skill name="Knight's Protection" id="53010" level="5" required-level="75" sp="2000000" />
+		<skill name="Dark Strike" id="45257" level="25" required-level="75" sp="2000000" />
+		<skill name="Emergency Rescue" id="70" level="45" required-level="75" sp="2000000" />
 	</skillTree>
 </list>

--- a/data/skillTrees/2ndClass/DarkElfUndertaker.xml
+++ b/data/skillTrees/2ndClass/DarkElfUndertaker.xml
@@ -1,0 +1,261 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
+	<skillTree type="classSkillTree" classId="206" parentClassId="205">
+
+		<!-- Master Buffs Lv. 40 -->
+		<skill name="Might" id="1068" level="3" required-level="40" sp="80000" />
+		<skill name="Shield" id="1040" level="3" required-level="40" sp="80000" />
+		<skill name="Acumen" id="45104" level="3" required-level="40" sp="80000" />
+		<skill name="Empower" id="45105" level="3" required-level="40" sp="80000" />
+		<skill name="Wild Magic" id="45106" level="2" required-level="40" sp="80000" />
+		<skill name="Magic Barrier" id="45108" level="2" required-level="40" sp="80000" />
+		<skill name="Focus" id="45109" level="3" required-level="40" sp="80000" />
+		<skill name="Death Whisper" id="45110" level="3" required-level="40" sp="80000" />
+		<skill name="Haste" id="45111" level="2" required-level="40" sp="80000" />
+		<skill name="Berserker Spirit" id="45112" level="2" required-level="40" sp="80000" />
+		<skill name="Clarity" id="45113" level="3" required-level="40" sp="80000" />
+
+		<skill name="Confusion" id="2" level="5" required-level="40" sp="80000" />
+		<skill name="Power Break" id="115" level="3" required-level="40" sp="80000" />
+		<skill name="Hex" id="122" level="1" required-level="40" sp="80000">
+			<item id="3050" count="1" /> <!-- Spellbook: Hex -->
+		</skill>
+		<skill name="Death Armor Mastery" id="45354" level="8" required-level="40" sp="80000" />
+		<skill name="Death Sword Mastery" id="45353" level="8" required-level="40" sp="80000" />
+		<skill name="Death Guard" id="45329" level="1" required-level="40" sp="80000">
+			<item id="93388" count="1" /> <!-- Spellbook: Death Guard -->
+		</skill>
+		<skill name="Soul Steal" id="45335" level="1" required-level="40" sp="80000" />
+		<skill name="Drain Magic Energy" id="45359" level="1" required-level="40" sp="80000">
+			<item id="93633" count="1" /> <!-- Spellbook: Drain Magic Energy -->
+		</skill>
+		<skill name="Death Points" id="45352" level="2" required-level="40" auto-learn="true" />
+		<skill name="Wipeout" id="45303" level="1" required-level="40" sp="80000" />
+		<skill name="Undying Body" id="45350" level="2" required-level="40" auto-learn="true" />
+		<skill name="Death Blind" id="45342" level="1" required-level="40" sp="80000" />
+		<skill name="Deadly Pull" id="45311" level="1" required-level="40" sp="80000" />
+		<skill name="Emergency Rescue" id="70" level="10" required-level="40" sp="80000" />
+
+		<skill name="Emergency Rescue" id="70" level="11" required-level="41" sp="80000" />
+
+		<skill name="Emergency Rescue" id="70" level="12" required-level="42" sp="80000" />
+
+		<skill name="Confusion" id="2" level="6" required-level="43" sp="80000" />
+		<skill name="Emergency Rescue" id="70" level="13" required-level="43" sp="80000" />
+		<skill name="Power Break" id="115" level="4" required-level="43" sp="80000" />
+		<skill name="Hex" id="122" level="2" required-level="43" sp="80000" />
+
+		<skill name="Punishment" id="45301" level="5" required-level="44" sp="120000" />
+		<skill name="Emergency Rescue" id="70" level="14" required-level="44" sp="120000" />
+
+		<skill name="Death Armor Mastery" id="45354" level="9" required-level="45" sp="120000" />
+		<skill name="Death Sword Mastery" id="45353" level="9" required-level="45" sp="120000" />
+		<skill name="Death Blind" id="45342" level="2" required-level="45" sp="120000" />
+		<skill name="Deadly Pull" id="45311" level="2" required-level="45" sp="120000" />
+		<skill name="Emergency Rescue" id="70" level="15" required-level="45" sp="120000" />
+
+		<skill name="Confusion" id="2" level="7" required-level="46" sp="120000" />
+		<skill name="Emergency Rescue" id="70" level="16" required-level="46" sp="120000" />
+		<skill name="Power Break" id="115" level="5" required-level="46" sp="120000" />
+		<skill name="Hex" id="122" level="3" required-level="46" sp="120000" />
+
+		<skill name="Emergency Rescue" id="70" level="17" required-level="47" sp="120000" />
+
+		<skill name="Emergency Rescue" id="70" level="18" required-level="48" sp="120000" />
+
+		<skill name="Confusion" id="2" level="8" required-level="49" sp="200000" />
+		<skill name="Emergency Rescue" id="70" level="19" required-level="49" sp="200000" />
+		<skill name="Power Break" id="115" level="6" required-level="49" sp="200000" />
+		<skill name="Hex" id="122" level="4" required-level="49" sp="200000" />
+
+		<skill name="Dark Elven Spirit" id="129" level="3" required-level="50" sp="200000" />
+		<skill name="Dark Aura" id="45330" level="1" required-level="50" sp="200000" />
+		<skill name="Death Armor Mastery" id="45354" level="10" required-level="50" sp="200000" />
+		<skill name="Death Sword Mastery" id="45353" level="10" required-level="50" sp="200000" />
+		<skill name="Recover HP" id="45176" level="2" required-level="50" sp="300000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Recover MP" id="45177" level="2" required-level="50" sp="300000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Punishment" id="45301" level="6" required-level="50" sp="200000" />
+		<skill name="Fist of Fury" id="45309" level="1" required-level="50" sp="200000" />
+		<skill name="Wipeout" id="45303" level="2" required-level="50" sp="200000" />
+		<skill name="Roar of Death" id="45328" level="2" required-level="50" sp="200000" />
+		<skill name="Death Blind" id="45342" level="3" required-level="50" sp="200000" />
+		<skill name="Deadly Pull" id="45311" level="3" required-level="50" sp="200000" />
+		<skill name="Emergency Rescue" id="70" level="20" required-level="50" sp="200000" />
+
+		<skill name="Emergency Rescue" id="70" level="21" required-level="51" sp="200000" />
+
+		<skill name="Confusion" id="2" level="9" required-level="52" sp="200000" />
+		<skill name="Power Break" id="115" level="7" required-level="52" sp="200000" />
+		<skill name="Hex" id="122" level="5" required-level="52" sp="200000" />
+		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="200000">
+			<item id="8618" count="1" /> <!-- Buff Expansion Book Lv. 1 -->
+		</skill>
+		<skill name="Death Armor Mastery" id="45354" level="11" required-level="52" sp="200000" />
+		<skill name="Death Sword Mastery" id="45353" level="11" required-level="52" sp="200000" />
+		<skill name="Emergency Rescue" id="70" level="22" required-level="52" sp="200000" />
+
+		<skill name="Fist of Fury" id="45309" level="2" required-level="53" sp="400000" />
+		<skill name="Emergency Rescue" id="70" level="23" required-level="53" sp="400000" />
+
+		<skill name="Death Armor Mastery" id="45354" level="12" required-level="54" sp="400000" />
+		<skill name="Death Sword Mastery" id="45353" level="12" required-level="54" sp="400000" />
+		<skill name="Punishment" id="45301" level="7" required-level="54" sp="400000" />
+		<skill name="Emergency Rescue" id="70" level="24" required-level="54" sp="400000" />
+
+		<skill name="Confusion" id="2" level="10" required-level="55" sp="450000" />
+		<skill name="Power Break" id="115" level="8" required-level="55" sp="450000" />
+		<skill name="Hex" id="122" level="6" required-level="55" sp="450000" />
+		<skill name="Bone Cage" id="45338" level="1" required-level="55" sp="450000" />
+		<skill name="Wipeout" id="45303" level="3" required-level="55" sp="450000" />
+		<skill name="Death Blind" id="45342" level="4" required-level="55" sp="450000" />
+		<skill name="Emergency Rescue" id="70" level="25" required-level="55" sp="450000" />
+
+		<skill name="Death Armor Mastery" id="45354" level="13" required-level="56" sp="500000" />
+		<skill name="Death Sword Mastery" id="45353" level="13" required-level="56" sp="500000" />
+		<skill name="Fist of Fury" id="45309" level="3" required-level="56" sp="500000" />
+		<skill name="Emergency Rescue" id="70" level="26" required-level="56" sp="500000" />
+
+		<skill name="Punishment" id="45301" level="8" required-level="57" sp="550000" />
+		<skill name="Emergency Rescue" id="70" level="27" required-level="57" sp="550000" />
+
+		<skill name="Confusion" id="2" level="11" required-level="58" sp="600000" />
+		<skill name="Power Break" id="115" level="9" required-level="58" sp="600000" />
+		<skill name="Hex" id="122" level="7" required-level="58" sp="600000" />
+		<skill name="Death Armor Mastery" id="45354" level="14" required-level="58" sp="600000" />
+		<skill name="Death Sword Mastery" id="45353" level="14" required-level="58" sp="600000" />
+		<skill name="Emergency Rescue" id="70" level="28" required-level="58" sp="600000" />
+
+		<skill name="Fist of Fury" id="45309" level="4" required-level="59" sp="700000" />
+		<skill name="Emergency Rescue" id="70" level="29" required-level="59" sp="700000" />
+
+		<skill name="Confusion" id="2" level="12" required-level="60" sp="800000" />
+		<skill name="Power Break" id="115" level="10" required-level="60" sp="800000" />
+		<skill name="Hex" id="122" level="8" required-level="60" sp="800000" />
+		<skill name="Dark Elven Spirit" id="129" level="4" required-level="60" sp="800000" />
+		<skill name="Death Armor Mastery" id="45354" level="15" required-level="60" sp="800000" />
+		<skill name="Death Sword Mastery" id="45353" level="15" required-level="60" sp="800000" />
+		<skill name="Call of Lightning" id="45326" level="1" required-level="60" sp="800000">
+			<item id="93391" count="1" /> <!-- Spellbook: Call of Lightning -->
+		</skill>
+		<skill name="Punishment" id="45301" level="9" required-level="60" sp="800000" />
+		<skill name="Bone Cage" id="45338" level="2" required-level="60" sp="800000" />
+		<skill name="Soul Steal" id="45335" level="2" required-level="60" sp="800000" />
+		<skill name="Drain Magic Energy" id="45359" level="2" required-level="60" sp="800000">
+			<item id="93633" count="1" /> <!-- Spellbook: Drain Magic Energy -->
+		</skill>
+		<skill name="Wipeout" id="45303" level="4" required-level="60" sp="800000" />
+		<skill name="Undying Body" id="45350" level="3" required-level="60" auto-learn="true" />
+		<skill name="Death Blind" id="45342" level="5" required-level="60" sp="800000" />
+		<skill name="Deadly Pull" id="45311" level="4" required-level="60" sp="800000" />
+		<skill name="Ability to Attack" id="77" level="3" required-level="60" sp="800000" />
+		<skill name="Emergency Rescue" id="70" level="30" required-level="60" sp="800000" />
+
+		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="900000">
+			<item id="8619" count="1" /> <!-- Buff Expansion Book Lv. 2 -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="31" required-level="61" sp="900000" />
+
+		<skill name="Confusion" id="2" level="13" required-level="62" sp="1000000" />
+		<skill name="Power Break" id="115" level="11" required-level="62" sp="1000000" />
+		<skill name="Hex" id="122" level="9" required-level="62" sp="1000000" />
+		<skill name="Death Armor Mastery" id="45354" level="16" required-level="62" sp="1000000" />
+		<skill name="Death Sword Mastery" id="45353" level="16" required-level="62" sp="1000000" />
+		<skill name="Fist of Fury" id="45309" level="5" required-level="62" sp="1000000" />
+		<skill name="Emergency Rescue" id="70" level="32" required-level="62" sp="1000000" />
+
+		<skill name="Punishment" id="45301" level="10" required-level="63" sp="1100000" />
+		<skill name="Emergency Rescue" id="70" level="33" required-level="63" sp="1100000" />
+
+		<skill name="Confusion" id="2" level="14" required-level="64" sp="1200000" />
+		<skill name="Power Break" id="115" level="12" required-level="64" sp="1200000" />
+		<skill name="Hex" id="122" level="10" required-level="64" sp="1200000" />
+		<skill name="Death Armor Mastery" id="45354" level="17" required-level="64" sp="1200000" />
+		<skill name="Death Sword Mastery" id="45353" level="17" required-level="64" sp="1200000" />
+		<skill name="Emergency Rescue" id="70" level="34" required-level="64" sp="1200000" />
+
+		<skill name="Fist of Fury" id="45309" level="6" required-level="65" sp="1300000" />
+		<skill name="Wipeout" id="45303" level="5" required-level="65" sp="1300000" />
+		<skill name="Death Blind" id="45342" level="6" required-level="65" sp="1300000" />
+		<skill name="Deadly Pull" id="45311" level="5" required-level="65" sp="1300000" />
+		<skill name="Emergency Rescue" id="70" level="35" required-level="65" sp="1300000" />
+
+		<skill name="Confusion" id="2" level="15" required-level="66" sp="1400000" />
+		<skill name="Power Break" id="115" level="13" required-level="66" sp="1400000" />
+		<skill name="Hex" id="122" level="11" required-level="66" sp="1400000" />
+		<skill name="Death Armor Mastery" id="45354" level="18" required-level="66" sp="1400000" />
+		<skill name="Death Sword Mastery" id="45353" level="18" required-level="66" sp="1400000" />
+		<skill name="Punishment" id="45301" level="11" required-level="66" sp="1400000" />
+		<skill name="Emergency Rescue" id="70" level="36" required-level="66" sp="1400000" />
+
+		<skill name="Emergency Rescue" id="70" level="37" required-level="67" sp="1500000" />
+
+		<skill name="Confusion" id="2" level="16" required-level="68" sp="1600000" />
+		<skill name="Power Break" id="115" level="14" required-level="68" sp="1600000" />
+		<skill name="Hex" id="122" level="12" required-level="68" sp="1600000" />
+		<skill name="Death Armor Mastery" id="45354" level="19" required-level="68" sp="1600000" />
+		<skill name="Death Sword Mastery" id="45353" level="19" required-level="68" sp="1600000" />
+		<skill name="Fist of Fury" id="45309" level="7" required-level="68" sp="1600000" />
+		<skill name="Emergency Rescue" id="70" level="38" required-level="68" sp="1600000" />
+
+		<skill name="Punishment" id="45301" level="12" required-level="69" sp="1700000" />
+		<skill name="Emergency Rescue" id="70" level="39" required-level="69" sp="1700000" />
+
+		<skill name="Confusion" id="2" level="17" required-level="70" sp="1800000" />
+		<skill name="Power Break" id="115" level="15" required-level="70" sp="1800000" />
+		<skill name="Hex" id="122" level="13" required-level="70" sp="1800000" />
+		<skill name="Dark Elven Spirit" id="129" level="5" required-level="70" sp="1800000" />
+		<skill name="Acceleration" id="45337" level="1" required-level="70" sp="1800000" />
+		<skill name="Death Armor Mastery" id="45354" level="20" required-level="70" sp="1800000" />
+		<skill name="Death Sword Mastery" id="45353" level="20" required-level="70" sp="1800000" />
+		<skill name="Bone Cage" id="45338" level="3" required-level="70" sp="1800000">
+			<item id="93392" count="1" /> <!-- Spellbook: Bone Cage -->
+		</skill>
+		<skill name="Soul Steal" id="45335" level="3" required-level="70" sp="1800000" />
+		<skill name="Drain Magic Energy" id="45359" level="3" required-level="70" sp="1800000">
+			<item id="93633" count="1" /> <!-- Spellbook: Drain Magic Energy -->
+		</skill>
+		<skill name="Flaming Body" id="45332" level="1" required-level="70" sp="1800000" />
+		<skill name="Wipeout" id="45303" level="6" required-level="70" sp="1800000" />
+		<skill name="Roar of Death" id="45328" level="3" required-level="70" sp="1800000" />
+		<skill name="Undying Body" id="45350" level="4" required-level="70" auto-learn="true" />
+		<skill name="Death Blind" id="45342" level="7" required-level="70" sp="1800000" />
+		<skill name="Deadly Pull" id="45311" level="6" required-level="70" sp="1800000" />
+		<skill name="Emergency Rescue" id="70" level="40" required-level="70" sp="1800000" />
+
+		<skill name="Fist of Fury" id="45309" level="8" required-level="71" sp="1900000" />
+		<skill name="Emergency Rescue" id="70" level="41" required-level="71" sp="1900000" />
+
+		<skill name="Confusion" id="2" level="18" required-level="72" sp="2000000" />
+		<skill name="Power Break" id="115" level="16" required-level="72" sp="2000000" />
+		<skill name="Hex" id="122" level="14" required-level="72" sp="2000000" />
+		<skill name="Death Armor Mastery" id="45354" level="21" required-level="72" sp="2000000" />
+		<skill name="Death Sword Mastery" id="45353" level="21" required-level="72" sp="2000000" />
+		<skill name="Punishment" id="45301" level="13" required-level="72" sp="2000000" />
+		<skill name="Death Blind" id="45342" level="8" required-level="72" sp="2000000" />
+		<skill name="Emergency Rescue" id="70" level="42" required-level="72" sp="2000000" />
+
+		<skill name="Emergency Rescue" id="70" level="43" required-level="73" sp="2100000" />
+
+		<skill name="Confusion" id="2" level="19" required-level="74" sp="2200000" />
+		<skill name="Power Break" id="115" level="17" required-level="74" sp="2200000" />
+		<skill name="Hex" id="122" level="15" required-level="74" sp="2200000" />
+		<skill name="Death Armor Mastery" id="45354" level="22" required-level="74" sp="2200000" />
+		<skill name="Death Sword Mastery" id="45353" level="22" required-level="74" sp="2200000" />
+		<skill name="Fist of Fury" id="45309" level="9" required-level="74" sp="2200000" />
+		<skill name="Death Blind" id="45342" level="9" required-level="74" sp="2200000" />
+		<skill name="Emergency Rescue" id="70" level="44" required-level="74" sp="2200000" />
+
+		<skill name="Confusion" id="2" level="20" required-level="75" sp="2300000" />
+		<skill name="Punishment" id="45301" level="14" required-level="75" sp="2300000" />
+		<skill name="Bone Cage" id="45338" level="4" required-level="75" sp="2300000" />
+		<skill name="Flaming Body" id="45332" level="2" required-level="75" sp="2300000" />
+		<skill name="Wipeout" id="45303" level="7" required-level="75" sp="2300000" />
+		<skill name="Death Blind" id="45342" level="10" required-level="75" sp="2300000" />
+		<skill name="Deadly Pull" id="45311" level="7" required-level="75" sp="2300000" />
+		<skill name="Emergency Rescue" id="70" level="45" required-level="75" sp="2300000" />
+	</skillTree>
+</list>

--- a/data/skillTrees/2ndClass/Destroyer.xml
+++ b/data/skillTrees/2ndClass/Destroyer.xml
@@ -1,9 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="46" parentClassId="45">
-		<skill name="Pirate" id="1800" level="1" required-level="45" auto-learn="true" />
-		<skill name="Dark Assassin" id="1801" level="1" required-level="60" auto-learn="true" />
-		<skill name="White Assassin" id="1802" level="1" required-level="70" auto-learn="true" />
+
+		<!-- Master Buffs Lv. 40 -->
+		<skill name="Chant of Shield" id="45127" level="3" required-level="40" sp="80000" />
+		<skill name="Chant of Might" id="45126" level="3" required-level="40" sp="80000" />
+		<skill name="Chant of Acumen" id="45135" level="3" required-level="40" sp="80000" />
+		<skill name="Chant of Empower" id="45136" level="3" required-level="40" sp="80000" />
+		<skill name="Chant of Wild Magic" id="45137" level="2" required-level="40" sp="80000" />
+		<skill name="Chant of Magic Barrier" id="45125" level="2" required-level="40" sp="80000" />
+		<skill name="Chant of Focus" id="45121" level="3" required-level="40" sp="80000" />
+		<skill name="Chant of Death Whisper" id="45122" level="3" required-level="40" sp="80000" />
+		<skill name="Chant of Haste" id="45123" level="2" required-level="40" sp="80000" />
+		<skill name="Chant of Berserker Spirit" id="45128" level="2" required-level="40" sp="80000" />
+		<skill name="Chant of Clarity" id="45129" level="3" required-level="40" sp="80000" />
+
+		<!-- Skills Lv40 -->
 		<skill name="Vicious Stance" id="312" level="6" required-level="40" sp="67000" />
 		<skill name="Battle Roar" id="121" level="2" required-level="40" sp="67000" />
 		<skill name="Fast HP Recovery" id="212" level="3" required-level="40" sp="67000" />
@@ -14,218 +26,264 @@
 		<skill name="Polearm Mastery" id="216" level="9" required-level="40" sp="67000" />
 		<skill name="Polearm Mastery" id="216" level="10" required-level="40" sp="67000" />
 		<skill name="Polearm Mastery" id="216" level="11" required-level="40" sp="67000" />
+		<skill name="Potion Mastery" id="45184" level="1" required-level="40">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Light Armor Mastery" id="227" level="14" required-level="40" sp="67000" />
 		<skill name="Light Armor Mastery" id="227" level="15" required-level="40" sp="67000" />
 		<skill name="Light Armor Mastery" id="227" level="16" required-level="40" sp="67000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="9" required-level="40" sp="67000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="10" required-level="40" sp="67000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="11" required-level="40" sp="67000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="9" required-level="40" sp="67000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="10" required-level="40" sp="67000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="11" required-level="40" sp="67000" />
+		<skill name="Weapon Mastery" id="141" level="4" required-level="40" sp="67000" />
 		<skill name="Heavy Armor Mastery" id="231" level="14" required-level="40" sp="67000" />
 		<skill name="Heavy Armor Mastery" id="231" level="15" required-level="40" sp="67000" />
 		<skill name="Heavy Armor Mastery" id="231" level="16" required-level="40" sp="67000" />
 		<skill name="Vital Force" id="148" level="3" required-level="40" sp="67000" />
-		<skill name="Power Crush" id="260" level="1" required-level="40" sp="67000" />
-		<skill name="Power Crush" id="260" level="2" required-level="40" sp="67000" />
-		<skill name="Power Crush" id="260" level="3" required-level="40" sp="67000" />
+		<skill name="Power Break" id="260" level="1" required-level="40" sp="67000" />
+		<skill name="Power Break" id="260" level="2" required-level="40" sp="67000" />
+		<skill name="Power Break" id="260" level="3" required-level="40" sp="67000" />
 		<skill name="Excruciating Strike" id="1607" level="1" required-level="40" sp="67000" />
 		<skill name="Excruciating Strike" id="1607" level="2" required-level="40" sp="67000" />
 		<skill name="Excruciating Strike" id="1607" level="3" required-level="40" sp="67000" />
+		<skill name="Rush" id="994" level="1" required-level="40" sp="67000" />
+		<skill name="Accuracy" id="256" level="2" required-level="40" sp="67000" >
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
 		<skill name="Fatal Strike" id="190" level="1" required-level="40" sp="67000" />
 		<skill name="Fatal Strike" id="190" level="2" required-level="40" sp="67000" />
 		<skill name="Fatal Strike" id="190" level="3" required-level="40" sp="67000" />
-		<skill name="Potion Mastery" id="45184" level="1" required-level="40">
-			<item id="57" count="1000000"/> <!-- Adena -->
-		</skill>
+		<skill name="Fatal Strike" id="190" level="4" required-level="40" sp="67000" />
+		<skill name="Fatal Strike" id="190" level="5" required-level="40" sp="67000" />
+		<skill name="Emergency Rescue" id="70" level="10" required-level="40" sp="67000" />
 
+		<!-- Skills Lv41 -->
 		<skill name="Spinning Slasher" id="36" level="4" required-level="41" sp="80000" />
 		<skill name="Polearm Mastery" id="216" level="12" required-level="41" sp="80000" />
 		<skill name="Light Armor Mastery" id="227" level="17" required-level="41" sp="80000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="12" required-level="41" sp="80000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="12" required-level="41" sp="80000" />
 		<skill name="Heavy Armor Mastery" id="231" level="17" required-level="41" sp="80000" />
-		<skill name="Power Crush" id="260" level="4" required-level="41" sp="80000" />
+		<skill name="Power Break" id="260" level="4" required-level="41" sp="80000" />
 		<skill name="Excruciating Strike" id="1607" level="4" required-level="41" sp="80000" />
-		<skill name="Fatal Strike" id="190" level="4" required-level="41" sp="80000" />
-		
+		<skill name="Fatal Strike" id="190" level="6" required-level="41" sp="80000" />
+		<skill name="Emergency Rescue" id="70" level="11" required-level="41" sp="80000" />
+
+		<!-- Skills Lv42 -->
 		<skill name="Spinning Slasher" id="36" level="5" required-level="42" sp="80000" />
 		<skill name="Polearm Mastery" id="216" level="13" required-level="42" sp="80000" />
 		<skill name="Light Armor Mastery" id="227" level="18" required-level="42" sp="80000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="13" required-level="42" sp="80000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="13" required-level="42" sp="80000" />
 		<skill name="Heavy Armor Mastery" id="231" level="18" required-level="42" sp="80000" />
-		<skill name="Power Crush" id="260" level="5" required-level="42" sp="80000" />
+		<skill name="Power Break" id="260" level="5" required-level="42" sp="80000" />
 		<skill name="Excruciating Strike" id="1607" level="5" required-level="42" sp="80000" />
-		<skill name="Fatal Strike" id="190" level="5" required-level="42" sp="80000" />
-		
+		<skill name="Fatal Strike" id="190" level="7" required-level="42" sp="80000" />
+		<skill name="Emergency Rescue" id="70" level="12" required-level="42" sp="80000" />
+
+		<!-- Skills Lv43 -->
 		<skill name="Vicious Stance" id="312" level="7" required-level="43" sp="80000" />
 		<skill name="Fast HP Recovery" id="212" level="4" required-level="43" sp="80000" />
 		<skill name="Spinning Slasher" id="36" level="6" required-level="43" sp="80000" />
 		<skill name="Two-handed Weapon Mastery" id="293" level="7" required-level="43" sp="80000" />
 		<skill name="Polearm Mastery" id="216" level="14" required-level="43" sp="80000" />
 		<skill name="Light Armor Mastery" id="227" level="19" required-level="43" sp="80000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="14" required-level="43" sp="80000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="14" required-level="43" sp="80000" />
 		<skill name="Heavy Armor Mastery" id="231" level="19" required-level="43" sp="80000" />
 		<skill name="Guts" id="139" level="2" required-level="43" sp="80000" />
-		<skill name="Power Crush" id="260" level="6" required-level="43" sp="80000" />
+		<skill name="Power Break" id="260" level="6" required-level="43" sp="80000" />
 		<skill name="Excruciating Strike" id="1607" level="6" required-level="43" sp="80000" />
 		<skill name="Boost HP" id="211" level="4" required-level="43" sp="80000" />
-		<skill name="Fatal Strike" id="190" level="6" required-level="43" sp="80000" />
-		
+		<skill name="Fatal Strike" id="190" level="8" required-level="43" sp="80000" />
+		<skill name="Emergency Rescue" id="70" level="13" required-level="43" sp="80000" />
+
+		<!-- Skills Lv44 -->
 		<skill name="Spinning Slasher" id="36" level="7" required-level="44" sp="120000" />
 		<skill name="Polearm Mastery" id="216" level="15" required-level="44" sp="120000" />
 		<skill name="Light Armor Mastery" id="227" level="20" required-level="44" sp="120000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="15" required-level="44" sp="120000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="15" required-level="44" sp="120000" />
 		<skill name="Heavy Armor Mastery" id="231" level="20" required-level="44" sp="120000" />
-		<skill name="Power Crush" id="260" level="7" required-level="44" sp="120000" />
+		<skill name="Power Break" id="260" level="7" required-level="44" sp="120000" />
 		<skill name="Excruciating Strike" id="1607" level="7" required-level="44" sp="120000" />
-		<skill name="Fatal Strike" id="190" level="7" required-level="44" sp="120000" />
-		
+		<skill name="Fatal Strike" id="190" level="9" required-level="44" sp="120000" />
+		<skill name="Emergency Rescue" id="70" level="14" required-level="44" sp="120000" />
+
+		<!-- Skills Lv45 -->
 		<skill name="Spinning Slasher" id="36" level="8" required-level="45" sp="120000" />
 		<skill name="Polearm Mastery" id="216" level="16" required-level="45" sp="120000" />
 		<skill name="Light Armor Mastery" id="227" level="21" required-level="45" sp="120000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="16" required-level="45" sp="120000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="16" required-level="45" sp="120000" />
 		<skill name="Heavy Armor Mastery" id="231" level="21" required-level="45" sp="120000" />
-		<skill name="Power Crush" id="260" level="8" required-level="45" sp="120000" />
+		<skill name="Bandage" id="34" level="2" required-level="45" sp="120000" />
+		<skill name="Power Break" id="260" level="8" required-level="45" sp="120000" />
 		<skill name="Excruciating Strike" id="1607" level="8" required-level="45" sp="120000" />
-		<skill name="Fatal Strike" id="190" level="8" required-level="45" sp="120000" />
-		
+		<skill name="Pirate Transformation" id="1800" level="1" required-level="45" auto-learn="true" />
+		<skill name="Fatal Strike" id="190" level="10" required-level="45" sp="120000" />
+		<skill name="Emergency Rescue" id="70" level="15" required-level="45" sp="120000" />
+
+		<!-- Skills Lv46 -->
 		<skill name="Frenzy" id="176" level="2" required-level="46" sp="120000" />
 		<skill name="Vicious Stance" id="312" level="8" required-level="46" sp="120000" />
 		<skill name="Spinning Slasher" id="36" level="9" required-level="46" sp="120000" />
 		<skill name="Two-handed Weapon Mastery" id="293" level="8" required-level="46" sp="120000" />
 		<skill name="Polearm Mastery" id="216" level="17" required-level="46" sp="120000" />
 		<skill name="Light Armor Mastery" id="227" level="22" required-level="46" sp="120000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="17" required-level="46" sp="120000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="17" required-level="46" sp="120000" />
 		<skill name="Heavy Armor Mastery" id="231" level="22" required-level="46" sp="120000" />
 		<skill name="Vital Force" id="148" level="4" required-level="46" sp="120000" />
-		<skill name="Bandage" id="34" level="2" required-level="46" sp="120000" />
-		<skill name="Power Crush" id="260" level="9" required-level="46" sp="120000" />
+		<skill name="Power Break" id="260" level="9" required-level="46" sp="120000" />
 		<skill name="Excruciating Strike" id="1607" level="9" required-level="46" sp="120000" />
-		<skill name="Fatal Strike" id="190" level="9" required-level="46" sp="120000" />
+		<skill name="Fatal Strike" id="190" level="11" required-level="46" sp="120000" />
 		<skill name="Sword Expert" id="1609" level="1" required-level="46" sp="120000" />
-		
+		<skill name="Emergency Rescue" id="70" level="16" required-level="46" sp="120000" />
+
+		<!-- Skills Lv47 -->
 		<skill name="Spinning Slasher" id="36" level="10" required-level="47" sp="160000" />
 		<skill name="Polearm Mastery" id="216" level="18" required-level="47" sp="160000" />
 		<skill name="Light Armor Mastery" id="227" level="23" required-level="47" sp="160000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="18" required-level="47" sp="160000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="18" required-level="47" sp="160000" />
 		<skill name="Heavy Armor Mastery" id="231" level="23" required-level="47" sp="160000" />
-		<skill name="Power Crush" id="260" level="10" required-level="47" sp="160000" />
+		<skill name="Power Break" id="260" level="10" required-level="47" sp="160000" />
 		<skill name="Excruciating Strike" id="1607" level="10" required-level="47" sp="160000" />
-		<skill name="Fatal Strike" id="190" level="10" required-level="47" sp="160000" />
-		
+		<skill name="Fatal Strike" id="190" level="12" required-level="47" sp="160000" />
+		<skill name="Emergency Rescue" id="70" level="17" required-level="47" sp="160000" />
+
+		<!-- Skills Lv48 -->
 		<skill name="Spinning Slasher" id="36" level="11" required-level="48" sp="160000" />
 		<skill name="Polearm Mastery" id="216" level="19" required-level="48" sp="160000" />
 		<skill name="Light Armor Mastery" id="227" level="24" required-level="48" sp="160000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="19" required-level="48" sp="160000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="19" required-level="48" sp="160000" />
 		<skill name="Heavy Armor Mastery" id="231" level="24" required-level="48" sp="160000" />
-		<skill name="Power Crush" id="260" level="11" required-level="48" sp="160000" />
+		<skill name="Power Break" id="260" level="11" required-level="48" sp="160000" />
 		<skill name="Excruciating Strike" id="1607" level="11" required-level="48" sp="160000" />
-		<skill name="Fatal Strike" id="190" level="11" required-level="48" sp="160000" />
-		
+		<skill name="Fatal Strike" id="190" level="13" required-level="48" sp="160000" />
+		<skill name="Emergency Rescue" id="70" level="18" required-level="48" sp="160000" />
+
+		<!-- Skills Lv49 -->
 		<skill name="Vicious Stance" id="312" level="9" required-level="49" sp="160000" />
 		<skill name="Battle Roar" id="121" level="3" required-level="49" sp="160000" />
 		<skill name="Spinning Slasher" id="36" level="12" required-level="49" sp="160000" />
 		<skill name="Two-handed Weapon Mastery" id="293" level="9" required-level="49" sp="160000" />
 		<skill name="Polearm Mastery" id="216" level="20" required-level="49" sp="160000" />
 		<skill name="Light Armor Mastery" id="227" level="25" required-level="49" sp="160000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="20" required-level="49" sp="160000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="20" required-level="49" sp="160000" />
 		<skill name="Heavy Armor Mastery" id="231" level="25" required-level="49" sp="160000" />
 		<skill name="Lionheart" id="287" level="2" required-level="49" sp="160000" />
-		<skill name="Power Crush" id="260" level="12" required-level="49" sp="160000" />
+		<skill name="Power Break" id="260" level="12" required-level="49" sp="160000" />
 		<skill name="Excruciating Strike" id="1607" level="12" required-level="49" sp="160000" />
 		<skill name="Boost HP" id="211" level="5" required-level="49" sp="160000" />
-		<skill name="Fatal Strike" id="190" level="12" required-level="49" sp="160000" />
+		<skill name="Fatal Strike" id="190" level="14" required-level="49" sp="160000" />
+		<skill name="Emergency Rescue" id="70" level="19" required-level="49" sp="160000" />
 
+		<!-- Skills Lv50 -->
 		<skill name="Spinning Slasher" id="36" level="13" required-level="50" sp="240000" />
 		<skill name="Polearm Mastery" id="216" level="21" required-level="50" sp="240000" />
-		<skill name="Light Armor Mastery" id="227" level="26" required-level="50" sp="240000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="21" required-level="50" sp="240000" />
-		<skill name="Heavy Armor Mastery" id="231" level="26" required-level="50" sp="240000" />
-		<skill name="Power Crush" id="260" level="13" required-level="50" sp="240000" />
-		<skill name="Excruciating Strike" id="1607" level="13" required-level="50" sp="240000" />
-		<skill name="Fatal Strike" id="190" level="13" required-level="50" sp="240000" />
 		<skill name="Potion Mastery" id="45184" level="2" required-level="50">
-			<item id="57" count="3000000"/> <!-- Adena -->
+			<item id="57" count="3000000" /> <!-- Adena -->
 		</skill>
-		
+		<skill name="Light Armor Mastery" id="227" level="26" required-level="50" sp="240000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="21" required-level="50" sp="240000" />
+		<skill name="Heavy Armor Mastery" id="231" level="26" required-level="50" sp="240000" />
+		<skill name="Recover HP" id="45176" level="2" required-level="50" sp="300000" >
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Recover MP" id="45177" level="2" required-level="50" sp="300000" >
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="260" level="13" required-level="50" sp="240000" />
+		<skill name="Excruciating Strike" id="1607" level="13" required-level="50" sp="240000" />
+		<skill name="Fatal Strike" id="190" level="15" required-level="50" sp="240000" />
+		<skill name="Emergency Rescue" id="70" level="20" required-level="50" sp="240000" />
+
 		<skill name="Spinning Slasher" id="36" level="14" required-level="51" sp="240000" />
 		<skill name="Polearm Mastery" id="216" level="22" required-level="51" sp="240000" />
 		<skill name="Light Armor Mastery" id="227" level="27" required-level="51" sp="240000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="22" required-level="51" sp="240000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="22" required-level="51" sp="240000" />
 		<skill name="Heavy Armor Mastery" id="231" level="27" required-level="51" sp="240000" />
-		<skill name="Power Crush" id="260" level="14" required-level="51" sp="240000" />
+		<skill name="Power Break" id="260" level="14" required-level="51" sp="240000" />
 		<skill name="Excruciating Strike" id="1607" level="14" required-level="51" sp="240000" />
-		<skill name="Fatal Strike" id="190" level="14" required-level="51" sp="240000" />
-		
+		<skill name="Fatal Strike" id="190" level="16" required-level="51" sp="240000" />
+		<skill name="Emergency Rescue" id="70" level="21" required-level="51" sp="240000" />
+
+		<!-- Skills Lv52 -->
 		<skill name="Vicious Stance" id="312" level="10" required-level="52" sp="240000" />
-		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="240000" />
+		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="240000" >
+			<item id="8618" count="1" /> <!-- Ancient Book: Divine Inspiration (Modern Language Version) Lv 1 -->
+		</skill>
 		<skill name="Fast HP Recovery" id="212" level="5" required-level="52" sp="240000" />
 		<skill name="Spinning Slasher" id="36" level="15" required-level="52" sp="240000" />
 		<skill name="Two-handed Weapon Mastery" id="293" level="10" required-level="52" sp="240000" />
 		<skill name="Polearm Mastery" id="216" level="23" required-level="52" sp="240000" />
 		<skill name="Light Armor Mastery" id="227" level="28" required-level="52" sp="240000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="23" required-level="52" sp="240000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="23" required-level="52" sp="240000" />
 		<skill name="Heavy Armor Mastery" id="231" level="28" required-level="52" sp="240000" />
 		<skill name="Vital Force" id="148" level="5" required-level="52" sp="240000" />
 		<skill name="Guts" id="139" level="3" required-level="52" sp="240000" />
-		<skill name="Power Crush" id="260" level="15" required-level="52" sp="240000" />
+		<skill name="Power Break" id="260" level="15" required-level="52" sp="240000" />
 		<skill name="Excruciating Strike" id="1607" level="15" required-level="52" sp="240000" />
-		<skill name="Fatal Strike" id="190" level="15" required-level="52" sp="240000" />
-		<skill name="Immortal Life" id="1608" level="1" required-level="52" sp="240000" >
-			<item id="49425"/>
-		</skill>
-		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="240000" >
-			<item id="8618"/> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
-		</skill>
-		
+		<skill name="Dynamic Recovery" id="1608" level="1" required-level="52" sp="240000" />
+		<skill name="Fatal Strike" id="190" level="17" required-level="52" sp="240000" />
+		<skill name="Emergency Rescue" id="70" level="22" required-level="52" sp="240000" />
+
+		<!-- Skills Lv53 -->
 		<skill name="Spinning Slasher" id="36" level="16" required-level="53" sp="330000" />
 		<skill name="Polearm Mastery" id="216" level="24" required-level="53" sp="330000" />
 		<skill name="Light Armor Mastery" id="227" level="29" required-level="53" sp="330000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="24" required-level="53" sp="330000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="24" required-level="53" sp="330000" />
 		<skill name="Heavy Armor Mastery" id="231" level="29" required-level="53" sp="330000" />
-		<skill name="Power Crush" id="260" level="16" required-level="53" sp="330000" />
+		<skill name="Power Break" id="260" level="16" required-level="53" sp="330000" />
 		<skill name="Excruciating Strike" id="1607" level="16" required-level="53" sp="330000" />
-		<skill name="Fatal Strike" id="190" level="16" required-level="53" sp="330000" />
-		
+		<skill name="Fatal Strike" id="190" level="18" required-level="53" sp="330000" />
+		<skill name="Emergency Rescue" id="70" level="23" required-level="53" sp="330000" />
+
+		<!-- Skills Lv54 -->
 		<skill name="Spinning Slasher" id="36" level="17" required-level="54" sp="330000" />
 		<skill name="Polearm Mastery" id="216" level="25" required-level="54" sp="330000" />
 		<skill name="Light Armor Mastery" id="227" level="30" required-level="54" sp="330000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="25" required-level="54" sp="330000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="25" required-level="54" sp="330000" />
 		<skill name="Heavy Armor Mastery" id="231" level="30" required-level="54" sp="330000" />
-		<skill name="Power Crush" id="260" level="17" required-level="54" sp="330000" />
+		<skill name="Power Break" id="260" level="17" required-level="54" sp="330000" />
 		<skill name="Excruciating Strike" id="1607" level="17" required-level="54" sp="330000" />
-		<skill name="Fatal Strike" id="190" level="17" required-level="54" sp="330000" />
-		
+		<skill name="Fatal Strike" id="190" level="19" required-level="54" sp="330000" />
+		<skill name="Emergency Rescue" id="70" level="24" required-level="54" sp="330000" />
+
+		<!-- Skills Lv55 -->
 		<skill name="Frenzy" id="176" level="3" required-level="55" sp="330000" />
 		<skill name="Vicious Stance" id="312" level="11" required-level="55" sp="330000" />
 		<skill name="Spinning Slasher" id="36" level="18" required-level="55" sp="330000" />
 		<skill name="Two-handed Weapon Mastery" id="293" level="11" required-level="55" sp="330000" />
 		<skill name="Polearm Mastery" id="216" level="26" required-level="55" sp="330000" />
 		<skill name="Light Armor Mastery" id="227" level="31" required-level="55" sp="330000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="26" required-level="55" sp="330000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="26" required-level="55" sp="330000" />
 		<skill name="Heavy Armor Mastery" id="231" level="31" required-level="55" sp="330000" />
 		<skill name="Rage" id="94" level="2" required-level="55" sp="330000" />
-		<skill name="Power Crush" id="260" level="18" required-level="55" sp="330000" />
+		<skill name="Power Break" id="260" level="18" required-level="55" sp="330000" />
 		<skill name="Excruciating Strike" id="1607" level="18" required-level="55" sp="330000" />
 		<skill name="Boost HP" id="211" level="6" required-level="55" sp="330000" />
-		<skill name="Fatal Strike" id="190" level="18" required-level="55" sp="330000" />
+		<skill name="Fatal Strike" id="190" level="20" required-level="55" sp="330000" />
+		<skill name="Emergency Rescue" id="70" level="25" required-level="55" sp="330000" />
 
+		<!-- Skills Lv56 -->
 		<skill name="Spinning Slasher" id="36" level="19" required-level="56" sp="450000" />
 		<skill name="Polearm Mastery" id="216" level="27" required-level="56" sp="450000" />
 		<skill name="Light Armor Mastery" id="227" level="32" required-level="56" sp="450000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="27" required-level="56" sp="450000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="27" required-level="56" sp="450000" />
 		<skill name="Heavy Armor Mastery" id="231" level="32" required-level="56" sp="450000" />
-		<skill name="Power Crush" id="260" level="19" required-level="56" sp="450000" />
+		<skill name="Power Break" id="260" level="19" required-level="56" sp="450000" />
 		<skill name="Excruciating Strike" id="1607" level="19" required-level="56" sp="450000" />
-		<skill name="Fatal Strike" id="190" level="19" required-level="56" sp="450000" />
-		
+		<skill name="Fatal Strike" id="190" level="21" required-level="56" sp="450000" />
+		<skill name="Emergency Rescue" id="70" level="26" required-level="56" sp="450000" />
+
+		<!-- Skills Lv57 -->
 		<skill name="Spinning Slasher" id="36" level="20" required-level="57" sp="450000" />
 		<skill name="Polearm Mastery" id="216" level="28" required-level="57" sp="450000" />
 		<skill name="Light Armor Mastery" id="227" level="33" required-level="57" sp="450000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="28" required-level="57" sp="450000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="28" required-level="57" sp="450000" />
 		<skill name="Heavy Armor Mastery" id="231" level="33" required-level="57" sp="450000" />
-		<skill name="Power Crush" id="260" level="20" required-level="57" sp="450000" />
+		<skill name="Power Break" id="260" level="20" required-level="57" sp="450000" />
 		<skill name="Excruciating Strike" id="1607" level="20" required-level="57" sp="450000" />
-		<skill name="Fatal Strike" id="190" level="20" required-level="57" sp="450000" />
-		
+		<skill name="Fatal Strike" id="190" level="22" required-level="57" sp="450000" />
+		<skill name="Emergency Rescue" id="70" level="27" required-level="57" sp="450000" />
+
+		<!-- Skills Lv58 -->
 		<skill name="Vicious Stance" id="312" level="12" required-level="58" sp="450000" />
 		<skill name="Battle Roar" id="121" level="4" required-level="58" sp="450000" />
 		<skill name="Fast HP Recovery" id="212" level="6" required-level="58" sp="450000" />
@@ -233,73 +291,88 @@
 		<skill name="Two-handed Weapon Mastery" id="293" level="12" required-level="58" sp="450000" />
 		<skill name="Polearm Mastery" id="216" level="29" required-level="58" sp="450000" />
 		<skill name="Light Armor Mastery" id="227" level="34" required-level="58" sp="450000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="29" required-level="58" sp="450000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="29" required-level="58" sp="450000" />
 		<skill name="Heavy Armor Mastery" id="231" level="34" required-level="58" sp="450000" />
 		<skill name="Vital Force" id="148" level="6" required-level="58" sp="450000" />
-		<skill name="Power Crush" id="260" level="21" required-level="58" sp="450000" />
+		<skill name="Power Break" id="260" level="21" required-level="58" sp="450000" />
 		<skill name="Excruciating Strike" id="1607" level="21" required-level="58" sp="450000" />
 		<skill name="Zealot" id="420" level="1" required-level="58" sp="450000" />
-		<skill name="Fatal Strike" id="190" level="21" required-level="58" sp="450000" />
+		<skill name="Fatal Strike" id="190" level="23" required-level="58" sp="450000" />
 		<skill name="Sword Expert" id="1609" level="2" required-level="58" sp="450000" />
+		<skill name="Emergency Rescue" id="70" level="28" required-level="58" sp="450000" />
 
+		<!-- Skills Lv59 -->
 		<skill name="Spinning Slasher" id="36" level="22" required-level="59" sp="660000" />
 		<skill name="Polearm Mastery" id="216" level="30" required-level="59" sp="660000" />
 		<skill name="Light Armor Mastery" id="227" level="35" required-level="59" sp="660000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="30" required-level="59" sp="660000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="30" required-level="59" sp="660000" />
 		<skill name="Heavy Armor Mastery" id="231" level="35" required-level="59" sp="660000" />
-		<skill name="Power Crush" id="260" level="22" required-level="59" sp="660000" />
+		<skill name="Power Break" id="260" level="22" required-level="59" sp="660000" />
 		<skill name="Excruciating Strike" id="1607" level="22" required-level="59" sp="660000" />
-		<skill name="Fatal Strike" id="190" level="22" required-level="59" sp="660000" />
-		
+		<skill name="Fatal Strike" id="190" level="24" required-level="59" sp="660000" />
+		<skill name="Emergency Rescue" id="70" level="29" required-level="59" sp="660000" />
+
+		<!-- Skills Lv60 -->
 		<skill name="Vicious Stance" id="312" level="13" required-level="60" sp="660000" />
 		<skill name="Spinning Slasher" id="36" level="23" required-level="60" sp="660000" />
 		<skill name="Two-handed Weapon Mastery" id="293" level="13" required-level="60" sp="660000" />
 		<skill name="Polearm Mastery" id="216" level="31" required-level="60" sp="660000" />
-		<skill name="Light Armor Mastery" id="227" level="36" required-level="60" sp="660000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="31" required-level="60" sp="660000" />
-		<skill name="Heavy Armor Mastery" id="231" level="36" required-level="60" sp="660000" />
-		<skill name="Power Crush" id="260" level="23" required-level="60" sp="660000" />
-		<skill name="Excruciating Strike" id="1607" level="23" required-level="60" sp="660000" />
-		<skill name="Fatal Strike" id="190" level="23" required-level="60" sp="660000" />
 		<skill name="Potion Mastery" id="45184" level="3" required-level="60">
-			<item id="57" count="6000000"/> <!-- Adena -->
+			<item id="57" count="6000000" /> <!-- Adena -->
 		</skill>
+		<skill name="Light Armor Mastery" id="227" level="36" required-level="60" sp="660000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="31" required-level="60" sp="660000" />
+		<skill name="Heavy Armor Mastery" id="231" level="36" required-level="60" sp="660000" />
+		<skill name="Bandage" id="34" level="3" required-level="60" sp="660000" />
+		<skill name="Power Break" id="260" level="23" required-level="60" sp="660000" />
+		<skill name="Excruciating Strike" id="1607" level="23" required-level="60" sp="660000" />
+		<skill name="Ability to Attack" id="77" level="3" required-level="60" sp="660000" />
+		<skill name="Rush" id="994" level="2" required-level="60" sp="660000" />
+		<skill name="Dark Assassin Transformation" id="1801" level="1" required-level="60" auto-learn="true" />
+		<skill name="Fatal Strike" id="190" level="25" required-level="60" sp="660000" />
+		<skill name="Emergency Rescue" id="70" level="30" required-level="60" sp="660000" />
 
+		<!-- Skills Lv61 -->
+		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="660000" >
+			<item id="8619" count="1" /> <!-- Ancient Book: Divine Inspiration (Modern Language Version) Lv 2 -->
+		</skill>
 		<skill name="Spinning Slasher" id="36" level="24" required-level="61" sp="660000" />
 		<skill name="Polearm Mastery" id="216" level="32" required-level="61" sp="660000" />
 		<skill name="Light Armor Mastery" id="227" level="37" required-level="61" sp="660000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="32" required-level="61" sp="660000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="32" required-level="61" sp="660000" />
 		<skill name="Heavy Armor Mastery" id="231" level="37" required-level="61" sp="660000" />
-		<skill name="Power Crush" id="260" level="24" required-level="61" sp="660000" />
+		<skill name="Power Break" id="260" level="24" required-level="61" sp="660000" />
 		<skill name="Excruciating Strike" id="1607" level="24" required-level="61" sp="660000" />
-		<skill name="Fatal Strike" id="190" level="24" required-level="61" sp="660000" />
-		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="660000" >
-			<item id="8619"/> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
-		</skill>
-		
+		<skill name="Fatal Strike" id="190" level="26" required-level="61" sp="660000" />
+		<skill name="Emergency Rescue" id="70" level="31" required-level="61" sp="660000" />
+
+		<!-- Skills Lv62 -->
 		<skill name="Vicious Stance" id="312" level="14" required-level="62" sp="810000" />
 		<skill name="Spinning Slasher" id="36" level="25" required-level="62" sp="810000" />
 		<skill name="Two-handed Weapon Mastery" id="293" level="14" required-level="62" sp="810000" />
 		<skill name="Polearm Mastery" id="216" level="33" required-level="62" sp="810000" />
 		<skill name="Light Armor Mastery" id="227" level="38" required-level="62" sp="810000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="33" required-level="62" sp="810000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="33" required-level="62" sp="810000" />
 		<skill name="Heavy Armor Mastery" id="231" level="38" required-level="62" sp="810000" />
 		<skill name="Lionheart" id="287" level="3" required-level="62" sp="810000" />
-		<skill name="Bandage" id="34" level="3" required-level="62" sp="810000" />
-		<skill name="Power Crush" id="260" level="25" required-level="62" sp="810000" />
+		<skill name="Power Break" id="260" level="25" required-level="62" sp="810000" />
 		<skill name="Excruciating Strike" id="1607" level="25" required-level="62" sp="810000" />
 		<skill name="Boost HP" id="211" level="7" required-level="62" sp="810000" />
-		<skill name="Fatal Strike" id="190" level="25" required-level="62" sp="810000" />
+		<skill name="Fatal Strike" id="190" level="27" required-level="62" sp="810000" />
+		<skill name="Emergency Rescue" id="70" level="32" required-level="62" sp="810000" />
 
+		<!-- Skills Lv63 -->
 		<skill name="Spinning Slasher" id="36" level="26" required-level="63" sp="810000" />
 		<skill name="Polearm Mastery" id="216" level="34" required-level="63" sp="810000" />
 		<skill name="Light Armor Mastery" id="227" level="39" required-level="63" sp="810000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="34" required-level="63" sp="810000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="34" required-level="63" sp="810000" />
 		<skill name="Heavy Armor Mastery" id="231" level="39" required-level="63" sp="810000" />
-		<skill name="Power Crush" id="260" level="26" required-level="63" sp="810000" />
+		<skill name="Power Break" id="260" level="26" required-level="63" sp="810000" />
 		<skill name="Excruciating Strike" id="1607" level="26" required-level="63" sp="810000" />
-		<skill name="Fatal Strike" id="190" level="26" required-level="63" sp="810000" />
-		
+		<skill name="Fatal Strike" id="190" level="28" required-level="63" sp="810000" />
+		<skill name="Emergency Rescue" id="70" level="33" required-level="63" sp="810000" />
+
+		<!-- Skills Lv64 -->
 		<skill name="Frenzy" id="176" level="4" required-level="64" sp="1000000" />
 		<skill name="Vicious Stance" id="312" level="15" required-level="64" sp="1000000" />
 		<skill name="Battle Roar" id="121" level="5" required-level="64" sp="1000000" />
@@ -307,124 +380,153 @@
 		<skill name="Two-handed Weapon Mastery" id="293" level="15" required-level="64" sp="1000000" />
 		<skill name="Polearm Mastery" id="216" level="35" required-level="64" sp="1000000" />
 		<skill name="Light Armor Mastery" id="227" level="40" required-level="64" sp="1000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="35" required-level="64" sp="1000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="35" required-level="64" sp="1000000" />
 		<skill name="Heavy Armor Mastery" id="231" level="40" required-level="64" sp="1000000" />
 		<skill name="Vital Force" id="148" level="7" required-level="64" sp="1000000" />
 		<skill name="Guts" id="139" level="4" required-level="64" sp="1000000" />
-		<skill name="Power Crush" id="260" level="27" required-level="64" sp="1000000" />
+		<skill name="Power Break" id="260" level="27" required-level="64" sp="1000000" />
 		<skill name="Excruciating Strike" id="1607" level="27" required-level="64" sp="1000000" />
-		<skill name="Fatal Strike" id="190" level="27" required-level="64" sp="1000000" />
+		<skill name="Fatal Strike" id="190" level="29" required-level="64" sp="1000000" />
+		<skill name="Emergency Rescue" id="70" level="34" required-level="64" sp="1000000" />
 
+		<!-- Skills Lv65 -->
 		<skill name="Spinning Slasher" id="36" level="28" required-level="65" sp="1000000" />
 		<skill name="Polearm Mastery" id="216" level="36" required-level="65" sp="1000000" />
 		<skill name="Light Armor Mastery" id="227" level="41" required-level="65" sp="1000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="36" required-level="65" sp="1000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="36" required-level="65" sp="1000000" />
 		<skill name="Heavy Armor Mastery" id="231" level="41" required-level="65" sp="1000000" />
-		<skill name="Power Crush" id="260" level="28" required-level="65" sp="1000000" />
+		<skill name="Power Break" id="260" level="28" required-level="65" sp="1000000" />
 		<skill name="Excruciating Strike" id="1607" level="28" required-level="65" sp="1000000" />
-		<skill name="Fatal Strike" id="190" level="28" required-level="65" sp="1000000" />
-		
+		<skill name="Fatal Strike" id="190" level="30" required-level="65" sp="1000000" />
+		<skill name="Emergency Rescue" id="70" level="35" required-level="65" sp="1000000" />
+
+		<!-- Skills Lv66 -->
 		<skill name="Vicious Stance" id="312" level="16" required-level="66" sp="1200000" />
 		<skill name="Spinning Slasher" id="36" level="29" required-level="66" sp="1200000" />
 		<skill name="Two-handed Weapon Mastery" id="293" level="16" required-level="66" sp="1200000" />
 		<skill name="Polearm Mastery" id="216" level="37" required-level="66" sp="1200000" />
 		<skill name="Light Armor Mastery" id="227" level="42" required-level="66" sp="1200000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="37" required-level="66" sp="1200000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="37" required-level="66" sp="1200000" />
 		<skill name="Heavy Armor Mastery" id="231" level="42" required-level="66" sp="1200000" />
-		<skill name="Power Crush" id="260" level="29" required-level="66" sp="1200000" />
+		<skill name="Power Break" id="260" level="29" required-level="66" sp="1200000" />
 		<skill name="Excruciating Strike" id="1607" level="29" required-level="66" sp="1200000" />
 		<skill name="Boost HP" id="211" level="8" required-level="66" sp="1200000" />
 		<skill name="Zealot" id="420" level="2" required-level="66" sp="1200000" />
-		<skill name="Fatal Strike" id="190" level="29" required-level="66" sp="1200000" />
+		<skill name="Fatal Strike" id="190" level="31" required-level="66" sp="1200000" />
+		<skill name="Emergency Rescue" id="70" level="36" required-level="66" sp="1200000" />
 
+		<!-- Skills Lv67 -->
 		<skill name="Spinning Slasher" id="36" level="30" required-level="67" sp="1200000" />
 		<skill name="Polearm Mastery" id="216" level="38" required-level="67" sp="1200000" />
 		<skill name="Light Armor Mastery" id="227" level="43" required-level="67" sp="1200000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="38" required-level="67" sp="1200000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="38" required-level="67" sp="1200000" />
 		<skill name="Heavy Armor Mastery" id="231" level="43" required-level="67" sp="1200000" />
-		<skill name="Power Crush" id="260" level="30" required-level="67" sp="1200000" />
+		<skill name="Power Break" id="260" level="30" required-level="67" sp="1200000" />
 		<skill name="Excruciating Strike" id="1607" level="30" required-level="67" sp="1200000" />
-		<skill name="Fatal Strike" id="190" level="30" required-level="67" sp="1200000" />
-		
+		<skill name="Fatal Strike" id="190" level="32" required-level="67" sp="1200000" />
+		<skill name="Emergency Rescue" id="70" level="37" required-level="67" sp="1200000" />
+
+		<!-- Skills Lv68 -->
 		<skill name="Vicious Stance" id="312" level="17" required-level="68" sp="1600000" />
 		<skill name="Fast HP Recovery" id="212" level="7" required-level="68" sp="1600000" />
 		<skill name="Spinning Slasher" id="36" level="31" required-level="68" sp="1600000" />
 		<skill name="Two-handed Weapon Mastery" id="293" level="17" required-level="68" sp="1600000" />
 		<skill name="Polearm Mastery" id="216" level="39" required-level="68" sp="1600000" />
 		<skill name="Light Armor Mastery" id="227" level="44" required-level="68" sp="1600000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="39" required-level="68" sp="1600000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="39" required-level="68" sp="1600000" />
 		<skill name="Heavy Armor Mastery" id="231" level="44" required-level="68" sp="1600000" />
-		<skill name="Power Crush" id="260" level="31" required-level="68" sp="1600000" />
+		<skill name="Power Break" id="260" level="31" required-level="68" sp="1600000" />
 		<skill name="Excruciating Strike" id="1607" level="31" required-level="68" sp="1600000" />
-		<skill name="Fatal Strike" id="190" level="31" required-level="68" sp="1600000" />
+		<skill name="Fatal Strike" id="190" level="33" required-level="68" sp="1600000" />
+		<skill name="Emergency Rescue" id="70" level="38" required-level="68" sp="1600000" />
 
+		<!-- Skills Lv69 -->
 		<skill name="Spinning Slasher" id="36" level="32" required-level="69" sp="1600000" />
 		<skill name="Polearm Mastery" id="216" level="40" required-level="69" sp="1600000" />
 		<skill name="Light Armor Mastery" id="227" level="45" required-level="69" sp="1600000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="40" required-level="69" sp="1600000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="40" required-level="69" sp="1600000" />
 		<skill name="Heavy Armor Mastery" id="231" level="45" required-level="69" sp="1600000" />
-		<skill name="Power Crush" id="260" level="32" required-level="69" sp="1600000" />
+		<skill name="Power Break" id="260" level="32" required-level="69" sp="1600000" />
 		<skill name="Excruciating Strike" id="1607" level="32" required-level="69" sp="1600000" />
-		<skill name="Fatal Strike" id="190" level="32" required-level="69" sp="1600000" />
-		
+		<skill name="Fatal Strike" id="190" level="34" required-level="69" sp="1600000" />
+		<skill name="Emergency Rescue" id="70" level="39" required-level="69" sp="1600000" />
+
+		<!-- Skills Lv70 -->
 		<skill name="Vicious Stance" id="312" level="18" required-level="70" sp="2000000" />
 		<skill name="Battle Roar" id="121" level="6" required-level="70" sp="2000000" />
 		<skill name="Spinning Slasher" id="36" level="33" required-level="70" sp="2000000" />
 		<skill name="Two-handed Weapon Mastery" id="293" level="18" required-level="70" sp="2000000" />
 		<skill name="Polearm Mastery" id="216" level="41" required-level="70" sp="2000000" />
 		<skill name="Light Armor Mastery" id="227" level="46" required-level="70" sp="2000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="41" required-level="70" sp="2000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="41" required-level="70" sp="2000000" />
 		<skill name="Heavy Armor Mastery" id="231" level="46" required-level="70" sp="2000000" />
-		<skill name="Power Crush" id="260" level="33" required-level="70" sp="2000000" />
+		<skill name="Power Break" id="260" level="33" required-level="70" sp="2000000" />
 		<skill name="Excruciating Strike" id="1607" level="33" required-level="70" sp="2000000" />
+		<skill name="White Assassin Transformation" id="1802" level="1" required-level="70" auto-learn="true" />
 		<skill name="Boost HP" id="211" level="9" required-level="70" sp="2000000" />
-		<skill name="Fatal Strike" id="190" level="33" required-level="70" sp="2000000" />
+		<skill name="Fatal Strike" id="190" level="35" required-level="70" sp="2000000" />
 		<skill name="Sword Expert" id="1609" level="3" required-level="70" sp="2000000" />
-		
+		<skill name="Emergency Rescue" id="70" level="40" required-level="70" sp="2000000" />
+
+		<!-- Skills Lv71 -->
 		<skill name="Spinning Slasher" id="36" level="34" required-level="71" sp="2000000" />
 		<skill name="Polearm Mastery" id="216" level="42" required-level="71" sp="2000000" />
 		<skill name="Light Armor Mastery" id="227" level="47" required-level="71" sp="2000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="42" required-level="71" sp="2000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="42" required-level="71" sp="2000000" />
 		<skill name="Heavy Armor Mastery" id="231" level="47" required-level="71" sp="2000000" />
-		<skill name="Power Crush" id="260" level="34" required-level="71" sp="2000000" />
+		<skill name="Power Break" id="260" level="34" required-level="71" sp="2000000" />
 		<skill name="Excruciating Strike" id="1607" level="34" required-level="71" sp="2000000" />
-		<skill name="Fatal Strike" id="190" level="34" required-level="71" sp="2000000" />
-		
+		<skill name="Fatal Strike" id="190" level="36" required-level="71" sp="2000000" />
+		<skill name="Emergency Rescue" id="70" level="41" required-level="71" sp="2000000" />
+
+		<!-- Skills Lv72 -->
 		<skill name="Vicious Stance" id="312" level="19" required-level="72" sp="2200000" />
 		<skill name="Spinning Slasher" id="36" level="35" required-level="72" sp="2200000" />
 		<skill name="Two-handed Weapon Mastery" id="293" level="19" required-level="72" sp="2200000" />
 		<skill name="Polearm Mastery" id="216" level="43" required-level="72" sp="2200000" />
 		<skill name="Light Armor Mastery" id="227" level="48" required-level="72" sp="2200000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="43" required-level="72" sp="2200000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="43" required-level="72" sp="2200000" />
 		<skill name="Heavy Armor Mastery" id="231" level="48" required-level="72" sp="2200000" />
 		<skill name="Vital Force" id="148" level="8" required-level="72" sp="2200000" />
-		<skill name="Power Crush" id="260" level="35" required-level="72" sp="2200000" />
+		<skill name="Power Break" id="260" level="35" required-level="72" sp="2200000" />
 		<skill name="Excruciating Strike" id="1607" level="35" required-level="72" sp="2200000" />
-		<skill name="Fatal Strike" id="190" level="35" required-level="72" sp="2200000" />
-		
+		<skill name="Fatal Strike" id="190" level="37" required-level="72" sp="2200000" />
+		<skill name="Emergency Rescue" id="70" level="42" required-level="72" sp="2200000" />
+
+		<!-- Skills Lv73 -->
 		<skill name="Spinning Slasher" id="36" level="36" required-level="73" sp="2200000" />
+		<skill name="Spinning Slasher" id="36" level="38" required-level="73" sp="2200000" />
 		<skill name="Polearm Mastery" id="216" level="44" required-level="73" sp="2200000" />
 		<skill name="Light Armor Mastery" id="227" level="49" required-level="73" sp="2200000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="44" required-level="73" sp="2200000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="44" required-level="73" sp="2200000" />
 		<skill name="Heavy Armor Mastery" id="231" level="49" required-level="73" sp="2200000" />
-		<skill name="Power Crush" id="260" level="36" required-level="73" sp="2200000" />
+		<skill name="Power Break" id="260" level="36" required-level="73" sp="2200000" />
 		<skill name="Excruciating Strike" id="1607" level="36" required-level="73" sp="2200000" />
-		<skill name="Fatal Strike" id="190" level="36" required-level="73" sp="2200000" />
-		
+		<skill name="Fatal Strike" id="190" level="38" required-level="73" sp="2200000" />
+		<skill name="Emergency Rescue" id="70" level="43" required-level="73" sp="2200000" />
+
+		<!-- Skills Lv74 -->
 		<skill name="Frenzy" id="176" level="5" required-level="74" sp="2200000" />
 		<skill name="Vicious Stance" id="312" level="20" required-level="74" sp="2200000" />
 		<skill name="Fast HP Recovery" id="212" level="8" required-level="74" sp="2200000" />
 		<skill name="Spinning Slasher" id="36" level="37" required-level="74" sp="2200000" />
+		<skill name="Spinning Slasher" id="36" level="39" required-level="74" sp="2200000" />
 		<skill name="Two-handed Weapon Mastery" id="293" level="20" required-level="74" sp="2200000" />
 		<skill name="Polearm Mastery" id="216" level="45" required-level="74" sp="2200000" />
 		<skill name="Light Armor Mastery" id="227" level="50" required-level="74" sp="2200000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="45" required-level="74" sp="2200000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="45" required-level="74" sp="2200000" />
 		<skill name="Heavy Armor Mastery" id="231" level="50" required-level="74" sp="2200000" />
 		<skill name="Guts" id="139" level="5" required-level="74" sp="2200000" />
-		<skill name="Power Crush" id="260" level="37" required-level="74" sp="2200000" />
+		<skill name="Power Break" id="260" level="37" required-level="74" sp="2200000" />
 		<skill name="Excruciating Strike" id="1607" level="37" required-level="74" sp="2200000" />
 		<skill name="Boost HP" id="211" level="10" required-level="74" sp="2200000" />
 		<skill name="Zealot" id="420" level="3" required-level="74" sp="2200000" />
-		<skill name="Fatal Strike" id="190" level="37" required-level="74" sp="2200000" />
+		<skill name="Fatal Strike" id="190" level="39" required-level="74" sp="2200000" />
+		<skill name="Emergency Rescue" id="70" level="44" required-level="74" sp="2200000" />
+
+		<!-- Skills Lv75 -->
+		<skill name="Spinning Slasher" id="36" level="40" required-level="75" sp="2200000" />
+		<skill name="Fatal Strike" id="190" level="40" required-level="75" sp="2200000" />
+		<skill name="Emergency Rescue" id="70" level="45" required-level="75" sp="2200000" />
 	</skillTree>
 </list>

--- a/data/skillTrees/2ndClass/ElementalSummoner.xml
+++ b/data/skillTrees/2ndClass/ElementalSummoner.xml
@@ -1,6 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="28" parentClassId="26">
+
+		<!-- Master Buffs Lv. 40 -->
+		<skill name="Might" id="1068" level="3" required-level="40" sp="80000" />
+		<skill name="Shield" id="1040" level="3" required-level="40" sp="80000" />
+		<skill name="Acumen" id="45104" level="3" required-level="40" sp="80000" />
+		<skill name="Empower" id="45105" level="3" required-level="40" sp="80000" />
+		<skill name="Wild Magic" id="45106" level="2" required-level="40" sp="80000" />
+		<skill name="Magic Barrier" id="45108" level="2" required-level="40" sp="80000" />
+		<skill name="Focus" id="45109" level="3" required-level="40" sp="80000" />
+		<skill name="Death Whisper" id="45110" level="3" required-level="40" sp="80000" />
+		<skill name="Haste" id="45111" level="2" required-level="40" sp="80000" />
+		<skill name="Berserker Spirit" id="45112" level="2" required-level="40" sp="80000" />
+		<skill name="Clarity" id="45113" level="3" required-level="40" sp="80000" />
+
 		<skill name="Pirate" id="1800" level="1" required-level="45" auto-learn="true" />
 		<skill name="Dark Assassin" id="1801" level="1" required-level="60" auto-learn="true" />
 		<skill name="White Assassin" id="1802" level="1" required-level="70" auto-learn="true" />
@@ -37,7 +51,7 @@
 		<skill name="Boost Mana" id="213" level="3" required-level="40" sp="100000" />
 		<skill name="Servitor Physical Shield" id="1140" level="1" required-level="40" sp="100000" />
 		<skill name="Summon Aqua Cubic" id="1280" level="1" required-level="40" sp="100000">
-			<item id="4923"/>
+			<item id="4923" count="1" />
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="16" required-level="42" sp="140000" />
@@ -72,7 +86,7 @@
 		<skill name="Servitor Haste" id="1141" level="1" required-level="44" sp="140000" />
 		<skill name="Aqua Swirl" id="1175" level="11" required-level="44" sp="140000" />
 		<skill name="Spirit Sharing" id="1547" level="1" required-level="44" sp="140000" >
-			<item id="49562"/>
+			<item id="49562" count="1" />
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="19" required-level="46" sp="220000" />
@@ -141,7 +155,7 @@
 		<skill name="Summon Life Cubic" id="67" level="3" required-level="52" sp="360000" />
 		<skill name="Servitor Haste" id="1141" level="2" required-level="52" sp="360000" />
 		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="360000" >
-			<item id="8618"/> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
+			<item id="8618" count="1" /> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="25" required-level="54" sp="570000" />
@@ -227,7 +241,7 @@
 		<skill name="Servitor Heal" id="1127" level="32" required-level="61" sp="850000" />
 		<skill name="Servitor Recharge" id="1126" level="21" required-level="61" sp="850000" />
 		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="850000" >
-			<item id="8619"/> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
+			<item id="8619" count="1" /> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="33" required-level="62" sp="850000" />

--- a/data/skillTrees/2ndClass/ElfUndertaker.xml
+++ b/data/skillTrees/2ndClass/ElfUndertaker.xml
@@ -1,0 +1,262 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
+	<skillTree type="classSkillTree" classId="202" parentClassId="201">
+
+		<!-- Master Buffs Lv. 40 -->
+		<skill name="Might" id="1068" level="3" required-level="40" sp="80000" />
+		<skill name="Shield" id="1040" level="3" required-level="40" sp="80000" />
+		<skill name="Acumen" id="45104" level="3" required-level="40" sp="80000" />
+		<skill name="Empower" id="45105" level="3" required-level="40" sp="80000" />
+		<skill name="Wild Magic" id="45106" level="2" required-level="40" sp="80000" />
+		<skill name="Magic Barrier" id="45108" level="2" required-level="40" sp="80000" />
+		<skill name="Focus" id="45109" level="3" required-level="40" sp="80000" />
+		<skill name="Death Whisper" id="45110" level="3" required-level="40" sp="80000" />
+		<skill name="Haste" id="45111" level="2" required-level="40" sp="80000" />
+		<skill name="Berserker Spirit" id="45112" level="2" required-level="40" sp="80000" />
+		<skill name="Clarity" id="45113" level="3" required-level="40" sp="80000" />
+
+		<skill name="Slowdown" id="15" level="18" required-level="40" sp="80000" />
+		<skill name="Elven Spirit" id="61" level="2" required-level="40" sp="80000" />
+		<skill name="Entangle" id="102" level="2" required-level="40" sp="80000" />
+		<skill name="Death Armor Mastery" id="45354" level="8" required-level="40" sp="80000" />
+		<skill name="Death Sword Mastery" id="45353" level="8" required-level="40" sp="80000" />
+		<skill name="Death Guard" id="45329" level="1" required-level="40" sp="80000">
+			<item id="93388" count="1" /> <!-- Spellbook: Death Guard -->
+		</skill>
+		<skill name="Soul Steal" id="45335" level="1" required-level="40" sp="80000" />
+		<skill name="Drain Magic Energy" id="45359" level="1" required-level="40" sp="80000">
+			<item id="93633" count="1" /> <!-- Spellbook: Drain Magic Energy -->
+		</skill>
+		<skill name="Death Points" id="45352" level="2" required-level="40" auto-learn="true" />
+		<skill name="Wipeout" id="45303" level="1" required-level="40" sp="80000" />
+		<skill name="Undying Body" id="45350" level="2" required-level="40" auto-learn="true" />
+		<skill name="Death Blind" id="45342" level="1" required-level="40" sp="80000" />
+		<skill name="Deadly Pull" id="45311" level="1" required-level="40" sp="80000" />
+		<skill name="Emergency Rescue" id="70" level="10" required-level="40" sp="80000" />
+
+		<skill name="Slowdown" id="15" level="19" required-level="41" sp="80000" />
+		<skill name="Emergency Rescue" id="70" level="11" required-level="41" sp="80000" />
+
+		<skill name="Slowdown" id="15" level="20" required-level="42" sp="80000" />
+		<skill name="Emergency Rescue" id="70" level="12" required-level="42" sp="80000" />
+
+		<skill name="Slowdown" id="15" level="21" required-level="43" sp="80000" />
+		<skill name="Emergency Rescue" id="70" level="13" required-level="43" sp="80000" />
+		<skill name="Entangle" id="102" level="3" required-level="43" sp="80000" />
+
+		<skill name="Slowdown" id="15" level="22" required-level="44" sp="120000" />
+		<skill name="Punishment" id="45301" level="5" required-level="44" sp="120000" />
+		<skill name="Emergency Rescue" id="70" level="14" required-level="44" sp="120000" />
+
+		<skill name="Slowdown" id="15" level="23" required-level="45" sp="120000" />
+		<skill name="Death Armor Mastery" id="45354" level="9" required-level="45" sp="120000" />
+		<skill name="Death Sword Mastery" id="45353" level="9" required-level="45" sp="120000" />
+		<skill name="Death Blind" id="45342" level="2" required-level="45" sp="120000" />
+		<skill name="Deadly Pull" id="45311" level="2" required-level="45" sp="120000" />
+		<skill name="Emergency Rescue" id="70" level="15" required-level="45" sp="120000" />
+
+		<skill name="Slowdown" id="15" level="24" required-level="46" sp="120000" />
+		<skill name="Emergency Rescue" id="70" level="16" required-level="46" sp="120000" />
+		<skill name="Entangle" id="102" level="4" required-level="46" sp="120000" />
+
+		<skill name="Slowdown" id="15" level="25" required-level="47" sp="120000" />
+		<skill name="Emergency Rescue" id="70" level="17" required-level="47" sp="120000" />
+
+		<skill name="Slowdown" id="15" level="26" required-level="48" sp="120000" />
+		<skill name="Emergency Rescue" id="70" level="18" required-level="48" sp="120000" />
+
+		<skill name="Slowdown" id="15" level="27" required-level="49" sp="200000" />
+		<skill name="Emergency Rescue" id="70" level="19" required-level="49" sp="200000" />
+		<skill name="Entangle" id="102" level="5" required-level="49" sp="200000" />
+
+		<skill name="Slowdown" id="15" level="28" required-level="50" sp="200000" />
+		<skill name="Sprint" id="230" level="2" required-level="50" sp="200000" />
+		<skill name="Dark Aura" id="45330" level="1" required-level="50" sp="200000" />
+		<skill name="Death Armor Mastery" id="45354" level="10" required-level="50" sp="200000" />
+		<skill name="Death Sword Mastery" id="45353" level="10" required-level="50" sp="200000" />
+		<skill name="Recover HP" id="45176" level="2" required-level="50" sp="300000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Recover MP" id="45177" level="2" required-level="50" sp="300000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Punishment" id="45301" level="6" required-level="50" sp="200000" />
+		<skill name="Fist of Fury" id="45307" level="1" required-level="50" sp="200000" />
+		<skill name="Wipeout" id="45303" level="2" required-level="50" sp="200000" />
+		<skill name="Roar of Death" id="45328" level="2" required-level="50" sp="200000" />
+		<skill name="Death Blind" id="45342" level="3" required-level="50" sp="200000" />
+		<skill name="Deadly Pull" id="45311" level="3" required-level="50" sp="200000" />
+		<skill name="Emergency Rescue" id="70" level="20" required-level="50" sp="200000" />
+
+		<skill name="Slowdown" id="15" level="29" required-level="51" sp="200000" />
+		<skill name="Emergency Rescue" id="70" level="21" required-level="51" sp="200000" />
+
+		<skill name="Slowdown" id="15" level="30" required-level="52" sp="200000" />
+		<skill name="Entangle" id="102" level="6" required-level="52" sp="200000" />
+		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="200000">
+			<item id="8618" count="1" /> <!-- Buff Expansion Book Lv. 1 -->
+		</skill>
+		<skill name="Death Armor Mastery" id="45354" level="11" required-level="52" sp="200000" />
+		<skill name="Death Sword Mastery" id="45353" level="11" required-level="52" sp="200000" />
+		<skill name="Emergency Rescue" id="70" level="22" required-level="52" sp="200000" />
+
+		<skill name="Slowdown" id="15" level="31" required-level="53" sp="400000" />
+		<skill name="Fist of Fury" id="45307" level="2" required-level="53" sp="400000" />
+		<skill name="Emergency Rescue" id="70" level="23" required-level="53" sp="400000" />
+
+		<skill name="Slowdown" id="15" level="32" required-level="54" sp="400000" />
+		<skill name="Death Armor Mastery" id="45354" level="12" required-level="54" sp="400000" />
+		<skill name="Death Sword Mastery" id="45353" level="12" required-level="54" sp="400000" />
+		<skill name="Punishment" id="45301" level="7" required-level="54" sp="400000" />
+		<skill name="Emergency Rescue" id="70" level="24" required-level="54" sp="400000" />
+
+		<skill name="Slowdown" id="15" level="33" required-level="55" sp="450000" />
+		<skill name="Entangle" id="102" level="7" required-level="55" sp="450000" />
+		<skill name="Bone Cage" id="45338" level="1" required-level="55" sp="450000">
+			<item id="93392" count="1" /> <!-- Spellbook: Bone Cage -->
+		</skill>
+		<skill name="Wipeout" id="45303" level="3" required-level="55" sp="450000" />
+		<skill name="Death Blind" id="45342" level="4" required-level="55" sp="450000" />
+		<skill name="Emergency Rescue" id="70" level="25" required-level="55" sp="450000" />
+
+		<skill name="Slowdown" id="15" level="34" required-level="56" sp="500000" />
+		<skill name="Death Armor Mastery" id="45354" level="13" required-level="56" sp="500000" />
+		<skill name="Death Sword Mastery" id="45353" level="13" required-level="56" sp="500000" />
+		<skill name="Fist of Fury" id="45307" level="3" required-level="56" sp="500000" />
+		<skill name="Emergency Rescue" id="70" level="26" required-level="56" sp="500000" />
+
+		<skill name="Slowdown" id="15" level="35" required-level="57" sp="550000" />
+		<skill name="Punishment" id="45301" level="8" required-level="57" sp="550000" />
+		<skill name="Emergency Rescue" id="70" level="27" required-level="57" sp="550000" />
+
+		<skill name="Slowdown" id="15" level="36" required-level="58" sp="600000" />
+		<skill name="Entangle" id="102" level="8" required-level="58" sp="600000" />
+		<skill name="Death Armor Mastery" id="45354" level="14" required-level="58" sp="600000" />
+		<skill name="Death Sword Mastery" id="45353" level="14" required-level="58" sp="600000" />
+		<skill name="Emergency Rescue" id="70" level="28" required-level="58" sp="600000" />
+
+		<skill name="Slowdown" id="15" level="37" required-level="59" sp="700000" />
+		<skill name="Fist of Fury" id="45307" level="4" required-level="59" sp="700000" />
+		<skill name="Emergency Rescue" id="70" level="29" required-level="59" sp="700000" />
+
+		<skill name="Slowdown" id="15" level="38" required-level="60" sp="800000" />
+		<skill name="Entangle" id="102" level="9" required-level="60" sp="800000" />
+		<skill name="Death Armor Mastery" id="45354" level="15" required-level="60" sp="800000" />
+		<skill name="Death Sword Mastery" id="45353" level="15" required-level="60" sp="800000" />
+		<skill name="Call of Flame" id="45322" level="1" required-level="60" sp="800000" />
+		<skill name="Punishment" id="45301" level="9" required-level="60" sp="800000" />
+		<skill name="Bone Cage" id="45338" level="2" required-level="60" sp="800000" />
+		<skill name="Soul Steal" id="45335" level="2" required-level="60" sp="800000" />
+		<skill name="Drain Magic Energy" id="45359" level="2" required-level="60" sp="800000">
+			<item id="93633" count="1" /> <!-- Spellbook: Drain Magic Energy -->
+		</skill>
+		<skill name="Wipeout" id="45303" level="4" required-level="60" sp="800000" />
+		<skill name="Undying Body" id="45350" level="3" required-level="60" auto-learn="true" />
+		<skill name="Death Blind" id="45342" level="5" required-level="60" sp="800000" />
+		<skill name="Deadly Pull" id="45311" level="4" required-level="60" sp="800000" />
+		<skill name="Ability to Attack" id="77" level="3" required-level="60" sp="800000" />
+		<skill name="Emergency Rescue" id="70" level="30" required-level="60" sp="800000" />
+		<skill name="Call of Frost" id="45324" level="1" required-level="60" sp="800000">
+			<item id="93390" count="1" /> <!-- Spellbook: Call of Frost -->
+		</skill>
+
+		<skill name="Slowdown" id="15" level="39" required-level="61" sp="900000" />
+		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="900000">
+			<item id="8619" count="1" /> <!-- Buff Expansion Book Lv. 2 -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="31" required-level="61" sp="900000" />
+
+		<skill name="Slowdown" id="15" level="40" required-level="62" sp="1000000" />
+		<skill name="Entangle" id="102" level="10" required-level="62" sp="1000000" />
+		<skill name="Death Armor Mastery" id="45354" level="16" required-level="62" sp="1000000" />
+		<skill name="Death Sword Mastery" id="45353" level="16" required-level="62" sp="1000000" />
+		<skill name="Fist of Fury" id="45307" level="5" required-level="62" sp="1000000" />
+		<skill name="Emergency Rescue" id="70" level="32" required-level="62" sp="1000000" />
+
+		<skill name="Slowdown" id="15" level="41" required-level="63" sp="1100000" />
+		<skill name="Punishment" id="45301" level="10" required-level="63" sp="1100000" />
+		<skill name="Emergency Rescue" id="70" level="33" required-level="63" sp="1100000" />
+
+		<skill name="Slowdown" id="15" level="42" required-level="64" sp="1200000" />
+		<skill name="Entangle" id="102" level="11" required-level="64" sp="1200000" />
+		<skill name="Death Armor Mastery" id="45354" level="17" required-level="64" sp="1200000" />
+		<skill name="Death Sword Mastery" id="45353" level="17" required-level="64" sp="1200000" />
+		<skill name="Emergency Rescue" id="70" level="34" required-level="64" sp="1200000" />
+
+		<skill name="Slowdown" id="15" level="43" required-level="65" sp="1300000" />
+		<skill name="Fist of Fury" id="45307" level="6" required-level="65" sp="1300000" />
+		<skill name="Wipeout" id="45303" level="5" required-level="65" sp="1300000" />
+		<skill name="Death Blind" id="45342" level="6" required-level="65" sp="1300000" />
+		<skill name="Deadly Pull" id="45311" level="5" required-level="65" sp="1300000" />
+		<skill name="Emergency Rescue" id="70" level="35" required-level="65" sp="1300000" />
+
+		<skill name="Slowdown" id="15" level="44" required-level="66" sp="1400000" />
+		<skill name="Entangle" id="102" level="12" required-level="66" sp="1400000" />
+		<skill name="Death Armor Mastery" id="45354" level="18" required-level="66" sp="1400000" />
+		<skill name="Death Sword Mastery" id="45353" level="18" required-level="66" sp="1400000" />
+		<skill name="Punishment" id="45301" level="11" required-level="66" sp="1400000" />
+		<skill name="Emergency Rescue" id="70" level="36" required-level="66" sp="1400000" />
+
+		<skill name="Slowdown" id="15" level="45" required-level="67" sp="1500000" />
+		<skill name="Emergency Rescue" id="70" level="37" required-level="67" sp="1500000" />
+
+		<skill name="Slowdown" id="15" level="46" required-level="68" sp="1600000" />
+		<skill name="Entangle" id="102" level="13" required-level="68" sp="1600000" />
+		<skill name="Death Armor Mastery" id="45354" level="19" required-level="68" sp="1600000" />
+		<skill name="Death Sword Mastery" id="45353" level="19" required-level="68" sp="1600000" />
+		<skill name="Fist of Fury" id="45307" level="7" required-level="68" sp="1600000" />
+		<skill name="Emergency Rescue" id="70" level="38" required-level="68" sp="1600000" />
+
+		<skill name="Slowdown" id="15" level="47" required-level="69" sp="1700000" />
+		<skill name="Punishment" id="45301" level="12" required-level="69" sp="1700000" />
+		<skill name="Emergency Rescue" id="70" level="39" required-level="69" sp="1700000" />
+
+		<skill name="Slowdown" id="15" level="48" required-level="70" sp="1800000" />
+		<skill name="Acceleration" id="45337" level="1" required-level="70" sp="1800000" />
+		<skill name="Death Armor Mastery" id="45354" level="20" required-level="70" sp="1800000" />
+		<skill name="Death Sword Mastery" id="45353" level="20" required-level="70" sp="1800000" />
+		<skill name="Bone Cage" id="45338" level="3" required-level="70" sp="1800000" />
+		<skill name="Soul Steal" id="45335" level="3" required-level="70" sp="1800000" />
+		<skill name="Drain Magic Energy" id="45359" level="3" required-level="70" sp="1800000">
+			<item id="93633" count="1" /> <!-- Spellbook: Drain Magic Energy -->
+		</skill>
+		<skill name="Flaming Body" id="45332" level="1" required-level="70" sp="1800000" />
+		<skill name="Wipeout" id="45303" level="6" required-level="70" sp="1800000" />
+		<skill name="Roar of Death" id="45328" level="3" required-level="70" sp="1800000" />
+		<skill name="Undying Body" id="45350" level="4" required-level="70" auto-learn="true" />
+		<skill name="Death Blind" id="45342" level="7" required-level="70" sp="1800000" />
+		<skill name="Deadly Pull" id="45311" level="6" required-level="70" sp="1800000" />
+		<skill name="Emergency Rescue" id="70" level="40" required-level="70" sp="1800000" />
+
+		<skill name="Slowdown" id="15" level="49" required-level="71" sp="1900000" />
+		<skill name="Fist of Fury" id="45307" level="8" required-level="71" sp="1900000" />
+		<skill name="Emergency Rescue" id="70" level="41" required-level="71" sp="1900000" />
+
+		<skill name="Slowdown" id="15" level="50" required-level="72" sp="2000000" />
+		<skill name="Entangle" id="102" level="15" required-level="72" sp="2000000" />
+		<skill name="Death Armor Mastery" id="45354" level="21" required-level="72" sp="2000000" />
+		<skill name="Death Sword Mastery" id="45353" level="21" required-level="72" sp="2000000" />
+		<skill name="Punishment" id="45301" level="13" required-level="72" sp="2000000" />
+		<skill name="Death Blind" id="45342" level="8" required-level="72" sp="2000000" />
+		<skill name="Emergency Rescue" id="70" level="42" required-level="72" sp="2000000" />
+
+		<skill name="Slowdown" id="15" level="51" required-level="73" sp="2100000" />
+		<skill name="Emergency Rescue" id="70" level="43" required-level="73" sp="2100000" />
+
+		<skill name="Slowdown" id="15" level="52" required-level="74" sp="2200000" />
+		<skill name="Entangle" id="102" level="16" required-level="74" sp="2200000" />
+		<skill name="Death Armor Mastery" id="45354" level="22" required-level="74" sp="2200000" />
+		<skill name="Death Sword Mastery" id="45353" level="22" required-level="74" sp="2200000" />
+		<skill name="Fist of Fury" id="45307" level="9" required-level="74" sp="2200000" />
+		<skill name="Death Blind" id="45342" level="9" required-level="74" sp="2200000" />
+		<skill name="Emergency Rescue" id="70" level="44" required-level="74" sp="2200000" />
+
+		<skill name="Punishment" id="45301" level="14" required-level="75" sp="2300000" />
+		<skill name="Bone Cage" id="45338" level="4" required-level="75" sp="2300000" />
+		<skill name="Flaming Body" id="45332" level="2" required-level="75" sp="2300000" />
+		<skill name="Wipeout" id="45303" level="7" required-level="75" sp="2300000" />
+		<skill name="Death Blind" id="45342" level="10" required-level="75" sp="2300000" />
+		<skill name="Deadly Pull" id="45311" level="7" required-level="75" sp="2300000" />
+		<skill name="Emergency Rescue" id="70" level="45" required-level="75" sp="2300000" />
+	</skillTree>
+</list>

--- a/data/skillTrees/2ndClass/ElvenElder.xml
+++ b/data/skillTrees/2ndClass/ElvenElder.xml
@@ -1,6 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="30" parentClassId="29">
+
+		<!-- Master Buffs Lv. 40 -->
+		<skill name="Might" id="1068" level="3" required-level="40" sp="80000" />
+		<skill name="Shield" id="1040" level="3" required-level="40" sp="80000" />
+		<skill name="Acumen" id="45104" level="3" required-level="40" sp="80000" />
+		<skill name="Empower" id="45105" level="3" required-level="40" sp="80000" />
+		<skill name="Wild Magic" id="45106" level="2" required-level="40" sp="80000" />
+		<skill name="Magic Barrier" id="45108" level="2" required-level="40" sp="80000" />
+		<skill name="Focus" id="45109" level="3" required-level="40" sp="80000" />
+		<skill name="Death Whisper" id="45110" level="3" required-level="40" sp="80000" />
+		<skill name="Haste" id="45111" level="2" required-level="40" sp="80000" />
+		<skill name="Berserker Spirit" id="45112" level="2" required-level="40" sp="80000" />
+		<skill name="Clarity" id="45113" level="3" required-level="40" sp="80000" />
+
 		<skill name="Pirate" id="1800" level="1" required-level="45" auto-learn="true" />
 		<skill name="Dark Assassin" id="1801" level="1" required-level="60" auto-learn="true" />
 		<skill name="White Assassin" id="1802" level="1" required-level="70" auto-learn="true" />
@@ -21,7 +35,6 @@
 		<skill name="Resurrection" id="1016" level="3" required-level="40" sp="83000" />
 		<skill name="Spell Master" id="1830" level="1" required-level="40" auto-learn="true" />
 		<skill name="Mental Shield" id="1035" level="2" required-level="40" sp="83000" />
-		<skill name="Might" id="1068" level="3" required-level="40" sp="83000" />
 		<skill name="Wind Shackle" id="1206" level="6" required-level="40" sp="83000" />
 		<skill name="Recharge" id="1013" level="5" required-level="40" sp="83000" />
 		<skill name="Recharge" id="1013" level="6" required-level="40" sp="83000" />
@@ -42,7 +55,7 @@
 		<skill name="Might of Heaven" id="1028" level="3" required-level="42" sp="120000" />
 		<skill name="Sleep" id="1069" level="13" required-level="42" sp="120000" />
 		<skill name="Advanced Block" id="1304" level="1" required-level="42" sp="120000">
-			<item id="5816"/>
+			<item id="5816" count="1"/>
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="17" required-level="43" sp="120000" />
@@ -106,7 +119,7 @@
 		<skill name="Boost Mana" id="213" level="4" required-level="48" sp="190000" />
 		<skill name="Sleep" id="1069" level="18" required-level="48" sp="190000" />
 		<skill name="Party Return" id="1255" level="1" required-level="48" sp="190000">
-			<item id="3942"/>
+			<item id="3942" count="1" />
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="22" required-level="50" sp="300000" />
@@ -148,7 +161,7 @@
 		<skill name="Stun Resistance" id="1259" level="2" required-level="52" sp="300000" />
 		<skill name="Sleep" id="1069" level="21" required-level="52" sp="300000" />
 		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="300000" >
-			<item id="8618"/> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
+			<item id="8618" count="1" /> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="25" required-level="54" sp="470000" />
@@ -248,7 +261,7 @@
 		<skill name="Recharge" id="1013" level="19" required-level="61" sp="700000" />
 		<skill name="Sleep" id="1069" level="29" required-level="61" sp="700000" />
 		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="700000" >
-			<item id="8619"/> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
+			<item id="8619" count="1" /> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
 		</skill>	
 		
 		<skill name="Anti Magic" id="146" level="33" required-level="62" sp="700000" />
@@ -264,7 +277,7 @@
 		<skill name="Might of Heaven" id="1028" level="13" required-level="62" sp="700000" />
 		<skill name="Sleep" id="1069" level="30" required-level="62" sp="700000" />
 		<skill name="Wild Magic" id="1303" level="1" required-level="62" sp="700000">
-			<item id="5815"/>
+			<item id="5815" count="1" />
 		</skill>
 			
 		<skill name="Anti Magic" id="146" level="34" required-level="63" sp="880000" />

--- a/data/skillTrees/2ndClass/Gladiator.xml
+++ b/data/skillTrees/2ndClass/Gladiator.xml
@@ -1,42 +1,69 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="2" parentClassId="1">
+		<!-- Master Buffs Lv. 40 -->
+		<skill name="Might" id="1068" level="3" required-level="40" sp="80000" />
+		<skill name="Shield" id="1040" level="3" required-level="40" sp="80000" />
+		<skill name="Acumen" id="45104" level="3" required-level="40" sp="80000" />
+		<skill name="Empower" id="45105" level="3" required-level="40" sp="80000" />
+		<skill name="Wild Magic" id="45106" level="2" required-level="40" sp="80000" />
+		<skill name="Magic Barrier" id="45108" level="2" required-level="40" sp="80000" />
+		<skill name="Focus" id="45109" level="3" required-level="40" sp="80000" />
+		<skill name="Death Whisper" id="45110" level="3" required-level="40" sp="80000" />
+		<skill name="Haste" id="45111" level="2" required-level="40" sp="80000" />
+		<skill name="Berserker Spirit" id="45112" level="2" required-level="40" sp="80000" />
+		<skill name="Clarity" id="45113" level="3" required-level="40" sp="80000" />
+
 		<skill name="Pirate" id="1800" level="1" required-level="45" auto-learn="true" />
 		<skill name="Dark Assassin" id="1801" level="1" required-level="60" auto-learn="true" />
 		<skill name="White Assassin" id="1802" level="1" required-level="70" auto-learn="true" />
-		<skill name="Vicious Stance" id="312" level="6" required-level="40" sp="55000" />
-		<skill name="Fast HP Recovery" id="212" level="3" required-level="40" sp="55000" />
-		<skill name="Sonic Mastery" id="992" level="1" required-level="40" sp="55000" />
-		<skill name="Light Armor Mastery" id="227" level="14" required-level="40" sp="55000" />
-		<skill name="Light Armor Mastery" id="227" level="15" required-level="40" sp="55000" />
-		<skill name="Light Armor Mastery" id="227" level="16" required-level="40" sp="55000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="9" required-level="40" sp="55000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="10" required-level="40" sp="55000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="11" required-level="40" sp="55000" />
-		<skill name="Dual Weapon Mastery" id="144" level="1" required-level="40" sp="55000" />
-		<skill name="Dual Weapon Mastery" id="144" level="2" required-level="40" sp="55000" />
-		<skill name="Dual Weapon Mastery" id="144" level="3" required-level="40" sp="55000" />
-		<skill name="Heavy Armor Mastery" id="231" level="14" required-level="40" sp="55000" />
-		<skill name="Heavy Armor Mastery" id="231" level="15" required-level="40" sp="55000" />
-		<skill name="Heavy Armor Mastery" id="231" level="16" required-level="40" sp="55000" />
+
+		<!-- Lv. 40 Skills -->
+		<skill name="Rising Attack" id="1" level="1" required-level="40" sp="55000" />
+		<skill name="Rising Attack" id="1" level="2" required-level="40" sp="55000" />
+		<skill name="Rising Attack" id="1" level="3" required-level="40" sp="55000" />
+		<skill name="Rising Attack" id="1" level="4" required-level="40" sp="55000" />
+		<skill name="Rising Attack" id="1" level="5" required-level="40" sp="55000" />
 		<skill name="Sonic Blaster" id="6" level="1" required-level="40" sp="55000" />
 		<skill name="Sonic Blaster" id="6" level="2" required-level="40" sp="55000" />
 		<skill name="Sonic Blaster" id="6" level="3" required-level="40" sp="55000" />
-		<skill name="Detect Animal Weakness" id="87" level="1" required-level="40" sp="55000" />
-		<skill name="Power Crush" id="260" level="1" required-level="40" sp="55000" />
-		<skill name="Power Crush" id="260" level="2" required-level="40" sp="55000" />
-		<skill name="Power Crush" id="260" level="3" required-level="40" sp="55000" />
-		<skill name="Triple Slash" id="1" level="1" required-level="40" sp="55000" />
-		<skill name="Triple Slash" id="1" level="2" required-level="40" sp="55000" />
-		<skill name="Triple Slash" id="1" level="3" required-level="40" sp="55000" />
+		<skill name="Sonic Focus" id="8" level="1" required-level="40" sp="55000" />
+		<skill name="Emergency Rescue" id="70" level="10" required-level="40" sp="55000" />
+		<skill name="Clear" id="88" level="1" required-level="40" sp="55000" />
+		<skill name="Insight" id="104" level="1" required-level="40" sp="55000" />
+		<skill name="Weapon Mastery" id="141" level="4" required-level="40" sp="55000" />
+		<skill name="Dual Weapon Mastery" id="144" level="1" required-level="40" sp="55000" />
+		<skill name="Dual Weapon Mastery" id="144" level="2" required-level="40" sp="55000" />
+		<skill name="Dual Weapon Mastery" id="144" level="3" required-level="40" sp="55000" />
 		<skill name="Fatal Strike" id="190" level="1" required-level="40" sp="55000" />
 		<skill name="Fatal Strike" id="190" level="2" required-level="40" sp="55000" />
 		<skill name="Fatal Strike" id="190" level="3" required-level="40" sp="55000" />
-		<skill name="Sonic Focus" id="8" level="1" required-level="40" sp="55000" />
+		<skill name="Fatal Strike" id="190" level="4" required-level="40" sp="55000" />
+		<skill name="Fatal Strike" id="190" level="5" required-level="40" sp="55000" />
+		<skill name="Fast HP Recovery" id="212" level="3" required-level="40" sp="55000" />
+		<skill name="Light Armor Mastery" id="227" level="14" required-level="40" sp="55000" />
+		<skill name="Light Armor Mastery" id="227" level="15" required-level="40" sp="55000" />
+		<skill name="Light Armor Mastery" id="227" level="16" required-level="40" sp="55000" />
+		<skill name="Heavy Armor Mastery" id="231" level="14" required-level="40" sp="55000" />
+		<skill name="Heavy Armor Mastery" id="231" level="15" required-level="40" sp="55000" />
+		<skill name="Heavy Armor Mastery" id="231" level="16" required-level="40" sp="55000" />
+		<skill name="Accuracy" id="256" level="2" required-level="40" sp="55000" />
+		<skill name="Sword/Blunt Weapon Mastery" id="257" level="9" required-level="40" sp="55000" />
+		<skill name="Sword/Blunt Weapon Mastery" id="257" level="10" required-level="40" sp="55000" />
+		<skill name="Sword/Blunt Weapon Mastery" id="257" level="11" required-level="40" sp="55000" />
+		<skill name="Power Crush" id="260" level="1" required-level="40" sp="55000" />
+		<skill name="Power Crush" id="260" level="2" required-level="40" sp="55000" />
+		<skill name="Power Crush" id="260" level="3" required-level="40" sp="55000" />
+		<skill name="Vicious Stance" id="312" level="6" required-level="40" sp="55000" />
+		<skill name="Sonic Mastery" id="992" level="1" required-level="40" sp="55000" />
+		<skill name="Rush" id="994" level="1" required-level="40" sp="82000" />
 		<skill name="Potion Mastery" id="45184" level="1" required-level="40">
 			<item id="57" count="1000000"/> <!-- Adena -->
 		</skill>
-		
+
+
+		<!-- Class Note: Tripple Slash is actually Rising Attack -->
+		<!-- Lv. 41 Skills -->
 		<skill name="Light Armor Mastery" id="227" level="17" required-level="41" sp="65000" />
 		<skill name="Sword/Blunt Weapon Mastery" id="257" level="12" required-level="41" sp="65000" />
 		<skill name="Dual Weapon Mastery" id="144" level="4" required-level="41" sp="65000" />
@@ -47,7 +74,7 @@
 		<skill name="Triple Slash" id="1" level="4" required-level="41" sp="65000" />
 		<skill name="Fatal Strike" id="190" level="4" required-level="41" sp="65000" />
 		<skill name="Dual Weapon Defense" id="1605 " level="1" required-level="41" sp="65000">
-			<item id="49423"/>
+			<item id="49423" count="1" />
 		</skill>
 	
 		<skill name="Light Armor Mastery" id="227" level="18" required-level="42" sp="65000" />
@@ -196,7 +223,7 @@
 		<skill name="Triple Slash" id="1" level="15" required-level="52" sp="190000" />
 		<skill name="Fatal Strike" id="190" level="15" required-level="52" sp="190000" />
 		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="190000" >
-			<item id="8618"/> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
+			<item id="8618" count="1" /> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
 		</skill>
 		
 		<skill name="Light Armor Mastery" id="227" level="29" required-level="53" sp="270000" />
@@ -256,7 +283,7 @@
 		<skill name="Triple Slash" id="1" level="19" required-level="56" sp="370000" />
 		<skill name="Fatal Strike" id="190" level="19" required-level="56" sp="370000" />
 		<skill name="Sonic Move" id="451" level="1" required-level="56" sp="370000">
-			<item id="49568"/>
+			<item id="49568" count="1" />
 		</skill>
 		
 		<skill name="Light Armor Mastery" id="227" level="33" required-level="57" sp="370000" />
@@ -335,7 +362,7 @@
 		<skill name="Triple Slash" id="1" level="24" required-level="61" sp="540000" />
 		<skill name="Fatal Strike" id="190" level="24" required-level="61" sp="540000" />
 		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="540000" >
-			<item id="8619"/> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
+			<item id="8619" count="1" /> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
 		</skill>
 		
 		<skill name="Vicious Stance" id="312" level="14" required-level="62" sp="670000" />

--- a/data/skillTrees/2ndClass/Hawkeye.xml
+++ b/data/skillTrees/2ndClass/Hawkeye.xml
@@ -1,6 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="9" parentClassId="7">
+
+		<!-- Master Buffs Lv. 40 -->
+		<skill name="Might" id="1068" level="3" required-level="40" sp="80000" />
+		<skill name="Shield" id="1040" level="3" required-level="40" sp="80000" />
+		<skill name="Acumen" id="45104" level="3" required-level="40" sp="80000" />
+		<skill name="Empower" id="45105" level="3" required-level="40" sp="80000" />
+		<skill name="Wild Magic" id="45106" level="2" required-level="40" sp="80000" />
+		<skill name="Magic Barrier" id="45108" level="2" required-level="40" sp="80000" />
+		<skill name="Focus" id="45109" level="3" required-level="40" sp="80000" />
+		<skill name="Death Whisper" id="45110" level="3" required-level="40" sp="80000" />
+		<skill name="Haste" id="45111" level="2" required-level="40" sp="80000" />
+		<skill name="Berserker Spirit" id="45112" level="2" required-level="40" sp="80000" />
+		<skill name="Clarity" id="45113" level="3" required-level="40" sp="80000" />
+		
 		<skill name="Pirate" id="1800" level="1" required-level="45" auto-learn="true" />
 		<skill name="Dark Assassin" id="1801" level="1" required-level="60" auto-learn="true" />
 		<skill name="White Assassin" id="1802" level="1" required-level="70" auto-learn="true" />
@@ -103,7 +117,7 @@
 		<skill name="Vital Force" id="148" level="5" required-level="52" sp="390000" />
 		<skill name="Stun Shot" id="101" level="18" required-level="52" sp="390000" />
 		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="390000" >
-			<item id="8618"/> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
+			<item id="8618" count="1" /> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
 		</skill>
 		
 		<skill name="Burst Shot" id="24" level="10" required-level="53" sp="540000" />
@@ -171,7 +185,7 @@
 		<skill name="Double Shot" id="19" level="24" required-level="61" sp="1100000" />
 		<skill name="Stun Shot" id="101" level="27" required-level="61" sp="1100000" />
 		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="1100000" >
-			<item id="8619"/> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
+			<item id="8619" count="1" /> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
 		</skill>
 		
 		<skill name="Vicious Stance" id="312" level="14" required-level="62" sp="1400000" />

--- a/data/skillTrees/2ndClass/HumanUndertaker.xml
+++ b/data/skillTrees/2ndClass/HumanUndertaker.xml
@@ -1,0 +1,210 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
+	<skillTree type="classSkillTree" classId="198" parentClassId="197">
+
+		<!-- Master Buffs Lv. 40 -->
+		<skill name="Might" id="1068" level="3" required-level="40" sp="80000" />
+		<skill name="Shield" id="1040" level="3" required-level="40" sp="80000" />
+		<skill name="Acumen" id="45104" level="3" required-level="40" sp="80000" />
+		<skill name="Empower" id="45105" level="3" required-level="40" sp="80000" />
+		<skill name="Wild Magic" id="45106" level="2" required-level="40" sp="80000" />
+		<skill name="Magic Barrier" id="45108" level="2" required-level="40" sp="80000" />
+		<skill name="Focus" id="45109" level="3" required-level="40" sp="80000" />
+		<skill name="Death Whisper" id="45110" level="3" required-level="40" sp="80000" />
+		<skill name="Haste" id="45111" level="2" required-level="40" sp="80000" />
+		<skill name="Berserker Spirit" id="45112" level="2" required-level="40" sp="80000" />
+		<skill name="Clarity" id="45113" level="3" required-level="40" sp="80000" />
+
+		<skill name="Death Armor Mastery" id="45354" level="8" required-level="40" sp="80000" />
+		<skill name="Death Sword Mastery" id="45353" level="8" required-level="40" sp="80000" />
+		<skill name="Death Guard" id="45329" level="1" required-level="40" sp="80000">
+			<item id="93388" count="1" /> <!-- Spellbook: Death Guard -->
+		</skill>
+		<skill name="Soul Steal" id="45335" level="1" required-level="40" sp="80000" />
+		<skill name="Drain Magic Energy" id="45359" level="1" required-level="40" sp="80000">
+			<item id="93633" count="1" /> <!-- Spellbook: Drain Magic Energy -->
+		</skill>
+		<skill name="Death Points" id="45352" level="2" required-level="40" auto-learn="true" />
+		<skill name="Wipeout" id="45303" level="1" required-level="40" sp="80000" />
+		<skill name="Undying Body" id="45350" level="2" required-level="40" auto-learn="true" />
+		<skill name="Death Blind" id="45342" level="1" required-level="40" sp="80000" />
+		<skill name="Deadly Pull" id="45311" level="1" required-level="40" sp="80000" />
+		<skill name="Emergency Rescue" id="70" level="10" required-level="40" sp="80000" />
+
+		<skill name="Emergency Rescue" id="70" level="11" required-level="41" sp="80000" />
+
+		<skill name="Emergency Rescue" id="70" level="12" required-level="42" sp="80000" />
+
+		<skill name="Emergency Rescue" id="70" level="13" required-level="43" sp="80000" />
+
+		<skill name="Punishment" id="45301" level="5" required-level="44" sp="120000" />
+		<skill name="Emergency Rescue" id="70" level="14" required-level="44" sp="120000" />
+
+		<skill name="Death Armor Mastery" id="45354" level="9" required-level="45" sp="120000" />
+		<skill name="Death Sword Mastery" id="45353" level="9" required-level="45" sp="120000" />
+		<skill name="Death Blind" id="45342" level="2" required-level="45" sp="120000" />
+		<skill name="Deadly Pull" id="45311" level="2" required-level="45" sp="120000" />
+		<skill name="Emergency Rescue" id="70" level="15" required-level="45" sp="120000" />
+
+		<skill name="Emergency Rescue" id="70" level="16" required-level="46" sp="120000" />
+
+		<skill name="Emergency Rescue" id="70" level="17" required-level="47" sp="120000" />
+
+		<skill name="Emergency Rescue" id="70" level="18" required-level="48" sp="120000" />
+
+		<skill name="Emergency Rescue" id="70" level="19" required-level="49" sp="200000" />
+
+		<skill name="Dark Aura" id="45330" level="1" required-level="50" sp="200000" />
+		<skill name="Death Armor Mastery" id="45354" level="10" required-level="50" sp="200000" />
+		<skill name="Death Sword Mastery" id="45353" level="10" required-level="50" sp="200000" />
+		<skill name="Recover HP" id="45176" level="2" required-level="50" sp="300000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Recover MP" id="45177" level="2" required-level="50" sp="300000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Punishment" id="45301" level="6" required-level="50" sp="200000" />
+		<skill name="Fist of Fury" id="45305" level="1" required-level="50" sp="200000" />
+		<skill name="Wipeout" id="45303" level="2" required-level="50" sp="200000" />
+		<skill name="Roar of Death" id="45328" level="2" required-level="50" sp="200000" />
+		<skill name="Death Blind" id="45342" level="3" required-level="50" sp="200000" />
+		<skill name="Deadly Pull" id="45311" level="3" required-level="50" sp="200000" />
+		<skill name="Emergency Rescue" id="70" level="20" required-level="50" sp="200000" />
+
+		<skill name="Emergency Rescue" id="70" level="21" required-level="51" sp="200000" />
+
+		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="200000">
+			<item id="8618" count="1" /> <!-- Buff Expansion Book Lv. 1 -->
+		</skill>
+		<skill name="Death Armor Mastery" id="45354" level="11" required-level="52" sp="200000" />
+		<skill name="Death Sword Mastery" id="45353" level="11" required-level="52" sp="200000" />
+		<skill name="Emergency Rescue" id="70" level="22" required-level="52" sp="200000" />
+
+		<skill name="Fist of Fury" id="45305" level="2" required-level="53" sp="400000" />
+		<skill name="Emergency Rescue" id="70" level="23" required-level="53" sp="400000" />
+
+		<skill name="Death Armor Mastery" id="45354" level="12" required-level="54" sp="400000" />
+		<skill name="Death Sword Mastery" id="45353" level="12" required-level="54" sp="400000" />
+		<skill name="Punishment" id="45301" level="7" required-level="54" sp="400000" />
+		<skill name="Emergency Rescue" id="70" level="24" required-level="54" sp="400000" />
+
+		<skill name="Bone Cage" id="45338" level="1" required-level="55" sp="450000">
+			<item id="93392" count="1" /> <!-- Spellbook: Bone Cage -->
+		</skill>
+		<skill name="Wipeout" id="45303" level="3" required-level="55" sp="450000" />
+		<skill name="Death Blind" id="45342" level="4" required-level="55" sp="450000" />
+		<skill name="Emergency Rescue" id="70" level="25" required-level="55" sp="450000" />
+
+		<skill name="Death Armor Mastery" id="45354" level="13" required-level="56" sp="500000" />
+		<skill name="Death Sword Mastery" id="45353" level="13" required-level="56" sp="500000" />
+		<skill name="Fist of Fury" id="45305" level="3" required-level="56" sp="500000" />
+		<skill name="Emergency Rescue" id="70" level="26" required-level="56" sp="500000" />
+
+		<skill name="Punishment" id="45301" level="8" required-level="57" sp="550000" />
+		<skill name="Emergency Rescue" id="70" level="27" required-level="57" sp="550000" />
+
+		<skill name="Death Armor Mastery" id="45354" level="14" required-level="58" sp="600000" />
+		<skill name="Death Sword Mastery" id="45353" level="14" required-level="58" sp="600000" />
+		<skill name="Emergency Rescue" id="70" level="28" required-level="58" sp="600000" />
+
+		<skill name="Fist of Fury" id="45305" level="4" required-level="59" sp="700000" />
+		<skill name="Emergency Rescue" id="70" level="29" required-level="59" sp="700000" />
+
+		<skill name="Death Armor Mastery" id="45354" level="15" required-level="60" sp="800000" />
+		<skill name="Death Sword Mastery" id="45353" level="15" required-level="60" sp="800000" />
+		<skill name="Call of Flame" id="45322" level="1" required-level="60" sp="800000">
+			<item id="93389" count="1" /> <!-- Spellbook: Call of Flame -->
+		</skill>
+		<skill name="Punishment" id="45301" level="9" required-level="60" sp="800000" />
+		<skill name="Bone Cage" id="45338" level="2" required-level="60" sp="800000" />
+		<skill name="Soul Steal" id="45335" level="2" required-level="60" sp="800000" />
+		<skill name="Drain Magic Energy" id="45359" level="2" required-level="60" sp="800000">
+			<item id="93633" count="1" /> <!-- Spellbook: Drain Magic Energy -->
+		</skill>
+		<skill name="Wipeout" id="45303" level="4" required-level="60" sp="800000" />
+		<skill name="Undying Body" id="45350" level="3" required-level="60" auto-learn="true" />
+		<skill name="Death Blind" id="45342" level="5" required-level="60" sp="800000" />
+		<skill name="Deadly Pull" id="45311" level="4" required-level="60" sp="800000" />
+		<skill name="Ability to Attack" id="77" level="3" required-level="60" sp="800000" />
+		<skill name="Emergency Rescue" id="70" level="30" required-level="60" sp="800000" />
+
+		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="900000">
+			<item id="8619" count="1" /> <!-- Buff Expansion Book Lv. 2 -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="31" required-level="61" sp="900000" />
+
+		<skill name="Death Armor Mastery" id="45354" level="16" required-level="62" sp="1000000" />
+		<skill name="Death Sword Mastery" id="45353" level="16" required-level="62" sp="1000000" />
+		<skill name="Fist of Fury" id="45305" level="5" required-level="62" sp="1000000" />
+		<skill name="Emergency Rescue" id="70" level="32" required-level="62" sp="1000000" />
+
+		<skill name="Punishment" id="45301" level="10" required-level="63" sp="1100000" />
+		<skill name="Emergency Rescue" id="70" level="33" required-level="63" sp="1100000" />
+
+		<skill name="Death Armor Mastery" id="45354" level="17" required-level="64" sp="1200000" />
+		<skill name="Death Sword Mastery" id="45353" level="17" required-level="64" sp="1200000" />
+		<skill name="Emergency Rescue" id="70" level="34" required-level="64" sp="1200000" />
+
+		<skill name="Fist of Fury" id="45305" level="6" required-level="65" sp="1300000" />
+		<skill name="Wipeout" id="45303" level="5" required-level="65" sp="1300000" />
+		<skill name="Death Blind" id="45342" level="6" required-level="65" sp="1300000" />
+		<skill name="Deadly Pull" id="45311" level="5" required-level="65" sp="1300000" />
+		<skill name="Emergency Rescue" id="70" level="35" required-level="65" sp="1300000" />
+
+		<skill name="Death Armor Mastery" id="45354" level="18" required-level="66" sp="1400000" />
+		<skill name="Death Sword Mastery" id="45353" level="18" required-level="66" sp="1400000" />
+		<skill name="Punishment" id="45301" level="11" required-level="66" sp="1400000" />
+		<skill name="Emergency Rescue" id="70" level="36" required-level="66" sp="1400000" />
+
+		<skill name="Emergency Rescue" id="70" level="37" required-level="67" sp="1500000" />
+
+		<skill name="Death Armor Mastery" id="45354" level="19" required-level="68" sp="1600000" />
+		<skill name="Death Sword Mastery" id="45353" level="19" required-level="68" sp="1600000" />
+		<skill name="Fist of Fury" id="45305" level="7" required-level="68" sp="1600000" />
+		<skill name="Emergency Rescue" id="70" level="38" required-level="68" sp="1600000" />
+
+		<skill name="Punishment" id="45301" level="12" required-level="69" sp="1700000" />
+		<skill name="Emergency Rescue" id="70" level="39" required-level="69" sp="1700000" />
+
+		<skill name="Acceleration" id="45337" level="1" required-level="70" sp="1800000" />
+		<skill name="Death Armor Mastery" id="45354" level="20" required-level="70" sp="1800000" />
+		<skill name="Death Sword Mastery" id="45353" level="20" required-level="70" sp="1800000" />
+		<skill name="Bone Cage" id="45338" level="3" required-level="70" sp="1800000" />
+		<skill name="Soul Steal" id="45335" level="3" required-level="70" sp="1800000" />
+		<skill name="Drain Magic Energy" id="45359" level="3" required-level="70" sp="1800000">
+			<item id="93633" count="1" /> <!-- Spellbook: Drain Magic Energy -->
+		</skill>
+		<skill name="Flaming Body" id="45332" level="1" required-level="70" sp="1800000" />
+		<skill name="Wipeout" id="45303" level="6" required-level="70" sp="1800000" />
+		<skill name="Roar of Death" id="45328" level="3" required-level="70" sp="1800000" />
+		<skill name="Undying Body" id="45350" level="4" required-level="70" auto-learn="true" />
+		<skill name="Death Blind" id="45342" level="7" required-level="70" sp="1800000" />
+		<skill name="Deadly Pull" id="45311" level="6" required-level="70" sp="1800000" />
+		<skill name="Emergency Rescue" id="70" level="40" required-level="70" sp="1800000" />
+
+		<skill name="Fist of Fury" id="45305" level="8" required-level="71" sp="1900000" />
+		<skill name="Emergency Rescue" id="70" level="41" required-level="71" sp="1900000" />
+
+		<skill name="Death Armor Mastery" id="45354" level="21" required-level="72" sp="2000000" />
+		<skill name="Death Sword Mastery" id="45353" level="21" required-level="72" sp="2000000" />
+		<skill name="Punishment" id="45301" level="13" required-level="72" sp="2000000" />
+		<skill name="Death Blind" id="45342" level="8" required-level="72" sp="2000000" />
+		<skill name="Emergency Rescue" id="70" level="42" required-level="72" sp="2000000" />
+
+		<skill name="Emergency Rescue" id="70" level="43" required-level="73" sp="2100000" />
+
+		<skill name="Death Armor Mastery" id="45354" level="22" required-level="74" sp="2200000" />
+		<skill name="Death Sword Mastery" id="45353" level="22" required-level="74" sp="2200000" />
+		<skill name="Fist of Fury" id="45305" level="9" required-level="74" sp="2200000" />
+		<skill name="Death Blind" id="45342" level="9" required-level="74" sp="2200000" />
+		<skill name="Emergency Rescue" id="70" level="44" required-level="74" sp="2200000" />
+
+		<skill name="Punishment" id="45301" level="14" required-level="75" sp="2300000" />
+		<skill name="Bone Cage" id="45338" level="4" required-level="75" sp="2300000" />
+		<skill name="Flaming Body" id="45332" level="2" required-level="75" sp="2300000" />
+		<skill name="Wipeout" id="45303" level="7" required-level="75" sp="2300000" />
+		<skill name="Death Blind" id="45342" level="10" required-level="75" sp="2300000" />
+		<skill name="Deadly Pull" id="45311" level="7" required-level="75" sp="2300000" />
+		<skill name="Emergency Rescue" id="70" level="45" required-level="75" sp="2300000" />
+	</skillTree>
+</list>

--- a/data/skillTrees/2ndClass/Necromancer.xml
+++ b/data/skillTrees/2ndClass/Necromancer.xml
@@ -1,6 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="13" parentClassId="11">
+
+		<!-- Master Buffs Lv. 40 -->
+		<skill name="Might" id="1068" level="3" required-level="40" sp="80000" />
+		<skill name="Shield" id="1040" level="3" required-level="40" sp="80000" />
+		<skill name="Acumen" id="45104" level="3" required-level="40" sp="80000" />
+		<skill name="Empower" id="45105" level="3" required-level="40" sp="80000" />
+		<skill name="Wild Magic" id="45106" level="2" required-level="40" sp="80000" />
+		<skill name="Magic Barrier" id="45108" level="2" required-level="40" sp="80000" />
+		<skill name="Focus" id="45109" level="3" required-level="40" sp="80000" />
+		<skill name="Death Whisper" id="45110" level="3" required-level="40" sp="80000" />
+		<skill name="Haste" id="45111" level="2" required-level="40" sp="80000" />
+		<skill name="Berserker Spirit" id="45112" level="2" required-level="40" sp="80000" />
+		<skill name="Clarity" id="45113" level="3" required-level="40" sp="80000" />
+
 		<skill name="Pirate" id="1800" level="1" required-level="45" auto-learn="true" />
 		<skill name="Dark Assassin" id="1801" level="1" required-level="60" auto-learn="true" />
 		<skill name="White Assassin" id="1802" level="1" required-level="70" auto-learn="true" />
@@ -33,10 +47,10 @@
 		<skill name="Sleep" id="1069" level="11" required-level="40" sp="55000" />
 		<skill name="Sleep" id="1069" level="12" required-level="40" sp="55000" />
 		<skill name="Anchor" id="1170" level="1" required-level="40" sp="55000">
-			<item id="3063"/>
+			<item id="3063" count="1" />
 		</skill>
 		<skill name="Silence" id="1064" level="1" required-level="40" sp="55000">
-			<item id="3064"/>
+			<item id="3064" count="1" />
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="16" required-level="42" sp="77000" />
@@ -116,7 +130,7 @@
 		<skill name="Higher Mana Gain" id="285" level="15" required-level="50" sp="200000" />
 		<skill name="Sleep" id="1069" level="19" required-level="50" sp="200000" />
 		<skill name="Curse Death Link" id="1159" level="1" required-level="50" sp="200000">
-			<item id="3066"/>
+			<item id="3066" count="1" />
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="23" required-level="51" sp="200000" />
@@ -148,7 +162,7 @@
 		<skill name="Death Spike" id="1148" level="3" required-level="52" sp="200000" />
 		<skill name="Anchor" id="1170" level="3" required-level="52" sp="200000" />
 		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="200000" >
-			<item id="8618"/> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
+			<item id="8618" count="1" /> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="25" required-level="54" sp="310000" />
@@ -219,7 +233,7 @@
 		<skill name="Death Spike" id="1148" level="5" required-level="58" sp="320000" />
 		<skill name="Anchor" id="1170" level="5" required-level="58" sp="320000" />
 		<skill name="Mass Curse Gloom" id="1382" level="1" required-level="58" sp="320000">
-			<item id="49570"/>
+			<item id="49570" count="1" />
 		</skill>		
 		
 		<skill name="Anti Magic" id="146" level="30" required-level="59" sp="380000" />
@@ -260,10 +274,10 @@
 		<skill name="Curse Death Link" id="1159" level="9" required-level="61" sp="460000" />
 		<skill name="Sleep" id="1069" level="29" required-level="61" sp="460000" />
 		<skill name="Mass Slow" id="1298" level="1" required-level="61" sp="460000">
-			<item id="5811"/>
+			<item id="5811" count="1" />
 		</skill>
 		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="460000" >
-			<item id="8619"/> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
+			<item id="8619" count="1" /> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="33" required-level="62" sp="460000" />

--- a/data/skillTrees/2ndClass/Overlord.xml
+++ b/data/skillTrees/2ndClass/Overlord.xml
@@ -1,6 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="51" parentClassId="50">
+
+		<!-- Master Buffs Lv. 40 -->
+		<skill name="Chant of Shield" id="45127" level="3" required-level="40" sp="80000" />
+		<skill name="Chant of Might" id="45126" level="3" required-level="40" sp="80000" />
+		<skill name="Chant of Acumen" id="45135" level="3" required-level="40" sp="80000" />
+		<skill name="Chant of Empower" id="45136" level="3" required-level="40" sp="80000" />
+		<skill name="Chant of Wild Magic" id="45137" level="2" required-level="40" sp="80000" />
+		<skill name="Chant of Magic Barrier" id="45125" level="2" required-level="40" sp="80000" />
+		<skill name="Chant of Focus" id="45121" level="3" required-level="40" sp="80000" />
+		<skill name="Chant of Death Whisper" id="45122" level="3" required-level="40" sp="80000" />
+		<skill name="Chant of Haste" id="45123" level="2" required-level="40" sp="80000" />
+		<skill name="Chant of Berserker Spirit" id="45128" level="2" required-level="40" sp="80000" />
+		<skill name="Chant of Clarity" id="45129" level="3" required-level="40" sp="80000" />
+
 		<skill name="Pirate" id="1800" level="1" required-level="45" auto-learn="true" />
 		<skill name="Dark Assassin" id="1801" level="1" required-level="60" auto-learn="true" />
 		<skill name="White Assassin" id="1802" level="1" required-level="70" auto-learn="true" />
@@ -86,7 +100,7 @@
 		<skill name="Madness" id="1105" level="6" required-level="44" sp="77000" />
 		<skill name="Boost HP" id="211" level="2" required-level="44" sp="77000" />
 		<skill name="Pa'agrio's Rage" id="1261" level="1" required-level="44" sp="77000">
-			<item id="4205"/>
+			<item id="4205" count="1" />
 		</skill>
 		
 		<skill name="Power Crush" id="260" level="8" required-level="45" sp="77000" />
@@ -135,13 +149,13 @@
 		<skill name="Boost HP" id="211" level="3" required-level="48" sp="120000" />
 		<skill name="Boost Mana" id="213" level="4" required-level="48" sp="120000" />
 		<skill name="Ritual of Life" id="1306" level="1" required-level="48" sp="120000">
-			<item id="6351"/>
+			<item id="6351" count="1" />
 		</skill>
 		<skill name="Seal of Silence" id="1246" level="1" required-level="48" sp="120000">
-			<item id="3109"/>
+			<item id="3109" count="1" />
 		</skill>
 		<skill name="Seal of Suspension" id="1248" level="1" required-level="48" sp="120000">
-			<item id="3111"/>
+			<item id="3111" count="1" />
 		</skill>
 		
 		<skill name="Power Crush" id="260" level="12" required-level="49" sp="120000" />
@@ -191,7 +205,7 @@
 		<skill name="Madness" id="1105" level="8" required-level="52" sp="200000" />
 		<skill name="Boost HP" id="211" level="4" required-level="52" sp="200000" />
 		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="200000" >
-			<item id="8618"/> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
+			<item id="8618" count="1" /> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
 		</skill>
 		
 		<skill name="Power Crush" id="260" level="16" required-level="53" sp="200000" />
@@ -244,7 +258,7 @@
 		<skill name="Boost HP" id="211" level="5" required-level="56" sp="310000" />
 		<skill name="Boost Mana" id="213" level="5" required-level="56" sp="310000" />
 		<skill name="Pa'agrio's Honor" id="1305" level="1" required-level="56" sp="310000">
-			<item id="6350"/>
+			<item id="6350" count="1" />
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="28" required-level="57" sp="320000" />
@@ -320,7 +334,7 @@
 		<skill name="Heavy Armor Mastery" id="253" level="30" required-level="61" sp="460000" />
 		<skill name="Power Crush" id="260" level="24" required-level="61" sp="460000" />
 		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="460000" >
-			<item id="8619"/> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
+			<item id="8619" count="1" /> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="33" required-level="62" sp="460000" />

--- a/data/skillTrees/2ndClass/Paladin.xml
+++ b/data/skillTrees/2ndClass/Paladin.xml
@@ -1,6 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="5" parentClassId="4">
+
+		<!-- Master Buffs Lv. 40 -->
+		<skill name="Might" id="1068" level="3" required-level="40" sp="80000" />
+		<skill name="Shield" id="1040" level="3" required-level="40" sp="80000" />
+		<skill name="Acumen" id="45104" level="3" required-level="40" sp="80000" />
+		<skill name="Empower" id="45105" level="3" required-level="40" sp="80000" />
+		<skill name="Wild Magic" id="45106" level="2" required-level="40" sp="80000" />
+		<skill name="Magic Barrier" id="45108" level="2" required-level="40" sp="80000" />
+		<skill name="Focus" id="45109" level="3" required-level="40" sp="80000" />
+		<skill name="Death Whisper" id="45110" level="3" required-level="40" sp="80000" />
+		<skill name="Haste" id="45111" level="2" required-level="40" sp="80000" />
+		<skill name="Berserker Spirit" id="45112" level="2" required-level="40" sp="80000" />
+		<skill name="Clarity" id="45113" level="3" required-level="40" sp="80000" />
+
 		<skill name="Pirate" id="1800" level="1" required-level="45" auto-learn="true" />
 		<skill name="Dark Assassin" id="1801" level="1" required-level="60" auto-learn="true" />
 		<skill name="White Assassin" id="1802" level="1" required-level="70" auto-learn="true" />
@@ -62,7 +76,7 @@
 		<skill name="Holy Blade" id="196" level="1" required-level="43" sp="73000" />
 		<skill name="Focus Mind" id="191" level="2" required-level="43" sp="73000" />
 		<skill name="Iron Will" id="72" level="1" required-level="43" sp="73000">
-			<item id="3047"/>
+			<item id="3047" count="1" />
 		</skill>
 		
 		<skill name="Aggression" id="28" level="19" required-level="44" sp="110000" />
@@ -134,7 +148,7 @@
 		<skill name="Divine Blessing" id="262" level="13" required-level="50" sp="220000" />
 		<skill name="Holy Strike" id="49" level="5" required-level="50" sp="220000" />
 		<skill name="Sacrifice" id="69" level="1" required-level="50" sp="220000">
-			<item id="3046"/>
+			<item id="3046" count="1" />
 		</skill>
 		
 		<skill name="Aggression" id="28" level="26" required-level="51" sp="220000" />
@@ -160,7 +174,7 @@
 		<skill name="Divine Blessing" id="262" level="15" required-level="52" sp="220000" />
 		<skill name="Holy Strike" id="49" level="6" required-level="52" sp="220000" />
 		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="220000" >
-			<item id="8618"/> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
+			<item id="8618" count="1" /> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
 		</skill>
 		
 		<skill name="Aggression" id="28" level="28" required-level="53" sp="300000" />
@@ -255,7 +269,7 @@
 		<skill name="Divine Blessing" id="262" level="23" required-level="60" sp="610000" />
 		<skill name="Holy Strike" id="49" level="12" required-level="60" sp="610000" />
 		<skill name="Shield Deflect Magic" id="916" level="1" required-level="60" sp="610000">
-			<item id="49427"/>
+			<item id="49427" count="1" />
 		</skill>
 		
 		<skill name="Aggression" id="28" level="36" required-level="61" sp="610000" />
@@ -268,7 +282,7 @@
 		<skill name="Divine Blessing" id="262" level="24" required-level="61" sp="610000" />
 		<skill name="Holy Strike" id="49" level="13" required-level="61" sp="610000" />
 		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="610000" >
-			<item id="8619"/> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
+			<item id="8619" count="1" /> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
 		</skill>
 		
 		<skill name="Aggression" id="28" level="37" required-level="62" sp="750000" />

--- a/data/skillTrees/2ndClass/PhantomRanger.xml
+++ b/data/skillTrees/2ndClass/PhantomRanger.xml
@@ -1,6 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="37" parentClassId="35">
+
+		<!-- Master Buffs Lv. 40 -->
+		<skill name="Might" id="1068" level="3" required-level="40" sp="80000" />
+		<skill name="Shield" id="1040" level="3" required-level="40" sp="80000" />
+		<skill name="Acumen" id="45104" level="3" required-level="40" sp="80000" />
+		<skill name="Empower" id="45105" level="3" required-level="40" sp="80000" />
+		<skill name="Wild Magic" id="45106" level="2" required-level="40" sp="80000" />
+		<skill name="Magic Barrier" id="45108" level="2" required-level="40" sp="80000" />
+		<skill name="Focus" id="45109" level="3" required-level="40" sp="80000" />
+		<skill name="Death Whisper" id="45110" level="3" required-level="40" sp="80000" />
+		<skill name="Haste" id="45111" level="2" required-level="40" sp="80000" />
+		<skill name="Berserker Spirit" id="45112" level="2" required-level="40" sp="80000" />
+		<skill name="Clarity" id="45113" level="3" required-level="40" sp="80000" />
+
 		<skill name="Pirate" id="1800" level="1" required-level="45" auto-learn="true" />
 		<skill name="Dark Assassin" id="1801" level="1" required-level="60" auto-learn="true" />
 		<skill name="White Assassin" id="1802" level="1" required-level="70" auto-learn="true" />
@@ -29,7 +43,7 @@
 		<skill name="Stun Shot" id="101" level="6" required-level="40" sp="72000" />
 		<skill name="Power Break" id="115" level="3" required-level="40" sp="72000" />
 		<skill name="Hex" id="122" level="1" required-level="40" sp="72000">
-			<item id="3050"/>
+			<item id="3050" count="1" />
 		</skill>
 		
 		<skill name="Light Armor Mastery" id="233" level="14" required-level="41" sp="85000" />
@@ -147,7 +161,7 @@
 		<skill name="Hex" id="122" level="5" required-level="52" sp="250000" />
 		<skill name="Power Break" id="115" level="7" required-level="52" sp="250000" />
 		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="250000" >
-			<item id="8618"/> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
+			<item id="8618" count="1" /> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
 		</skill>
 		
 		<skill name="Light Armor Mastery" id="233" level="26" required-level="53" sp="350000" />
@@ -238,7 +252,7 @@
 		<skill name="Fatal Counter" id="314" level="3" required-level="61" sp="710000" />
 		<skill name="Stun Shot" id="101" level="27" required-level="61" sp="710000" />
 		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="710000" >
-			<item id="8619"/> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
+			<item id="8619" count="1" /> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
 		</skill>
 		
 		<skill name="Vicious Stance" id="312" level="14" required-level="62" sp="870000" />

--- a/data/skillTrees/2ndClass/PhantomSummoner.xml
+++ b/data/skillTrees/2ndClass/PhantomSummoner.xml
@@ -1,6 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="41" parentClassId="39">
+
+		<!-- Master Buffs Lv. 40 -->
+		<skill name="Might" id="1068" level="3" required-level="40" sp="80000" />
+		<skill name="Shield" id="1040" level="3" required-level="40" sp="80000" />
+		<skill name="Acumen" id="45104" level="3" required-level="40" sp="80000" />
+		<skill name="Empower" id="45105" level="3" required-level="40" sp="80000" />
+		<skill name="Wild Magic" id="45106" level="2" required-level="40" sp="80000" />
+		<skill name="Magic Barrier" id="45108" level="2" required-level="40" sp="80000" />
+		<skill name="Focus" id="45109" level="3" required-level="40" sp="80000" />
+		<skill name="Death Whisper" id="45110" level="3" required-level="40" sp="80000" />
+		<skill name="Haste" id="45111" level="2" required-level="40" sp="80000" />
+		<skill name="Berserker Spirit" id="45112" level="2" required-level="40" sp="80000" />
+		<skill name="Clarity" id="45113" level="3" required-level="40" sp="80000" />
+
 		<skill name="Pirate" id="1800" level="1" required-level="45" auto-learn="true" />
 		<skill name="Dark Assassin" id="1801" level="1" required-level="60" auto-learn="true" />
 		<skill name="White Assassin" id="1802" level="1" required-level="70" auto-learn="true" />
@@ -37,7 +51,7 @@
 		<skill name="Boost Mana" id="213" level="3" required-level="40" sp="100000" />
 		<skill name="Servitor Physical Shield" id="1140" level="1" required-level="40" sp="100000" />
 		<skill name="Summon Spark Cubic" id="1281" level="1" required-level="40" sp="100000">
-			<item id="4924"/>
+			<item id="4924" count="1" />
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="16" required-level="42" sp="140000" />
@@ -72,7 +86,7 @@
 		<skill name="Twister" id="1178" level="11" required-level="44" sp="140000" />
 		<skill name="Servitor Haste" id="1141" level="1" required-level="44" sp="140000" />
 		<skill name="Spirit Sharing" id="1547" level="1" required-level="44" sp="140000">
-			<item id="49562"/>
+			<item id="49562" count="1" />
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="19" required-level="46" sp="230000" />
@@ -142,7 +156,7 @@
 		<skill name="Twister" id="1178" level="15" required-level="52" sp="360000" />
 		<skill name="Servitor Haste" id="1141" level="2" required-level="52" sp="370000" />
 		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="370000" >
-			<item id="8618"/> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
+			<item id="8618" count="1" /> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="25" required-level="54" sp="590000" />
@@ -229,7 +243,7 @@
 		<skill name="Servitor Heal" id="1127" level="32" required-level="61" sp="870000" />
 		<skill name="Servitor Recharge" id="1126" level="21" required-level="61" sp="870000" />
 		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="870000" >
-			<item id="8619"/> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
+			<item id="8619" count="1" /> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="33" required-level="62" sp="870000" />

--- a/data/skillTrees/2ndClass/PlainsWalker.xml
+++ b/data/skillTrees/2ndClass/PlainsWalker.xml
@@ -1,6 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="23" parentClassId="22">
+
+		<!-- Master Buffs Lv. 40 -->
+		<skill name="Might" id="1068" level="3" required-level="40" sp="80000" />
+		<skill name="Shield" id="1040" level="3" required-level="40" sp="80000" />
+		<skill name="Acumen" id="45104" level="3" required-level="40" sp="80000" />
+		<skill name="Empower" id="45105" level="3" required-level="40" sp="80000" />
+		<skill name="Wild Magic" id="45106" level="2" required-level="40" sp="80000" />
+		<skill name="Magic Barrier" id="45108" level="2" required-level="40" sp="80000" />
+		<skill name="Focus" id="45109" level="3" required-level="40" sp="80000" />
+		<skill name="Death Whisper" id="45110" level="3" required-level="40" sp="80000" />
+		<skill name="Haste" id="45111" level="2" required-level="40" sp="80000" />
+		<skill name="Berserker Spirit" id="45112" level="2" required-level="40" sp="80000" />
+		<skill name="Clarity" id="45113" level="3" required-level="40" sp="80000" />
+
 		<skill name="Pirate" id="1800" level="1" required-level="45" auto-learn="true" />
 		<skill name="Dark Assassin" id="1801" level="1" required-level="60" auto-learn="true" />
 		<skill name="White Assassin" id="1802" level="1" required-level="70" auto-learn="true" />
@@ -30,7 +44,7 @@
 		<skill name="Backstab" id="30" level="3" required-level="40" sp="80000" />
 		<skill name="Critical Chance" id="137" level="2" required-level="40" sp="80000" />
 		<skill name="Spirit Barrier" id="123" level="1" required-level="40" sp="80000">
-			<item id="3051"/>
+			<item id="3051" count="1" />
 		</skill>
 		<skill name="Potion Mastery" id="45184" level="1" required-level="40">
 			<item id="57" count="1000000"/> <!-- Adena -->
@@ -139,7 +153,7 @@
 		<skill name="Deadly Blow" id="263" level="14" required-level="51" sp="280000" />
 		<skill name="Backstab" id="30" level="14" required-level="51" sp="280000" />
 		<skill name="Hide" id="922" level="1" required-level="51" sp="280000">
-			<item id="49429"/>
+			<item id="49429" count="1" />
 		</skill>
 		
 		<skill name="Vicious Stance" id="312" level="10" required-level="52" sp="280000" />
@@ -156,7 +170,7 @@
 		<skill name="Sprint" id="230" level="2" required-level="52" sp="280000" />
 		<skill name="Backstab" id="30" level="15" required-level="52" sp="280000" />
 		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="280000" >
-			<item id="8618"/> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
+			<item id="8618" count="1" /> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
 		</skill>
 		
 		<skill name="Dagger Mastery" id="209" level="24" required-level="53" sp="390000" />
@@ -189,7 +203,7 @@
 		<skill name="Deadly Blow" id="263" level="18" required-level="55" sp="390000" />
 		<skill name="Backstab" id="30" level="18" required-level="55" sp="390000" />
 		<skill name="Sand Bomb" id="412" level="1" required-level="55" sp="390000">
-			<item id="49569"/>
+			<item id="49569" count="1" />
 		</skill>
 		
 		<skill name="Dagger Mastery" id="209" level="27" required-level="56" sp="540000" />
@@ -250,7 +264,7 @@
 		<skill name="Hide" id="922" level="2" required-level="61" sp="790000" />
 		<skill name="Backstab" id="30" level="24" required-level="61" sp="790000" />
 		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="790000" >
-			<item id="8619"/> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
+			<item id="8619" count="1" /> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
 		</skill>
 		
 		<skill name="Vicious Stance" id="312" level="14" required-level="62" sp="970000" />

--- a/data/skillTrees/2ndClass/Prophet.xml
+++ b/data/skillTrees/2ndClass/Prophet.xml
@@ -1,6 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="17" parentClassId="15">
+
+		<!-- Master Buffs Lv. 40 -->
+		<skill name="Might" id="1068" level="3" required-level="40" sp="80000" />
+		<skill name="Shield" id="1040" level="3" required-level="40" sp="80000" />
+		<skill name="Acumen" id="45104" level="3" required-level="40" sp="80000" />
+		<skill name="Empower" id="45105" level="3" required-level="40" sp="80000" />
+		<skill name="Wild Magic" id="45106" level="2" required-level="40" sp="80000" />
+		<skill name="Magic Barrier" id="45108" level="2" required-level="40" sp="80000" />
+		<skill name="Focus" id="45109" level="3" required-level="40" sp="80000" />
+		<skill name="Death Whisper" id="45110" level="3" required-level="40" sp="80000" />
+		<skill name="Haste" id="45111" level="2" required-level="40" sp="80000" />
+		<skill name="Berserker Spirit" id="45112" level="2" required-level="40" sp="80000" />
+		<skill name="Clarity" id="45113" level="3" required-level="40" sp="80000" />
+
 		<skill name="Pirate" id="1800" level="1" required-level="45" auto-learn="true" />
 		<skill name="Dark Assassin" id="1801" level="1" required-level="60" auto-learn="true" />
 		<skill name="White Assassin" id="1802" level="1" required-level="70" auto-learn="true" />
@@ -35,7 +49,7 @@
 		<skill name="Boost Mana" id="213" level="3" required-level="40" sp="97000" />
 		<skill name="Invigor" id="1032" level="1" required-level="40" sp="97000" />
 		<skill name="Death Whisper" id="1242" level="1" required-level="40" sp="97000">
-			<item id="3101"/>
+			<item id="3101" count="1" />
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="16" required-level="42" sp="140000" />
@@ -71,7 +85,7 @@
 		<skill name="Focus" id="1077" level="2" required-level="44" sp="140000" />
 		<skill name="Shield" id="1040" level="3" required-level="44" sp="140000" />
 		<skill name="Haste" id="1086" level="1" required-level="44" sp="140000">
-			<item id="3099"/>
+			<item id="3099" count="1" />
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="19" required-level="46" sp="220000" />
@@ -125,7 +139,7 @@
 		<skill name="Heavy Armor Mastery" id="259" level="11" required-level="51" sp="350000" />
 		<skill name="Dryad Root" id="1201" level="20" required-level="51" sp="350000" />
 		<skill name="Mystic Immunity" id="1411" level="1" required-level="51" sp="350000">
-			<item id="49430"/>
+			<item id="49430" count="1" />
 		</skill>
 
 		<skill name="Anti Magic" id="146" level="24" required-level="52" sp="350000" />
@@ -148,7 +162,7 @@
 		<skill name="Haste" id="1086" level="2" required-level="52" sp="350000" />
 		<skill name="Focus" id="1077" level="3" required-level="52" sp="350000" />
 		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="350000" >
-			<item id="8618"/> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
+			<item id="8618" count="1" /> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="25" required-level="54" sp="550000" />
@@ -205,10 +219,10 @@
 		<skill name="Holy Attack Resistance" id="1392" level="1" required-level="58" sp="560000" />
 		<skill name="Dark Attack Resistance" id="1393" level="1" required-level="58" sp="560000" />
 		<skill name="Greater Might" id="1388" level="1" required-level="58" sp="560000">
-			<item id="8388"/>
+			<item id="8388" count="1" />
 		</skill>
 		<skill name="Greater Shield" id="1389" level="1" required-level="58" sp="560000">
-			<item id="8389"/>
+			<item id="8389" count="1" />
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="30" required-level="59" sp="680000" />
@@ -237,7 +251,7 @@
 		<skill name="Weapon Mastery" id="249" level="29" required-level="61" sp="830000" />
 		<skill name="Heavy Armor Mastery" id="259" level="20" required-level="61" sp="830000" />
 		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="830000" >
-			<item id="8619"/> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
+			<item id="8619" count="1" /> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="33" required-level="62" sp="830000" />

--- a/data/skillTrees/2ndClass/ShillienElder.xml
+++ b/data/skillTrees/2ndClass/ShillienElder.xml
@@ -1,6 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="43" parentClassId="42">
+
+		<!-- Master Buffs Lv. 40 -->
+		<skill name="Might" id="1068" level="3" required-level="40" sp="80000" />
+		<skill name="Shield" id="1040" level="3" required-level="40" sp="80000" />
+		<skill name="Acumen" id="45104" level="3" required-level="40" sp="80000" />
+		<skill name="Empower" id="45105" level="3" required-level="40" sp="80000" />
+		<skill name="Wild Magic" id="45106" level="2" required-level="40" sp="80000" />
+		<skill name="Magic Barrier" id="45108" level="2" required-level="40" sp="80000" />
+		<skill name="Focus" id="45109" level="3" required-level="40" sp="80000" />
+		<skill name="Death Whisper" id="45110" level="3" required-level="40" sp="80000" />
+		<skill name="Haste" id="45111" level="2" required-level="40" sp="80000" />
+		<skill name="Berserker Spirit" id="45112" level="2" required-level="40" sp="80000" />
+		<skill name="Clarity" id="45113" level="3" required-level="40" sp="80000" />
+
 		<skill name="Pirate" id="1800" level="1" required-level="45" auto-learn="true" />
 		<skill name="Dark Assassin" id="1801" level="1" required-level="60" auto-learn="true" />
 		<skill name="White Assassin" id="1802" level="1" required-level="70" auto-learn="true" />
@@ -32,10 +46,10 @@
 		<skill name="Might of Heaven" id="1028" level="2" required-level="40" sp="90000" />
 		<skill name="Boost Mana" id="213" level="3" required-level="40" sp="90000" />
 		<skill name="Death Whisper" id="1242" level="1" required-level="40" sp="90000">
-			<item id="3101"/>
+			<item id="3101" count="1" />
 		</skill>
 		<skill name="Stigma of Shilien" id="1539" level="1" required-level="40" sp="90000">
-			<item id="49432"/>
+			<item id="49432" count="1" />
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="16" required-level="42" sp="130000" />
@@ -68,7 +82,7 @@
 		<skill name="Focus" id="1077" level="2" required-level="44" sp="130000" />
 		<skill name="Shield" id="1040" level="3" required-level="44" sp="130000" />
 		<skill name="Purify" id="1018" level="1" required-level="44" sp="130000">
-			<item id="3072"/>
+			<item id="3072" count="1" />
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="19" required-level="46" sp="200000" />
@@ -145,7 +159,7 @@
 		<skill name="Stigma of Shilen" id="1539" level="2" required-level="52" sp="330000" />
 		<skill name="Focus" id="1077" level="3" required-level="52" sp="330000" />
 		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="330000" >
-			<item id="8618"/> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
+			<item id="8618" count="1" /> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="25" required-level="54" sp="520000" />
@@ -236,7 +250,7 @@
 		<skill name="Weapon Mastery" id="249" level="29" required-level="61" sp="770000" />
 		<skill name="Recharge" id="1013" level="19" required-level="61" sp="770000" />
 		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="770000" >
-			<item id="8619"/> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
+			<item id="8619" count="1" /> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="33" required-level="62" sp="770000" />
@@ -254,7 +268,7 @@
 		<skill name="Might of Heaven" id="1028" level="13" required-level="62" sp="770000" />
 		<skill name="Stigma of Shilen" id="1539" level="3" required-level="62" sp="770000" />
 		<skill name="Wild Magic" id="1303" level="1" required-level="62" sp="770000">
-			<item id="5815"/>
+			<item id="5815" count="1" />
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="34" required-level="63" sp="960000" />

--- a/data/skillTrees/2ndClass/ShillienKnight.xml
+++ b/data/skillTrees/2ndClass/ShillienKnight.xml
@@ -1,6 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="33" parentClassId="32">
+
+		<!-- Master Buffs Lv. 40 -->
+		<skill name="Might" id="1068" level="3" required-level="40" sp="80000" />
+		<skill name="Shield" id="1040" level="3" required-level="40" sp="80000" />
+		<skill name="Acumen" id="45104" level="3" required-level="40" sp="80000" />
+		<skill name="Empower" id="45105" level="3" required-level="40" sp="80000" />
+		<skill name="Wild Magic" id="45106" level="2" required-level="40" sp="80000" />
+		<skill name="Magic Barrier" id="45108" level="2" required-level="40" sp="80000" />
+		<skill name="Focus" id="45109" level="3" required-level="40" sp="80000" />
+		<skill name="Death Whisper" id="45110" level="3" required-level="40" sp="80000" />
+		<skill name="Haste" id="45111" level="2" required-level="40" sp="80000" />
+		<skill name="Berserker Spirit" id="45112" level="2" required-level="40" sp="80000" />
+		<skill name="Clarity" id="45113" level="3" required-level="40" sp="80000" />
+
 		<skill name="Pirate" id="1800" level="1" required-level="45" auto-learn="true" />
 		<skill name="Dark Assassin" id="1801" level="1" required-level="60" auto-learn="true" />
 		<skill name="White Assassin" id="1802" level="1" required-level="70" auto-learn="true" />
@@ -33,10 +47,10 @@
 		<skill name="Judgment" id="401" level="1" required-level="40" sp="56000" />
 		<skill name="Power Break" id="115" level="3" required-level="40" sp="56000" />
 		<skill name="Summon Phantom Cubic" id="33" level="1" required-level="40" sp="56000">
-			<item id="3041"/>
+			<item id="3041" count="1" />
 		</skill>
 		<skill name="Hex" id="122" level="1" required-level="40" sp="56000">
-			<item id="3050"/>
+			<item id="3050" count ="1" />
 		</skill>
 		<skill name="Potion Mastery" id="45184" level="1" required-level="40">
 			<item id="57" count="1000000"/> <!-- Adena -->
@@ -181,10 +195,10 @@
 		<skill name="Hex" id="122" level="5" required-level="52" sp="200000" />
 		<skill name="Power Break" id="115" level="7" required-level="52" sp="200000" />
 		<skill name="Aegis" id="316" level="1" required-level="52" sp="200000">
-			<item id="49428"/>
+			<item id="49428" count="1" />
 		</skill>
 		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="200000" >
-			<item id="8618"/> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
+			<item id="8618" count="1" /> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
 		</skill>
 		
 		<skill name="Aggression" id="28" level="28" required-level="53" sp="270000" />
@@ -258,7 +272,7 @@
 		<skill name="Power Break" id="115" level="9" required-level="58" sp="380000" />
 		<skill name="Corpse Plague" id="103" level="2" required-level="58" sp="380000" />
 		<skill name="Lightning Strike" id="279" level="1" required-level="58" sp="380000">
-			<item id="3055"/>
+			<item id="3055" count="1" />
 		</skill>
 
 		<skill name="Aggression" id="28" level="34" required-level="59" sp="550000" />
@@ -286,7 +300,7 @@
 		<skill name="Hex" id="122" level="8" required-level="60" sp="550000" />
 		<skill name="Power Break" id="115" level="10" required-level="60" sp="550000" />
 		<skill name="Shield Deflect Magic" id="916" level="1" required-level="60" sp="550000">
-			<item id="49427"/>
+			<item id="49427" count="1" />
 		</skill>
 		
 		<skill name="Aggression" id="28" level="36" required-level="61" sp="550000" />
@@ -297,7 +311,7 @@
 		<skill name="Drain Energy" id="70" level="40" required-level="61" sp="550000" />
 		<skill name="Magic Resistance" id="147" level="38" required-level="61" sp="550000" />
 		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="550000" >
-			<item id="8619"/> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
+			<item id="8619" count="1" /> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
 		</skill>
 		
 		<skill name="Aggression" id="28" level="37" required-level="62" sp="680000" />

--- a/data/skillTrees/2ndClass/SilverRanger.xml
+++ b/data/skillTrees/2ndClass/SilverRanger.xml
@@ -1,6 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="24" parentClassId="22">
+
+		<!-- Master Buffs Lv. 40 -->
+		<skill name="Might" id="1068" level="3" required-level="40" sp="80000" />
+		<skill name="Shield" id="1040" level="3" required-level="40" sp="80000" />
+		<skill name="Acumen" id="45104" level="3" required-level="40" sp="80000" />
+		<skill name="Empower" id="45105" level="3" required-level="40" sp="80000" />
+		<skill name="Wild Magic" id="45106" level="2" required-level="40" sp="80000" />
+		<skill name="Magic Barrier" id="45108" level="2" required-level="40" sp="80000" />
+		<skill name="Focus" id="45109" level="3" required-level="40" sp="80000" />
+		<skill name="Death Whisper" id="45110" level="3" required-level="40" sp="80000" />
+		<skill name="Haste" id="45111" level="2" required-level="40" sp="80000" />
+		<skill name="Berserker Spirit" id="45112" level="2" required-level="40" sp="80000" />
+		<skill name="Clarity" id="45113" level="3" required-level="40" sp="80000" />
+
 		<skill name="Pirate" id="1800" level="1" required-level="45" auto-learn="true" />
 		<skill name="Dark Assassin" id="1801" level="1" required-level="60" auto-learn="true" />
 		<skill name="White Assassin" id="1802" level="1" required-level="70" auto-learn="true" />
@@ -27,7 +41,7 @@
 		<skill name="Elemental Heal" id="58" level="20" required-level="40" sp="85000" />
 		<skill name="Elemental Heal" id="58" level="21" required-level="40" sp="85000" />
 		<skill name="Spirit Barrier" id="123" level="1" required-level="40" sp="85000">
-			<item id="3051"/>
+			<item id="3051" count="1" />
 		</skill>
 		
 		<skill name="Light Armor Mastery" id="233" level="14" required-level="41" sp="100000" />
@@ -140,7 +154,7 @@
 		<skill name="Elemental Heal" id="58" level="33" required-level="52" sp="300000" />
 		<skill name="Sprint" id="230" level="2" required-level="52" sp="300000" />
 		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="300000" >
-			<item id="8618"/> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
+			<item id="8618" count="1" /> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
 		</skill>
 		
 		<skill name="Burst Shot" id="24" level="10" required-level="53" sp="410000" />
@@ -227,7 +241,7 @@
 		<skill name="Charm" id="15" level="39" required-level="61" sp="830000" />
 		<skill name="Elemental Heal" id="58" level="42" required-level="61" sp="830000" />
 		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="830000" >
-			<item id="8619"/> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
+			<item id="8619" count="1" /> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
 		</skill>
 		
 		<skill name="Rapid Fire" id="413" level="2" required-level="62" sp="1000000" />

--- a/data/skillTrees/2ndClass/Sorcerer.xml
+++ b/data/skillTrees/2ndClass/Sorcerer.xml
@@ -1,6 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="12" parentClassId="11">
+
+		<!-- Master Buffs Lv. 40 -->
+		<skill name="Might" id="1068" level="3" required-level="40" sp="80000" />
+		<skill name="Shield" id="1040" level="3" required-level="40" sp="80000" />
+		<skill name="Acumen" id="45104" level="3" required-level="40" sp="80000" />
+		<skill name="Empower" id="45105" level="3" required-level="40" sp="80000" />
+		<skill name="Wild Magic" id="45106" level="2" required-level="40" sp="80000" />
+		<skill name="Magic Barrier" id="45108" level="2" required-level="40" sp="80000" />
+		<skill name="Focus" id="45109" level="3" required-level="40" sp="80000" />
+		<skill name="Death Whisper" id="45110" level="3" required-level="40" sp="80000" />
+		<skill name="Haste" id="45111" level="2" required-level="40" sp="80000" />
+		<skill name="Berserker Spirit" id="45112" level="2" required-level="40" sp="80000" />
+		<skill name="Clarity" id="45113" level="3" required-level="40" sp="80000" />
+
 		<skill name="Pirate" id="1800" level="1" required-level="45" auto-learn="true" />
 		<skill name="Dark Assassin" id="1801" level="1" required-level="60" auto-learn="true" />
 		<skill name="White Assassin" id="1802" level="1" required-level="70" auto-learn="true" />
@@ -33,7 +47,7 @@
 		<skill name="Sleep" id="1069" level="11" required-level="40" sp="84000" />
 		<skill name="Sleep" id="1069" level="12" required-level="40" sp="84000" />
 		<skill name="Clear Mind" id="1297" level="1" required-level="40" sp="84000">
-			<item id="49571"/>
+			<item id="49571" count="1" />
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="16" required-level="42" sp="120000" />
@@ -64,7 +78,7 @@
 		<skill name="Higher Mana Gain" id="285" level="12" required-level="44" sp="120000" />
 		<skill name="Sleep" id="1069" level="15" required-level="44" sp="120000" />
 		<skill name="Sleeping Cloud" id="1072" level="1" required-level="44" sp="120000">
-			<item id="3080"/>
+			<item id="3080" count="1" />
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="19" required-level="46" sp="190000" />
@@ -98,7 +112,7 @@
 		<skill name="Higher Mana Gain" id="285" level="14" required-level="48" sp="190000" />
 		<skill name="Sleep" id="1069" level="18" required-level="48" sp="190000" />
 		<skill name="Cancellation" id="1056" level="1" required-level="48" sp="190000">
-			<item id="3079"/>
+			<item id="3079" count="1" />
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="22" required-level="50" sp="300000" />
@@ -131,7 +145,7 @@
 		<skill name="Higher Mana Gain" id="285" level="16" required-level="52" sp="300000" />
 		<skill name="Sleep" id="1069" level="21" required-level="52" sp="300000" />
 		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="300000" >
-			<item id="8618"/> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
+			<item id="8618" count="1" /> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="25" required-level="54" sp="480000" />
@@ -188,7 +202,7 @@
 		<skill name="Higher Mana Gain" id="285" level="19" required-level="58" sp="490000" />
 		<skill name="Sleep" id="1069" level="26" required-level="58" sp="490000" />
 		<skill name="Aura Flash" id="1417" level="1" required-level="58" sp="490000">
-			<item id="8891"/>
+			<item id="8891" count="1" />
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="30" required-level="59" sp="590000" />
@@ -222,7 +236,7 @@
 		<skill name="Aura Flare" id="1231" level="15" required-level="61" sp="710000" />
 		<skill name="Sleep" id="1069" level="29" required-level="61" sp="710000" />
 		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="710000" >
-			<item id="8619"/> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
+			<item id="8619" count="1" /> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="33" required-level="62" sp="710000" />

--- a/data/skillTrees/2ndClass/SoulBreaker.xml
+++ b/data/skillTrees/2ndClass/SoulBreaker.xml
@@ -2,7 +2,20 @@
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
     <skillTree type="classSkillTree" classId="194" parentClassId="193">
 
+        <!-- Lv. 40 Master Buffs -->
+        <skill name="Soul Empower" id="45147" level="3" required-level="40" sp="80000" />
+        <skill name="Soul Wild Magic" id="45148" level="2" required-level="40" sp="80000" />
+        <skill name="Soul Berserker Spirit" id="45149" level="2" required-level="40" sp="80000" />
+        <skill name="Soul Magic Barrier" id="45143" level="2" required-level="40" sp="80000" />
+        <skill name="Soul Might" id="45144" level="3" required-level="40" sp="80000" />
+        <skill name="Soul Acumen" id="45146" level="3" required-level="40" sp="80000" />
+        <skill name="Soul Haste" id="45141" level="2" required-level="40" sp="80000" />
+        <skill name="Soul Focus" id="45139" level="3" required-level="40" sp="80000" />
+        <skill name="Soul Clarity" id="45150" level="3" required-level="40" sp="80000" />
+        <skill name="Soul Death Whisper" id="45140" level="3" required-level="40" sp="80000" />
+        <skill name="Soul Shield" id="45145" level="3" required-level="40" sp="80000" />
         <skill name="Armor Mastery" id="464" level="3" required-level="40" sp="80000"/>
+
         <skill name="Potion Mastery" id="45184" level="1" required-level="40">
             <item id="57" count="1000000"/> <!-- Adena -->
         </skill>
@@ -40,7 +53,7 @@
         <skill name="Soul Thrust" id="45161" level="2" required-level="50" sp="200000" />
 
         <skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="200000">
-            <item id="8618"/> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
+            <item id="8618" count="1"/> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
         </skill>
 
         <skill name="Magic Immunity" id="466" level="3" required-level="55" sp="450000" />
@@ -54,7 +67,7 @@
         <skill name="Light Armor Mastery" id="465" level="5" required-level="60" sp="800000" />
         <skill name="Rapier Mastery" id="474" level="5" required-level="60" sp="800000"/>
         <skill name="Light Master" id="45178" level="2" required-level="60" sp="800000">
-            <item id="91944"/> <!-- Book of Light -->
+            <item id="91944" count="1"/> <!-- Book of Light -->
         </skill>
         <skill name="Soul Spark" id="45163" level="3" required-level="60" sp="800000" />
         <skill name="Art of Rapier" id="1444" level="3" required-level="60" sp="800000">
@@ -80,7 +93,7 @@
         <skill name="Light Armor Mastery" id="465" level="6" required-level="70" sp="1800000" />
         <skill name="Rapier Mastery" id="474" level="6" required-level="70" sp="1800000"/>
         <skill name="Shadow Master" id="45179" level="2" required-level="70" sp="1800000">
-            <item id="91945"/> <!-- Book of Darkness -->
+            <item id="91945" count="1"/> <!-- Book of Darkness -->
         </skill>
         <skill name="Soul Spark" id="45163" level="4" required-level="70" sp="1800000">
             <item id="57" count="500000"/> <!-- Adena -->

--- a/data/skillTrees/2ndClass/Spellhowler.xml
+++ b/data/skillTrees/2ndClass/Spellhowler.xml
@@ -1,6 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="40" parentClassId="39">
+
+		<!-- Master Buffs Lv. 40 -->
+		<skill name="Might" id="1068" level="3" required-level="40" sp="80000" />
+		<skill name="Shield" id="1040" level="3" required-level="40" sp="80000" />
+		<skill name="Acumen" id="45104" level="3" required-level="40" sp="80000" />
+		<skill name="Empower" id="45105" level="3" required-level="40" sp="80000" />
+		<skill name="Wild Magic" id="45106" level="2" required-level="40" sp="80000" />
+		<skill name="Magic Barrier" id="45108" level="2" required-level="40" sp="80000" />
+		<skill name="Focus" id="45109" level="3" required-level="40" sp="80000" />
+		<skill name="Death Whisper" id="45110" level="3" required-level="40" sp="80000" />
+		<skill name="Haste" id="45111" level="2" required-level="40" sp="80000" />
+		<skill name="Berserker Spirit" id="45112" level="2" required-level="40" sp="80000" />
+		<skill name="Clarity" id="45113" level="3" required-level="40" sp="80000" />
+
 		<skill name="Pirate" id="1800" level="1" required-level="45" auto-learn="true" />
 		<skill name="Dark Assassin" id="1801" level="1" required-level="60" auto-learn="true" />
 		<skill name="White Assassin" id="1802" level="1" required-level="70" auto-learn="true" />
@@ -33,10 +47,10 @@
 		<skill name="Sleep" id="1069" level="11" required-level="40" sp="70000" />
 		<skill name="Sleep" id="1069" level="12" required-level="40" sp="70000" />
 		<skill name="Silence" id="1064" level="1" required-level="40" sp="70000">
-			<item id="3064"/>
+			<item id="3064" count="1" />
 		</skill>
 		<skill name="Clear Mind" id="1297" level="1" required-level="40" sp="70000">
-			<item id="49571"/>
+			<item id="49571" count="1" />
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="16" required-level="42" sp="100000" />
@@ -77,7 +91,7 @@
 		<skill name="Higher Mana Gain" id="285" level="13" required-level="46" sp="160000" />
 		<skill name="Sleep" id="1069" level="16" required-level="46" sp="160000" />
 		<skill name="Tempest" id="1176" level="1" required-level="46" sp="160000">
-			<item id="3089"/>
+			<item id="3089" count="1" />
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="20" required-level="47" sp="160000" />
@@ -114,7 +128,7 @@
 		<skill name="Higher Mana Gain" id="285" level="15" required-level="50" sp="250000" />
 		<skill name="Sleep" id="1069" level="19" required-level="50" sp="250000" />
 		<skill name="Curse Death Link" id="1159" level="1" required-level="50" sp="250000">
-			<item id="3066"/>
+			<item id="3066" count="1" />
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="23" required-level="51" sp="250000" />
@@ -142,7 +156,7 @@
 		<skill name="Higher Mana Gain" id="285" level="16" required-level="52" sp="250000" />
 		<skill name="Sleep" id="1069" level="21" required-level="52" sp="250000" />
 		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="250000" >
-			<item id="8618"/> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
+			<item id="8618" count="1" /> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="25" required-level="54" sp="390000" />
@@ -206,7 +220,7 @@
 		<skill name="Higher Mana Gain" id="285" level="19" required-level="58" sp="400000" />
 		<skill name="Sleep" id="1069" level="26" required-level="58" sp="400000" />
 		<skill name="Aura Flash" id="1417" level="1" required-level="58" sp="400000">
-			<item id="8891"/>
+			<item id="8891" count="1" />
 		</skill>
 
 		<skill name="Anti Magic" id="146" level="30" required-level="59" sp="490000" />
@@ -244,7 +258,7 @@
 		<skill name="Hurricane" id="1239" level="15" required-level="61" sp="600000" />
 		<skill name="Sleep" id="1069" level="29" required-level="61" sp="600000" />
 		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="600000" >
-			<item id="8619"/> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
+			<item id="8619" count="1" /> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="33" required-level="62" sp="600000" />

--- a/data/skillTrees/2ndClass/Spellsinger.xml
+++ b/data/skillTrees/2ndClass/Spellsinger.xml
@@ -1,6 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="27" parentClassId="26">
+
+		<!-- Master Buffs Lv. 40 -->
+		<skill name="Might" id="1068" level="3" required-level="40" sp="80000" />
+		<skill name="Shield" id="1040" level="3" required-level="40" sp="80000" />
+		<skill name="Acumen" id="45104" level="3" required-level="40" sp="80000" />
+		<skill name="Empower" id="45105" level="3" required-level="40" sp="80000" />
+		<skill name="Wild Magic" id="45106" level="2" required-level="40" sp="80000" />
+		<skill name="Magic Barrier" id="45108" level="2" required-level="40" sp="80000" />
+		<skill name="Focus" id="45109" level="3" required-level="40" sp="80000" />
+		<skill name="Death Whisper" id="45110" level="3" required-level="40" sp="80000" />
+		<skill name="Haste" id="45111" level="2" required-level="40" sp="80000" />
+		<skill name="Berserker Spirit" id="45112" level="2" required-level="40" sp="80000" />
+		<skill name="Clarity" id="45113" level="3" required-level="40" sp="80000" />
+
 		<skill name="Pirate" id="1800" level="1" required-level="45" auto-learn="true" />
 		<skill name="Dark Assassin" id="1801" level="1" required-level="60" auto-learn="true" />
 		<skill name="White Assassin" id="1802" level="1" required-level="70" auto-learn="true" />
@@ -34,7 +48,7 @@
 		<skill name="Sleep" id="1069" level="11" required-level="40" sp="75000" />
 		<skill name="Sleep" id="1069" level="12" required-level="40" sp="75000" />
 		<skill name="Clear Mind" id="1297" level="1" required-level="40" sp="75000">
-			<item id="49571"/>
+			<item id="49571" count="1" /> 
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="16" required-level="42" sp="110000" />
@@ -68,7 +82,7 @@
 		<skill name="Higher Mana Gain" id="285" level="12" required-level="44" sp="110000" />
 		<skill name="Sleep" id="1069" level="15" required-level="44" sp="110000" />
 		<skill name="Sleeping Cloud" id="1072" level="1" required-level="44" sp="110000">
-			<item id="3080"/>
+			<item id="3080" count="1" />
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="19" required-level="46" sp="170000" />
@@ -104,7 +118,7 @@
 		<skill name="Higher Mana Gain" id="285" level="14" required-level="48" sp="170000" />
 		<skill name="Sleep" id="1069" level="18" required-level="48" sp="170000" />
 		<skill name="Cancellation" id="1056" level="1" required-level="48" sp="170000">
-			<item id="3079"/>
+			<item id="3079" count="1" />
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="22" required-level="50" sp="270000" />
@@ -142,7 +156,7 @@
 		<skill name="Higher Mana Gain" id="285" level="16" required-level="52" sp="270000" />
 		<skill name="Sleep" id="1069" level="21" required-level="52" sp="270000" />
 		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="270000" >
-			<item id="8618"/> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
+			<item id="8618" count="1" /> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="25" required-level="54" sp="430000" />
@@ -207,7 +221,7 @@
 		<skill name="Higher Mana Gain" id="285" level="19" required-level="58" sp="440000" />
 		<skill name="Sleep" id="1069" level="26" required-level="58" sp="440000" />
 		<skill name="Aura Flash" id="1417" level="1" required-level="58" sp="440000">
-			<item id="8891"/>
+			<item id="8891" count="1" />
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="30" required-level="59" sp="530000" />
@@ -245,7 +259,7 @@
 		<skill name="Frost Wall" id="1174" level="9" required-level="61" sp="640000" />
 		<skill name="Sleep" id="1069" level="29" required-level="61" sp="640000" />
 		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="640000" >
-			<item id="8619"/> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
+			<item id="8619" count="1" /> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="33" required-level="62" sp="640000" />

--- a/data/skillTrees/2ndClass/Swordsinger.xml
+++ b/data/skillTrees/2ndClass/Swordsinger.xml
@@ -1,6 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="21" parentClassId="19">
+
+		<!-- Master Buffs Lv. 40 -->
+		<skill name="Might" id="1068" level="3" required-level="40" sp="80000" />
+		<skill name="Shield" id="1040" level="3" required-level="40" sp="80000" />
+		<skill name="Acumen" id="45104" level="3" required-level="40" sp="80000" />
+		<skill name="Empower" id="45105" level="3" required-level="40" sp="80000" />
+		<skill name="Wild Magic" id="45106" level="2" required-level="40" sp="80000" />
+		<skill name="Magic Barrier" id="45108" level="2" required-level="40" sp="80000" />
+		<skill name="Focus" id="45109" level="3" required-level="40" sp="80000" />
+		<skill name="Death Whisper" id="45110" level="3" required-level="40" sp="80000" />
+		<skill name="Haste" id="45111" level="2" required-level="40" sp="80000" />
+		<skill name="Berserker Spirit" id="45112" level="2" required-level="40" sp="80000" />
+		<skill name="Clarity" id="45113" level="3" required-level="40" sp="80000" />
+
 		<skill name="Pirate" id="1800" level="1" required-level="45" auto-learn="true" />
 		<skill name="Dark Assassin" id="1801" level="1" required-level="60" auto-learn="true" />
 		<skill name="White Assassin" id="1802" level="1" required-level="70" auto-learn="true" />
@@ -23,7 +37,7 @@
 		<skill name="Elemental Heal" id="58" level="20" required-level="40" sp="120000" />
 		<skill name="Elemental Heal" id="58" level="21" required-level="40" sp="120000" />
 		<skill name="Spirit Barrier" id="123" level="1" required-level="40" sp="120000">
-			<item id="3051"/> <!-- Spellbook: Spirit Barrier -->
+			<item id="3051" count="1" /> <!-- Spellbook: Spirit Barrier -->
 		</skill>
 		<skill name="Potion Mastery" id="45184" level="1" required-level="40">
 			<item id="57" count="1000000"/> <!-- Adena -->
@@ -118,7 +132,7 @@
 		<skill name="Elemental Heal" id="58" level="33" required-level="52" sp="410000" />
 		<skill name="Sprint" id="230" level="2" required-level="52" sp="410000" />
 		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="410000" >
-			<item id="8618"/> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
+			<item id="8618" count="1" /> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
 		</skill>
 		
 		<skill name="Sword/Blunt Weapon Mastery" id="217" level="24" required-level="53" sp="570000" />
@@ -190,7 +204,7 @@
 		<skill name="Song of Warding" id="267" level="2" required-level="61" sp="1100000" />
 		<skill name="Elemental Heal" id="58" level="42" required-level="61" sp="1100000" />
 		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="1100000" >
-			<item id="8619"/> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
+			<item id="8619" count="1" /> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
 		</skill>
 		
 		<skill name="Arrest" id="402" level="4" required-level="62" sp="1400000" />

--- a/data/skillTrees/2ndClass/TempleKnight.xml
+++ b/data/skillTrees/2ndClass/TempleKnight.xml
@@ -1,6 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="20" parentClassId="19">
+
+		<!-- Master Buffs Lv. 40 -->
+		<skill name="Might" id="1068" level="3" required-level="40" sp="80000" />
+		<skill name="Shield" id="1040" level="3" required-level="40" sp="80000" />
+		<skill name="Acumen" id="45104" level="3" required-level="40" sp="80000" />
+		<skill name="Empower" id="45105" level="3" required-level="40" sp="80000" />
+		<skill name="Wild Magic" id="45106" level="2" required-level="40" sp="80000" />
+		<skill name="Magic Barrier" id="45108" level="2" required-level="40" sp="80000" />
+		<skill name="Focus" id="45109" level="3" required-level="40" sp="80000" />
+		<skill name="Death Whisper" id="45110" level="3" required-level="40" sp="80000" />
+		<skill name="Haste" id="45111" level="2" required-level="40" sp="80000" />
+		<skill name="Berserker Spirit" id="45112" level="2" required-level="40" sp="80000" />
+		<skill name="Clarity" id="45113" level="3" required-level="40" sp="80000" />
+
 		<skill name="Pirate" id="1800" level="1" required-level="45" auto-learn="true" />
 		<skill name="Dark Assassin" id="1801" level="1" required-level="60" auto-learn="true" />
 		<skill name="White Assassin" id="1802" level="1" required-level="70" auto-learn="true" />
@@ -32,7 +46,7 @@
 		<skill name="Holy Armor" id="197" level="1" required-level="40" sp="67000" />
 		<skill name="Tribunal" id="400" level="1" required-level="40" sp="67000" />
 		<skill name="Spirit Barrier" id="123" level="1" required-level="40" sp="67000">
-			<item id="3051"/>
+			<item id="3051" count="1" />
 		</skill>
 		<skill name="Potion Mastery" id="45184" level="1" required-level="40">
 			<item id="57" count="1000000"/> <!-- Adena -->
@@ -54,7 +68,7 @@
 		<skill name="Charm" id="15" level="20" required-level="42" sp="78000" />
 		<skill name="Elemental Heal" id="58" level="23" required-level="42" sp="78000" />
 		<skill name="Summon Life Cubic" id="67" level="1" required-level="42" sp="78000">
-			<item id="3045"/>
+			<item id="3045" count="1" />
 		</skill>
 		
 		<skill name="Aggression" id="28" level="18" required-level="43" sp="78000" />
@@ -162,10 +176,10 @@
 		<skill name="Sprint" id="230" level="2" required-level="52" sp="230000" />
 		<skill name="Tribunal" id="400" level="5" required-level="52" sp="230000" />
 		<skill name="Aegis" id="316" level="1" required-level="52" sp="230000">
-			<item id="49428"/>
+			<item id="49428" count="1" />
 		</skill>
 		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="230000" >
-			<item id="8618"/> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
+			<item id="8618" count="1" /> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
 		</skill>
 		
 		<skill name="Aggression" id="28" level="28" required-level="53" sp="320000" />
@@ -253,7 +267,7 @@
 		<skill name="Holy Aura" id="107" level="2" required-level="60" sp="650000" />
 		<skill name="Tribunal" id="400" level="8" required-level="60" sp="650000" />
 		<skill name="Shield Deflect Magic" id="916" level="1" required-level="60" sp="650000">
-			<item id="49427"/>
+			<item id="49427" count="1" />
 		</skill>
 		
 		<skill name="Aggression" id="28" level="36" required-level="61" sp="650000" />
@@ -264,7 +278,7 @@
 		<skill name="Charm" id="15" level="39" required-level="61" sp="650000" />
 		<skill name="Elemental Heal" id="58" level="42" required-level="61" sp="650000" />
 		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="650000" >
-			<item id="8619"/> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
+			<item id="8619" count="1" /> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
 		</skill>
 		
 		<skill name="Aggression" id="28" level="37" required-level="62" sp="810000" />
@@ -283,7 +297,7 @@
 		<skill name="Holy Aura" id="107" level="3" required-level="62" sp="810000" />
 		<skill name="Tribunal" id="400" level="9" required-level="62" sp="810000" />
 		<skill name="Summon Attractive Cubic" id="449" level="1" required-level="62" sp="810000">
-			<item id="8890"/>
+			<item id="8890" count="1" />
 		</skill>
 		
 		<skill name="Aggression" id="28" level="38" required-level="63" sp="810000" />

--- a/data/skillTrees/2ndClass/TreasureHunter.xml
+++ b/data/skillTrees/2ndClass/TreasureHunter.xml
@@ -1,6 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="8" parentClassId="7">
+
+		<!-- Master Buffs Lv. 40 -->
+		<skill name="Might" id="1068" level="3" required-level="40" sp="80000" />
+		<skill name="Shield" id="1040" level="3" required-level="40" sp="80000" />
+		<skill name="Acumen" id="45104" level="3" required-level="40" sp="80000" />
+		<skill name="Empower" id="45105" level="3" required-level="40" sp="80000" />
+		<skill name="Wild Magic" id="45106" level="2" required-level="40" sp="80000" />
+		<skill name="Magic Barrier" id="45108" level="2" required-level="40" sp="80000" />
+		<skill name="Focus" id="45109" level="3" required-level="40" sp="80000" />
+		<skill name="Death Whisper" id="45110" level="3" required-level="40" sp="80000" />
+		<skill name="Haste" id="45111" level="2" required-level="40" sp="80000" />
+		<skill name="Berserker Spirit" id="45112" level="2" required-level="40" sp="80000" />
+		<skill name="Clarity" id="45113" level="3" required-level="40" sp="80000" />
+
 		<skill name="Pirate" id="1800" level="1" required-level="45" auto-learn="true" />
 		<skill name="Dark Assassin" id="1801" level="1" required-level="60" auto-learn="true" />
 		<skill name="White Assassin" id="1802" level="1" required-level="70" auto-learn="true" />
@@ -106,7 +120,7 @@
 		<skill name="Deadly Blow" id="263" level="14" required-level="51" sp="330000" />
 		<skill name="Backstab" id="30" level="14" required-level="51" sp="330000" />
 		<skill name="Hide" id="922" level="1" required-level="51" sp="330000">
-			<item id="49429"/>
+			<item id="49429" count="1" />
 		</skill>
 		
 		<skill name="Vicious Stance" id="312" level="10" required-level="52" sp="330000" />
@@ -122,7 +136,7 @@
 		<skill name="Trick" id="11" level="2" required-level="52" sp="330000" />
 		<skill name="Backstab" id="30" level="15" required-level="52" sp="330000" />
 		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="330000" >
-			<item id="8618"/> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
+			<item id="8618" count="1" /> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
 		</skill>
 		
 		<skill name="Dagger Mastery" id="209" level="24" required-level="53" sp="460000" />
@@ -149,7 +163,7 @@
 		<skill name="Trick" id="11" level="3" required-level="55" sp="460000" />
 		<skill name="Backstab" id="30" level="18" required-level="55" sp="460000" />
 		<skill name="Sand Bomb" id="412" level="1" required-level="55" sp="460000">
-			<item id="49569"/>
+			<item id="49569" count="1" />
 		</skill>
 		
 		<skill name="Dagger Mastery" id="209" level="27" required-level="56" sp="640000" />
@@ -197,7 +211,7 @@
 		<skill name="Hide" id="922" level="2" required-level="61" sp="930000" />
 		<skill name="Backstab" id="30" level="24" required-level="61" sp="930000" />
 		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="930000" >
-			<item id="8619"/> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
+			<item id="8619" count="1" /> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
 		</skill>
 		
 		<skill name="Vicious Stance" id="312" level="14" required-level="62" sp="1200000" />

--- a/data/skillTrees/2ndClass/Tyrant.xml
+++ b/data/skillTrees/2ndClass/Tyrant.xml
@@ -1,6 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="48" parentClassId="47">
+
+		<!-- Master Buffs Lv. 40 -->
+		<skill name="Chant of Shield" id="45127" level="3" required-level="40" sp="80000" />
+		<skill name="Chant of Might" id="45126" level="3" required-level="40" sp="80000" />
+		<skill name="Chant of Acumen" id="45135" level="3" required-level="40" sp="80000" />
+		<skill name="Chant of Empower" id="45136" level="3" required-level="40" sp="80000" />
+		<skill name="Chant of Wild Magic" id="45137" level="2" required-level="40" sp="80000" />
+		<skill name="Chant of Magic Barrier" id="45125" level="2" required-level="40" sp="80000" />
+		<skill name="Chant of Focus" id="45121" level="3" required-level="40" sp="80000" />
+		<skill name="Chant of Death Whisper" id="45122" level="3" required-level="40" sp="80000" />
+		<skill name="Chant of Haste" id="45123" level="2" required-level="40" sp="80000" />
+		<skill name="Chant of Berserker Spirit" id="45128" level="2" required-level="40" sp="80000" />
+		<skill name="Chant of Clarity" id="45129" level="3" required-level="40" sp="80000" />
+
 		<skill name="Pirate" id="1800" level="1" required-level="45" auto-learn="true" />
 		<skill name="Dark Assassin" id="1801" level="1" required-level="60" auto-learn="true" />
 		<skill name="White Assassin" id="1802" level="1" required-level="70" auto-learn="true" />
@@ -145,10 +159,10 @@
 		<skill name="Focus Force" id="50" level="4" required-level="52" sp="240000" />
 		<skill name="Cripple" id="95" level="10" required-level="52" sp="240000" />
 		<skill name="Break Duress" id="461" level="1" required-level="52" sp="240000">
-			<item id="49426"/>
+			<item id="49426" count="1" />
 		</skill>
 		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="240000" >
-			<item id="8618"/> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
+			<item id="8618" count="1" /> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
 		</skill>
 		
 		<skill name="Force Burst" id="17" level="13" required-level="53" sp="340000" />
@@ -244,7 +258,7 @@
 		<skill name="Force Storm" id="35" level="15" required-level="61" sp="680000" />
 		<skill name="Hurricane Assault" id="284" level="27" required-level="61" sp="680000" />
 		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="680000" >
-			<item id="8619"/> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
+			<item id="8619" count="1" /> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
 		</skill>
 		
 		<skill name="Force Burst" id="17" level="22" required-level="62" sp="840000" />

--- a/data/skillTrees/2ndClass/Warcryer.xml
+++ b/data/skillTrees/2ndClass/Warcryer.xml
@@ -1,6 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="52" parentClassId="50">
+
+		<!-- Master Buffs Lv. 40 -->
+		<skill name="Chant of Shield" id="45127" level="3" required-level="40" sp="80000" />
+		<skill name="Chant of Might" id="45126" level="3" required-level="40" sp="80000" />
+		<skill name="Chant of Acumen" id="45135" level="3" required-level="40" sp="80000" />
+		<skill name="Chant of Empower" id="45136" level="3" required-level="40" sp="80000" />
+		<skill name="Chant of Wild Magic" id="45137" level="2" required-level="40" sp="80000" />
+		<skill name="Chant of Magic Barrier" id="45125" level="2" required-level="40" sp="80000" />
+		<skill name="Chant of Focus" id="45121" level="3" required-level="40" sp="80000" />
+		<skill name="Chant of Death Whisper" id="45122" level="3" required-level="40" sp="80000" />
+		<skill name="Chant of Haste" id="45123" level="2" required-level="40" sp="80000" />
+		<skill name="Chant of Berserker Spirit" id="45128" level="2" required-level="40" sp="80000" />
+		<skill name="Chant of Clarity" id="45129" level="3" required-level="40" sp="80000" />
+
 		<skill name="Pirate" id="1800" level="1" required-level="45" auto-learn="true" />
 		<skill name="Dark Assassin" id="1801" level="1" required-level="60" auto-learn="true" />
 		<skill name="White Assassin" id="1802" level="1" required-level="70" auto-learn="true" />
@@ -74,13 +88,13 @@
 		<skill name="Madness" id="1105" level="6" required-level="44" sp="120000" />
 		<skill name="Boost HP" id="211" level="2" required-level="44" sp="120000" />
 		<skill name="Chant of Rage" id="1253" level="1" required-level="44" sp="120000">
-			<item id="3118"/>
+			<item id="3118" count="1" />
 		</skill>
 		<skill name="Chant of Vampire" id="1310" level="1" required-level="44" sp="120000">
-			<item id="6397"/>
+			<item id="6397" count="1" />
 		</skill>
 		<skill name="Chant of Movement" id="1535" level="1" required-level="44" sp="120000">
-			<item id="49433"/>
+			<item id="49433" count="1" />
 		</skill>
 		
 		<skill name="Power Crush" id="260" level="8" required-level="45" sp="120000" />
@@ -119,7 +133,7 @@
 		<skill name="Boost HP" id="211" level="3" required-level="48" sp="190000" />
 		<skill name="Boost Mana" id="213" level="4" required-level="48" sp="190000" />
 		<skill name="Chant of Fury" id="1251" level="1" required-level="48" sp="190000">
-			<item id="3116"/>
+			<item id="3116" count="1" />
 		</skill>
 		
 		<skill name="Power Crush" id="260" level="12" required-level="49" sp="190000" />
@@ -160,7 +174,7 @@
 		<skill name="Madness" id="1105" level="8" required-level="52" sp="300000" />
 		<skill name="Boost HP" id="211" level="4" required-level="52" sp="300000" />
 		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="300000" >
-			<item id="8618"/> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
+			<item id="8618" count="1" /> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
 		</skill>
 		
 		<skill name="Power Crush" id="260" level="16" required-level="53" sp="300000" />
@@ -257,7 +271,7 @@
 		<skill name="Heavy Armor Mastery" id="253" level="30" required-level="61" sp="700000" />
 		<skill name="Power Crush" id="260" level="24" required-level="61" sp="700000" />
 		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="700000" >
-			<item id="8619"/> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
+			<item id="8619" count="1" /> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="33" required-level="62" sp="700000" />

--- a/data/skillTrees/2ndClass/Warlock.xml
+++ b/data/skillTrees/2ndClass/Warlock.xml
@@ -1,6 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="14" parentClassId="11">
+
+		<!-- Master Buffs Lv. 40 -->
+		<skill name="Might" id="1068" level="3" required-level="40" sp="80000" />
+		<skill name="Shield" id="1040" level="3" required-level="40" sp="80000" />
+		<skill name="Acumen" id="45104" level="3" required-level="40" sp="80000" />
+		<skill name="Empower" id="45105" level="3" required-level="40" sp="80000" />
+		<skill name="Wild Magic" id="45106" level="2" required-level="40" sp="80000" />
+		<skill name="Magic Barrier" id="45108" level="2" required-level="40" sp="80000" />
+		<skill name="Focus" id="45109" level="3" required-level="40" sp="80000" />
+		<skill name="Death Whisper" id="45110" level="3" required-level="40" sp="80000" />
+		<skill name="Haste" id="45111" level="2" required-level="40" sp="80000" />
+		<skill name="Berserker Spirit" id="45112" level="2" required-level="40" sp="80000" />
+		<skill name="Clarity" id="45113" level="3" required-level="40" sp="80000" />
+
 		<skill name="Pirate" id="1800" level="1" required-level="45" auto-learn="true" />
 		<skill name="Dark Assassin" id="1801" level="1" required-level="60" auto-learn="true" />
 		<skill name="White Assassin" id="1802" level="1" required-level="70" auto-learn="true" />
@@ -37,7 +51,7 @@
 		<skill name="Boost Mana" id="213" level="3" required-level="40" sp="100000" />
 		<skill name="Servitor Physical Shield" id="1140" level="1" required-level="40" sp="100000" />
 		<skill name="Summon Binding Cubic" id="1279" level="1" required-level="40" sp="140000">
-			<item id="4922"/>
+			<item id="4922" count="1" />
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="16" required-level="42" sp="140000" />
@@ -72,7 +86,7 @@
 		<skill name="Summon Storm Cubic" id="10" level="2" required-level="44" sp="140000" />
 		<skill name="Servitor Haste" id="1141" level="1" required-level="44" sp="140000" />
 		<skill name="Spirit Sharing" id="1547" level="1" required-level="44" sp="140000">
-			<item id="49562"/>
+			<item id="49562" count="1" />
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="19" required-level="46" sp="220000" />
@@ -140,7 +154,7 @@
 		<skill name="Summon Storm Cubic" id="10" level="3" required-level="52" sp="360000" />
 		<skill name="Servitor Haste" id="1141" level="2" required-level="52" sp="360000" />
 		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="360000" >
-			<item id="8618"/> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
+			<item id="8618" count="1" /> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="25" required-level="54" sp="570000" />
@@ -226,7 +240,7 @@
 		<skill name="Servitor Heal" id="1127" level="32" required-level="61" sp="850000" />
 		<skill name="Servitor Recharge" id="1126" level="21" required-level="61" sp="850000" />
 		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="850000" >
-			<item id="8619"/> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
+			<item id="8619" count="1" /> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
 		</skill>
 		
 		<skill name="Anti Magic" id="146" level="33" required-level="62" sp="850000" />

--- a/data/skillTrees/2ndClass/Warlord.xml
+++ b/data/skillTrees/2ndClass/Warlord.xml
@@ -1,6 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="3" parentClassId="1">
+
+		<!-- Master Buffs Lv. 40 -->
+		<skill name="Might" id="1068" level="3" required-level="40" sp="80000" />
+		<skill name="Shield" id="1040" level="3" required-level="40" sp="80000" />
+		<skill name="Acumen" id="45104" level="3" required-level="40" sp="80000" />
+		<skill name="Empower" id="45105" level="3" required-level="40" sp="80000" />
+		<skill name="Wild Magic" id="45106" level="2" required-level="40" sp="80000" />
+		<skill name="Magic Barrier" id="45108" level="2" required-level="40" sp="80000" />
+		<skill name="Focus" id="45109" level="3" required-level="40" sp="80000" />
+		<skill name="Death Whisper" id="45110" level="3" required-level="40" sp="80000" />
+		<skill name="Haste" id="45111" level="2" required-level="40" sp="80000" />
+		<skill name="Berserker Spirit" id="45112" level="2" required-level="40" sp="80000" />
+		<skill name="Clarity" id="45113" level="3" required-level="40" sp="80000" />
+
 		<skill name="Pirate" id="1800" level="1" required-level="45" auto-learn="true" />
 		<skill name="Dark Assassin" id="1801" level="1" required-level="60" auto-learn="true" />
 		<skill name="White Assassin" id="1802" level="1" required-level="70" auto-learn="true" />
@@ -118,7 +132,7 @@
 		<skill name="Heavy Armor Mastery" id="231" level="27" required-level="51" sp="290000" />
 		<skill name="Thunder Storm" id="48" level="14" required-level="51" sp="290000" />
 		<skill name="Fell Swoop" id="421" level="1" required-level="51" sp="290000">
-			<item id="49424"/> <!-- Spellbook: Broad Sweep -->
+			<item id="49424" count="1" /> <!-- Spellbook: Broad Sweep -->
 		</skill>
 		
 		<skill name="Vicious Stance" id="312" level="10" required-level="52" sp="290000" />
@@ -133,7 +147,7 @@
 		<skill name="Final Frenzy" id="290" level="4" required-level="52" sp="290000" />
 		<skill name="Focus Attack" id="317" level="2" required-level="52" sp="290000" />
 		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="290000" >
-			<item id="8618"/> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
+			<item id="8618" count="1" /> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
 		</skill>
 		
 		<skill name="Spinning Slasher" id="36" level="16" required-level="53" sp="400000" />
@@ -215,7 +229,7 @@
 		<skill name="Heavy Armor Mastery" id="231" level="37" required-level="61" sp="800000" />
 		<skill name="Thunder Storm" id="48" level="24" required-level="61" sp="800000" />
 		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="800000" >
-			<item id="8619"/> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
+			<item id="8619" count="1" /> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
 		</skill>
 		
 		<skill name="Vicious Stance" id="312" level="14" required-level="62" sp="1000000" />

--- a/data/skillTrees/2ndClass/Warsmith.xml
+++ b/data/skillTrees/2ndClass/Warsmith.xml
@@ -1,349 +1,333 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="57" parentClassId="56">
-		<skill name="Pirate" id="1800" level="1" required-level="45" auto-learn="true" />
-		<skill name="Dark Assassin" id="1801" level="1" required-level="60" auto-learn="true" />
-		<skill name="White Assassin" id="1802" level="1" required-level="70" auto-learn="true" />
-		<skill name="Golem Reinforcement" id="824" level="1" required-level="40" sp="90000" />
-		<skill name="Fast HP Recovery" id="212" level="3" required-level="40" sp="90000" />
-		<skill name="Spinning Slasher" id="36" level="1" required-level="40" sp="90000" />
-		<skill name="Spinning Slasher" id="36" level="2" required-level="40" sp="90000" />
-		<skill name="Spinning Slasher" id="36" level="3" required-level="40" sp="90000" />
-		<skill name="Polearm Mastery" id="216" level="9" required-level="40" sp="90000" />
-		<skill name="Polearm Mastery" id="216" level="10" required-level="40" sp="90000" />
-		<skill name="Polearm Mastery" id="216" level="11" required-level="40" sp="90000" />
-		<skill name="Light Armor Mastery" id="227" level="14" required-level="40" sp="90000" />
-		<skill name="Light Armor Mastery" id="227" level="15" required-level="40" sp="90000" />
-		<skill name="Light Armor Mastery" id="227" level="16" required-level="40" sp="90000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="9" required-level="40" sp="90000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="10" required-level="40" sp="90000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="11" required-level="40" sp="90000" />
-		<skill name="Heavy Armor Mastery" id="231" level="14" required-level="40" sp="90000" />
-		<skill name="Heavy Armor Mastery" id="231" level="15" required-level="40" sp="90000" />
-		<skill name="Heavy Armor Mastery" id="231" level="16" required-level="40" sp="90000" />
-		<skill name="Vital Force" id="148" level="3" required-level="40" sp="90000" />
-		<skill name="Crystallize" id="248" level="2" required-level="40" sp="90000" />
-		<skill name="Repair Golem" id="822" level="1" required-level="40" sp="90000" />
-		<skill name="Power Crush" id="260" level="1" required-level="40" sp="90000" />
-		<skill name="Power Crush" id="260" level="2" required-level="40" sp="90000" />
-		<skill name="Power Crush" id="260" level="3" required-level="40" sp="90000" />
+
+		<!-- Master Buffs Lv. 40 -->
+		<skill name="Maphr's Shield" id="45120" level="3" required-level="40" sp="80000" />
+		<skill name="Maphr's Might" id="45119" level="3" required-level="40" sp="80000" />
+		<skill name="Maphr's Acumen" id="45130" level="3" required-level="40" sp="80000" />
+		<skill name="Maphr's Empower" id="45131" level="3" required-level="40" sp="80000" />
+		<skill name="Maphr's Wild Magic" id="45132" level="2" required-level="40" sp="80000" />
+		<skill name="Maphr's Magic Barrier" id="45118" level="2" required-level="40" sp="80000" />
+		<skill name="Maphr's Focus" id="45114" level="3" required-level="40" sp="80000" />
+		<skill name="Maphr's Death Whisper" id="45115" level="3" required-level="40" sp="80000" />
+		<skill name="Maphr's Haste" id="45116" level="2" required-level="40" sp="80000" />
+		<skill name="Maphr's Berserker Spirit" id="45133" level="2" required-level="40" sp="80000" />
+		<skill name="Maphr's Clarity" id="45134" level="3" required-level="40" sp="80000" />
+
+
+		<!-- Lv. 40 Skills -->
+		<skill name="Spinning Slasher" id="36" level="1" required-level="40" sp="82000" />
+		<skill name="Spinning Slasher" id="36" level="2" required-level="40" sp="82000" />
+		<skill name="Spinning Slasher" id="36" level="3" required-level="40" sp="82000" />
+		<skill name="Spinning Slasher" id="36" level="4" required-level="40" sp="82000" />
+		<skill name="Spinning Slasher" id="36" level="5" required-level="40" sp="82000" />
+		<skill name="Weapon Mastery" id="141" level="4" required-level="40" sp="82000" />
+		<skill name="Fatal Strike" id="190" level="1" required-level="40" sp="82000" />
+		<skill name="Fatal Strike" id="190" level="2" required-level="40" sp="82000" />
+		<skill name="Fatal Strike" id="190" level="3" required-level="40" sp="82000" />
+		<skill name="Fatal Strike" id="190" level="4" required-level="40" sp="82000" />
+		<skill name="Fatal Strike" id="190" level="5" required-level="40" sp="82000" />
+		<skill name="Crystallize" id="248" level="2" required-level="40" sp="82000" />
+		<skill name="Power Crush" id="260" level="1" required-level="40" sp="82000" />
+		<skill name="Power Crush" id="260" level="2" required-level="40" sp="82000" />
+		<skill name="Power Crush" id="260" level="3" required-level="40" sp="82000" />
+		<skill name="Repair Golem" id="822" level="1" required-level="40" sp="82000" />
+		<skill name="Golem Reinforcement" id="824" level="1" required-level="40" sp="82000" />
+		<skill name="Rush" id="45252" level="1" required-level="40" sp="82000" />
+		<skill name="Dwarven Armor Mastery" id="47236" level="2" required-level="40" sp="82000" />
+		<skill name="Dwarven Weapon Mastery" id="47235" level="2" required-level="40" sp="82000" />
+		<skill name="Dwarven Restore Mastery" id="47237" level="1" required-level="40" sp="82000" />
 		<skill name="Potion Mastery" id="45184" level="1" required-level="40">
 			<item id="57" count="1000000"/> <!-- Adena -->
 		</skill>
 
-		<skill name="Spinning Slasher" id="36" level="4" required-level="41" sp="110000" />
-		<skill name="Polearm Mastery" id="216" level="12" required-level="41" sp="110000" />
-		<skill name="Light Armor Mastery" id="227" level="17" required-level="41" sp="110000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="12" required-level="41" sp="110000" />
-		<skill name="Heavy Armor Mastery" id="231" level="17" required-level="41" sp="110000" />
+		<!-- Lv. 41 Skills -->
+		<skill name="Spinning Slasher" id="36" level="6" required-level="41" sp="110000" />
 		<skill name="Power Crush" id="260" level="4" required-level="41" sp="110000" />
-		
-		<skill name="Spinning Slasher" id="36" level="5" required-level="42" sp="110000" />
-		<skill name="Polearm Mastery" id="216" level="13" required-level="42" sp="110000" />
-		<skill name="Light Armor Mastery" id="227" level="18" required-level="42" sp="110000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="13" required-level="42" sp="110000" />
-		<skill name="Heavy Armor Mastery" id="231" level="18" required-level="42" sp="110000" />
+		<skill name="Fatal Strike" id="190" level="6" required-level="41" sp="11000" />
+
+		<!-- Lv. 42 Skills -->
+
+		<skill name="Spinning Slasher" id="36" level="7" required-level="42" sp="110000" />
+		<skill name="Fatal Strike" id="190" level="7" required-level="42" sp="110000" />
 		<skill name="Power Crush" id="260" level="5" required-level="42" sp="110000" />
+		<skill name="Body Crush" id="1613" level="1" required-level="42" sp="110000" />
 		<skill name="Weapon Reinforcement" id="1615" level="1" required-level="42" sp="110000" />
-		
-		<skill name="Fast HP Recovery" id="212" level="4" required-level="43" sp="110000" />
-		<skill name="Spinning Slasher" id="36" level="6" required-level="43" sp="110000" />
-		<skill name="Polearm Mastery" id="216" level="14" required-level="43" sp="110000" />
-		<skill name="Light Armor Mastery" id="227" level="19" required-level="43" sp="110000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="14" required-level="43" sp="110000" />
-		<skill name="Heavy Armor Mastery" id="231" level="19" required-level="43" sp="110000" />
+
+		<!-- Lv. 43 Skills -->
 		<skill name="Summon Mechanic Golem" id="25" level="3" required-level="43" sp="110000" />
-		<skill name="Provoke" id="286" level="1" required-level="43" sp="110000" />
+		<skill name="Spinning Slasher" id="36" level="8" required-level="43" sp="110000" />
 		<skill name="Create Item" id="172" level="5" required-level="43" sp="110000" />
-		<skill name="Power Crush" id="260" level="6" required-level="43" sp="110000" />
+		<skill name="Fatal Strike" id="190" level="8" required-level="43" sp="110000" />
 		<skill name="Boost HP" id="211" level="4" required-level="43" sp="110000" />
+		<skill name="Power Crush" id="260" level="6" required-level="43" sp="110000" />
+		<skill name="Provoke" id="286" level="1" required-level="43" sp="110000" />
+		<skill name="Final Frenzy" id="290" level="1" required-level="43" sp="110000" />
 		<skill name="Strengthen Golem" id="823" level="1" required-level="43" sp="110000" />
 
-		<skill name="Spinning Slasher" id="36" level="7" required-level="44" sp="160000" />
-		<skill name="Polearm Mastery" id="216" level="15" required-level="44" sp="160000" />
-		<skill name="Light Armor Mastery" id="227" level="20" required-level="44" sp="160000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="15" required-level="44" sp="160000" />
-		<skill name="Heavy Armor Mastery" id="231" level="20" required-level="44" sp="160000" />
-		<skill name="Tenacity" id="1617" level="1" required-level="44" sp="160000" />
+		<!-- Lv. 44 Skills -->
+		<skill name="Spinning Slasher" id="36" level="9" required-level="44" sp="160000" />
+		<skill name="Fatal Strike" id="190" level="9" required-level="42" sp="160000" />
 		<skill name="Power Crush" id="260" level="7" required-level="44" sp="160000" />
-		
-		<skill name="Spinning Slasher" id="36" level="8" required-level="45" sp="160000" />
-		<skill name="Polearm Mastery" id="216" level="16" required-level="45" sp="160000" />
-		<skill name="Light Armor Mastery" id="227" level="21" required-level="45" sp="160000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="16" required-level="45" sp="160000" />
-		<skill name="Heavy Armor Mastery" id="231" level="21" required-level="45" sp="160000" />
+		<skill name="Tenacity" id="1617" level="1" required-level="44" sp="160000" />
+
+		<!-- Lv. 45 Skills -->
+
+		<skill name="Bandage" id="34" level="2" required-level="42" sp="160000" />
+		<skill name="Spinning Slasher" id="36" level="10" required-level="45" sp="160000" />
+		<skill name="Fatal Strike" id="190" level="10" required-level="45" sp="160000" />
 		<skill name="Power Crush" id="260" level="8" required-level="45" sp="160000" />
-		
-		<skill name="Spinning Slasher" id="36" level="9" required-level="46" sp="160000" />
-		<skill name="Polearm Mastery" id="216" level="17" required-level="46" sp="160000" />
-		<skill name="Light Armor Mastery" id="227" level="22" required-level="46" sp="160000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="17" required-level="46" sp="160000" />
-		<skill name="Heavy Armor Mastery" id="231" level="22" required-level="46" sp="160000" />
-		<skill name="Vital Force" id="148" level="4" required-level="46" sp="160000" />
-		<skill name="Encase Armor" id="828" level="1" required-level="46" sp="160000" />
+		<skill name="Pirate" id="1800" level="1" required-level="45" auto-learn="true" />
+
+		<!-- Lv. 46 Skills -->
+		<skill name="Spinning Slasher" id="36" level="11" required-level="46" sp="160000" />
 		<skill name="Weight Limit" id="150" level="3" required-level="46" sp="160000" />
-		<skill name="Bandage" id="34" level="2" required-level="46" sp="160000" />
+		<skill name="Fatal Strike" id="190" level="11" required-level="42" sp="160000" />
+		<skill name="Final Frenzy" id="290" level="2" required-level="43" sp="160000" />
+		<skill name="Encase Armor" id="828" level="1" required-level="46" sp="160000" />
+		<skill name="Body Crush" id="1613" level="2" required-level="46" sp="110000" />
 		<skill name="Power Crush" id="260" level="9" required-level="46" sp="160000" />
 
-		<skill name="Spinning Slasher" id="36" level="10" required-level="47" sp="220000" />
-		<skill name="Polearm Mastery" id="216" level="18" required-level="47" sp="220000" />
-		<skill name="Light Armor Mastery" id="227" level="23" required-level="47" sp="220000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="18" required-level="47" sp="220000" />
-		<skill name="Heavy Armor Mastery" id="231" level="23" required-level="47" sp="220000" />
+		<!-- Lv. 47 Skills -->
+		<skill name="Spinning Slasher" id="36" level="12" required-level="47" sp="220000" />
+		<skill name="Fatal Strike" id="190" level="12" required-level="47" sp="220000" />
 		<skill name="Power Crush" id="260" level="10" required-level="47" sp="220000" />
-		
-		<skill name="Spinning Slasher" id="36" level="11" required-level="48" sp="220000" />
-		<skill name="Polearm Mastery" id="216" level="19" required-level="48" sp="220000" />
-		<skill name="Light Armor Mastery" id="227" level="24" required-level="48" sp="220000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="19" required-level="48" sp="220000" />
-		<skill name="Heavy Armor Mastery" id="231" level="24" required-level="48" sp="220000" />
-		<skill name="Power Crush" id="260" level="11" required-level="48" sp="220000" />
-		
-		<skill name="Golem Reinforcement" id="824" level="2" required-level="49" sp="220000" />
-		<skill name="Spinning Slasher" id="36" level="12" required-level="49" sp="220000" />
-		<skill name="Polearm Mastery" id="216" level="20" required-level="49" sp="220000" />
-		<skill name="Light Armor Mastery" id="227" level="25" required-level="49" sp="220000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="20" required-level="49" sp="220000" />
-		<skill name="Heavy Armor Mastery" id="231" level="25" required-level="49" sp="220000" />
-		<skill name="Lionheart" id="287" level="2" required-level="49" sp="220000" />
-		<skill name="Repair Golem" id="822" level="2" required-level="49" sp="220000" />
-		<skill name="Summon Mechanic Golem" id="25" level="4" required-level="49" sp="220000" />
-		<skill name="Create Item" id="172" level="6" required-level="49" sp="220000" />
-		<skill name="Power Crush" id="260" level="12" required-level="49" sp="220000" />
-		<skill name="Boost HP" id="211" level="5" required-level="49" sp="220000" />
-		<skill name="Spike" id="826" level="1" required-level="49" sp="220000" />
-		<skill name="Summon Siege Golem" id="13" level="1" required-level="49" sp="220000">
-			<item id="3940"/>
-		</skill>
+		<skill name="Dwarven Armor Mastery" id="47236" level="3" required-level="47" sp="220000" />
 
-		<skill name="Spinning Slasher" id="36" level="13" required-level="50" sp="310000" />
-		<skill name="Polearm Mastery" id="216" level="21" required-level="50" sp="310000" />
-		<skill name="Light Armor Mastery" id="227" level="26" required-level="50" sp="310000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="21" required-level="50" sp="310000" />
-		<skill name="Heavy Armor Mastery" id="231" level="26" required-level="50" sp="310000" />
+		<!-- Lv. 48 Skills -->
+		<skill name="Spinning Slasher" id="36" level="13" required-level="48" sp="220000" />
+		<skill name="Fatal Strike" id="190" level="13" required-level="48" sp="220000" />
+		<skill name="Power Crush" id="260" level="11" required-level="48" sp="220000" />
+		<skill name="Dwarven Weapon Mastery" id="47235" level="3" required-level="48" sp="220000" />
+
+		<!-- Lv. 49 Skills -->
+		<skill name="Summon Siege Golem" id="13" level="1" required-level="49" sp="220000">
+			<item id="3940" count="1" />
+		</skill>
+		<skill name="Summon Mechanic Golem" id="25" level="4" required-level="49" sp="220000" />
+		<skill name="Spinning Slasher" id="36" level="14" required-level="49" sp="220000" />
+		<skill name="Create Item" id="172" level="6" required-level="49" sp="220000" />
+		<skill name="Fatal Strike" id="190" level="14" required-level="49" sp="220000" />
+		<skill name="Boost HP" id="211" level="5" required-level="49" sp="220000" />
+		<skill name="Power Crush" id="260" level="12" required-level="49" sp="220000" />
+		<skill name="Lionheart" id="287" level="2" required-level="49" sp="220000" />
+		<skill name="Final Frenzy" id="290" level="3" required-level="49" sp="220000" />
+		<skill name="Repair Golem" id="822" level="2" required-level="49" sp="220000" />
+		<skill name="Golem Reinforcement" id="824" level="2" required-level="49" sp="220000" />
+		<skill name="Spike" id="826" level="1" required-level="49" sp="220000" />
+
+		<!-- Lv. 50 Skills -->
+		<skill name="Spinning Slasher" id="36" level="15" required-level="50" sp="310000" />
+		<skill name="Fatal Strike" id="190" level="15" required-level="50" sp="310000" />
 		<skill name="Power Crush" id="260" level="13" required-level="50" sp="310000" />
+		<skill name="Body Crush" id="1613" level="3" required-level="50" sp="310000" />
+		<skill name="Restore HP" id="45176" level="2" required-level="50" sp="310000" />
+		<skill name="Restore MP" id="45177" level="2" required-level="50" sp="310000" />
 		<skill name="Potion Mastery" id="45184" level="2" required-level="50">
 			<item id="57" count="3000000"/> <!-- Adena -->
 		</skill>
-		
-		<skill name="Spinning Slasher" id="36" level="14" required-level="51" sp="310000" />
-		<skill name="Polearm Mastery" id="216" level="22" required-level="51" sp="310000" />
-		<skill name="Light Armor Mastery" id="227" level="27" required-level="51" sp="310000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="22" required-level="51" sp="310000" />
-		<skill name="Heavy Armor Mastery" id="231" level="27" required-level="51" sp="310000" />
+		<skill name="Mechanic Assistance" id="45245" level="1" required-level="50" sp="310000" />
+
+		<!-- Lv. 51 Skills -->
+		<skill name="Spinning Slasher" id="36" level="16" required-level="51" sp="310000" />
+		<skill name="Fatal Strike" id="190" level="16" required-level="51" sp="310000" />
 		<skill name="Power Crush" id="260" level="14" required-level="51" sp="310000" />
-		
-		<skill name="Fast HP Recovery" id="212" level="5" required-level="52" sp="310000" />
-		<skill name="Spinning Slasher" id="36" level="15" required-level="52" sp="310000" />
-		<skill name="Polearm Mastery" id="216" level="23" required-level="52" sp="310000" />
-		<skill name="Light Armor Mastery" id="227" level="28" required-level="52" sp="310000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="23" required-level="52" sp="310000" />
-		<skill name="Heavy Armor Mastery" id="231" level="28" required-level="52" sp="310000" />
-		<skill name="Vital Force" id="148" level="5" required-level="52" sp="310000" />
+
+		<!-- Lv. 52 Skills -->
+		<skill name="Spinning Slasher" id="36" level="17" required-level="52" sp="310000" />
+		<skill name="Fatal Strike" id="190" level="17" required-level="52" sp="310000" />
 		<skill name="Crystallize" id="248" level="3" required-level="52" sp="310000" />
 		<skill name="Power Crush" id="260" level="15" required-level="52" sp="310000" />
+		<skill name="Final Frenzy" id="290" level="4" required-level="52" sp="310000" />
+		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="310000" >
+			<item id="8618" count="1" /> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
+		</skill>
 		<skill name="Weapon Reinforcement" id="1615" level="2" required-level="52" sp="310000" />
 		<skill name="Strengthen Golem" id="823" level="2" required-level="52" sp="310000" />
-		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="310000" >
-			<item id="8618"/> <!-- Ancient Book: Divine Inspiration (Modern Language Version) -->
-		</skill>
-		
-		<skill name="Spinning Slasher" id="36" level="16" required-level="53" sp="440000" />
-		<skill name="Polearm Mastery" id="216" level="24" required-level="53" sp="440000" />
-		<skill name="Light Armor Mastery" id="227" level="29" required-level="53" sp="440000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="24" required-level="53" sp="440000" />
-		<skill name="Heavy Armor Mastery" id="231" level="29" required-level="53" sp="440000" />
+		<skill name="Dwarven Restore Mastery" id="47237" level="2" required-level="52" sp="310000" />
+
+		<!-- Lv. 53 Skills -->
+		<skill name="Spinning Slasher" id="36" level="18" required-level="53" sp="440000" />
+		<skill name="Fatal Strike" id="190" level="18" required-level="53" sp="440000" />
 		<skill name="Power Crush" id="260" level="16" required-level="53" sp="440000" />
-		
-		<skill name="Spinning Slasher" id="36" level="17" required-level="54" sp="440000" />
-		<skill name="Polearm Mastery" id="216" level="25" required-level="54" sp="440000" />
-		<skill name="Light Armor Mastery" id="227" level="30" required-level="54" sp="440000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="25" required-level="54" sp="440000" />
-		<skill name="Heavy Armor Mastery" id="231" level="30" required-level="54" sp="440000" />
+		<skill name="Dwarven Armor Mastery" id="47236" level="4" required-level="53" sp="440000" />
+
+		<!-- Lv. 54 Skills -->
+		<skill name="Spinning Slasher" id="36" level="19" required-level="54" sp="440000" />
+		<skill name="Fatal Strike" id="190" level="19" required-level="54" sp="440000" />
 		<skill name="Power Crush" id="260" level="17" required-level="54" sp="440000" />
-		
-		<skill name="Golem Reinforcement" id="824" level="3" required-level="55" sp="440000" />
-		<skill name="Spinning Slasher" id="36" level="18" required-level="55" sp="440000" />
-		<skill name="Polearm Mastery" id="216" level="26" required-level="55" sp="440000" />
-		<skill name="Light Armor Mastery" id="227" level="31" required-level="55" sp="440000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="26" required-level="55" sp="440000" />
-		<skill name="Heavy Armor Mastery" id="231" level="31" required-level="55" sp="440000" />
-		<skill name="Repair Golem" id="822" level="3" required-level="55" sp="440000" />
+		<skill name="Body Crush" id="1613" level="4" required-level="54" sp="440000" />
+		<skill name="Dwarven Weapon Mastery" id="47235" level="4" required-level="54" sp="440000" />
+
+		<!-- Lv. 55 Skills -->
 		<skill name="Summon Mechanic Golem" id="25" level="5" required-level="55" sp="440000" />
-		<skill name="Provoke" id="286" level="2" required-level="55" sp="440000" />
+		<skill name="Spinning Slasher" id="36" level="20" required-level="55" sp="440000" />
 		<skill name="Create Item" id="172" level="7" required-level="55" sp="440000" />
-		<skill name="Power Crush" id="260" level="18" required-level="55" sp="440000" />
+		<skill name="Fatal Strike" id="190" level="20" required-level="55" sp="440000" />
 		<skill name="Boost HP" id="211" level="6" required-level="55" sp="440000" />
+		<skill name="Power Crush" id="260" level="18" required-level="55" sp="440000" />
+		<skill name="Provoke" id="286" level="2" required-level="55" sp="440000" />
+		<skill name="Final Frenzy" id="290" level="5" required-level="55" sp="440000" />
+		<skill name="Repair Golem" id="822" level="3" required-level="55" sp="440000" />
+		<skill name="Golem Reinforcement" id="824" level="3" required-level="55" sp="440000" />
 
-		<skill name="Spinning Slasher" id="36" level="19" required-level="56" sp="600000" />
-		<skill name="Polearm Mastery" id="216" level="27" required-level="56" sp="600000" />
-		<skill name="Light Armor Mastery" id="227" level="32" required-level="56" sp="600000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="27" required-level="56" sp="600000" />
-		<skill name="Heavy Armor Mastery" id="231" level="32" required-level="56" sp="600000" />
-		<skill name="Tenacity" id="1617" level="2" required-level="56" sp="600000" />
+		<!-- Lv. 56 Skills -->
+		<skill name="Spinning Slasher" id="36" level="21" required-level="56" sp="600000" />
+		<skill name="Fatal Strike" id="190" level="21" required-level="56" sp="600000" />
 		<skill name="Power Crush" id="260" level="19" required-level="56" sp="600000" />
-		
-		<skill name="Spinning Slasher" id="36" level="20" required-level="57" sp="600000" />
-		<skill name="Polearm Mastery" id="216" level="28" required-level="57" sp="600000" />
-		<skill name="Light Armor Mastery" id="227" level="33" required-level="57" sp="600000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="28" required-level="57" sp="600000" />
-		<skill name="Heavy Armor Mastery" id="231" level="33" required-level="57" sp="600000" />
-		<skill name="Power Crush" id="260" level="20" required-level="57" sp="600000" />
-		
-		<skill name="Fast HP Recovery" id="212" level="6" required-level="58" sp="600000" />
-		<skill name="Spinning Slasher" id="36" level="21" required-level="58" sp="600000" />
-		<skill name="Polearm Mastery" id="216" level="29" required-level="58" sp="600000" />
-		<skill name="Light Armor Mastery" id="227" level="34" required-level="58" sp="600000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="29" required-level="58" sp="600000" />
-		<skill name="Heavy Armor Mastery" id="231" level="34" required-level="58" sp="600000" />
-		<skill name="Vital Force" id="148" level="6" required-level="58" sp="600000" />
-		<skill name="Power Crush" id="260" level="21" required-level="58" sp="600000" />
-		<skill name="Strengthen Golem" id="823" level="3" required-level="58" sp="600000" />
-		<skill name="Summon Wild Hog Cannon" id="299" level="1" required-level="58" sp="600000">
-			<item id="4915"/>
-		</skill>
+		<skill name="Tenacity" id="1617" level="2" required-level="56" sp="600000" />
 
-		<skill name="Spinning Slasher" id="36" level="22" required-level="59" sp="880000" />
-		<skill name="Polearm Mastery" id="216" level="30" required-level="59" sp="880000" />
-		<skill name="Light Armor Mastery" id="227" level="35" required-level="59" sp="880000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="30" required-level="59" sp="880000" />
-		<skill name="Heavy Armor Mastery" id="231" level="35" required-level="59" sp="880000" />
+		<!-- Lv. 57 Skills -->
+		<skill name="Spinning Slasher" id="36" level="22" required-level="57" sp="600000" />
+		<skill name="Fatal Strike" id="190" level="22" required-level="57" sp="600000" />
+		<skill name="Power Crush" id="260" level="20" required-level="57" sp="600000" />
+
+		<!-- Lv. 58 Skills -->
+		<skill name="Spinning Slasher" id="36" level="23" required-level="58" sp="600000" />
+		<skill name="Fatal Strike" id="190" level="23" required-level="58" sp="600000" />
+		<skill name="Power Crush" id="260" level="21" required-level="58" sp="600000" />
+		<skill name="Final Frenzy" id="290" level="6" required-level="55" sp="600000" />
+		<skill name="Summon Wild Hog Cannon" id="299" level="1" required-level="58" sp="600000">
+			<item id="4915" count="1" />
+		</skill>
+		<skill name="Strengthen Golem" id="823" level="3" required-level="58" sp="600000" />
+		<skill name="Body Crush" id="1613" level="5" required-level="58" sp="600000" />
+
+		<!-- Lv. 59 Skills -->
+		<skill name="Spinning Slasher" id="36" level="24" required-level="59" sp="880000" />
+		<skill name="Fatal Strike" id="190" level="24" required-level="59" sp="880000" />
 		<skill name="Power Crush" id="260" level="22" required-level="59" sp="880000" />
-		
-		<skill name="Spinning Slasher" id="36" level="23" required-level="60" sp="880000" />
-		<skill name="Polearm Mastery" id="216" level="31" required-level="60" sp="880000" />
-		<skill name="Light Armor Mastery" id="227" level="36" required-level="60" sp="880000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="31" required-level="60" sp="880000" />
-		<skill name="Heavy Armor Mastery" id="231" level="36" required-level="60" sp="880000" />
-		<skill name="Crystallize" id="248" level="4" required-level="60" sp="880000" />
+		<skill name="Dwarven Armor Mastery" id="47236" level="5" required-level="53" sp="440000" />
+
+		<!-- Lv. 60 Skills -->
 		<skill name="Summon Mechanic Golem" id="25" level="6" required-level="60" sp="880000" />
-		<skill name="Provoke" id="286" level="3" required-level="60" sp="880000" />
+		<skill name="Bandage" id="34" level="3" required-level="60" sp="880000" />
+		<skill name="Spinning Slasher" id="36" level="25" required-level="60" sp="880000" />
+		<skill name="Attack Ability" id="77" level="3" required-level="60" sp="880000" />
+		<skill name="Fatal Strike" id="190" level="25" required-level="60" sp="880000" />
+		<skill name="Crystallize" id="248" level="4" required-level="60" sp="880000" />
 		<skill name="Power Crush" id="260" level="23" required-level="60" sp="880000" />
+		<skill name="Provoke" id="286" level="3" required-level="60" sp="880000" />
+		<skill name="Final Frenzy" id="290" level="7" required-level="60" sp="880000" />
+		<skill name="Rush" id="45252" level="2" required-level="55" sp="880000" />
+		<skill name="Dark Assassin" id="1801" level="1" required-level="60" auto-learn="true" />
 		<skill name="Potion Mastery" id="45184" level="3" required-level="60">
 			<item id="57" count="6000000"/> <!-- Adena -->
 		</skill>
+		<skill name="Dwarven Weapon Mastery" id="47235" level="5" required-level="60" sp="880000" />
 
-		<skill name="Spinning Slasher" id="36" level="24" required-level="61" sp="880000" />
-		<skill name="Polearm Mastery" id="216" level="32" required-level="61" sp="880000" />
-		<skill name="Light Armor Mastery" id="227" level="37" required-level="61" sp="880000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="32" required-level="61" sp="880000" />
-		<skill name="Heavy Armor Mastery" id="231" level="37" required-level="61" sp="880000" />
+		<!-- Lv. 61 Skills -->
+		<skill name="Spinning Slasher" id="36" level="26" required-level="61" sp="880000" />
+		<skill name="Fatal Strike" id="190" level="26" required-level="61" sp="880000" />
 		<skill name="Power Crush" id="260" level="24" required-level="61" sp="880000" />
 		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="880000" >
-			<item id="8619"/> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
+			<item id="8619" count="1" /> <!-- Ancient Book: Divine Inspiration (Original Language Version) -->
 		</skill>
-		
-		<skill name="Spinning Slasher" id="36" level="25" required-level="62" sp="1100000" />
-		<skill name="Polearm Mastery" id="216" level="33" required-level="62" sp="1100000" />
-		<skill name="Light Armor Mastery" id="227" level="38" required-level="62" sp="1100000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="33" required-level="62" sp="1100000" />
-		<skill name="Heavy Armor Mastery" id="231" level="38" required-level="62" sp="1100000" />
-		<skill name="Lionheart" id="287" level="3" required-level="62" sp="1100000" />
-		<skill name="Bandage" id="34" level="3" required-level="62" sp="1100000" />
+
+		<!-- Lv. 62 Skills -->
+		<skill name="Spinning Slasher" id="36" level="27" required-level="62" sp="1100000" />
 		<skill name="Create Item" id="172" level="8" required-level="62" sp="1100000" />
-		<skill name="Power Crush" id="260" level="25" required-level="62" sp="1100000" />
+		<skill name="Fatal Strike" id="190" level="27" required-level="62" sp="1100000" />
 		<skill name="Boost HP" id="211" level="7" required-level="62" sp="1100000" />
+		<skill name="Power Crush" id="260" level="25" required-level="62" sp="1100000" />
+		<skill name="Lionheart" id="287" level="3" required-level="62" sp="1100000" />
+		<skill name="Final Frenzy" id="290" level="8" required-level="62" sp="1100000" />
+		<skill name="Body Crush" id="1613" level="6" required-level="62" sp="1100000" />
 		<skill name="Weapon Reinforcement" id="1615" level="3" required-level="62" sp="1100000" />
-		
-		<skill name="Spinning Slasher" id="36" level="26" required-level="63" sp="1100000" />
-		<skill name="Polearm Mastery" id="216" level="34" required-level="63" sp="1100000" />
-		<skill name="Light Armor Mastery" id="227" level="39" required-level="63" sp="1100000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="34" required-level="63" sp="1100000" />
-		<skill name="Heavy Armor Mastery" id="231" level="39" required-level="63" sp="1100000" />
+
+		<!-- Lv. 63 Skills -->
+		<skill name="Spinning Slasher" id="36" level="28" required-level="63" sp="1100000" />
+		<skill name="Fatal Strike" id="190" level="28" required-level="63" sp="1100000" />
 		<skill name="Power Crush" id="260" level="26" required-level="63" sp="1100000" />
-		
-		<skill name="Spinning Slasher" id="36" level="27" required-level="64" sp="1400000" />
-		<skill name="Polearm Mastery" id="216" level="35" required-level="64" sp="1400000" />
-		<skill name="Light Armor Mastery" id="227" level="40" required-level="64" sp="1400000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="35" required-level="64" sp="1400000" />
-		<skill name="Heavy Armor Mastery" id="231" level="40" required-level="64" sp="1400000" />
-		<skill name="Vital Force" id="148" level="7" required-level="64" sp="1400000" />
-		<skill name="Tenacity" id="1617" level="3" required-level="64" sp="1400000" />
+
+		<!-- Lv. 64 Skills -->
 		<skill name="Summon Mechanic Golem" id="25" level="7" required-level="64" sp="1400000" />
-		<skill name="Provoke" id="286" level="4" required-level="64" sp="1400000" />
+		<skill name="Spinning Slasher" id="36" level="29" required-level="64" sp="1400000" />
+		<skill name="Fatal Strike" id="190" level="29" required-level="64" sp="1100000" />
 		<skill name="Power Crush" id="260" level="27" required-level="64" sp="1400000" />
+		<skill name="Provoke" id="286" level="4" required-level="64" sp="1400000" />
+		<skill name="Final Frenzy" id="290" level="9" required-level="64" sp="1400000" />
+		<skill name="Tenacity" id="1617" level="3" required-level="64" sp="1400000" />
+		<skill name="Dwarven Restore Mastery" id="47237" level="3" required-level="64" sp="1400000" />
 
-		<skill name="Spinning Slasher" id="36" level="28" required-level="65" sp="1400000" />
-		<skill name="Polearm Mastery" id="216" level="36" required-level="65" sp="1400000" />
-		<skill name="Light Armor Mastery" id="227" level="41" required-level="65" sp="1400000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="36" required-level="65" sp="1400000" />
-		<skill name="Heavy Armor Mastery" id="231" level="41" required-level="65" sp="1400000" />
+		<!-- Lv. 65 Skills -->
+		<skill name="Spinning Slasher" id="36" level="30" required-level="65" sp="1400000" />
+		<skill name="Fatal Strike" id="190" level="30" required-level="65" sp="1400000" />
 		<skill name="Power Crush" id="260" level="28" required-level="65" sp="1400000" />
-		
-		<skill name="Spinning Slasher" id="36" level="29" required-level="66" sp="1500000" />
-		<skill name="Polearm Mastery" id="216" level="37" required-level="66" sp="1500000" />
-		<skill name="Light Armor Mastery" id="227" level="42" required-level="66" sp="1500000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="37" required-level="66" sp="1500000" />
-		<skill name="Heavy Armor Mastery" id="231" level="42" required-level="66" sp="1500000" />
-		<skill name="Power Crush" id="260" level="29" required-level="66" sp="1500000" />
+		<skill name="Dwarven Armor Mastery" id="47236" level="6" required-level="65" sp="1400000" />
+
+		<!-- Lv. 66 Skills -->
+		<skill name="Spinning Slasher" id="36" level="31" required-level="66" sp="1500000" />
+		<skill name="Fatal Strike" id="190" level="31" required-level="66" sp="1500000" />
 		<skill name="Boost HP" id="211" level="8" required-level="66" sp="1500000" />
+		<skill name="Power Crush" id="260" level="29" required-level="66" sp="1500000" />
+		<skill name="Final Frenzy" id="290" level="10" required-level="66" sp="1500000" />
+		<skill name="Body Crush" id="1613" level="7" required-level="66" sp="1500000" />
+		<skill name="Dwarven Weapon Mastery" id="47235" level="6" required-level="66" sp="1500000" />
 
-		<skill name="Spinning Slasher" id="36" level="30" required-level="67" sp="1500000" />
-		<skill name="Polearm Mastery" id="216" level="38" required-level="67" sp="1500000" />
-		<skill name="Light Armor Mastery" id="227" level="43" required-level="67" sp="1500000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="38" required-level="67" sp="1500000" />
-		<skill name="Heavy Armor Mastery" id="231" level="43" required-level="67" sp="1500000" />
+		<!-- Lv. 67 Skills -->
+		<skill name="Spinning Slasher" id="36" level="32" required-level="67" sp="1500000" />
+		<skill name="Fatal Strike" id="190" level="32" required-level="67" sp="1500000" />
 		<skill name="Power Crush" id="260" level="30" required-level="67" sp="1500000" />
-		
-		<skill name="Fast HP Recovery" id="212" level="7" required-level="68" sp="2100000" />
-		<skill name="Spinning Slasher" id="36" level="31" required-level="68" sp="2100000" />
-		<skill name="Polearm Mastery" id="216" level="39" required-level="68" sp="2100000" />
-		<skill name="Light Armor Mastery" id="227" level="44" required-level="68" sp="2100000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="39" required-level="68" sp="2100000" />
-		<skill name="Heavy Armor Mastery" id="231" level="44" required-level="68" sp="2100000" />
-		<skill name="Summon Mechanic Golem" id="25" level="8" required-level="68" sp="2100000" />
-		<skill name="Provoke" id="286" level="5" required-level="68" sp="2100000" />
-		<skill name="Power Crush" id="260" level="31" required-level="68" sp="2100000" />
-		
-		<skill name="Spinning Slasher" id="36" level="32" required-level="69" sp="2100000" />
-		<skill name="Polearm Mastery" id="216" level="40" required-level="69" sp="2100000" />
-		<skill name="Light Armor Mastery" id="227" level="45" required-level="69" sp="2100000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="40" required-level="69" sp="2100000" />
-		<skill name="Heavy Armor Mastery" id="231" level="45" required-level="69" sp="2100000" />
-		<skill name="Power Crush" id="260" level="32" required-level="69" sp="2100000" />
-		
-		<skill name="Spinning Slasher" id="36" level="33" required-level="70" sp="2600000" />
-		<skill name="Polearm Mastery" id="216" level="41" required-level="70" sp="2600000" />
-		<skill name="Light Armor Mastery" id="227" level="46" required-level="70" sp="2600000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="41" required-level="70" sp="2600000" />
-		<skill name="Heavy Armor Mastery" id="231" level="46" required-level="70" sp="2600000" />
-		<skill name="Crystallize" id="248" level="5" required-level="70" sp="2600000" />
-		<skill name="Create Item" id="172" level="9" required-level="70" sp="2600000" />
-		<skill name="Power Crush" id="260" level="33" required-level="70" sp="2600000" />
-		<skill name="Boost HP" id="211" level="9" required-level="70" sp="2600000" />
 
-		<skill name="Spinning Slasher" id="36" level="34" required-level="71" sp="2600000" />
-		<skill name="Polearm Mastery" id="216" level="42" required-level="71" sp="2600000" />
-		<skill name="Light Armor Mastery" id="227" level="47" required-level="71" sp="2600000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="42" required-level="71" sp="2600000" />
-		<skill name="Heavy Armor Mastery" id="231" level="47" required-level="71" sp="2600000" />
+		<!-- Lv. 68 Skills -->
+		<skill name="Summon Mechanic Golem" id="25" level="8" required-level="68" sp="2100000" />
+		<skill name="Spinning Slasher" id="36" level="33" required-level="68" sp="2100000" />
+		<skill name="Fatal Strike" id="190" level="33" required-level="66" sp="2100000" />
+		<skill name="Power Crush" id="260" level="31" required-level="68" sp="2100000" />
+		<skill name="Provoke" id="286" level="5" required-level="68" sp="2100000" />
+		<skill name="Final Frenzy" id="290" level="11" required-level="68" sp="2100000" />
+
+		<!-- Lv. 69 Skills -->
+		<skill name="Spinning Slasher" id="36" level="34" required-level="69" sp="2100000" />
+		<skill name="Fatal Strike" id="190" level="34" required-level="69" sp="2100000" />
+		<skill name="Power Crush" id="260" level="32" required-level="69" sp="2100000" />
+
+		<!-- Lv. 70 Skills -->
+		<skill name="Spinning Slasher" id="36" level="35" required-level="70" sp="2600000" />
+		<skill name="Create Item" id="172" level="9" required-level="70" sp="2600000" />
+		<skill name="Fatal Strike" id="190" level="35" required-level="70" sp="2600000" />
+		<skill name="Boost HP" id="211" level="9" required-level="70" sp="2600000" />
+		<skill name="Crystallize" id="248" level="5" required-level="70" sp="2600000" />
+		<skill name="Power Crush" id="260" level="33" required-level="70" sp="2600000" />
+		<skill name="Final Frenzy" id="290" level="12" required-level="70" sp="2600000" />
+		<skill name="Body Crush" id="1613" level="8" required-level="70" sp="2600000" />
+		<skill name="White Assassin" id="1802" level="1" required-level="70" auto-learn="true" />
+		<skill name="Dwarven Restore Mastery" id="47237" level="4" required-level="70" sp="2600000" />
+
+		<!-- Lv. 71 Skills -->
+		<skill name="Spinning Slasher" id="36" level="36" required-level="71" sp="2600000" />
+		<skill name="Fatal Strike" id="190" level="36" required-level="71" sp="2600000" />
 		<skill name="Power Crush" id="260" level="34" required-level="71" sp="2600000" />
-		
-		<skill name="Spinning Slasher" id="36" level="35" required-level="72" sp="2900000" />
-		<skill name="Polearm Mastery" id="216" level="43" required-level="72" sp="2900000" />
-		<skill name="Light Armor Mastery" id="227" level="48" required-level="72" sp="2900000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="43" required-level="72" sp="2900000" />
-		<skill name="Heavy Armor Mastery" id="231" level="48" required-level="72" sp="2900000" />
-		<skill name="Vital Force" id="148" level="8" required-level="72" sp="2900000" />
+		<skill name="Dwarven Armor Mastery" id="47236" level="7" required-level="71" sp="2600000" />
+
+		<!-- Lv. 72 Skills -->
 		<skill name="Summon Mechanic Golem" id="25" level="9" required-level="72" sp="2900000" />
-		<skill name="Provoke" id="286" level="6" required-level="72" sp="2900000" />
+		<skill name="Spinning Slasher" id="36" level="37" required-level="72" sp="2900000" />
+		<skill name="Fatal Strike" id="190" level="37" required-level="72" sp="2900000" />
 		<skill name="Power Crush" id="260" level="35" required-level="72" sp="2900000" />
-		
-		<skill name="Spinning Slasher" id="36" level="36" required-level="73" sp="2900000" />
-		<skill name="Polearm Mastery" id="216" level="44" required-level="73" sp="2900000" />
-		<skill name="Light Armor Mastery" id="227" level="49" required-level="73" sp="2900000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="44" required-level="73" sp="2900000" />
-		<skill name="Heavy Armor Mastery" id="231" level="49" required-level="73" sp="2900000" />
+		<skill name="Provoke" id="286" level="6" required-level="72" sp="2900000" />
+		<skill name="Final Frenzy" id="290" level="13" required-level="72" sp="2900000" />
+		<skill name="Dwarven Weapon Mastery" id="47235" level="7" required-level="72" sp="2900000" />
+
+		<!-- Lv. 73 Skills -->
+		<skill name="Spinning Slasher" id="36" level="38" required-level="73" sp="2900000" />
+		<skill name="Fatal Strike" id="190" level="38" required-level="73" sp="2900000" />
 		<skill name="Power Crush" id="260" level="36" required-level="73" sp="2900000" />
-		
-		<skill name="Fast HP Recovery" id="212" level="8" required-level="74" sp="2900000" />
-		<skill name="Spinning Slasher" id="36" level="37" required-level="74" sp="2900000" />
-		<skill name="Polearm Mastery" id="216" level="45" required-level="74" sp="2900000" />
-		<skill name="Light Armor Mastery" id="227" level="50" required-level="74" sp="2900000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="45" required-level="74" sp="2900000" />
-		<skill name="Heavy Armor Mastery" id="231" level="50" required-level="74" sp="2900000" />
-		<skill name="Provoke" id="286" level="7" required-level="74" sp="2900000" />
-		<skill name="Power Crush" id="260" level="37" required-level="74" sp="2900000" />
+
+		<!-- Lv. 74 Skills -->
+		<skill name="Spinning Slasher" id="36" level="39" required-level="74" sp="2900000" />
+		<skill name="Fatal Strike" id="190" level="39" required-level="74" sp="2900000" />
 		<skill name="Boost HP" id="211" level="10" required-level="74" sp="2900000" />
+		<skill name="Power Crush" id="260" level="37" required-level="74" sp="2900000" />
+		<skill name="Provoke" id="286" level="7" required-level="74" sp="2900000" />
+		<skill name="Final Frenzy" id="290" level="14" required-level="74" sp="2900000" />
+		<skill name="Body Crush" id="1613" level="9" required-level="74" sp="2900000" />
+
+		<!-- Lv. 75 Skills -->
+		<skill name="Spinning Slasher" id="36" level="40" required-level="75" sp="2900000" />
+		<skill name="Fatal Strike" id="190" level="40" required-level="75" sp="2900000" />
+
 	</skillTree>
 </list>

--- a/data/skillTrees/2ndClass/WindHunter.xml
+++ b/data/skillTrees/2ndClass/WindHunter.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
+	<skillTree type="classSkillTree" classId="210" parentClassId="209">
+	
+		<!-- Skills Lv40 -->		
+		<skill name="Weapon Mastery" id="141" level="4" required-level="40" sp="100000"/>
+		<skill name="Armor Mastery" id="142" level="4" required-level="40" sp="100000"/>
+		<skill name="Dual Blow" id="47002" level="6" required-level="40" sp="100000" />
+		<skill name="Freezing Wound" id="47011" level="1" required-level="40" sp="100000" />
+		<skill name="Elemental Focus" id="47021" level="3" required-level="40" sp="80000" />
+		<skill name="Elemental Death Whisper" id="47022" level="3" required-level="40" sp="80000" />
+		<skill name="Elemental Haste" id="47023" level="2" required-level="40" sp="80000" />
+		<skill name="Elemental Magic Barrier" id="47025" level="2" required-level="40" sp="80000" />
+		<skill name="Elemental Might" id="47026" level="3" required-level="40" sp="80000" />
+		<skill name="Elemental Shield" id="47027" level="3" required-level="40" sp="80000" />
+		<skill name="Elemental Acumen" id="47028" level="3" required-level="40" sp="80000" />
+		<skill name="Elemental Empower" id="47029" level="3" required-level="40" sp="80000" />
+		<skill name="Elemental Wild Magic" id="47030" level="2" required-level="40" sp="80000" />
+		<skill name="Elemental Berserker Spirit" id="47031" level="2" required-level="40" sp="80000" />
+		<skill name="Elemental Clarity" id="47032" level="3" required-level="40" sp="80000" />
+		<skill name="Elemental Wind" id="47061" level="1" required-level="40" sp="100000" />
+		<skill name="Time Burst" id="47062" level="1" required-level="40" sp="100000" />
+		<skill name="Firearms Mastery" id="47081" level="2" required-level="40" sp="100000" />
+		<skill name="Light Armor Mastery" id="47082" level="2" required-level="40" sp="10000" />
+		<skill name="Elemental Spirit" id="47101" level="2" required-level="40" sp="100000" />
+		<skill name="Elemental Connection" id="47104" level="3" required-level="40" sp="100000" />
+		<skill name="Elemental Recovery" id="47105" level="1" required-level="40" sp="100000" />
+		<skill name="Recover HP" id="45176" level="1" required-level="20" sp="1000" />
+		<skill name="Recover MP" id="45177" level="1" required-level="20" sp="1000" />
+		<skill name="Elemental Wind Walk" id="47024" level="1" required-level="20" sp="1000" />
+		<skill name="Ability to Protect" id="91" level="2" required-level="20" sp="1000" />
+		<skill name="Soul Strike" id="1516" level="1" required-level="20" sp="1000" />
+		<skill name="Elemental Clarity" id="47032" level="1" required-level="20" sp="1000" />
+		<skill name="Dual Blow" id="47002" level="1" required-level="20" sp="1000" />
+
+		<!-- Skills Lv41 -->		
+		<skill name="Boost Evasion" id="198" level="1" required-level="41" sp="110000" />
+
+		<!-- Skills Lv42 -->		
+		<skill name="Quick Step" id="169" level="1" required-level="42" sp="120000" />
+
+		<!-- Skills Lv43 -->		
+		<skill name="Dual Blow" id="47002" level="7" required-level="43" sp="130000" />
+
+		<!-- Skills Lv44 -->		
+		<skill name="Quick Recharge" id="47083" level="1" required-level="44" sp="140000" />
+
+		<!-- Skills Lv45 -->
+		<skill name="Critical Chance" id="137" level="2" required-level="45" sp="150000" />
+		<skill name="Pirate Transformation" id="1800" level="1" required-level="45" auto-learn="true" />
+		
+		<!-- Skills Lv46 -->		
+		<skill name="Dual Blow" id="47002" level="8" required-level="46" sp="160000" />
+		
+		<!-- Skills Lv47 -->		
+		<skill name="Light Armor Mastery" id="47082" level="3" required-level="47" sp="170000" />
+		
+		<!-- Skills Lv48 -->		
+		<skill name="Firearms Mastery" id="47081" level="3" required-level="48" sp="180000" />
+
+		<!-- Skills Lv49 -->		
+		<skill name="Dual Blow" id="47002" level="9" required-level="49" sp="200000" />
+		
+		<!-- Skills Lv50 -->		
+		<skill name="Quick Step" id="169" level="2" required-level="50" sp="220000" />
+		<skill name="Recover HP" id="45176" level="2" required-level="50" sp="300000" />
+		<skill name="Recover MP" id="45177" level="2" required-level="50" sp="300000" />
+		<skill name="Freezing Wound" id="47011" level="2" required-level="50" sp="220000" />
+
+		<!-- Skills Lv52 -->
+		<skill name="Divine Inspiration" id="1405" level="1" required-level="52" sp="300000" />
+		<skill name="Ability to Attack" id="77" level="2" required-level="25" sp="5500" />
+		<skill name="Dual Blow" id="47002" level="10" required-level="52" sp="300000" />
+		<skill name="Elemental Recovery" id="47105" level="2" required-level="52" sp="300000" />
+
+		<!-- Skills Lv53 -->
+		<skill name="Light Armor Mastery" id="47082" level="4" required-level="53" sp="400000" />
+
+		<!-- Skills Lv54 -->		
+		<skill name="Firearms Mastery" id="47081" level="4" required-level="54" sp="400000" />
+
+		<!-- Skills Lv55 -->		
+		<skill name="Boost Evasion" id="198" level="2" required-level="55" sp="450000" />
+		<skill name="Dual Blow" id="47002" level="11" required-level="55" sp="450000" />
+		<skill name="Long Range Attack" id="47084" level="2" required-level="55" sp="450000" />
+		
+		<!-- Skills Lv58 -->
+		<skill name="Dual Blow" id="47002" level="12" required-level="58" sp="600000" />
+		<skill name="Elemental Care" id="47054" level="1" required-level="58" sp="600000" />
+		<skill name="Quick Recharge" id="47083" level="2" required-level="58" sp="600000" />
+		
+		<!-- Skills Lv59 -->
+		<skill name="Light Armor Mastery" id="47082" level="5" required-level="59" sp="700000" />
+		
+		<!-- Skills Lv60 -->
+		<skill name="Firearms Mastery" id="47081" level="5" required-level="60" sp="800000" />
+		<skill name="Assasin Transformation" id="1801" level="1" required-level="60" auto-learn="true" />
+			
+		<!-- Skills Lv61 -->
+		<skill name="Divine Inspiration" id="1405" level="2" required-level="61" sp="900000" />
+		<skill name="Dual Blow" id="47002" level="13" required-level="61" sp="900000" />
+
+		<!-- Skills Lv62 -->
+		<skill name="Freezing Wound" id="47011" level="3" required-level="62" sp="1000000" />
+
+		<!-- Skills Lv63 -->
+		<skill name="Dual Blow" id="47002" level="14" required-level="63" sp="1100000" />
+
+		<!-- Skills Lv64 -->
+		<skill name="Elemental Recovery" id="47105" level="3" required-level="64" sp="1200000" />
+
+		<!-- Skills Lv65 -->
+		<skill name="Dual Blow" id="47002" level="15" required-level="65" sp="1300000" />
+		<skill name="Light Armor Mastery" id="47082" level="6" required-level="65" sp="1300000" />
+
+		<!-- Skills Lv66 -->		
+		<skill name="Firearms Mastery" id="47081" level="6" required-level="66" sp="1400000" />
+		
+		<!-- Skills Lv67 -->		
+		<skill name="Dual Blow" id="47002" level="16" required-level="67" sp="1500000" />
+		
+		<!-- Skills Lv68 -->		
+		<skill name="Quick Recharge" id="47083" level="3" required-level="68" sp="1600000" />
+
+		<!-- Skills Lv69 -->		
+		<skill name="Dual Blow" id="47002" level="17" required-level="69" sp="1700000" />
+		
+		<!-- Skills Lv70 -->		
+		<skill name="Light Assasin Transformation" id="1802" level="1" required-level="70" auto-learn="true" />
+		<skill name="Elemental Recovery" id="47105" level="4" required-level="70" sp="1800000" />
+				
+		<!-- Skills Lv71 -->		
+		<skill name="Dual Blow" id="47002" level="18" required-level="71" sp="1900000" />
+		<skill name="Light Armor Mastery" id="47082" level="7" required-level="71" sp="1900000" />
+				
+		<!-- Skills Lv72 -->		
+		<skill name="Firearms Mastery" id="47081" level="7" required-level="72" sp="2000000" />
+		
+		<!-- Skills Lv73 -->		
+		<skill name="Dual Blow" id="47002" level="19" required-level="73" sp="2100000" />
+
+		<!-- Skills Lv74 -->
+		<skill name="Freezing Wound" id="47011" level="4" required-level="74" sp="2200000" />
+
+		<!-- Skills Lv75 -->
+		<skill name="Dual Blow" id="47002" level="20" required-level="75" sp="2300000" />
+		
+	</skillTree>
+</list>

--- a/data/skillTrees/3rdClass/Adventurer.xml
+++ b/data/skillTrees/3rdClass/Adventurer.xml
@@ -1,79 +1,142 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
-	<skillTree type="classSkillTree" classId="93" parentClassId="8">
-		<skill name="White Guardian" id="54102" level="1" required-level="80" >
-			<item id="92401"/>
+
+<skillTree type="classSkillTree" classId="93" parentClassId="8">
+
+		<skill name="Bluff" id="358" level="1" required-level="76" sp="8300000">
+			<item id="91294" count="1" /> <!-- Scroll: Bluff -->
 		</skill>
-		<skill name="Bluff" id="358" level="1" required-level="76" sp="8300000" />
+		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="8300000">
+			<item id="8620" count="1" /> <!-- Buff Expansion Book Lv. 3 -->
+		</skill>
+		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="8300000">
+			<item id="8621" count="1" /> <!-- Buff Expansion Book Lv. 4 -->
+		</skill>
 		<skill name="Throw Dagger in Wrist" id="1629" level="1" required-level="76" sp="8300000" />
 		<skill name="Dagger Mastery" id="209" level="46" required-level="76" sp="8300000" />
 		<skill name="Light Armor Mastery" id="233" level="48" required-level="76" sp="8300000" />
+		<skill name="Weapon Mastery" id="141" level="5" required-level="76" sp="8300000" />
+		<skill name="Evolution Defense" id="45188" level="1" required-level="76">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Bleed" id="96" level="7" required-level="76" sp="8300000" />
-		<skill name="Deadly Blow" id="263" level="38" required-level="76" sp="8300000" />
+		<!-- Might Lv. 4 -->
+		<skill name="Might" id="1068" level="4" required-level="76" sp="8300000">
+			<item id="94135" count="1" /> <!-- Master's Book: Might -->
+		</skill>
+		<!-- Shield Lv. 4 -->
+	    <skill name="Shield" id="1040" level="4" required-level="76" sp="8300000">
+		<item id="94136" count="1" /> <!-- Master's Book: Shield -->
+	    </skill>
+		<!-- Acumen Lv. 4 -->
+		<skill name="Acumen" id="45104" level="4" required-level="76" sp="8300000">
+		<item id="94370" count="1" /> <!-- Master's Book: Acumen -->
+		</skill>
+	    <!-- Empower Lv. 4 -->
+	<skill name="Empower" id="45105" level="4" required-level="76" sp="8300000">
+		<item id="94361" count="1" /> <!-- Master's Book: Empower -->
+	</skill>
+		<!-- Wild Magic Lv. 3 -->
+	<skill name="Wild Magic" id="45106" level="3" required-level="76" sp="8300000">
+		<item id="94368" count="1" /> <!-- Master's Book: Wild Magic -->
+	</skill>
+		<!-- Wind Walk Lv. 3 -->
+	<skill name="Wind Walk" id="45107" level="3" required-level="76" sp="8300000">
+		<item id="94365" count="1" /> <!-- Master's Book: Wind Walk -->
+	</skill>
+		<!-- Magic Barrier Lv. 3 -->
+	<skill name="Magic Barrier" id="45108" level="3" required-level="76" sp="8300000">
+		<item id="94362" count="1" /> <!-- Master's Book: Magic Barrier -->
+	</skill>
+		<!-- Focus Lv. 4 -->
+	<skill name="Focus" id="45109" level="4" required-level="76" sp="8300000">
+		<item id="94363" count="1" /> <!-- Master's Book: Focus -->
+	</skill>
+		<!-- Death Whisper Lv. 4 -->
+	<skill name="Death Whisper" id="45110" level="4" required-level="76" sp="8300000">
+		<item id="94364" count="1" /> <!-- Master's Book: Death Whisper -->
+	</skill>
+		<!-- Haste Lv. 3 -->
+	<skill name="Haste" id="45111" level="3" required-level="76" sp="8300000">
+		<item id="94369" count="1" /> <!-- Master's Book: Haste -->
+	</skill>
+		<!-- Berserker Spirit Lv. 3 -->
+	<skill name="Berserker Spirit" id="45112" level="3" required-level="76" sp="8300000">
+		<item id="94366" count="1" /> <!-- Master's Book: Berserker Spirit -->
+	</skill>
+		<!-- Clarity Lv. 4 -->
+	<skill name="Clarity" id="45113" level="4" required-level="76" sp="8300000">
+		<item id="94367" count="1" /> <!-- Master's Book: Clarity -->
+	</skill>
+		<skill name="Detection" id="45190" level="1" required-level="76" sp="8300000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Mount Golden Lion" id="1833" level="1" required-level="76">
+			<item id="90038" count="1" /> <!-- Spellbook - Ride Golden Lion -->
+		</skill>
+		<skill name="Deadly Blow" id="263" level="41" required-level="76" sp="8300000" />
 		<skill name="Lethal Blow" id="344" level="1" required-level="76" sp="8300000" />
 		<skill name="Backstab" id="30" level="38" required-level="76" sp="8300000" />
-		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="8300000">
-			<item id="8620"/> <!-- Ancient Book: Divine Inspiration (Manuscript) -->
-		</skill>
-		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="8300000">
-			<item id="8621"/> <!-- Ancient Book: Divine Inspiration (Original Version) -->
-		</skill>
-		<skill name="Mount Gold Maned Lion" id="1833" level="1" required-level="76">
-			<item id="90038"/> <!-- Spellbook: Mount Golden Lion -->
-		</skill>
-		<skill name="Glory Ability" id="45361" level="1" required-level="86">
-			<item id="94046"/> <!-- Spellbook: Glory Ability Lv. 1 -->
-		</skill>
-		<skill name="Mount White Wings" id="54200" level="1" required-level="87">
-			<item id="93059"/> <!-- Spellbook: Summon White Wings -->
-		</skill>	
-		<skill name="Mount Shining Lady" id="54202" level="1" required-level="89">
-			<item id="93061"/> <!-- Spellbook: Summon Silver Saint -->
-		</skill>	
-		
+		<skill name="Emergency Rescue" id="70" level="46" required-level="76" sp="8300000" />
+
 		<skill name="Bluff" id="358" level="2" required-level="77" sp="8300000" />
 		<skill name="Dagger Mastery" id="209" level="47" required-level="77" sp="8300000" />
 		<skill name="Light Armor Mastery" id="233" level="49" required-level="77" sp="8300000" />
-		<skill name="Bleed" id="96" level="8" required-level="77" sp="8300000" />
-		<skill name="Deadly Blow" id="263" level="39" required-level="77" sp="8300000" />
-		<skill name="Backstab" id="30" level="39" required-level="77" sp="8300000" />
 		<skill name="Critical Wound" id="531" level="1" required-level="77" sp="8300000">
-			<item id="90055"/> <!-- Scroll: Critical Wound -->
+			<item id="90055" count="1" /> <!-- Scroll: Critical Wound -->
 		</skill>
+		<skill name="Bleed" id="96" level="8" required-level="77" sp="8300000" />
 		<skill name="Clear Movements" id="1631" level="1" required-level="77" sp="8300000">
-			<item id="90054"/> <!-- Scroll: Clear Movements -->
+			<item id="90054" count="1" /> <!-- Scroll: Clear Movements -->
 		</skill>
-		
+		<skill name="Deadly Blow" id="263" level="42" required-level="77" sp="8300000" />
+		<skill name="Lethal Blow" id="344" level="2" required-level="77" sp="8300000" />
+		<skill name="Backstab" id="30" level="39" required-level="77" sp="8300000" />
+		<skill name="Emergency Rescue" id="70" level="47" required-level="77" sp="8300000" />
+
 		<skill name="Bluff" id="358" level="3" required-level="78" sp="19400000" />
 		<skill name="Dagger Mastery" id="209" level="48" required-level="78" sp="19400000" />
 		<skill name="Light Armor Mastery" id="233" level="50" required-level="78" sp="19400000" />
 		<skill name="Bleed" id="96" level="9" required-level="78" sp="19400000" />
 		<skill name="Sand Bomb" id="412" level="11" required-level="78" sp="19400000" />
-		<skill name="Deadly Blow" id="263" level="40" required-level="78" sp="19400000" />
+		<skill name="Deadly Blow" id="263" level="43" required-level="78" sp="19400000" />
+		<skill name="Lethal Blow" id="344" level="3" required-level="78" sp="19400000" />
 		<skill name="Backstab" id="30" level="40" required-level="78" sp="19400000" />
-		<skill name="Shadow Step" id="821" level="8" required-level="78" sp="19400000" />
 		<skill name="Focus Power" id="357" level="1" required-level="78" sp="19400000">
-			<item id="90056"/> <!-- Scroll: Focus Power -->
+			<item id="90056" count="1" /> <!-- Scroll: Focus Power -->
 		</skill>
 		<skill name="Focus Chance" id="356" level="1" required-level="78" sp="19400000">
-			<item id="90057"/> <!-- Scroll: Focus Chance -->
+			<item id="90057" count="1" /> <!-- Scroll: Focus Chance -->
 		</skill>
-		
+		<skill name="Shadow Step" id="821" level="8" required-level="78" sp="19400000" />
+		<skill name="Emergency Rescue" id="70" level="48" required-level="78" sp="19400000" />
+
 		<skill name="Bluff" id="358" level="4" required-level="79" sp="19400000" />
 		<skill name="Bleed" id="96" level="10" required-level="79" sp="19400000" />
 		<skill name="Mirage" id="445" level="1" required-level="79" sp="19400000">
-			<item id="90059"/> <!-- Scroll: Mirage -->
+			<item id="90059" count="1" /> <!-- Scroll: Mirage -->
 		</skill>
-		
+		<skill name="Deadly Blow" id="263" level="44" required-level="79" sp="19400000" />
+		<skill name="Lethal Blow" id="344" level="4" required-level="79" sp="19400000" />
+		<skill name="Emergency Rescue" id="70" level="49" required-level="79" sp="19400000" />
+
 		<skill name="Bluff" id="358" level="5" required-level="80" sp="19400000" />
 		<skill name="Dagger Mastery" id="209" level="49" required-level="80" sp="19400000" />
 		<skill name="Light Armor Mastery" id="233" level="51" required-level="80" sp="19400000" />
 		<skill name="Bleed" id="96" level="11" required-level="80" sp="19400000" />
-		<skill name="Deadly Blow" id="263" level="41" required-level="80" sp="19400000" />
-		<skill name="Backstab" id="30" level="41" required-level="80" sp="19400000" />
-		<skill name="Exciting Adventure" id="768" level="1" required-level="80" sp="19400000">
-			<item id="90133"/> <!-- Scroll: Exciting Adventure -->
+		<skill name="Evolution Power" id="45189" level="1" required-level="80">
+			<item id="57" count="10000000" /> <!-- Adena -->
 		</skill>
+		<skill name="Deadly Blow" id="263" level="45" required-level="80" sp="19400000" />
+		<skill name="Lethal Blow" id="344" level="5" required-level="80" sp="19400000" />
+		<skill name="White Guardian Transformation" id="54102" level="1" required-level="80">
+			<item id="92401" count="1" /> <!-- Spellbook - White Guardian -->
+		</skill>
+		<skill name="Exciting Adventure" id="768" level="1" required-level="80" sp="19400000">
+			<item id="90133" count="1" /> <!-- Scroll: Exciting Adventure -->
+		</skill>
+		<skill name="Backstab" id="30" level="41" required-level="80" sp="19400000" />
+		<skill name="Emergency Rescue" id="70" level="50" required-level="80" sp="19400000" />
 
 		<skill name="Bluff" id="358" level="6" required-level="81" sp="160000000" />
 		<skill name="Dagger Mastery" id="209" level="50" required-level="81" sp="160000000" />
@@ -81,42 +144,72 @@
 		<skill name="Critical Wound" id="531" level="2" required-level="81" sp="160000000" />
 		<skill name="Bleed" id="96" level="12" required-level="81" sp="160000000" />
 		<skill name="Clear Movements" id="1631" level="2" required-level="81" sp="160000000" />
-		<skill name="Deadly Blow" id="263" level="42" required-level="81" sp="160000000" />
+		<skill name="Deadly Blow" id="263" level="46" required-level="81" sp="160000000" />
+		<skill name="Lethal Blow" id="344" level="6" required-level="81" sp="160000000" />
 		<skill name="Backstab" id="30" level="42" required-level="81" sp="160000000" />
+		<skill name="Emergency Rescue" id="70" level="51" required-level="81" sp="160000000" />
 
 		<skill name="Bluff" id="358" level="7" required-level="82" sp="170000000" />
 		<skill name="Dagger Mastery" id="209" level="51" required-level="82" sp="170000000" />
 		<skill name="Light Armor Mastery" id="233" level="53" required-level="82" sp="170000000" />
 		<skill name="Bleed" id="96" level="13" required-level="82" sp="170000000" />
-		<skill name="Deadly Blow" id="263" level="43" required-level="82" sp="170000000" />
-		<skill name="Lethal Blow" id="344" level="2" required-level="82" sp="170000000" />
+		<skill name="Deadly Blow" id="263" level="47" required-level="82" sp="170000000" />
+		<skill name="Lethal Blow" id="344" level="7" required-level="82" sp="170000000" />
 		<skill name="Backstab" id="30" level="43" required-level="82" sp="170000000" />
-		
+		<skill name="Emergency Rescue" id="70" level="52" required-level="82" sp="170000000" />
+
 		<skill name="Bluff" id="358" level="8" required-level="83" sp="240000000" />
 		<skill name="Dagger Mastery" id="209" level="52" required-level="83" sp="240000000" />
 		<skill name="Light Armor Mastery" id="233" level="54" required-level="83" sp="240000000" />
 		<skill name="Bleed" id="96" level="14" required-level="83" sp="240000000" />
-		<skill name="Deadly Blow" id="263" level="44" required-level="83" sp="240000000" />
+		<skill name="Deadly Blow" id="263" level="48" required-level="83" sp="240000000" />
+		<skill name="Lethal Blow" id="344" level="8" required-level="83" sp="240000000" />
 		<skill name="Backstab" id="30" level="44" required-level="83" sp="240000000" />
-		
+		<skill name="Emergency Rescue" id="70" level="53" required-level="83" sp="240000000" />
+
 		<skill name="Bluff" id="358" level="9" required-level="84" sp="240000000" />
 		<skill name="Dagger Mastery" id="209" level="53" required-level="84" sp="240000000" />
 		<skill name="Light Armor Mastery" id="233" level="55" required-level="84" sp="240000000" />
 		<skill name="Bleed" id="96" level="15" required-level="84" sp="240000000" />
-		<skill name="Deadly Blow" id="263" level="45" required-level="84" sp="240000000" />
+		<skill name="Deadly Blow" id="263" level="49" required-level="84" sp="240000000" />
+		<skill name="Lethal Blow" id="344" level="9" required-level="84" sp="240000000" />
 		<skill name="Backstab" id="30" level="45" required-level="84" sp="240000000" />
-		
+		<skill name="Emergency Rescue" id="70" level="54" required-level="84" sp="240000000" />
+
 		<skill name="Dagger Mastery" id="209" level="54" required-level="85" sp="840000000" />
-		<skill name="Dagger Mastery" id="209" level="55" required-level="86" sp="924000000" />
-		<skill name="Dagger Mastery" id="209" level="56" required-level="87" sp="1016400000" />
-		<skill name="Dagger Mastery" id="209" level="57" required-level="88" sp="1118040000" />
-		<skill name="Dagger Mastery" id="209" level="58" required-level="89" sp="1229844000" />
-		<skill name="Dagger Mastery" id="209" level="59" required-level="90" sp="1352828400" />
 		<skill name="Light Armor Mastery" id="233" level="56" required-level="85" sp="840000000" />
-		<skill name="Light Armor Mastery" id="233" level="57" required-level="86" sp="924000000" />
-		<skill name="Light Armor Mastery" id="233" level="58" required-level="87" sp="1016400000" />
-		<skill name="Light Armor Mastery" id="233" level="59" required-level="88" sp="1118040000" />
-		<skill name="Light Armor Mastery" id="233" level="60" required-level="89" sp="1229844000" />
-		<skill name="Light Armor Mastery" id="233" level="61" required-level="90" sp="1352828400" />
+		<skill name="Deadly Blow" id="263" level="50" required-level="85" sp="840000000" />
+		<skill name="Lethal Blow" id="344" level="10" required-level="85" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="55" required-level="85" sp="840000000" />
+
+		<skill name="Dagger Mastery" id="209" level="55" required-level="86" sp="840000000" />
+		<skill name="Light Armor Mastery" id="233" level="57" required-level="86" sp="840000000" />
+		<skill name="Deadly Blow" id="263" level="51" required-level="86" sp="840000000" />
+		<skill name="Lethal Blow" id="344" level="11" required-level="86" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="56" required-level="86" sp="840000000" />
+
+		<skill name="Dagger Mastery" id="209" level="56" required-level="87" sp="840000000" />
+		<skill name="Light Armor Mastery" id="233" level="58" required-level="87" sp="840000000" />
+		<skill name="Deadly Blow" id="263" level="52" required-level="87" sp="840000000" />
+		<skill name="Lethal Blow" id="344" level="12" required-level="87" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="57" required-level="87" sp="840000000" />
+
+		<skill name="Dagger Mastery" id="209" level="57" required-level="88" sp="840000000" />
+		<skill name="Light Armor Mastery" id="233" level="59" required-level="88" sp="840000000" />
+		<skill name="Deadly Blow" id="263" level="53" required-level="88" sp="840000000" />
+		<skill name="Lethal Blow" id="344" level="13" required-level="88" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="58" required-level="88" sp="840000000" />
+
+		<skill name="Dagger Mastery" id="209" level="58" required-level="89" sp="840000000" />
+		<skill name="Light Armor Mastery" id="233" level="60" required-level="89" sp="840000000" />
+		<skill name="Deadly Blow" id="263" level="54" required-level="89" sp="840000000" />
+		<skill name="Lethal Blow" id="344" level="14" required-level="89" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="59" required-level="89" sp="840000000" />
+
+		<skill name="Dagger Mastery" id="209" level="59" required-level="90" sp="840000000" />
+		<skill name="Light Armor Mastery" id="233" level="61" required-level="90" sp="840000000" />
+		<skill name="Deadly Blow" id="263" level="55" required-level="90" sp="840000000" />
+		<skill name="Lethal Blow" id="344" level="15" required-level="90" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="60" required-level="90" sp="840000000" />
 	</skillTree>
 </list>

--- a/data/skillTrees/3rdClass/ArcanaLord.xml
+++ b/data/skillTrees/3rdClass/ArcanaLord.xml
@@ -1,52 +1,104 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
-	<skillTree type="classSkillTree" classId="96" parentClassId="14">
-		<skill name="White Guardian" id="54102" level="1" required-level="80" >
-			<item id="92401"/>
-		</skill>
+<skillTree type="classSkillTree" classId="96" parentClassId="14">
+
 		<skill name="Anti Magic" id="146" level="46" required-level="76" sp="8100000" />
 		<skill name="Warrior Bane" id="1350" level="1" required-level="76" sp="8100000" />
 		<skill name="Mage Bane" id="1351" level="1" required-level="76" sp="8100000" />
+		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="8100000">
+			<item id="8620" count="1" /> <!-- Buff Expansion Book Lv. 3 -->
+		</skill>
+		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="8100000">
+			<item id="8621" count="1" /> <!-- Buff Expansion Book Lv. 4 -->
+		</skill>
 		<skill name="Light Armor Mastery" id="258" level="34" required-level="76" sp="8100000" />
 		<skill name="Robe Mastery" id="234" level="42" required-level="76" sp="8100000" />
 		<skill name="Weapon Mastery" id="249" level="43" required-level="76" sp="8100000" />
 		<skill name="Blaze" id="1220" level="27" required-level="76" sp="8100000" />
+		<skill name="Evolution Defense" id="45188" level="1" required-level="76">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Servitor Heal" id="1127" level="46" required-level="76" sp="8100000" />
+	<!-- Might Lv. 4 -->
+		<skill name="Might" id="1068" level="4" required-level="76" sp="8100000">
+			<item id="94135" count="1" /> <!-- Master's Book: Might -->
+		</skill>
+	<!-- Shield Lv. 4 -->
+	<skill name="Shield" id="1040" level="4" required-level="76" sp="8100000">
+		<item id="94136" count="1" /> <!-- Master's Book: Shield -->
+	</skill>
+	<!-- Acumen Lv. 4 -->
+	<skill name="Acumen" id="45104" level="4" required-level="76" sp="8100000">
+		<item id="94370" count="1" /> <!-- Master's Book: Acumen -->
+	</skill>
+	<!-- Empower Lv. 4 -->
+	<skill name="Empower" id="45105" level="4" required-level="76" sp="8100000">
+		<item id="94361" count="1" /> <!-- Master's Book: Empower -->
+	</skill>
+	<!-- Wild Magic Lv. 3 -->
+	<skill name="Wild Magic" id="45106" level="3" required-level="76" sp="8100000">
+		<item id="94368" count="1" /> <!-- Master's Book: Wild Magic -->
+	</skill>
+	<!-- Wind Walk Lv. 3 -->
+	<skill name="Wind Walk" id="45107" level="3" required-level="76" sp="8100000">
+		<item id="94365" count="1" /> <!-- Master's Book: Wind Walk -->
+	</skill>
+	<!-- Magic Barrier Lv. 3 -->
+	<skill name="Magic Barrier" id="45108" level="3" required-level="76" sp="8100000">
+		<item id="94362" count="1" /> <!-- Master's Book: Magic Barrier -->
+	</skill>
+	<!-- Focus Lv. 4 -->
+	<skill name="Focus" id="45109" level="4" required-level="76" sp="8100000">
+		<item id="94363" count="1" /> <!-- Master's Book: Focus -->
+	</skill>
+	<!-- Death Whisper Lv. 4 -->
+	<skill name="Death Whisper" id="45110" level="4" required-level="76" sp="8100000">
+		<item id="94364" count="1" /> <!-- Master's Book: Death Whisper -->
+	</skill>
+	<!-- Haste Lv. 3 -->
+	<skill name="Haste" id="45111" level="3" required-level="76" sp="8100000">
+		<item id="94369" count="1" /> <!-- Master's Book: Haste -->
+	</skill>
+	<!-- Berserker Spirit Lv. 3 -->
+	<skill name="Berserker Spirit" id="45112" level="3" required-level="76" sp="8100000">
+		<item id="94366" count="1" /> <!-- Master's Book: Berserker Spirit -->
+	</skill>
+	<!-- Clarity Lv. 4 -->
+	<skill name="Clarity" id="45113" level="4" required-level="76" sp="8100000">
+		<item id="94367" count="1" /> <!-- Master's Book: Clarity -->
+	</skill>
+
+	<skill name="Detection" id="45190" level="1" required-level="76" sp="8100000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Mount Golden Lion" id="1833" level="1" required-level="76">
+			<item id="90038" count="1" /> <!-- Spellbook - Ride Golden Lion -->
+		</skill>
 		<skill name="Servitor Recharge" id="1126" level="35" required-level="76" sp="8100000" />
 		<skill name="Summon Binding Cubic" id="1279" level="11" required-level="76" sp="8100000" />
 		<skill name="Summon Storm Cubic" id="10" level="9" required-level="76" sp="8100000" />
 		<skill name="Servitor Share" id="1557" level="1" required-level="76" sp="8100000">
-			<item id="90131"/> <!-- Scroll: Servitor Share -->
+			<item id="90131" count="1" /> <!-- Scroll: Servitor Share -->
 		</skill>
-		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="8100000">
-			<item id="8620"/> <!-- Ancient Book: Divine Inspiration (Manuscript) -->
+		<skill name="Weakness" id="1164" level="20" required-level="76" sp="8100000" />
+		<skill name="Swift Servitor Heal" id="45362" level="46" required-level="76" sp="8100000" />
+		<skill name="Ethereal Strike" id="45377" level="1" required-level="76" sp="8100000">
+			<item id="93870" count="1" /> <!-- Spellbook: Ethereal Strike -->
 		</skill>
-		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="8100000">
-			<item id="8621"/> <!-- Ancient Book: Divine Inspiration (Original Version) -->
-		</skill>
-		<skill name="Mount Gold Maned Lion" id="1833" level="1" required-level="76">
-			<item id="90038"/> <!-- Spellbook: Mount Golden Lion -->
-		</skill>
-		<skill name="Glory Ability" id="45361" level="1" required-level="86">
-			<item id="94046"/> <!-- Spellbook: Glory Ability Lv. 1 -->
-		</skill>
-		<skill name="Mount White Wings" id="54200" level="1" required-level="87">
-			<item id="93059"/> <!-- Spellbook: Summon White Wings -->
-		</skill>	
-		<skill name="Mount Shining Lady" id="54202" level="1" required-level="89">
-			<item id="93061"/> <!-- Spellbook: Summon Silver Saint -->
-		</skill>		
-		
+
 		<skill name="Anti Magic" id="146" level="47" required-level="77" sp="8100000" />
 		<skill name="Light Armor Mastery" id="258" level="35" required-level="77" sp="8100000" />
 		<skill name="Robe Mastery" id="234" level="43" required-level="77" sp="8100000" />
 		<skill name="Weapon Mastery" id="249" level="44" required-level="77" sp="8100000" />
 		<skill name="Servitor Heal" id="1127" level="47" required-level="77" sp="8100000" />
 		<skill name="Servitor Recharge" id="1126" level="36" required-level="77" sp="8100000" />
-		<skill name="Summon Feline Queen" id="1331" level="1" required-level="77" sp="8100000" />
+		<skill name="Summon Feline Queen" id="1331" level="1" required-level="77" sp="8100000">
+			<item id="91203" count="1" /> <!-- Scroll: Summon Feline Queen -->
+		</skill>
 		<skill name="Summon Feline King" id="1406" level="1" required-level="77" sp="8100000" />
-		
-		
+		<skill name="Swift Servitor Heal" id="45362" level="47" required-level="77" sp="8100000" />
+		<skill name="Ethereal Strike" id="45377" level="2" required-level="77" sp="8100000" />
+
 		<skill name="Anti Magic" id="146" level="48" required-level="78" sp="17900000" />
 		<skill name="Warrior Bane" id="1350" level="2" required-level="78" sp="17900000" />
 		<skill name="Mage Bane" id="1351" level="2" required-level="78" sp="17900000" />
@@ -60,38 +112,59 @@
 		<skill name="Summon Storm Cubic" id="10" level="10" required-level="78" sp="17900000" />
 		<skill name="Spirit Sharing" id="1547" level="4" required-level="78" sp="17900000" />
 		<skill name="Servitor Share" id="1557" level="2" required-level="78" sp="17900000" />
+		<skill name="Weakness" id="1164" level="21" required-level="78" sp="17900000" />
 		<skill name="Warrior Servitor" id="1346" level="1" required-level="78" sp="17900000">
-			<item id="90127"/> <!-- Scroll: Warrior Servitor -->
+			<item id="90127" count="1" /> <!-- Scroll: Warrior Servitor -->
 		</skill>
-		
+		<skill name="Swift Servitor Heal" id="45362" level="48" required-level="78" sp="17900000" />
+		<skill name="Ethereal Strike" id="45377" level="3" required-level="78" sp="17900000" />
+
+		<skill name="Blaze" id="1220" level="29" required-level="79" sp="17900000" />
 		<skill name="Summon Feline Queen" id="1331" level="2" required-level="79" sp="17900000" />
 		<skill name="Final Servitor" id="1349" level="1" required-level="79" sp="17900000">
-			<item id="90130"/> <!-- Scroll: Final Servitor -->
+			<item id="90130" count="1" /> <!-- Scroll: Final Servitor -->
 		</skill>
-		
+		<skill name="Ethereal Strike" id="45377" level="4" required-level="79" sp="17900000" />
+
 		<skill name="Anti Magic" id="146" level="49" required-level="80" sp="17900000" />
 		<skill name="Warrior Bane" id="1350" level="3" required-level="80" sp="17900000" />
 		<skill name="Mage Bane" id="1351" level="3" required-level="80" sp="17900000" />
 		<skill name="Light Armor Mastery" id="258" level="37" required-level="80" sp="17900000" />
 		<skill name="Robe Mastery" id="234" level="45" required-level="80" sp="17900000" />
 		<skill name="Weapon Mastery" id="249" level="46" required-level="80" sp="17900000" />
-		<skill name="Blaze" id="1220" level="29" required-level="80" sp="17900000" />
+		<skill name="Blaze" id="1220" level="30" required-level="80" sp="17900000" />
 		<skill name="Servitor Heal" id="1127" level="49" required-level="80" sp="17900000" />
+		<skill name="Spell Master" id="1829" level="4" required-level="80" sp="2400000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Evolution Power" id="45189" level="1" required-level="80">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Poison" id="1168" level="8" required-level="80" sp="17900000" />
 		<skill name="Servitor Recharge" id="1126" level="38" required-level="80" sp="17900000" />
 		<skill name="Power Supremacy" id="1611" level="5" required-level="80" sp="17900000" />
 		<skill name="Summon Binding Cubic" id="1279" level="13" required-level="80" sp="17900000" />
 		<skill name="Summon Storm Cubic" id="10" level="11" required-level="80" sp="17900000" />
 		<skill name="Servitor Share" id="1557" level="3" required-level="80" sp="17900000" />
-		
+		<skill name="Weakness" id="1164" level="22" required-level="80" sp="17900000" />
+		<skill name="White Guardian Transformation" id="54102" level="1" required-level="80">
+			<item id="92401" count="1" /> <!-- Spellbook - White Guardian -->
+		</skill>
+		<skill name="Swift Servitor Heal" id="45362" level="49" required-level="80" sp="17900000" />
+		<skill name="Ethereal Strike" id="45377" level="5" required-level="80" sp="17900000" />
+
 		<skill name="Anti Magic" id="146" level="50" required-level="81" sp="160000000" />
 		<skill name="Light Armor Mastery" id="258" level="38" required-level="81" sp="160000000" />
 		<skill name="Robe Mastery" id="234" level="46" required-level="81" sp="160000000" />
 		<skill name="Weapon Mastery" id="249" level="47" required-level="81" sp="160000000" />
-		<skill name="Blaze" id="1220" level="30" required-level="81" sp="160000000" />
+		<skill name="Blaze" id="1220" level="31" required-level="81" sp="160000000" />
 		<skill name="Servitor Heal" id="1127" level="50" required-level="81" sp="160000000" />
 		<skill name="Servitor Recharge" id="1126" level="39" required-level="81" sp="160000000" />
 		<skill name="Summon Feline Queen" id="1331" level="3" required-level="81" sp="160000000" />
 		<skill name="Summon Feline King" id="1406" level="2" required-level="81" sp="160000000" />
+		<skill name="Weakness" id="1164" level="23" required-level="81" sp="160000000" />
+		<skill name="Swift Servitor Heal" id="45362" level="50" required-level="81" sp="160000000" />
+		<skill name="Ethereal Strike" id="45377" level="6" required-level="81" sp="160000000" />
 
 		<skill name="Anti Magic" id="146" level="51" required-level="82" sp="170000000" />
 		<skill name="Warrior Bane" id="1350" level="4" required-level="82" sp="170000000" />
@@ -99,7 +172,7 @@
 		<skill name="Light Armor Mastery" id="258" level="39" required-level="82" sp="170000000" />
 		<skill name="Robe Mastery" id="234" level="47" required-level="82" sp="170000000" />
 		<skill name="Weapon Mastery" id="249" level="48" required-level="82" sp="170000000" />
-		<skill name="Blaze" id="1220" level="31" required-level="82" sp="170000000" />
+		<skill name="Blaze" id="1220" level="32" required-level="82" sp="170000000" />
 		<skill name="Servitor Heal" id="1127" level="51" required-level="82" sp="170000000" />
 		<skill name="Servitor Recharge" id="1126" level="40" required-level="82" sp="170000000" />
 		<skill name="Summon Feline King" id="1406" level="3" required-level="82" sp="170000000" />
@@ -107,16 +180,22 @@
 		<skill name="Summon Storm Cubic" id="10" level="12" required-level="82" sp="170000000" />
 		<skill name="Spirit Sharing" id="1547" level="5" required-level="82" sp="170000000" />
 		<skill name="Servitor Share" id="1557" level="4" required-level="82" sp="170000000" />
+		<skill name="Weakness" id="1164" level="24" required-level="82" sp="170000000" />
+		<skill name="Swift Servitor Heal" id="45362" level="51" required-level="82" sp="170000000" />
+		<skill name="Ethereal Strike" id="45377" level="7" required-level="82" sp="170000000" />
 
 		<skill name="Anti Magic" id="146" level="52" required-level="83" sp="240000000" />
 		<skill name="Light Armor Mastery" id="258" level="40" required-level="83" sp="240000000" />
 		<skill name="Robe Mastery" id="234" level="48" required-level="83" sp="240000000" />
 		<skill name="Weapon Mastery" id="249" level="49" required-level="83" sp="240000000" />
-		<skill name="Blaze" id="1220" level="32" required-level="83" sp="240000000" />
+		<skill name="Blaze" id="1220" level="33" required-level="83" sp="240000000" />
 		<skill name="Servitor Heal" id="1127" level="52" required-level="83" sp="240000000" />
 		<skill name="Servitor Recharge" id="1126" level="41" required-level="83" sp="240000000" />
 		<skill name="Summon Feline Queen" id="1331" level="4" required-level="83" sp="240000000" />
 		<skill name="Summon Feline King" id="1406" level="4" required-level="83" sp="240000000" />
+		<skill name="Weakness" id="1164" level="25" required-level="83" sp="240000000" />
+		<skill name="Swift Servitor Heal" id="45362" level="52" required-level="83" sp="240000000" />
+		<skill name="Ethereal Strike" id="45377" level="8" required-level="83" sp="240000000" />
 
 		<skill name="Anti Magic" id="146" level="53" required-level="84" sp="240000000" />
 		<skill name="Warrior Bane" id="1350" level="5" required-level="84" sp="240000000" />
@@ -124,7 +203,7 @@
 		<skill name="Light Armor Mastery" id="258" level="41" required-level="84" sp="240000000" />
 		<skill name="Robe Mastery" id="234" level="49" required-level="84" sp="240000000" />
 		<skill name="Weapon Mastery" id="249" level="50" required-level="84" sp="240000000" />
-		<skill name="Blaze" id="1220" level="33" required-level="84" sp="240000000" />
+		<skill name="Blaze" id="1220" level="34" required-level="84" sp="240000000" />
 		<skill name="Servitor Heal" id="1127" level="53" required-level="84" sp="240000000" />
 		<skill name="Servitor Recharge" id="1126" level="42" required-level="84" sp="240000000" />
 		<skill name="Power Supremacy" id="1611" level="6" required-level="84" sp="240000000" />
@@ -133,32 +212,54 @@
 		<skill name="Summon Binding Cubic" id="1279" level="15" required-level="84" sp="240000000" />
 		<skill name="Summon Storm Cubic" id="10" level="13" required-level="84" sp="240000000" />
 		<skill name="Servitor Share" id="1557" level="5" required-level="84" sp="240000000" />
+		<skill name="Weakness" id="1164" level="26" required-level="84" sp="240000000" />
+		<skill name="Swift Servitor Heal" id="45362" level="53" required-level="84" sp="240000000" />
+		<skill name="Ethereal Strike" id="45377" level="9" required-level="84" sp="240000000" />
 
 		<skill name="Anti Magic" id="146" level="54" required-level="85" sp="840000000" />
-		<skill name="Anti Magic" id="146" level="55" required-level="86" sp="924000000" />
-		<skill name="Anti Magic" id="146" level="56" required-level="87" sp="1016400000" />
-		<skill name="Anti Magic" id="146" level="57" required-level="88" sp="1118040000" />
-		<skill name="Anti Magic" id="146" level="58" required-level="89" sp="1229844000" />
-		<skill name="Anti Magic" id="146" level="59" required-level="90" sp="1352828400" />
 		<skill name="Light Armor Mastery" id="258" level="42" required-level="85" sp="840000000" />
-		<skill name="Light Armor Mastery" id="258" level="43" required-level="86" sp="924000000" />
-		<skill name="Light Armor Mastery" id="258" level="44" required-level="87" sp="1016400000" />
-		<skill name="Light Armor Mastery" id="258" level="45" required-level="88" sp="1118040000" />
-		<skill name="Light Armor Mastery" id="258" level="46" required-level="89" sp="1229844000" />
-		<skill name="Light Armor Mastery" id="258" level="47" required-level="90" sp="1352828400" />
 		<skill name="Robe Mastery" id="234" level="50" required-level="85" sp="840000000" />
-		<skill name="Robe Mastery" id="234" level="51" required-level="86" sp="924000000" />
-		<skill name="Robe Mastery" id="234" level="52" required-level="87" sp="1016400000" />
-		<skill name="Robe Mastery" id="234" level="53" required-level="88" sp="1118040000" />
-		<skill name="Robe Mastery" id="234" level="54" required-level="89" sp="1229844000" />
-		<skill name="Robe Mastery" id="234" level="55" required-level="90" sp="1352828400" />
 		<skill name="Weapon Mastery" id="249" level="51" required-level="85" sp="840000000" />
-		<skill name="Weapon Mastery" id="249" level="52" required-level="86" sp="924000000" />
-		<skill name="Weapon Mastery" id="249" level="53" required-level="87" sp="1016400000" />
-		<skill name="Weapon Mastery" id="249" level="54" required-level="88" sp="1118040000" />
-		<skill name="Weapon Mastery" id="249" level="55" required-level="89" sp="1229844000" />
-		<skill name="Weapon Mastery" id="249" level="56" required-level="90" sp="1352828400" />
+		<skill name="Blaze" id="1220" level="35" required-level="85" sp="840000000" />
+		<skill name="Poison" id="1168" level="9" required-level="85" sp="840000000" />
 		<skill name="Summon Feline Queen" id="1331" level="6" required-level="85" sp="840000000" />
 		<skill name="Summon Feline King" id="1406" level="6" required-level="85" sp="840000000" />
+		<skill name="Ethereal Strike" id="45377" level="10" required-level="85" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="55" required-level="86" sp="840000000" />
+		<skill name="Light Armor Mastery" id="258" level="43" required-level="86" sp="840000000" />
+		<skill name="Robe Mastery" id="234" level="51" required-level="86" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="52" required-level="86" sp="840000000" />
+		<skill name="Blaze" id="1220" level="36" required-level="86" sp="840000000" />
+		<skill name="Ethereal Strike" id="45377" level="11" required-level="86" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="56" required-level="87" sp="840000000" />
+		<skill name="Light Armor Mastery" id="258" level="44" required-level="87" sp="840000000" />
+		<skill name="Robe Mastery" id="234" level="52" required-level="87" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="53" required-level="87" sp="840000000" />
+		<skill name="Blaze" id="1220" level="37" required-level="87" sp="840000000" />
+		<skill name="Ethereal Strike" id="45377" level="12" required-level="87" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="57" required-level="88" sp="840000000" />
+		<skill name="Light Armor Mastery" id="258" level="45" required-level="88" sp="840000000" />
+		<skill name="Robe Mastery" id="234" level="53" required-level="88" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="54" required-level="88" sp="840000000" />
+		<skill name="Blaze" id="1220" level="38" required-level="88" sp="840000000" />
+		<skill name="Ethereal Strike" id="45377" level="13" required-level="88" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="58" required-level="89" sp="840000000" />
+		<skill name="Light Armor Mastery" id="258" level="46" required-level="89" sp="840000000" />
+		<skill name="Robe Mastery" id="234" level="54" required-level="89" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="55" required-level="89" sp="840000000" />
+		<skill name="Blaze" id="1220" level="39" required-level="89" sp="840000000" />
+		<skill name="Ethereal Strike" id="45377" level="14" required-level="89" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="59" required-level="90" sp="840000000" />
+		<skill name="Light Armor Mastery" id="258" level="47" required-level="90" sp="840000000" />
+		<skill name="Robe Mastery" id="234" level="55" required-level="90" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="56" required-level="90" sp="840000000" />
+		<skill name="Blaze" id="1220" level="40" required-level="90" sp="840000000" />
+		<skill name="Poison" id="1168" level="10" required-level="90" sp="840000000" />
+		<skill name="Ethereal Strike" id="45377" level="15" required-level="90" sp="840000000" />
 	</skillTree>
 </list>

--- a/data/skillTrees/3rdClass/Archmage.xml
+++ b/data/skillTrees/3rdClass/Archmage.xml
@@ -1,113 +1,181 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="94" parentClassId="12">
-		<skill name="White Guardian" id="54102" level="1" required-level="80" >
-			<item id="92401"/>
-		</skill>
+
 		<skill name="Anti Magic" id="146" level="46" required-level="76" sp="6900000" />
+		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="6900000">
+			<item id="8620" count="1" /> <!-- Buff Expansion Book Lv. 3 -->
+		</skill>
+		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="6900000">
+			<item id="8621" count="1" /> <!-- Buff Expansion Book Lv. 4 -->
+		</skill>
+		<skill name="Flame Explosion" id="45378" level="1" required-level="76" sp="6900000">
+			<item id="93869" count="1" /> <!-- Spellbook: Elemental Burst -->
+		</skill>
 		<skill name="Robe Mastery" id="234" level="42" required-level="76" sp="6900000" />
 		<skill name="Weapon Mastery" id="249" level="43" required-level="76" sp="6900000" />
 		<skill name="Slow" id="1160" level="16" required-level="76" sp="6900000" />
+		<skill name="Evolution Defense" id="45188" level="1" required-level="76">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Inferno" id="1289" level="2" required-level="76" sp="6900000" />
+		<!-- Might Lv. 4 -->
+		<skill name="Might" id="1068" level="4" required-level="76" sp="6900000">
+			<item id="94135" count="1" /> <!-- Master's Book: Might -->
+		</skill>
+		<!-- Shield Lv. 4 -->
+		<skill name="Shield" id="1040" level="4" required-level="76" sp="6900000">
+			<item id="94136" count="1" /> <!-- Master's Book: Shield -->
+		</skill>
+		<!-- Acumen Lv. 4 -->
+		<skill name="Acumen" id="45104" level="4" required-level="76" sp="6900000">
+			<item id="94370" count="1" /> <!-- Master's Book: Acumen -->
+		</skill>
+		<!-- Empower Lv. 4 -->
+		<skill name="Empower" id="45105" level="4" required-level="76" sp="6900000">
+			<item id="94361" count="1" /> <!-- Master's Book: Empower -->
+		</skill>
+		<!-- Wild Magic Lv. 3 -->
+		<skill name="Wild Magic" id="45106" level="3" required-level="76" sp="6900000">
+			<item id="94368" count="1" /> <!-- Master's Book: Wild Magic -->
+		</skill>
+		<!-- Wind Walk Lv. 3 -->
+		<skill name="Wind Walk" id="45107" level="3" required-level="76" sp="6900000">
+			<item id="94365" count="1" /> <!-- Master's Book: Wind Walk -->
+		</skill>
+		<!-- Magic Barrier Lv. 3 -->
+		<skill name="Magic Barrier" id="45108" level="3" required-level="76" sp="6900000">
+			<item id="94362" count="1" /> <!-- Master's Book: Magic Barrier -->
+		</skill>
+		<!-- Focus Lv. 4 -->
+		<skill name="Focus" id="45109" level="4" required-level="76" sp="6900000">
+			<item id="94363" count="1" /> <!-- Master's Book: Focus -->
+		</skill>
+		<!-- Death Whisper Lv. 4 -->
+		<skill name="Death Whisper" id="45110" level="4" required-level="76" sp="6900000">
+			<item id="94364" count="1" /> <!-- Master's Book: Death Whisper -->
+		</skill>
+		<!-- Haste Lv. 3 -->
+		<skill name="Haste" id="45111" level="3" required-level="76" sp="6900000">
+			<item id="94369" count="1" /> <!-- Master's Book: Haste -->
+		</skill>
+		<!-- Berserker Spirit Lv. 3 -->
+		<skill name="Berserker Spirit" id="45112" level="3" required-level="76" sp="6900000">
+			<item id="94366" count="1" /> <!-- Master's Book: Berserker Spirit -->
+		</skill>
+		<!-- Clarity Lv. 4 -->
+		<skill name="Clarity" id="45113" level="4" required-level="76" sp="6900000">
+			<item id="94367" count="1" /> <!-- Master's Book: Clarity -->
+		</skill>
+		<skill name="Detection" id="45190" level="1" required-level="76" sp="6900000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Fire Vortex" id="1339" level="1" required-level="76" sp="6900000" />
 		<skill name="Rain of Fire" id="1296" level="10" required-level="76" sp="6900000" />
-		<skill name="Bind" id="53006" level="1" required-level="76" sp="6900000" />
-		<skill name="Prominence" id="1230" level="29" required-level="76" sp="6900000" />
+		<skill name="Mount Golden Lion" id="1833" level="1" required-level="76">
+			<item id="90038" count="1" /> <!-- Spellbook - Ride Golden Lion -->
+		</skill>
+		<skill name="Bind" id="53006" level="1" required-level="76" sp="6900000">
+			<item id="91483" count="1" /> <!-- Scroll: Bind -->
+		</skill>
+		<skill name="Prominence" id="1230" level="31" required-level="76" sp="6900000" />
 		<skill name="Blazing Circle" id="1171" level="20" required-level="76" sp="6900000" />
 		<skill name="Aura Flare" id="1231" level="29" required-level="76" sp="6900000" />
+		<skill name="Weakness" id="1164" level="20" required-level="76" sp="6900000" />
 		<skill name="Higher Mana Gain" id="285" level="28" required-level="76" sp="6900000" />
-		<skill name="Sleep" id="1069" level="43" required-level="76" sp="6900000" />
+		<skill name="Sleep" id="1069" level="46" required-level="76" sp="6900000" />
 		<skill name="Sleeping Cloud" id="1072" level="6" required-level="76" sp="6900000" />
-		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="6900000">
-			<item id="8620"/> <!-- Ancient Book: Divine Inspiration (Manuscript) -->
-		</skill>
-		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="6900000">
-			<item id="8621"/> <!-- Ancient Book: Divine Inspiration (Original Version) -->
-		</skill>
-		<skill name="Mount Gold Maned Lion" id="1833" level="1" required-level="76">
-			<item id="90038"/> <!-- Spellbook: Mount Golden Lion -->
-		</skill>
-		<skill name="Glory Ability" id="45361" level="1" required-level="86">
-			<item id="94046"/> <!-- Spellbook: Glory Ability Lv. 1 -->
-		</skill>
-		<skill name="Mount White Wings" id="54200" level="1" required-level="87">
-			<item id="93059"/> <!-- Spellbook: Summon White Wings -->
-		</skill>	
-		<skill name="Mount Shining Lady" id="54202" level="1" required-level="89">
-			<item id="93061"/> <!-- Spellbook: Summon Silver Saint -->
-		</skill>
-		
 		<skill name="Anti Magic" id="146" level="47" required-level="77" sp="6900000" />
+		<skill name="Flame Explosion" id="45378" level="2" required-level="77" sp="6900000" />
 		<skill name="Robe Mastery" id="234" level="43" required-level="77" sp="6900000" />
 		<skill name="Weapon Mastery" id="249" level="44" required-level="77" sp="6900000" />
-		<skill name="Prominence" id="1230" level="30" required-level="77" sp="6900000" />
+		<skill name="Prominence" id="1230" level="32" required-level="77" sp="6900000" />
 		<skill name="Aura Flare" id="1231" level="30" required-level="77" sp="6900000" />
-		<skill name="Higher Mana Gain" id="285" level="29" required-level="77" sp="6900000" />
-		<skill name="Sleep" id="1069" level="44" required-level="77" sp="6900000" />
-		<skill name="Sleeping Cloud" id="1072" level="7" required-level="77" sp="6900000" />
 		<skill name="Arcane Power" id="337" level="1" required-level="77" sp="6900000">
-			<item id="90081"/> <!-- Scroll: Arcane Power -->
+			<item id="90081" count="1" /> <!-- Scroll: Arcane Power -->
 		</skill>
-		
+		<skill name="Higher Mana Gain" id="285" level="29" required-level="77" sp="6900000" />
+		<skill name="Sleep" id="1069" level="47" required-level="77" sp="6900000" />
+		<skill name="Sleeping Cloud" id="1072" level="7" required-level="77" sp="6900000" />
+
 		<skill name="Anti Magic" id="146" level="48" required-level="78" sp="15100000" />
+		<skill name="Fire Vortex Buster" id="1451" level="1" required-level="78" sp="15100000">
+			<item id="90082" count="1" /> <!-- Scroll: Fire Vortex Buster -->
+		</skill>
+		<skill name="Flame Explosion" id="45378" level="3" required-level="78" sp="15100000" />
 		<skill name="Robe Mastery" id="234" level="44" required-level="78" sp="15100000" />
 		<skill name="Weapon Mastery" id="249" level="45" required-level="78" sp="15100000" />
 		<skill name="Slow" id="1160" level="17" required-level="78" sp="15100000" />
 		<skill name="Inferno" id="1289" level="3" required-level="78" sp="15100000" />
 		<skill name="Rain of Fire" id="1296" level="11" required-level="78" sp="15100000" />
 		<skill name="Bind" id="53006" level="2" required-level="78" sp="15100000" />
-		<skill name="Prominence" id="1230" level="31" required-level="78" sp="15100000" />
+		<skill name="Prominence" id="1230" level="33" required-level="78" sp="15100000" />
 		<skill name="Blazing Circle" id="1171" level="21" required-level="78" sp="15100000" />
 		<skill name="Aura Flare" id="1231" level="31" required-level="78" sp="15100000" />
+		<skill name="Weakness" id="1164" level="21" required-level="78" sp="15100000" />
 		<skill name="Arcane Power" id="337" level="2" required-level="78" sp="15100000" />
 		<skill name="Higher Mana Gain" id="285" level="30" required-level="78" sp="15100000" />
-		<skill name="Sleep" id="1069" level="45" required-level="78" sp="15100000" />
+		<skill name="Sleep" id="1069" level="48" required-level="78" sp="15100000" />
 		<skill name="Sleeping Cloud" id="1072" level="8" required-level="78" sp="15100000" />
-		<skill name="Fire Vortex Buster" id="1451" level="1" required-level="78" sp="15100000">
-			<item id="90082"/> <!-- Scroll: Fire Vortex Buster -->
-		</skill>
-		
+
+		<skill name="Flame Explosion" id="45378" level="4" required-level="79" sp="15100000" />
 		<skill name="Rain of Fire" id="1296" level="12" required-level="79" sp="15100000" />
+		<skill name="Prominence" id="1230" level="34" required-level="79" sp="15100000" />
 		<skill name="Blazing Circle" id="1171" level="22" required-level="79" sp="15100000" />
 		<skill name="Arcane Power" id="337" level="3" required-level="79" sp="15100000" />
-		<skill name="Sleep" id="1069" level="46" required-level="79" sp="15100000" />
-		<skill name="Sleeping Cloud" id="1072" level="9" required-level="79" sp="15100000" />
 		<skill name="Arcane Chaos" id="1338" level="1" required-level="79" sp="15100000">
-			<item id="90085"/>  <!-- Scroll: Arcane Chaos -->
+			<item id="90085" count="1" /> <!-- Scroll: Arcane Chaos -->
 		</skill>
-		
+		<skill name="Sleep" id="1069" level="49" required-level="79" sp="15100000" />
+		<skill name="Sleeping Cloud" id="1072" level="9" required-level="79" sp="15100000" />
+
 		<skill name="Anti Magic" id="146" level="49" required-level="80" sp="15100000" />
+		<skill name="Flame Explosion" id="45378" level="5" required-level="80" sp="15100000" />
 		<skill name="Robe Mastery" id="234" level="45" required-level="80" sp="15100000" />
 		<skill name="Weapon Mastery" id="249" level="46" required-level="80" sp="15100000" />
 		<skill name="Inferno" id="1289" level="4" required-level="80" sp="15100000" />
+		<skill name="Spell Master" id="1829" level="4" required-level="80" sp="2400000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Arcane Shield" id="1556" level="1" required-level="80" sp="15100000">
+			<item id="90086" count="1" /> <!-- Scroll: Arcane Shield -->
+		</skill>
+		<skill name="Evolution Power" id="45189" level="1" required-level="80">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Rain of Fire" id="1296" level="13" required-level="80" sp="15100000" />
+		<skill name="Poison" id="1168" level="8" required-level="80" sp="15100000" />
 		<skill name="Bind" id="53006" level="3" required-level="80" sp="15100000" />
-		<skill name="Prominence" id="1230" level="32" required-level="80" sp="15100000" />
+		<skill name="Prominence" id="1230" level="35" required-level="80" sp="15100000" />
 		<skill name="Blazing Circle" id="1171" level="23" required-level="80" sp="15100000" />
 		<skill name="Mana Regeneration" id="1047" level="5" required-level="80" sp="15100000" />
-		<skill name="Body To Mind" id="1157" level="6" required-level="80" sp="15100000" />
+		<skill name="Body to Mind" id="1157" level="6" required-level="80" sp="15100000" />
+		<skill name="Weakness" id="1164" level="22" required-level="80" sp="15100000" />
 		<skill name="Arcane Power" id="337" level="4" required-level="80" sp="15100000" />
-		<skill name="Higher Mana Gain" id="285" level="31" required-level="80" sp="15100000" />
-		<skill name="Sleep" id="1069" level="47" required-level="80" sp="15100000" />
-		<skill name="Sleeping Cloud" id="1072" level="10" required-level="80" sp="15100000" />
-		<skill name="Arcane Shield" id="1556" level="1" required-level="80" sp="15100000">
-			<item id="90086"/> <!-- Scroll: Arcane Shield -->
+		<skill name="White Guardian Transformation" id="54102" level="1" required-level="80">
+			<item id="92401" count="1" /> <!-- Spellbook - White Guardian -->
 		</skill>
+		<skill name="Higher Mana Gain" id="285" level="31" required-level="80" sp="15100000" />
+		<skill name="Sleep" id="1069" level="50" required-level="80" sp="15100000" />
+		<skill name="Sleeping Cloud" id="1072" level="10" required-level="80" sp="15100000" />
 
 		<skill name="Anti Magic" id="146" level="50" required-level="81" sp="160000000" />
+		<skill name="Flame Explosion" id="45378" level="6" required-level="81" sp="160000000" />
 		<skill name="Robe Mastery" id="234" level="46" required-level="81" sp="160000000" />
 		<skill name="Weapon Mastery" id="249" level="47" required-level="81" sp="160000000" />
 		<skill name="Arcane Shield" id="1556" level="2" required-level="81" sp="160000000" />
 		<skill name="Rain of Fire" id="1296" level="14" required-level="81" sp="160000000" />
-		<skill name="Prominence" id="1230" level="33" required-level="81" sp="160000000" />
+		<skill name="Prominence" id="1230" level="36" required-level="81" sp="160000000" />
 		<skill name="Blazing Circle" id="1171" level="24" required-level="81" sp="160000000" />
-		<skill name="Body To Mind" id="1157" level="7" required-level="81" sp="160000000" />
+		<skill name="Body to Mind" id="1157" level="7" required-level="81" sp="160000000" />
+		<skill name="Weakness" id="1164" level="23" required-level="81" sp="160000000" />
 		<skill name="Arcane Power" id="337" level="5" required-level="81" sp="160000000" />
 		<skill name="Higher Mana Gain" id="285" level="32" required-level="81" sp="160000000" />
-		<skill name="Sleep" id="1069" level="48" required-level="81" sp="160000000" />
+		<skill name="Sleep" id="1069" level="51" required-level="81" sp="160000000" />
 		<skill name="Sleeping Cloud" id="1072" level="11" required-level="81" sp="160000000" />
 
 		<skill name="Anti Magic" id="146" level="51" required-level="82" sp="170000000" />
+		<skill name="Flame Explosion" id="45378" level="7" required-level="82" sp="170000000" />
 		<skill name="Robe Mastery" id="234" level="47" required-level="82" sp="170000000" />
 		<skill name="Weapon Mastery" id="249" level="48" required-level="82" sp="170000000" />
 		<skill name="Inferno" id="1289" level="5" required-level="82" sp="170000000" />
@@ -115,29 +183,33 @@
 		<skill name="Fire Vortex" id="1339" level="2" required-level="82" sp="170000000" />
 		<skill name="Rain of Fire" id="1296" level="15" required-level="82" sp="170000000" />
 		<skill name="Bind" id="53006" level="4" required-level="82" sp="170000000" />
-		<skill name="Prominence" id="1230" level="34" required-level="82" sp="170000000" />
+		<skill name="Prominence" id="1230" level="37" required-level="82" sp="170000000" />
 		<skill name="Blazing Circle" id="1171" level="25" required-level="82" sp="170000000" />
-		<skill name="Body To Mind" id="1157" level="8" required-level="82" sp="170000000" />
+		<skill name="Body to Mind" id="1157" level="8" required-level="82" sp="170000000" />
+		<skill name="Weakness" id="1164" level="24" required-level="82" sp="170000000" />
 		<skill name="Arcane Power" id="337" level="6" required-level="82" sp="170000000" />
 		<skill name="Higher Mana Gain" id="285" level="33" required-level="82" sp="170000000" />
-		<skill name="Sleep" id="1069" level="49" required-level="82" sp="170000000" />
+		<skill name="Sleep" id="1069" level="52" required-level="82" sp="170000000" />
 		<skill name="Sleeping Cloud" id="1072" level="12" required-level="82" sp="170000000" />
 
 		<skill name="Anti Magic" id="146" level="52" required-level="83" sp="240000000" />
+		<skill name="Flame Explosion" id="45378" level="8" required-level="83" sp="240000000" />
 		<skill name="Robe Mastery" id="234" level="48" required-level="83" sp="240000000" />
 		<skill name="Weapon Mastery" id="249" level="49" required-level="83" sp="240000000" />
 		<skill name="Arcane Shield" id="1556" level="4" required-level="83" sp="240000000" />
 		<skill name="Rain of Fire" id="1296" level="16" required-level="83" sp="240000000" />
-		<skill name="Prominence" id="1230" level="35" required-level="83" sp="240000000" />
+		<skill name="Prominence" id="1230" level="38" required-level="83" sp="240000000" />
 		<skill name="Blazing Circle" id="1171" level="26" required-level="83" sp="240000000" />
-		<skill name="Body To Mind" id="1157" level="9" required-level="83" sp="240000000" />
+		<skill name="Body to Mind" id="1157" level="9" required-level="83" sp="240000000" />
+		<skill name="Weakness" id="1164" level="25" required-level="83" sp="240000000" />
 		<skill name="Arcane Power" id="337" level="7" required-level="83" sp="240000000" />
 		<skill name="Higher Mana Gain" id="285" level="34" required-level="83" sp="240000000" />
-		<skill name="Sleep" id="1069" level="50" required-level="83" sp="240000000" />
-		<skill name="Sleeping Cloud" id="1072" level="13" required-level="84" sp="240000000" />
+		<skill name="Sleep" id="1069" level="53" required-level="83" sp="240000000" />
+		<skill name="Sleeping Cloud" id="1072" level="13" required-level="83" sp="240000000" />
 
 		<skill name="Anti Magic" id="146" level="53" required-level="84" sp="240000000" />
 		<skill name="Fire Vortex Buster" id="1451" level="2" required-level="84" sp="240000000" />
+		<skill name="Flame Explosion" id="45378" level="9" required-level="84" sp="240000000" />
 		<skill name="Robe Mastery" id="234" level="49" required-level="84" sp="240000000" />
 		<skill name="Weapon Mastery" id="249" level="50" required-level="84" sp="240000000" />
 		<skill name="Inferno" id="1289" level="6" required-level="84" sp="240000000" />
@@ -145,31 +217,58 @@
 		<skill name="Fire Vortex" id="1339" level="3" required-level="84" sp="240000000" />
 		<skill name="Rain of Fire" id="1296" level="17" required-level="84" sp="240000000" />
 		<skill name="Bind" id="53006" level="5" required-level="84" sp="240000000" />
-		<skill name="Prominence" id="1230" level="36" required-level="84" sp="240000000" />
+		<skill name="Prominence" id="1230" level="39" required-level="84" sp="240000000" />
 		<skill name="Blazing Circle" id="1171" level="27" required-level="84" sp="240000000" />
-		<skill name="Body To Mind" id="1157" level="10" required-level="84" sp="240000000" />
+		<skill name="Body to Mind" id="1157" level="10" required-level="84" sp="240000000" />
+		<skill name="Weakness" id="1164" level="26" required-level="84" sp="240000000" />
 		<skill name="Arcane Power" id="337" level="8" required-level="84" sp="240000000" />
 		<skill name="Higher Mana Gain" id="285" level="35" required-level="84" sp="240000000" />
-		<skill name="Sleep" id="1069" level="51" required-level="84" sp="240000000" />
+		<skill name="Sleep" id="1069" level="54" required-level="84" sp="240000000" />
 		<skill name="Sleeping Cloud" id="1072" level="14" required-level="84" sp="240000000" />
 
 		<skill name="Anti Magic" id="146" level="54" required-level="85" sp="840000000" />
-		<skill name="Anti Magic" id="146" level="55" required-level="86" sp="924000000" />
-		<skill name="Anti Magic" id="146" level="56" required-level="87" sp="1016400000" />
-		<skill name="Anti Magic" id="146" level="57" required-level="88" sp="1118040000" />
-		<skill name="Anti Magic" id="146" level="58" required-level="89" sp="1229844000" />
-		<skill name="Anti Magic" id="146" level="59" required-level="90" sp="1352828400" />
+		<skill name="Flame Explosion" id="45378" level="10" required-level="85" sp="840000000" />
 		<skill name="Robe Mastery" id="234" level="50" required-level="85" sp="840000000" />
-		<skill name="Robe Mastery" id="234" level="51" required-level="86" sp="924000000" />
-		<skill name="Robe Mastery" id="234" level="52" required-level="87" sp="1016400000" />
-		<skill name="Robe Mastery" id="234" level="53" required-level="88" sp="1118040000" />
-		<skill name="Robe Mastery" id="234" level="54" required-level="89" sp="1229844000" />
-		<skill name="Robe Mastery" id="234" level="55" required-level="90" sp="1352828400" />
 		<skill name="Weapon Mastery" id="249" level="51" required-level="85" sp="840000000" />
-		<skill name="Weapon Mastery" id="249" level="52" required-level="86" sp="924000000" />
-		<skill name="Weapon Mastery" id="249" level="53" required-level="87" sp="1016400000" />
-		<skill name="Weapon Mastery" id="249" level="54" required-level="88" sp="1118040000" />
-		<skill name="Weapon Mastery" id="249" level="55" required-level="89" sp="1229844000" />
-		<skill name="Weapon Mastery" id="249" level="56" required-level="90" sp="1352828400" />
+		<skill name="Poison" id="1168" level="9" required-level="85" sp="840000000" />
+		<skill name="Prominence" id="1230" level="40" required-level="85" sp="240000000" />
+		<skill name="Higher Mana Gain" id="285" level="36" required-level="85" sp="840000000" />
+		<skill name="Sleep" id="1069" level="55" required-level="85" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="55" required-level="86" sp="840000000" />
+		<skill name="Flame Explosion" id="45378" level="11" required-level="86" sp="840000000" />
+		<skill name="Robe Mastery" id="234" level="51" required-level="86" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="52" required-level="86" sp="840000000" />
+		<skill name="Prominence" id="1230" level="41" required-level="86" sp="240000000" />
+		<skill name="Sleep" id="1069" level="56" required-level="86" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="56" required-level="87" sp="840000000" />
+		<skill name="Flame Explosion" id="45378" level="12" required-level="87" sp="840000000" />
+		<skill name="Robe Mastery" id="234" level="52" required-level="87" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="53" required-level="87" sp="840000000" />
+		<skill name="Prominence" id="1230" level="42" required-level="87" sp="240000000" />
+		<skill name="Sleep" id="1069" level="57" required-level="87" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="57" required-level="88" sp="840000000" />
+		<skill name="Flame Explosion" id="45378" level="13" required-level="88" sp="840000000" />
+		<skill name="Robe Mastery" id="234" level="53" required-level="88" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="54" required-level="88" sp="840000000" />
+		<skill name="Prominence" id="1230" level="43" required-level="88" sp="240000000" />
+		<skill name="Sleep" id="1069" level="58" required-level="88" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="58" required-level="89" sp="840000000" />
+		<skill name="Flame Explosion" id="45378" level="14" required-level="89" sp="840000000" />
+		<skill name="Robe Mastery" id="234" level="54" required-level="89" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="55" required-level="89" sp="840000000" />
+		<skill name="Prominence" id="1230" level="44" required-level="89" sp="240000000" />
+		<skill name="Sleep" id="1069" level="59" required-level="89" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="59" required-level="90" sp="840000000" />
+		<skill name="Flame Explosion" id="45378" level="15" required-level="90" sp="840000000" />
+		<skill name="Robe Mastery" id="234" level="55" required-level="90" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="56" required-level="90" sp="840000000" />
+		<skill name="Poison" id="1168" level="10" required-level="90" sp="840000000" />
+		<skill name="Prominence" id="1230" level="45" required-level="90" sp="240000000" />
+		<skill name="Sleep" id="1069" level="60" required-level="90" sp="840000000" />
 	</skillTree>
 </list>

--- a/data/skillTrees/3rdClass/Cardinal.xml
+++ b/data/skillTrees/3rdClass/Cardinal.xml
@@ -1,43 +1,102 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="97" parentClassId="16">
-		<skill name="White Guardian" id="54102" level="1" required-level="80" >
-			<item id="92401"/>
-		</skill>
+
 		<skill name="Anti Magic" id="146" level="46" required-level="76" sp="5700000" />
+		<skill name="Balance Life" id="1335" level="1" required-level="76" sp="5700000">
+			<item id="90122" count="1" /> <!-- Scroll: Balance Life -->
+		</skill>
 		<skill name="Benediction" id="1271" level="2" required-level="76" sp="5700000" />
+		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="5700000">
+			<item id="8620" count="1" /> <!-- Buff Expansion Book Lv. 3 -->
+		</skill>
+		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="5700000">
+			<item id="8621" count="1" /> <!-- Buff Expansion Book Lv. 4 -->
+		</skill>
 		<skill name="Greater Battle Heal" id="1218" level="34" required-level="76" sp="5700000" />
 		<skill name="Greater Group Heal" id="1219" level="34" required-level="76" sp="5700000" />
 		<skill name="Greater Heal" id="1217" level="34" required-level="76" sp="5700000" />
+		<skill name="Root Mastery" id="45238" level="1" required-level="76" sp="5700000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Light Armor Mastery" id="236" level="42" required-level="76" sp="5700000" />
 		<skill name="Robe Mastery" id="235" level="42" required-level="76" sp="5700000" />
 		<skill name="Weapon Mastery" id="249" level="43" required-level="76" sp="5700000" />
+		<skill name="Sleep Mastery" id="45239" level="1" required-level="76" sp="5700000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Evolution Defense" id="45188" level="1" required-level="76">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Dryad Root" id="1201" level="33" required-level="76" sp="5700000" />
 		<skill name="Magical Backfire" id="1396" level="11" required-level="76" sp="5700000" />
-		<skill name="Hold Undead" id="1042" level="13" required-level="76" sp="5700000" />
-		<skill name="Might of Heaven" id="1028" level="20" required-level="76" sp="5700000" />
-		<skill name="Sleep" id="1069" level="43" required-level="76" sp="5700000" />
-		<skill name="Balance Life" id="1335" level="1" required-level="76" sp="5700000">
-			<item id="90122"/>
+		<!-- Might Lv. 4 -->
+		<skill name="Might" id="1068" level="4" required-level="76" sp="5700000">
+			<item id="94135" count="1" /> <!-- Master's Book: Might -->
 		</skill>
-		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="5700000">
-			<item id="8620"/> <!-- Ancient Book: Divine Inspiration (Manuscript) -->
+		<!-- Shield Lv. 4 -->
+		<skill name="Shield" id="1040" level="4" required-level="76" sp="5700000">
+			<item id="94136" count="1" /> <!-- Master's Book: Shield -->
 		</skill>
-		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="5700000">
-			<item id="8621"/> <!-- Ancient Book: Divine Inspiration (Original Version) -->
+		<!-- Acumen Lv. 4 -->
+		<skill name="Acumen" id="45104" level="4" required-level="76" sp="5700000">
+			<item id="94370" count="1" /> <!-- Master's Book: Acumen -->
 		</skill>
-		<skill name="Mount Gold Maned Lion" id="1833" level="1" required-level="76">
-			<item id="90038"/> <!-- Spellbook: Mount Golden Lion -->
+		<!-- Empower Lv. 4 -->
+		<skill name="Empower" id="45105" level="4" required-level="76" sp="5700000">
+			<item id="94361" count="1" /> <!-- Master's Book: Empower -->
 		</skill>
-		<skill name="Glory Ability" id="45361" level="1" required-level="86">
-			<item id="94046"/> <!-- Spellbook: Glory Ability Lv. 1 -->
+		<!-- Wild Magic Lv. 3 -->
+		<skill name="Wild Magic" id="45106" level="3" required-level="76" sp="5700000">
+			<item id="94368" count="1" /> <!-- Master's Book: Wild Magic -->
 		</skill>
-		<skill name="Mount White Wings" id="54200" level="1" required-level="87">
-			<item id="93059"/> <!-- Spellbook: Summon White Wings -->
-		</skill>	
-		<skill name="Mount Shining Lady" id="54202" level="1" required-level="89">
-			<item id="93061"/> <!-- Spellbook: Summon Silver Saint -->
+		<!-- Wind Walk Lv. 3 -->
+		<skill name="Wind Walk" id="45107" level="3" required-level="76" sp="5700000">
+			<item id="94365" count="1" /> <!-- Master's Book: Wind Walk -->
 		</skill>
-		
+		<!-- Magic Barrier Lv. 3 -->
+		<skill name="Magic Barrier" id="45108" level="3" required-level="76" sp="5700000">
+			<item id="94362" count="1" /> <!-- Master's Book: Magic Barrier -->
+		</skill>
+		<!-- Focus Lv. 4 -->
+		<skill name="Focus" id="45109" level="4" required-level="76" sp="5700000">
+			<item id="94363" count="1" /> <!-- Master's Book: Focus -->
+		</skill>
+		<!-- Death Whisper Lv. 4 -->
+		<skill name="Death Whisper" id="45110" level="4" required-level="76" sp="5700000">
+			<item id="94364" count="1" /> <!-- Master's Book: Death Whisper -->
+		</skill>
+		<!-- Haste Lv. 3 -->
+		<skill name="Haste" id="45111" level="3" required-level="76" sp="5700000">
+			<item id="94369" count="1" /> <!-- Master's Book: Haste -->
+		</skill>
+		<!-- Berserker Spirit Lv. 3 -->
+		<skill name="Berserker Spirit" id="45112" level="3" required-level="76" sp="5700000">
+			<item id="94366" count="1" /> <!-- Master's Book: Berserker Spirit -->
+		</skill>
+		<!-- Clarity Lv. 4 -->
+		<skill name="Clarity" id="45113" level="4" required-level="76" sp="5700000">
+			<item id="94367" count="1" /> <!-- Master's Book: Clarity -->
+		</skill>
+		<skill name="Detection" id="45190" level="1" required-level="76" sp="5700000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Mount Golden Lion" id="1833" level="1" required-level="76">
+			<item id="90038" count="1" /> <!-- Spellbook - Ride Golden Lion -->
+		</skill>
+		<skill name="Paralysis" id="1042" level="13" required-level="76" sp="5700000" />
+		<skill name="Mana Gain" id="1460" level="1" required-level="76" sp="5700000">
+			<item id="90106" count="1" /> <!-- Scroll: Mana Gain -->
+		</skill>
+		<skill name="Prophecy of Light" id="45236" level="1" required-level="76" sp="5700000">
+			<item id="93105" count="1" /> <!-- Scroll: Prophecy of Light -->
+		</skill>
+		<skill name="Divine Beam" id="45241" level="1" required-level="76" sp="5700000">
+			<item id="93103" count="1" /> <!-- Spellbook: Divine Beam -->
+		</skill>
+		<skill name="Might of Heaven" id="1028" level="21" required-level="76" sp="5700000" />
+		<skill name="Weakness" id="1164" level="20" required-level="76" sp="5700000" />
+		<skill name="Sleep" id="1069" level="46" required-level="76" sp="5700000" />
 		<skill name="Anti Magic" id="146" level="47" required-level="77" sp="5700000" />
 		<skill name="Greater Battle Heal" id="1218" level="35" required-level="77" sp="5700000" />
 		<skill name="Greater Group Heal" id="1219" level="35" required-level="77" sp="5700000" />
@@ -45,11 +104,14 @@
 		<skill name="Light Armor Mastery" id="236" level="43" required-level="77" sp="5700000" />
 		<skill name="Robe Mastery" id="235" level="43" required-level="77" sp="5700000" />
 		<skill name="Weapon Mastery" id="249" level="44" required-level="77" sp="5700000" />
-		<skill name="Sleep" id="1069" level="44" required-level="77" sp="5700000" />
 		<skill name="Cleanse" id="1409" level="1" required-level="77" sp="5700000">
-			<item id="90123"/> <!-- Scroll: Cleanse -->
+			<item id="90123" count="1" /> <!-- Scroll: Cleanse -->
 		</skill>
-		
+		<skill name="Mana Gain" id="1460" level="2" required-level="77" sp="5700000" />
+		<skill name="Divine Beam" id="45241" level="2" required-level="77" sp="5700000" />
+		<skill name="Might of Heaven" id="1028" level="22" required-level="77" sp="5700000" />
+		<skill name="Sleep" id="1069" level="47" required-level="77" sp="5700000" />
+
 		<skill name="Anti Magic" id="146" level="48" required-level="78" sp="12500000" />
 		<skill name="Greater Battle Heal" id="1218" level="36" required-level="78" sp="12500000" />
 		<skill name="Greater Group Heal" id="1219" level="36" required-level="78" sp="12500000" />
@@ -57,34 +119,65 @@
 		<skill name="Light Armor Mastery" id="236" level="44" required-level="78" sp="12500000" />
 		<skill name="Robe Mastery" id="235" level="44" required-level="78" sp="12500000" />
 		<skill name="Weapon Mastery" id="249" level="45" required-level="78" sp="12500000" />
+		<skill name="Dryad Root" id="1201" level="34" required-level="78" sp="12500000" />
 		<skill name="Magical Backfire" id="1396" level="12" required-level="78" sp="12500000" />
-		<skill name="Hold Undead" id="1042" level="14" required-level="78" sp="12500000" />
-		<skill name="Might of Heaven" id="1028" level="21" required-level="78" sp="12500000" />
-		<skill name="Sleep" id="1069" level="45" required-level="78" sp="12500000" />
+		<skill name="Paralysis" id="1042" level="14" required-level="78" sp="12500000" />
+		<skill name="Mana Gain" id="1460" level="3" required-level="78" sp="12500000" />
+		<skill name="Enlightenment" id="1533" level="1" required-level="78" sp="12500000">
+			<item id="90111" count="1" /> <!-- Scroll: Enlightenment -->
+		</skill>
+		<skill name="Divine Beam" id="45241" level="3" required-level="78" sp="12500000" />
+		<skill name="Might of Heaven" id="1028" level="23" required-level="78" sp="12500000" />
+		<skill name="Weakness" id="1164" level="21" required-level="78" sp="12500000" />
+		<skill name="Sleep" id="1069" level="48" required-level="78" sp="12500000" />
 		<skill name="Chain Heal" id="1553" level="1" required-level="78" sp="12500000">
-			<item id="90124"/> <!-- Scroll: Chain Heal -->
+			<item id="90124" count="1" /> <!-- Scroll: Chain Heal -->
 		</skill>
-		
+
+		<skill name="Root Mastery" id="45238" level="2" required-level="79" sp="12500000">
+			<item id="57" count="2000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Sleep Mastery" id="45239" level="2" required-level="79" sp="12500000">
+			<item id="57" count="2000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Magical Backfire" id="1396" level="13" required-level="79" sp="12500000" />
-		<skill name="Sleep" id="1069" level="46" required-level="79" sp="12500000" />
+		<skill name="Mana Gain" id="1460" level="4" required-level="79" sp="12500000" />
+		<skill name="Divine Beam" id="45241" level="4" required-level="79" sp="12500000" />
+		<skill name="Might of Heaven" id="1028" level="24" required-level="79" sp="12500000" />
 		<skill name="Salvation" id="1410" level="1" required-level="79" sp="12500000">
-			<item id="90125"/> <!-- Scroll: Salvation -->
+			<item id="90125" count="1" /> <!-- Scroll: Salvation -->
 		</skill>
-		
+		<skill name="Sleep" id="1069" level="49" required-level="79" sp="12500000" />
+
 		<skill name="Anti Magic" id="146" level="49" required-level="80" sp="12500000" />
 		<skill name="Greater Battle Heal" id="1218" level="37" required-level="80" sp="12500000" />
 		<skill name="Greater Group Heal" id="1219" level="37" required-level="80" sp="12500000" />
 		<skill name="Greater Heal" id="1217" level="37" required-level="80" sp="12500000" />
+		<skill name="Swap Defense" id="1392" level="4" required-level="80" sp="10000000" />
 		<skill name="Light Armor Mastery" id="236" level="45" required-level="80" sp="12500000" />
 		<skill name="Robe Mastery" id="235" level="45" required-level="80" sp="12500000" />
 		<skill name="Weapon Mastery" id="249" level="46" required-level="80" sp="12500000" />
+		<skill name="Dryad Root" id="1201" level="35" required-level="80" sp="12500000" />
 		<skill name="Magical Backfire" id="1396" level="14" required-level="80" sp="12500000" />
-		<skill name="Might of Heaven" id="1028" level="22" required-level="80" sp="12500000" />
-		<skill name="Sleep" id="1069" level="47" required-level="80" sp="12500000" />
-		<skill name="Miracle" id="1426" level="1" required-level="80" sp="12500000">
-			<item id="90126"/> <!-- Scroll: Miracle -->
+		<skill name="Spell Master" id="1829" level="4" required-level="80" sp="2400000">
+			<item id="57" count="500000" /> <!-- Adena -->
 		</skill>
-		
+		<skill name="Evolution Power" id="45189" level="1" required-level="80">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Poison" id="1168" level="8" required-level="80" sp="12500000" />
+		<skill name="Mana Gain" id="1460" level="5" required-level="80" sp="12500000" />
+		<skill name="Divine Beam" id="45241" level="5" required-level="80" sp="12500000" />
+		<skill name="Might of Heaven" id="1028" level="25" required-level="80" sp="12500000" />
+		<skill name="Weakness" id="1164" level="22" required-level="80" sp="12500000" />
+		<skill name="White Guardian Transformation" id="54102" level="1" required-level="80">
+			<item id="92401" count="1" /> <!-- Spellbook - White Guardian -->
+		</skill>
+		<skill name="Sleep" id="1069" level="50" required-level="80" sp="12500000" />
+		<skill name="Miracle" id="1426" level="1" required-level="80" sp="12500000">
+			<item id="90126" count="1" /> <!-- Scroll: Miracle -->
+		</skill>
+
 		<skill name="Anti Magic" id="146" level="50" required-level="81" sp="160000000" />
 		<skill name="Greater Battle Heal" id="1218" level="38" required-level="81" sp="160000000" />
 		<skill name="Greater Group Heal" id="1219" level="38" required-level="81" sp="160000000" />
@@ -92,23 +185,35 @@
 		<skill name="Light Armor Mastery" id="236" level="46" required-level="81" sp="160000000" />
 		<skill name="Robe Mastery" id="235" level="46" required-level="81" sp="160000000" />
 		<skill name="Weapon Mastery" id="249" level="47" required-level="81" sp="160000000" />
+		<skill name="Dryad Root" id="1201" level="36" required-level="81" sp="160000000" />
 		<skill name="Magical Backfire" id="1396" level="15" required-level="81" sp="160000000" />
-		<skill name="Might of Heaven" id="1028" level="23" required-level="81" sp="160000000" />
-		<skill name="Sleep" id="1069" level="48" required-level="81" sp="160000000" />
-		<skill name="Sublime Self-Sacrifice" id="1505" level="1" required-level="81" sp="160000000">
-			<item id="91202"/> <!-- Scroll: Sublime Self-Sacrifice -->
-		</skill>
+		<skill name="Mana Gain" id="1460" level="6" required-level="81" sp="160000000" />
+		<skill name="Divine Beam" id="45241" level="6" required-level="81" sp="160000000" />
+		<skill name="Might of Heaven" id="1028" level="26" required-level="81" sp="160000000" />
+		<skill name="Weakness" id="1164" level="23" required-level="81" sp="160000000" />
+		<skill name="Sleep" id="1069" level="51" required-level="81" sp="160000000" />
 
 		<skill name="Anti Magic" id="146" level="51" required-level="82" sp="170000000" />
 		<skill name="Greater Battle Heal" id="1218" level="39" required-level="82" sp="170000000" />
 		<skill name="Greater Group Heal" id="1219" level="39" required-level="82" sp="170000000" />
 		<skill name="Greater Heal" id="1217" level="39" required-level="82" sp="170000000" />
+		<skill name="Root Mastery" id="45238" level="3" required-level="82" sp="170000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Light Armor Mastery" id="236" level="47" required-level="82" sp="170000000" />
 		<skill name="Robe Mastery" id="235" level="47" required-level="82" sp="170000000" />
 		<skill name="Weapon Mastery" id="249" level="48" required-level="82" sp="170000000" />
+		<skill name="Sleep Mastery" id="45239" level="3" required-level="82" sp="170000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Dryad Root" id="1201" level="37" required-level="82" sp="170000000" />
 		<skill name="Magical Backfire" id="1396" level="16" required-level="82" sp="170000000" />
-		<skill name="Might of Heaven" id="1028" level="24" required-level="82" sp="170000000" />
-		<skill name="Sleep" id="1069" level="49" required-level="82" sp="170000000" />
+		<skill name="Mana Gain" id="1460" level="7" required-level="82" sp="170000000" />
+		<skill name="Prophecy of Light" id="45236" level="2" required-level="82" sp="170000000" />
+		<skill name="Divine Beam" id="45241" level="7" required-level="82" sp="170000000" />
+		<skill name="Might of Heaven" id="1028" level="27" required-level="82" sp="170000000" />
+		<skill name="Weakness" id="1164" level="24" required-level="82" sp="170000000" />
+		<skill name="Sleep" id="1069" level="52" required-level="82" sp="170000000" />
 		<skill name="Chain Heal" id="1553" level="2" required-level="82" sp="170000000" />
 
 		<skill name="Anti Magic" id="146" level="52" required-level="83" sp="240000000" />
@@ -118,9 +223,13 @@
 		<skill name="Light Armor Mastery" id="236" level="48" required-level="83" sp="240000000" />
 		<skill name="Robe Mastery" id="235" level="48" required-level="83" sp="240000000" />
 		<skill name="Weapon Mastery" id="249" level="49" required-level="83" sp="240000000" />
+		<skill name="Dryad Root" id="1201" level="38" required-level="83" sp="240000000" />
 		<skill name="Magical Backfire" id="1396" level="17" required-level="83" sp="240000000" />
-		<skill name="Might of Heaven" id="1028" level="25" required-level="83" sp="240000000" />
-		<skill name="Sleep" id="1069" level="50" required-level="83" sp="240000000" />
+		<skill name="Mana Gain" id="1460" level="8" required-level="83" sp="240000000" />
+		<skill name="Divine Beam" id="45241" level="8" required-level="83" sp="240000000" />
+		<skill name="Might of Heaven" id="1028" level="28" required-level="83" sp="240000000" />
+		<skill name="Weakness" id="1164" level="25" required-level="83" sp="240000000" />
+		<skill name="Sleep" id="1069" level="53" required-level="83" sp="240000000" />
 
 		<skill name="Anti Magic" id="146" level="53" required-level="84" sp="240000000" />
 		<skill name="Greater Battle Heal" id="1218" level="41" required-level="84" sp="240000000" />
@@ -129,33 +238,71 @@
 		<skill name="Light Armor Mastery" id="236" level="49" required-level="84" sp="240000000" />
 		<skill name="Robe Mastery" id="235" level="49" required-level="84" sp="240000000" />
 		<skill name="Weapon Mastery" id="249" level="50" required-level="84" sp="240000000" />
+		<skill name="Dryad Root" id="1201" level="39" required-level="84" sp="240000000" />
 		<skill name="Magical Backfire" id="1396" level="18" required-level="84" sp="240000000" />
-		<skill name="Might of Heaven" id="1028" level="26" required-level="84" sp="240000000" />
-		<skill name="Sleep" id="1069" level="51" required-level="84" sp="240000000" />
-		
+		<skill name="Mana Gain" id="1460" level="9" required-level="84" sp="240000000" />
+		<skill name="Divine Beam" id="45241" level="9" required-level="84" sp="240000000" />
+		<skill name="Might of Heaven" id="1028" level="29" required-level="84" sp="240000000" />
+		<skill name="Weakness" id="1164" level="26" required-level="84" sp="240000000" />
+		<skill name="Sleep" id="1069" level="54" required-level="84" sp="240000000" />
+
 		<skill name="Anti Magic" id="146" level="54" required-level="85" sp="840000000" />
-		<skill name="Anti Magic" id="146" level="55" required-level="86" sp="924000000" />
-		<skill name="Anti Magic" id="146" level="56" required-level="87" sp="1016400000" />
-		<skill name="Anti Magic" id="146" level="57" required-level="88" sp="1118040000" />
-		<skill name="Anti Magic" id="146" level="58" required-level="89" sp="1229844000" />
-		<skill name="Anti Magic" id="146" level="59" required-level="90" sp="1352828400" />
+		<skill name="Root Mastery" id="45238" level="4" required-level="85" sp="840000000" />
 		<skill name="Light Armor Mastery" id="236" level="50" required-level="85" sp="840000000" />
-		<skill name="Light Armor Mastery" id="236" level="51" required-level="86" sp="924000000" />
-		<skill name="Light Armor Mastery" id="236" level="52" required-level="87" sp="1016400000" />
-		<skill name="Light Armor Mastery" id="236" level="53" required-level="88" sp="1118040000" />
-		<skill name="Light Armor Mastery" id="236" level="54" required-level="89" sp="1229844000" />
-		<skill name="Light Armor Mastery" id="236" level="55" required-level="90" sp="1352828400" />
 		<skill name="Robe Mastery" id="235" level="50" required-level="85" sp="840000000" />
-		<skill name="Robe Mastery" id="235" level="51" required-level="86" sp="924000000" />
-		<skill name="Robe Mastery" id="235" level="52" required-level="87" sp="1016400000" />
-		<skill name="Robe Mastery" id="235" level="53" required-level="88" sp="1118040000" />
-		<skill name="Robe Mastery" id="235" level="54" required-level="89" sp="1229844000" />
-		<skill name="Robe Mastery" id="235" level="55" required-level="90" sp="1352828400" />
 		<skill name="Weapon Mastery" id="249" level="51" required-level="85" sp="840000000" />
-		<skill name="Weapon Mastery" id="249" level="52" required-level="86" sp="924000000" />
-		<skill name="Weapon Mastery" id="249" level="53" required-level="87" sp="1016400000" />
-		<skill name="Weapon Mastery" id="249" level="54" required-level="88" sp="1118040000" />
-		<skill name="Weapon Mastery" id="249" level="55" required-level="89" sp="1229844000" />
-		<skill name="Weapon Mastery" id="249" level="56" required-level="90" sp="1352828400" />
+		<skill name="Sleep Mastery" id="45239" level="4" required-level="85" sp="840000000" />
+		<skill name="Dryad Root" id="1201" level="40" required-level="85" sp="840000000" />
+		<skill name="Poison" id="1168" level="9" required-level="85" sp="840000000" />
+		<skill name="Mana Gain" id="1460" level="10" required-level="85" sp="840000000" />
+		<skill name="Divine Beam" id="45241" level="10" required-level="85" sp="840000000" />
+		<skill name="Might of Heaven" id="1028" level="30" required-level="85" sp="840000000" />
+		<skill name="Sleep" id="1069" level="55" required-level="85" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="55" required-level="86" sp="840000000" />
+		<skill name="Light Armor Mastery" id="236" level="51" required-level="86" sp="840000000" />
+		<skill name="Robe Mastery" id="235" level="51" required-level="86" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="52" required-level="86" sp="840000000" />
+		<skill name="Dryad Root" id="1201" level="41" required-level="86" sp="840000000" />
+		<skill name="Divine Beam" id="45241" level="11" required-level="86" sp="840000000" />
+		<skill name="Might of Heaven" id="1028" level="31" required-level="86" sp="840000000" />
+		<skill name="Sleep" id="1069" level="56" required-level="86" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="56" required-level="87" sp="840000000" />
+		<skill name="Light Armor Mastery" id="236" level="52" required-level="87" sp="840000000" />
+		<skill name="Robe Mastery" id="235" level="52" required-level="87" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="53" required-level="87" sp="840000000" />
+		<skill name="Dryad Root" id="1201" level="42" required-level="87" sp="840000000" />
+		<skill name="Divine Beam" id="45241" level="12" required-level="87" sp="840000000" />
+		<skill name="Might of Heaven" id="1028" level="32" required-level="87" sp="840000000" />
+		<skill name="Sleep" id="1069" level="57" required-level="87" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="57" required-level="88" sp="840000000" />
+		<skill name="Light Armor Mastery" id="236" level="53" required-level="88" sp="840000000" />
+		<skill name="Robe Mastery" id="235" level="53" required-level="88" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="54" required-level="88" sp="840000000" />
+		<skill name="Dryad Root" id="1201" level="43" required-level="88" sp="840000000" />
+		<skill name="Divine Beam" id="45241" level="13" required-level="88" sp="840000000" />
+		<skill name="Might of Heaven" id="1028" level="33" required-level="88" sp="840000000" />
+		<skill name="Sleep" id="1069" level="58" required-level="88" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="58" required-level="89" sp="840000000" />
+		<skill name="Light Armor Mastery" id="236" level="54" required-level="89" sp="840000000" />
+		<skill name="Robe Mastery" id="235" level="54" required-level="89" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="55" required-level="89" sp="840000000" />
+		<skill name="Dryad Root" id="1201" level="44" required-level="89" sp="840000000" />
+		<skill name="Divine Beam" id="45241" level="14" required-level="89" sp="840000000" />
+		<skill name="Might of Heaven" id="1028" level="34" required-level="89" sp="840000000" />
+		<skill name="Sleep" id="1069" level="59" required-level="89" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="59" required-level="90" sp="840000000" />
+		<skill name="Light Armor Mastery" id="236" level="55" required-level="90" sp="840000000" />
+		<skill name="Robe Mastery" id="235" level="55" required-level="90" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="56" required-level="90" sp="840000000" />
+		<skill name="Dryad Root" id="1201" level="45" required-level="90" sp="840000000" />
+		<skill name="Poison" id="1168" level="10" required-level="90" sp="840000000" />
+		<skill name="Divine Beam" id="45241" level="15" required-level="90" sp="840000000" />
+		<skill name="Might of Heaven" id="1028" level="35" required-level="90" sp="840000000" />
+		<skill name="Sleep" id="1069" level="60" required-level="90" sp="840000000" />
 	</skillTree>
 </list>

--- a/data/skillTrees/3rdClass/DarkElfDeathKnight.xml
+++ b/data/skillTrees/3rdClass/DarkElfDeathKnight.xml
@@ -1,0 +1,273 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
+	<skillTree type="classSkillTree" classId="207" parentClassId="206">
+
+		<skill name="Confusion" id="2" level="21" required-level="76" sp="8000000" />
+		<skill name="Power Break" id="115" level="18" required-level="76" sp="8000000" />
+		<skill name="Hex" id="122" level="16" required-level="76" sp="8000000" />
+		<skill name="Hellfire" id="45312" level="1" required-level="76" sp="8000000">
+			<item id="93631" count="1" /> <!-- Spellbook - Hellfire -->
+		</skill>
+		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="8000000">
+			<item id="8620" count="1" /> <!-- Buff Expansion Book Lv. 3 -->
+		</skill>
+		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="8000000">
+			<item id="8621" count="1" /> <!-- Buff Expansion Book Lv. 4 -->
+		</skill>
+		<skill name="Death Armor Mastery" id="45354" level="23" required-level="76" sp="8000000" />
+		<skill name="Death Sword Mastery" id="45353" level="23" required-level="76" sp="8000000" />
+		<skill name="Evolution Defense" id="45188" level="1" required-level="76">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Death Guard" id="45329" level="2" required-level="76" sp="8000000">
+			<item id="93388" count="1" /> <!-- Spellbook: Death Guard -->
+		</skill>
+		<skill name="Fist of Fury" id="45309" level="10" required-level="76" sp="8000000" />
+		<skill name="Might" id="1068" level="4" required-level="76" sp="8000000">
+			<item id="94135" count="1" /> <!-- Master's Book: Might -->
+		</skill>
+		<skill name="Ultimate Death Knight Transformation" id="54206" level="1" required-level="76" sp="8000000">
+			<item id="93387" count="1" /> <!-- Spellbook - Ultimate Death Knight Form -->
+		</skill>
+		<skill name="Detection" id="45190" level="1" required-level="76" sp="8000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Mount Night Mare" id="54207" level="1" required-level="76">
+			<item id="93383" count="1" /> <!-- Spellbook - Mount Nightmare Steed -->
+		</skill>
+		<skill name="Death Points" id="45352" level="3" required-level="76" auto-learn="true" />
+		<skill name="Devour" id="45389" level="1" required-level="76" sp="8000000">
+			<item id="94137" count="1" /> <!-- Spellbook: Devour -->
+		</skill>
+		<skill name="Deadly Ligament Rupture" id="45343" level="1" required-level="76" sp="8000000" />
+		<skill name="Death Blind" id="45342" level="11" required-level="76" sp="8000000" />
+		<skill name="Shield" id="1040" level="4" required-level="76" sp="8000000">
+			<item id="94136" count="1" /> <!-- Master's Book: Shield -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="46" required-level="76" sp="8000000" />
+
+		<skill name="Confusion" id="2" level="22" required-level="77" sp="10000000" />
+		<skill name="Hex" id="122" level="17" required-level="77" sp="10000000" />
+		<skill name="Confusion" id="2" level="22" required-level="77" sp="10000000" />
+		<skill name="Hex" id="122" level="17" required-level="77" sp="10000000" />
+		<skill name="Hellfire" id="45312" level="2" required-level="77" sp="10000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="2" required-level="77" sp="10000000" />
+		<skill name="Death Blind" id="45342" level="12" required-level="77" sp="10000000" />
+		<skill name="Emergency Rescue" id="70" level="47" required-level="77" sp="10000000" />
+
+		<skill name="Confusion" id="2" level="23" required-level="78" sp="12000000" />
+		<skill name="Power Break" id="115" level="19" required-level="78" sp="12000000" />
+		<skill name="Hex" id="122" level="18" required-level="78" sp="12000000" />
+		<skill name="Hellfire" id="45312" level="3" required-level="78" sp="12000000" />
+		<skill name="Death Armor Mastery" id="45354" level="24" required-level="78" sp="12000000" />
+		<skill name="Death Sword Mastery" id="45353" level="24" required-level="78" sp="12000000" />
+		<skill name="Punishment" id="45301" level="15" required-level="78" sp="12000000" />
+		<skill name="Fist of Fury" id="45309" level="11" required-level="78" sp="12000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="3" required-level="78" sp="12000000" />
+		<skill name="Death Blind" id="45342" level="13" required-level="78" sp="12000000" />
+		<skill name="Emergency Rescue" id="70" level="48" required-level="78" sp="12000000" />
+
+		<skill name="Confusion" id="2" level="24" required-level="79" sp="15000000" />
+		<skill name="Hex" id="122" level="19" required-level="79" sp="15000000" />
+		<skill name="Hellfire" id="45312" level="4" required-level="79" sp="15000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="4" required-level="79" sp="15000000" />
+		<skill name="Death Blind" id="45342" level="14" required-level="79" sp="15000000" />
+		<skill name="Emergency Rescue" id="70" level="49" required-level="79" sp="15000000" />
+
+		<skill name="Confusion" id="2" level="25" required-level="80" sp="18000000" />
+		<skill name="Hellfire" id="45312" level="5" required-level="80" sp="18000000" />
+		<skill name="Death Armor Mastery" id="45354" level="25" required-level="80" sp="18000000" />
+		<skill name="Death Sword Mastery" id="45353" level="25" required-level="80" sp="18000000" />
+		<skill name="Lightning Storm" id="45319" level="1" required-level="80" sp="18000000">
+			<item id="93386" count="1" /> <!-- Spellbook: Lightning Storm -->
+		</skill>
+		<skill name="Bone Cage" id="45338" level="5" required-level="80" sp="18000000" />
+		<skill name="Soul Steal" id="45335" level="4" required-level="80" sp="18000000" />
+		<skill name="Fist of Fury" id="45309" level="12" required-level="80" sp="18000000" />
+		<skill name="Evolution Power" id="45189" level="1" required-level="80">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Flaming Body" id="45332" level="3" required-level="80" sp="18000000" />
+		<skill name="Wipeout" id="45303" level="8" required-level="80" sp="18000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="5" required-level="80" sp="18000000" />
+		<skill name="Roar of Death" id="45328" level="4" required-level="80" sp="18000000" />
+		<skill name="Undying Body" id="45350" level="5" required-level="80" auto-learn="true" />
+		<skill name="Death Blind" id="45342" level="15" required-level="80" sp="18000000" />
+		<skill name="Deadly Pull" id="45311" level="8" required-level="80" sp="18000000" />
+		<skill name="Emergency Rescue" id="70" level="50" required-level="80" sp="18000000" />
+		<skill name="Power Break" id="115" level="20" required-level="80" sp="18000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Hex" id="122" level="20" required-level="80" sp="18000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+
+		<skill name="Confusion" id="2" level="26" required-level="81" sp="160000000" />
+		<skill name="Hellfire" id="45312" level="6" required-level="81" sp="160000000" />
+		<skill name="Death Armor Mastery" id="45354" level="26" required-level="81" sp="160000000" />
+		<skill name="Death Sword Mastery" id="45353" level="26" required-level="81" sp="160000000" />
+		<skill name="Punishment" id="45301" level="16" required-level="81" sp="160000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="6" required-level="81" sp="160000000" />
+		<skill name="Death Blind" id="45342" level="16" required-level="81" sp="160000000" />
+		<skill name="Emergency Rescue" id="70" level="51" required-level="81" sp="160000000" />
+		<skill name="Power Break" id="115" level="21" required-level="81" sp="160000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Hex" id="122" level="21" required-level="81" sp="160000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+
+		<skill name="Confusion" id="2" level="27" required-level="82" sp="170000000" />
+		<skill name="Hellfire" id="45312" level="7" required-level="82" sp="170000000" />
+		<skill name="Death Armor Mastery" id="45354" level="27" required-level="82" sp="170000000" />
+		<skill name="Death Sword Mastery" id="45353" level="27" required-level="82" sp="170000000" />
+		<skill name="Bone Cage" id="45338" level="6" required-level="82" sp="170000000" />
+		<skill name="Fist of Fury" id="45309" level="13" required-level="82" sp="170000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="7" required-level="82" sp="170000000" />
+		<skill name="Death Blind" id="45342" level="17" required-level="82" sp="170000000" />
+		<skill name="Emergency Rescue" id="70" level="52" required-level="82" sp="170000000" />
+		<skill name="Power Break" id="115" level="22" required-level="82" sp="170000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Hex" id="122" level="22" required-level="82" sp="170000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+
+		<skill name="Confusion" id="2" level="28" required-level="83" sp="240000000" />
+		<skill name="Hellfire" id="45312" level="8" required-level="83" sp="240000000" />
+		<skill name="Death Armor Mastery" id="45354" level="28" required-level="83" sp="240000000" />
+		<skill name="Death Sword Mastery" id="45353" level="28" required-level="83" sp="240000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="8" required-level="83" sp="240000000" />
+		<skill name="Death Blind" id="45342" level="18" required-level="83" sp="240000000" />
+		<skill name="Emergency Rescue" id="70" level="53" required-level="83" sp="240000000" />
+		<skill name="Power Break" id="115" level="23" required-level="83" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Hex" id="122" level="23" required-level="83" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+
+		<skill name="Confusion" id="2" level="29" required-level="84" sp="240000000" />
+		<skill name="Hellfire" id="45312" level="9" required-level="84" sp="240000000" />
+		<skill name="Death Armor Mastery" id="45354" level="29" required-level="84" sp="240000000" />
+		<skill name="Death Sword Mastery" id="45353" level="29" required-level="84" sp="240000000" />
+		<skill name="Bone Cage" id="45338" level="7" required-level="84" sp="240000000" />
+		<skill name="Fist of Fury" id="45309" level="14" required-level="84" sp="240000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="9" required-level="84" sp="240000000" />
+		<skill name="Death Blind" id="45342" level="19" required-level="84" sp="240000000" />
+		<skill name="Emergency Rescue" id="70" level="54" required-level="84" sp="240000000" />
+		<skill name="Power Break" id="115" level="24" required-level="84" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Hex" id="122" level="24" required-level="84" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+
+		<skill name="Confusion" id="2" level="30" required-level="85" sp="840000000" />
+		<skill name="Hellfire" id="45312" level="10" required-level="85" sp="840000000" />
+		<skill name="Death Armor Mastery" id="45354" level="30" required-level="85" sp="840000000" />
+		<skill name="Death Sword Mastery" id="45353" level="30" required-level="85" sp="840000000" />
+		<skill name="Lightning Storm" id="45319" level="2" required-level="85" sp="840000000" />
+		<skill name="Punishment" id="45301" level="17" required-level="85" sp="840000000" />
+		<skill name="Fist of Fury" id="45309" level="15" required-level="85" sp="840000000" />
+		<skill name="Flaming Body" id="45332" level="4" required-level="85" sp="840000000" />
+		<skill name="Wipeout" id="45303" level="9" required-level="85" sp="840000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="10" required-level="85" sp="840000000" />
+		<skill name="Death Blind" id="45342" level="20" required-level="85" sp="840000000" />
+		<skill name="Deadly Pull" id="45311" level="9" required-level="85" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="55" required-level="85" sp="840000000" />
+		<skill name="Power Break" id="115" level="25" required-level="85" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Hex" id="122" level="25" required-level="85" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+
+		<skill name="Confusion" id="2" level="31" required-level="86" sp="840000000" />
+		<skill name="Hellfire" id="45312" level="11" required-level="86" sp="840000000" />
+		<skill name="Death Armor Mastery" id="45354" level="31" required-level="86" sp="840000000" />
+		<skill name="Death Sword Mastery" id="45353" level="31" required-level="86" sp="840000000" />
+		<skill name="Bone Cage" id="45338" level="8" required-level="86" sp="840000000" />
+		<skill name="Fist of Fury" id="45309" level="16" required-level="86" sp="840000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="11" required-level="86" sp="840000000" />
+		<skill name="Death Blind" id="45342" level="21" required-level="86" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="56" required-level="86" sp="840000000" />
+		<skill name="Power Break" id="115" level="26" required-level="86" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Hex" id="122" level="26" required-level="86" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+
+		<skill name="Confusion" id="2" level="32" required-level="87" sp="840000000" />
+		<skill name="Hellfire" id="45312" level="12" required-level="87" sp="840000000" />
+		<skill name="Death Armor Mastery" id="45354" level="32" required-level="87" sp="840000000" />
+		<skill name="Death Sword Mastery" id="45353" level="32" required-level="87" sp="840000000" />
+		<skill name="Punishment" id="45301" level="18" required-level="87" sp="840000000" />
+		<skill name="Fist of Fury" id="45309" level="17" required-level="87" sp="840000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="12" required-level="87" sp="840000000" />
+		<skill name="Death Blind" id="45342" level="22" required-level="87" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="57" required-level="87" sp="840000000" />
+		<skill name="Power Break" id="115" level="27" required-level="87" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Hex" id="122" level="27" required-level="87" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+
+		<skill name="Confusion" id="2" level="33" required-level="88" sp="840000000" />
+		<skill name="Hellfire" id="45312" level="13" required-level="88" sp="840000000" />
+		<skill name="Death Armor Mastery" id="45354" level="33" required-level="88" sp="840000000" />
+		<skill name="Death Sword Mastery" id="45353" level="33" required-level="88" sp="840000000" />
+		<skill name="Bone Cage" id="45338" level="9" required-level="88" sp="840000000" />
+		<skill name="Fist of Fury" id="45309" level="18" required-level="88" sp="840000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="13" required-level="88" sp="840000000" />
+		<skill name="Death Blind" id="45342" level="23" required-level="88" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="58" required-level="88" sp="840000000" />
+		<skill name="Power Break" id="115" level="28" required-level="88" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Hex" id="122" level="28" required-level="88" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+
+		<skill name="Confusion" id="2" level="34" required-level="89" sp="840000000" />
+		<skill name="Hellfire" id="45312" level="14" required-level="89" sp="840000000" />
+		<skill name="Death Armor Mastery" id="45354" level="34" required-level="89" sp="840000000" />
+		<skill name="Death Sword Mastery" id="45353" level="34" required-level="89" sp="840000000" />
+		<skill name="Punishment" id="45301" level="19" required-level="89" sp="840000000" />
+		<skill name="Fist of Fury" id="45309" level="19" required-level="89" sp="840000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="14" required-level="89" sp="840000000" />
+		<skill name="Death Blind" id="45342" level="24" required-level="89" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="59" required-level="89" sp="840000000" />
+		<skill name="Power Break" id="115" level="29" required-level="89" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Hex" id="122" level="29" required-level="89" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+
+		<skill name="Confusion" id="2" level="35" required-level="90" sp="840000000" />
+		<skill name="Hellfire" id="45312" level="15" required-level="90" sp="840000000" />
+		<skill name="Death Armor Mastery" id="45354" level="35" required-level="90" sp="840000000" />
+		<skill name="Death Sword Mastery" id="45353" level="35" required-level="90" sp="840000000" />
+		<skill name="Lightning Storm" id="45319" level="3" required-level="90" sp="840000000" />
+		<skill name="Punishment" id="45301" level="20" required-level="90" sp="840000000" />
+		<skill name="Bone Cage" id="45338" level="10" required-level="90" sp="840000000" />
+		<skill name="Soul Steal" id="45335" level="5" required-level="90" sp="840000000" />
+		<skill name="Fist of Fury" id="45309" level="20" required-level="90" sp="840000000" />
+		<skill name="Flaming Body" id="45332" level="5" required-level="90" sp="840000000" />
+		<skill name="Wipeout" id="45303" level="10" required-level="90" sp="840000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="15" required-level="90" sp="840000000" />
+		<skill name="Roar of Death" id="45328" level="5" required-level="90" sp="840000000" />
+		<skill name="Death Blind" id="45342" level="25" required-level="90" sp="840000000" />
+		<skill name="Deadly Pull" id="45311" level="10" required-level="90" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="60" required-level="90" sp="840000000" />
+		<skill name="Power Break" id="115" level="30" required-level="90" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Hex" id="122" level="30" required-level="90" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+	</skillTree>
+</list>

--- a/data/skillTrees/3rdClass/Dominator.xml
+++ b/data/skillTrees/3rdClass/Dominator.xml
@@ -1,15 +1,77 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="115" parentClassId="51">
-		<skill name="White Guardian" id="54102" level="1" required-level="80" >
-			<item id="92401"/>
-		</skill>
+
 		<skill name="Anti Magic" id="146" level="46" required-level="76" sp="4500000" />
+		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="4500000">
+			<item id="8620" count="1" /> <!-- Buff Expansion Book Lv. 3 -->
+		</skill>
+		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="4500000">
+			<item id="8621" count="1" /> <!-- Buff Expansion Book Lv. 4 -->
+		</skill>
 		<skill name="Light Armor Mastery" id="252" level="46" required-level="76" sp="4500000" />
 		<skill name="Robe Mastery" id="251" level="46" required-level="76" sp="4500000" />
 		<skill name="Weapon Mastery" id="250" level="43" required-level="76" sp="4500000" />
 		<skill name="Heavy Armor Mastery" id="253" level="44" required-level="76" sp="4500000" />
+		<skill name="Evolution Defense" id="45188" level="1" required-level="76">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Steal Essence" id="1245" level="15" required-level="76" sp="4500000" />
+		<!-- Might Lv. 4 -->
+		<skill name="Chant of Might" id="45126" level="4" required-level="76" sp="4500000">
+			<item id="94135" count="1" /> <!-- Master's Book: Might -->
+		</skill>
+		<!-- Shield Lv. 4 -->
+		<skill name="Chant of Shield" id="45127" level="4" required-level="76" sp="4500000">
+			<item id="94136" count="1" /> <!-- Master's Book: Shield -->
+		</skill>
+        <!-- Acumen Lv. 4 -->
+        <skill name="Chant of Acumen" id="45135" level="4" required-level="76" sp="4500000">
+            <item id="94370" count="1" /> <!-- Master's Book: Acumen -->
+        </skill>
+        <!-- Empower Lv. 4 -->
+        <skill name="Chant of Empower" id="45136" level="4" required-level="76" sp="4500000">
+            <item id="94361" count="1" /> <!-- Master's Book: Empower -->
+        </skill>
+        <!-- Wild Magic Lv. 3 -->
+        <skill name="Chant of Wild Magic" id="45137" level="3" required-level="76" sp="4500000">
+            <item id="94368" count="1" /> <!-- Master's Book: Wild Magic -->
+        </skill>
+        <!-- Wind Walk Lv. 3 -->
+        <skill name="Chant of Wind Walk" id="45124" level="3" required-level="76" sp="4500000">
+            <item id="94365" count="1" /> <!-- Master's Book: Wind Walk -->
+        </skill>
+        <!-- Magic Barrier Lv. 3 -->
+        <skill name="Chant Of Magic Barrier" id="45125" level="3" required-level="76" sp="4500000">
+            <item id="94362" count="1" /> <!-- Master's Book: Magic Barrier -->
+        </skill>
+        <!-- Focus Lv. 4 -->
+        <skill name="Chant Of Focus" id="45121" level="4" required-level="76" sp="4500000">
+            <item id="94363" count="1" /> <!-- Master's Book: Focus -->
+        </skill>
+        <!-- Death Whisper Lv. 4 -->
+        <skill name="Chant Of Death Whisper" id="45122" level="4" required-level="76" sp="4500000">
+            <item id="94364" count="1" /> <!-- Master's Book: Death Whisper -->
+        </skill>
+        <!-- Haste Lv. 3 -->
+        <skill name="Chant of Haste" id="45123" level="3" required-level="76" sp="4500000">
+            <item id="94369" count="1" /> <!-- Master's Book: Haste -->
+        </skill>
+        <!-- Berserker Spirit Lv. 3 -->
+        <skill name="Chant Of Berserker Spirit" id="45128" level="3" required-level="76" sp="4500000">
+            <item id="94366" count="1" /> <!-- Master's Book: Berserker Spirit -->
+        </skill>
+        <!-- Clarity Lv. 4 -->
+        <skill name="Chant Of Clarity" id="45129" level="4" required-level="76" sp="4500000">
+            <item id="94367" count="1" /> <!-- Master's Book: Clarity -->
+        </skill>
+
+        <skill name="Detection" id="45190" level="1" required-level="76" sp="4500000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Mount Black Bear" id="1837" level="1" required-level="76">
+			<item id="90042" count="1" /> <!-- Spellbook - Mount Black Bear -->
+		</skill>
 		<skill name="Seal of Silence" id="1246" level="13" required-level="76" sp="4500000" />
 		<skill name="Seal of Slow" id="1099" level="16" required-level="76" sp="4500000" />
 		<skill name="Seal of Winter" id="1104" level="15" required-level="76" sp="4500000" />
@@ -17,52 +79,43 @@
 		<skill name="Seal of Binding" id="1208" level="18" required-level="76" sp="4500000" />
 		<skill name="Seal of Suspension" id="1248" level="13" required-level="76" sp="4500000" />
 		<skill name="Seal of Chaos" id="1096" level="17" required-level="76" sp="4500000" />
+		<skill name="Mana Gain" id="1460" level="1" required-level="76" sp="4500000">
+			<item id="90106" count="1" /> <!-- Scroll: Mana Gain -->
+		</skill>
+		<skill name="Prophecy of Pa'agrio" id="1414" level="1" required-level="76" sp="4500000">
+			<item id="90117" count="1" /> <!-- Scroll: Prophecy of Pa'agrio -->
+		</skill>
 		<skill name="Ritual of Life" id="1306" level="11" required-level="76" sp="4500000" />
 		<skill name="Pa'agrio's Heart" id="1256" level="14" required-level="76" sp="4500000" />
-		<skill name="Power Crush" id="260" level="38" required-level="76" sp="4500000" />
+		<skill name="Power Break" id="260" level="38" required-level="76" sp="4500000" />
 		<skill name="Dreaming Spirit" id="1097" level="21" required-level="76" sp="4500000" />
 		<skill name="Life Rescue" id="1610" level="21" required-level="76" sp="4500000" />
 		<skill name="Fear" id="1092" level="20" required-level="76" sp="4500000" />
+		<skill name="Fatal Strike" id="190" level="38" required-level="76" sp="4500000" />
 		<skill name="Pa'agrio's Honor" id="1305" level="11" required-level="76" sp="4500000" />
-		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="4500000">
-			<item id="8620"/> <!-- Ancient Book: Divine Inspiration (Manuscript) -->
-		</skill>
-		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="4500000">
-			<item id="8621"/> <!-- Ancient Book: Divine Inspiration (Original Version) -->
-		</skill>
-		<skill name="Mount Black Bear" id="1837" level="1" required-level="76">
-			<item id="90042"/> <!--  Spellbook: Mount Black Bear -->
-		</skill>
-		<skill name="Glory Ability" id="45361" level="1" required-level="86">
-			<item id="94046"/> <!-- Spellbook: Glory Ability Lv. 1 -->
-		</skill>
-		<skill name="Mount White Wings" id="54200" level="1" required-level="87">
-			<item id="93059"/> <!-- Spellbook: Summon White Wings -->
-		</skill>	
-		<skill name="Mount Shining Lady" id="54202" level="1" required-level="89">
-			<item id="93061"/> <!-- Spellbook: Summon Silver Saint -->
-		</skill>
-		<skill name="Victories of Pa'agrio" id="1414" level="1" required-level="76" sp="4500000">
-			<item id="90117"/> <!-- Scroll: Victories of Pa'agrio -->
-		</skill>
-		
+
 		<skill name="Anti Magic" id="146" level="47" required-level="77" sp="4500000" />
 		<skill name="Light Armor Mastery" id="252" level="47" required-level="77" sp="4500000" />
 		<skill name="Robe Mastery" id="251" level="47" required-level="77" sp="4500000" />
 		<skill name="Weapon Mastery" id="250" level="44" required-level="77" sp="4500000" />
 		<skill name="Heavy Armor Mastery" id="253" level="45" required-level="77" sp="4500000" />
-		<skill name="Power Crush" id="260" level="39" required-level="77" sp="4500000" />
-		<skill name="Life Rescue" id="1610" level="22" required-level="77" sp="4500000" />
 		<skill name="Seal of Disease" id="1367" level="1" required-level="77" sp="4500000">
-			<item id="90118"/> <!-- Scroll: Seal of Disease -->
+			<item id="90118" count="1" /> <!-- Scroll: Seal of Disease -->
 		</skill>
-		
+		<skill name="Mana Gain" id="1460" level="2" required-level="77" sp="4500000" />
+		<skill name="Power Break" id="260" level="39" required-level="77" sp="4500000" />
+		<skill name="Life Rescue" id="1610" level="22" required-level="77" sp="4500000" />
+		<skill name="Fatal Strike" id="190" level="39" required-level="77" sp="4500000" />
+
 		<skill name="Anti Magic" id="146" level="48" required-level="78" sp="9800000" />
 		<skill name="Light Armor Mastery" id="252" level="48" required-level="78" sp="9800000" />
 		<skill name="Robe Mastery" id="251" level="48" required-level="78" sp="9800000" />
 		<skill name="Weapon Mastery" id="250" level="45" required-level="78" sp="9800000" />
 		<skill name="Heavy Armor Mastery" id="253" level="46" required-level="78" sp="9800000" />
 		<skill name="Steal Essence" id="1245" level="16" required-level="78" sp="9800000" />
+		<skill name="Pa'agrio's Fist" id="1416" level="1" required-level="78" sp="9800000">
+			<item id="90119" count="1" /> <!-- Scroll: Pa'agrio's Fist -->
+		</skill>
 		<skill name="Seal of Silence" id="1246" level="14" required-level="78" sp="9800000" />
 		<skill name="Seal of Slow" id="1099" level="17" required-level="78" sp="9800000" />
 		<skill name="Seal of Winter" id="1104" level="16" required-level="78" sp="9800000" />
@@ -70,50 +123,61 @@
 		<skill name="Seal of Binding" id="1208" level="19" required-level="78" sp="9800000" />
 		<skill name="Seal of Suspension" id="1248" level="14" required-level="78" sp="9800000" />
 		<skill name="Seal of Chaos" id="1096" level="18" required-level="78" sp="9800000" />
+		<skill name="Mana Gain" id="1460" level="3" required-level="78" sp="9800000" />
 		<skill name="Ritual of Life" id="1306" level="12" required-level="78" sp="9800000" />
 		<skill name="Pa'agrio's Heart" id="1256" level="15" required-level="78" sp="9800000" />
-		<skill name="Power Crush" id="260" level="40" required-level="78" sp="9800000" />
+		<skill name="Power Break" id="260" level="40" required-level="78" sp="9800000" />
 		<skill name="Dreaming Spirit" id="1097" level="22" required-level="78" sp="9800000" />
 		<skill name="Life Rescue" id="1610" level="23" required-level="78" sp="9800000" />
 		<skill name="Fear" id="1092" level="21" required-level="78" sp="9800000" />
+		<skill name="Fatal Strike" id="190" level="40" required-level="78" sp="9800000" />
 		<skill name="Pa'agrio's Honor" id="1305" level="12" required-level="78" sp="9800000" />
-		<skill name="Pa'agrio's Fist" id="1416" level="1" required-level="78" sp="9800000">
-			<item id="90119"/> <!-- Scroll: Pa'agrio's Fist -->
-		</skill>
-		
+
 		<skill name="Seal of Silence" id="1246" level="15" required-level="79" sp="9800000" />
-		<skill name="Seal of Blockade" id="1462" level="1" required-level="79" sp="9800000" />
+		<skill name="Seal of Blockade" id="1462" level="1" required-level="79" sp="9800000">
+			<item id="91487" count="1" /> <!-- Scroll: Seal of Blockade -->
+		</skill>
 		<skill name="Seal of Slow" id="1099" level="18" required-level="79" sp="9800000" />
 		<skill name="Seal of Winter" id="1104" level="17" required-level="79" sp="9800000" />
 		<skill name="Seal of Binding" id="1208" level="20" required-level="79" sp="9800000" />
 		<skill name="Seal of Suspension" id="1248" level="15" required-level="79" sp="9800000" />
+		<skill name="Seal of Despair" id="1366" level="1" required-level="79" sp="9800000">
+			<item id="90120" count="1" /> <!-- Scroll: Seal of Despair -->
+		</skill>
+		<skill name="Mana Gain" id="1460" level="4" required-level="79" sp="9800000" />
 		<skill name="Ritual of Life" id="1306" level="13" required-level="79" sp="9800000" />
 		<skill name="Life Rescue" id="1610" level="24" required-level="79" sp="9800000" />
 		<skill name="Pa'agrio's Honor" id="1305" level="13" required-level="79" sp="9800000" />
-		<skill name="Seal of Despair" id="1366" level="1" required-level="79" sp="9800000">
-			<item id="90120"/> <!-- Scroll: Seal of Despair -->
-		</skill>
-		
+
 		<skill name="Anti Magic" id="146" level="49" required-level="80" sp="9800000" />
 		<skill name="Light Armor Mastery" id="252" level="49" required-level="80" sp="9800000" />
 		<skill name="Robe Mastery" id="251" level="49" required-level="80" sp="9800000" />
 		<skill name="Weapon Mastery" id="250" level="46" required-level="80" sp="9800000" />
+		<skill name="Swap Defense" id="1392" level="4" required-level="80" sp="10000000" />
 		<skill name="Heavy Armor Mastery" id="253" level="47" required-level="80" sp="9800000" />
 		<skill name="Steal Essence" id="1245" level="17" required-level="80" sp="9800000" />
+		<skill name="Spell Master" id="1832" level="4" required-level="80" sp="2400000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Evolution Power" id="45189" level="1" required-level="80">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Seal of Silence" id="1246" level="16" required-level="80" sp="9800000" />
 		<skill name="Seal of Slow" id="1099" level="19" required-level="80" sp="9800000" />
 		<skill name="Seal of Winter" id="1104" level="18" required-level="80" sp="9800000" />
 		<skill name="Seal of Binding" id="1208" level="21" required-level="80" sp="9800000" />
 		<skill name="Seal of Suspension" id="1248" level="16" required-level="80" sp="9800000" />
 		<skill name="Seal of Despair" id="1366" level="2" required-level="80" sp="9800000" />
+		<skill name="Mana Gain" id="1460" level="5" required-level="80" sp="9800000" />
 		<skill name="Ritual of Life" id="1306" level="14" required-level="80" sp="9800000" />
 		<skill name="Pa'agrio's Heart" id="1256" level="16" required-level="80" sp="9800000" />
 		<skill name="Dreaming Spirit" id="1097" level="23" required-level="80" sp="9800000" />
 		<skill name="Life Rescue" id="1610" level="25" required-level="80" sp="9800000" />
-		<skill name="Pa'agrio's Honor" id="1305" level="14" required-level="80" sp="9800000" />
-		<skill name="Flames of Invincibility" id="1427" level="1" required-level="80" sp="9800000">
-			<item id="90121"/> <!-- Scroll: Flames of Invincibility -->
+		<skill name="White Guardian Transformation" id="54102" level="1" required-level="80">
+			<item id="92401" count="1" /> <!-- Spellbook - White Guardian -->
 		</skill>
+		<skill name="Fatal Strike" id="190" level="41" required-level="80" sp="9800000" />
+		<skill name="Pa'agrio's Honor" id="1305" level="14" required-level="80" sp="9800000" />
 
 		<skill name="Anti Magic" id="146" level="50" required-level="81" sp="160000000" />
 		<skill name="Light Armor Mastery" id="252" level="50" required-level="81" sp="160000000" />
@@ -127,8 +191,10 @@
 		<skill name="Seal of Binding" id="1208" level="22" required-level="81" sp="160000000" />
 		<skill name="Seal of Suspension" id="1248" level="17" required-level="81" sp="160000000" />
 		<skill name="Seal of Despair" id="1366" level="3" required-level="81" sp="160000000" />
+		<skill name="Mana Gain" id="1460" level="6" required-level="81" sp="160000000" />
 		<skill name="Ritual of Life" id="1306" level="15" required-level="81" sp="160000000" />
 		<skill name="Life Rescue" id="1610" level="26" required-level="81" sp="160000000" />
+		<skill name="Fatal Strike" id="190" level="42" required-level="81" sp="160000000" />
 		<skill name="Pa'agrio's Honor" id="1305" level="15" required-level="81" sp="160000000" />
 
 		<skill name="Anti Magic" id="146" level="51" required-level="82" sp="170000000" />
@@ -143,11 +209,13 @@
 		<skill name="Seal of Binding" id="1208" level="23" required-level="82" sp="170000000" />
 		<skill name="Seal of Suspension" id="1248" level="18" required-level="82" sp="170000000" />
 		<skill name="Seal of Despair" id="1366" level="4" required-level="82" sp="170000000" />
-		<skill name="Victories of Pa'agrio" id="1414" level="2" required-level="82" sp="170000000" />
+		<skill name="Mana Gain" id="1460" level="7" required-level="82" sp="170000000" />
+		<skill name="Prophecy of Pa'agrio" id="1414" level="2" required-level="82" sp="170000000" />
 		<skill name="Ritual of Life" id="1306" level="16" required-level="82" sp="170000000" />
 		<skill name="Pa'agrio's Heart" id="1256" level="17" required-level="82" sp="170000000" />
 		<skill name="Dreaming Spirit" id="1097" level="24" required-level="82" sp="170000000" />
 		<skill name="Life Rescue" id="1610" level="27" required-level="82" sp="170000000" />
+		<skill name="Fatal Strike" id="190" level="43" required-level="82" sp="170000000" />
 		<skill name="Pa'agrio's Honor" id="1305" level="16" required-level="82" sp="170000000" />
 
 		<skill name="Anti Magic" id="146" level="52" required-level="83" sp="240000000" />
@@ -162,8 +230,10 @@
 		<skill name="Seal of Binding" id="1208" level="24" required-level="83" sp="240000000" />
 		<skill name="Seal of Suspension" id="1248" level="19" required-level="83" sp="240000000" />
 		<skill name="Seal of Despair" id="1366" level="5" required-level="83" sp="240000000" />
+		<skill name="Mana Gain" id="1460" level="8" required-level="83" sp="240000000" />
 		<skill name="Ritual of Life" id="1306" level="17" required-level="83" sp="240000000" />
 		<skill name="Life Rescue" id="1610" level="28" required-level="83" sp="240000000" />
+		<skill name="Fatal Strike" id="190" level="44" required-level="83" sp="240000000" />
 		<skill name="Pa'agrio's Honor" id="1305" level="17" required-level="83" sp="240000000" />
 
 		<skill name="Anti Magic" id="146" level="53" required-level="84" sp="240000000" />
@@ -178,41 +248,55 @@
 		<skill name="Seal of Binding" id="1208" level="25" required-level="84" sp="240000000" />
 		<skill name="Seal of Suspension" id="1248" level="20" required-level="84" sp="240000000" />
 		<skill name="Seal of Despair" id="1366" level="6" required-level="84" sp="240000000" />
+		<skill name="Mana Gain" id="1460" level="9" required-level="84" sp="240000000" />
 		<skill name="Ritual of Life" id="1306" level="18" required-level="84" sp="240000000" />
 		<skill name="Pa'agrio's Heart" id="1256" level="18" required-level="84" sp="240000000" />
 		<skill name="Dreaming Spirit" id="1097" level="25" required-level="84" sp="240000000" />
 		<skill name="Life Rescue" id="1610" level="29" required-level="84" sp="240000000" />
+		<skill name="Fatal Strike" id="190" level="45" required-level="84" sp="240000000" />
 		<skill name="Pa'agrio's Honor" id="1305" level="18" required-level="84" sp="240000000" />
-		
+
 		<skill name="Anti Magic" id="146" level="54" required-level="85" sp="840000000" />
-		<skill name="Anti Magic" id="146" level="55" required-level="86" sp="924000000" />
-		<skill name="Anti Magic" id="146" level="56" required-level="87" sp="1016400000" />
-		<skill name="Anti Magic" id="146" level="57" required-level="88" sp="1118040000" />
-		<skill name="Anti Magic" id="146" level="58" required-level="89" sp="1229844000" />
-		<skill name="Anti Magic" id="146" level="59" required-level="90" sp="1352828400" />
 		<skill name="Light Armor Mastery" id="252" level="54" required-level="85" sp="840000000" />
-		<skill name="Light Armor Mastery" id="252" level="55" required-level="86" sp="924000000" />
-		<skill name="Light Armor Mastery" id="252" level="56" required-level="87" sp="1016400000" />
-		<skill name="Light Armor Mastery" id="252" level="57" required-level="88" sp="1118040000" />
-		<skill name="Light Armor Mastery" id="252" level="58" required-level="89" sp="1229844000" />
-		<skill name="Light Armor Mastery" id="252" level="59" required-level="90" sp="1352828400" />
 		<skill name="Robe Mastery" id="251" level="54" required-level="85" sp="840000000" />
-		<skill name="Robe Mastery" id="251" level="55" required-level="86" sp="924000000" />
-		<skill name="Robe Mastery" id="251" level="56" required-level="87" sp="1016400000" />
-		<skill name="Robe Mastery" id="251" level="57" required-level="88" sp="1118040000" />
-		<skill name="Robe Mastery" id="251" level="58" required-level="89" sp="1229844000" />
-		<skill name="Robe Mastery" id="251" level="59" required-level="90" sp="1352828400" />
 		<skill name="Weapon Mastery" id="250" level="51" required-level="85" sp="840000000" />
-		<skill name="Weapon Mastery" id="250" level="52" required-level="86" sp="924000000" />
-		<skill name="Weapon Mastery" id="250" level="53" required-level="87" sp="1016400000" />
-		<skill name="Weapon Mastery" id="250" level="54" required-level="88" sp="1118040000" />
-		<skill name="Weapon Mastery" id="250" level="55" required-level="89" sp="1229844000" />
-		<skill name="Weapon Mastery" id="250" level="56" required-level="90" sp="1352828400" />
 		<skill name="Heavy Armor Mastery" id="253" level="52" required-level="85" sp="840000000" />
-		<skill name="Heavy Armor Mastery" id="253" level="53" required-level="86" sp="924000000" />
-		<skill name="Heavy Armor Mastery" id="253" level="54" required-level="87" sp="1016400000" />
-		<skill name="Heavy Armor Mastery" id="253" level="55" required-level="88" sp="1118040000" />
-		<skill name="Heavy Armor Mastery" id="253" level="56" required-level="89" sp="1229844000" />
-		<skill name="Heavy Armor Mastery" id="253" level="57" required-level="90" sp="1352828400" />
+		<skill name="Steal Essence" id="1245" level="20" required-level="85" sp="840000000" />
+		<skill name="Mana Gain" id="1460" level="10" required-level="85" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="55" required-level="86" sp="840000000" />
+		<skill name="Light Armor Mastery" id="252" level="55" required-level="86" sp="840000000" />
+		<skill name="Robe Mastery" id="251" level="55" required-level="86" sp="840000000" />
+		<skill name="Weapon Mastery" id="250" level="52" required-level="86" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="253" level="53" required-level="86" sp="840000000" />
+		<skill name="Steal Essence" id="1245" level="21" required-level="86" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="56" required-level="87" sp="840000000" />
+		<skill name="Light Armor Mastery" id="252" level="56" required-level="87" sp="840000000" />
+		<skill name="Robe Mastery" id="251" level="56" required-level="87" sp="840000000" />
+		<skill name="Weapon Mastery" id="250" level="53" required-level="87" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="253" level="54" required-level="87" sp="840000000" />
+		<skill name="Steal Essence" id="1245" level="22" required-level="87" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="57" required-level="88" sp="840000000" />
+		<skill name="Light Armor Mastery" id="252" level="57" required-level="88" sp="840000000" />
+		<skill name="Robe Mastery" id="251" level="57" required-level="88" sp="840000000" />
+		<skill name="Weapon Mastery" id="250" level="54" required-level="88" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="253" level="55" required-level="88" sp="840000000" />
+		<skill name="Steal Essence" id="1245" level="23" required-level="88" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="58" required-level="89" sp="840000000" />
+		<skill name="Light Armor Mastery" id="252" level="58" required-level="89" sp="840000000" />
+		<skill name="Robe Mastery" id="251" level="58" required-level="89" sp="840000000" />
+		<skill name="Weapon Mastery" id="250" level="55" required-level="89" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="253" level="56" required-level="89" sp="840000000" />
+		<skill name="Steal Essence" id="1245" level="24" required-level="89" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="59" required-level="90" sp="840000000" />
+		<skill name="Light Armor Mastery" id="252" level="59" required-level="90" sp="840000000" />
+		<skill name="Robe Mastery" id="251" level="59" required-level="90" sp="840000000" />
+		<skill name="Weapon Mastery" id="250" level="56" required-level="90" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="253" level="57" required-level="90" sp="840000000" />
+		<skill name="Steal Essence" id="1245" level="25" required-level="90" sp="840000000" />
 	</skillTree>
 </list>

--- a/data/skillTrees/3rdClass/DoomBringer.xml
+++ b/data/skillTrees/3rdClass/DoomBringer.xml
@@ -1,134 +1,215 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
-    <skillTree type="classSkillTree" classId="131" parentClassId="127">
+	<skillTree type="classSkillTree" classId="131" parentClassId="127">
 
-        <skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="8000000">
-            <item id="8620"/> <!-- Ancient Book: Divine Inspiration (Manuscript) -->
-        </skill>
-        <skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="8000000">
-            <item id="8621"/> <!-- Ancient Book: Divine Inspiration (Original Version) -->
-        </skill>
-        <skill name="Armor Mastery" id="464" level="4" required-level="76" sp="8000000">
-            <item id="57" count="1000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Weapon Mastery" id="463" level="4" required-level="76" sp="8000000">
-            <item id="57" count="1000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Final Secret" id="917" level="1" required-level="76" sp="8000000">
-            <item  id="90080"/> <!-- Scroll: Final Secret -->
-        </skill>
-        <skill name="Mount Griffin" id="62002" level="1" required-level="76">
-            <item id="91946"/> <!-- Spellbook: Mount Griffin -->
-        </skill>
-		<skill name="Glory Ability" id="45361" level="1" required-level="86">
-			<item id="94046"/> <!-- Spellbook: Glory Ability Lv. 1 -->
+		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="8000000">
+			<item id="8620" count="1" /> <!-- Buff Expansion Book Lv. 3 -->
 		</skill>
-		<skill name="Mount White Wings" id="54200" level="1" required-level="87">
-			<item id="93059"/> <!-- Spellbook: Summon White Wings -->
-		</skill>	
-		<skill name="Mount Shining Lady" id="54202" level="1" required-level="89">
-			<item id="93061"/> <!-- Spellbook: Summon Silver Saint -->
+		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="8000000">
+			<item id="8621" count="1" /> <!-- Buff Expansion Book Lv. 4 -->
 		</skill>
-        <skill name="Disarm" id="485" level="1" required-level="76" sp="8000000">
-            <item id="91921"/> <!-- Scroll: Disarm" -->
-        </skill>
-        <skill name="Collect Light Souls" id="45151" level="2" required-level="76" sp="8000000">
-            <item id="91942"/> <!-- Crystal of Light -->
-        </skill>
-        <skill name="Collect Shadow Souls" id="45152" level="2" required-level="76" sp="8000000">
-            <item id="91943"/> <!-- Crystal of Shadows -->
-        </skill>
-        <skill name="Magic Break" id="501" level="1" required-level="76" sp="8000000">
-            <item id="91920"/> <!-- Scroll: Magic Break -->
-        </skill>
-        <skill name="Rush" id="994" level="3" required-level="76" sp="8000000" />
-        <skill name="Increase Power" id="1432" level="3" required-level="76" sp="8000000" />
+		<skill name="Armor Mastery" id="464" level="4" required-level="76" sp="8000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Weapon Mastery" id="463" level="4" required-level="76" sp="8000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Amazing Soul Smash Mastery" id="45365" level="1" required-level="76" sp="8000000">
+			<item id="93868" count="1" /> <!-- Scroll: Amazing Soul Smash Mastery -->
+		</skill>
+		<skill name="Evolution Defense" id="45188" level="1" required-level="76">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Master of Combat" id="430" level="1" required-level="76" sp="8000000" />
+		<!-- Might Lv. 4 -->
+		<skill name="Soul Might" id="45144" level="4" required-level="76" sp="8000000">
+			<item id="94135" count="1" /> <!-- Master's Book: Might -->
+		</skill>
+		<!-- Shield Lv. 4 -->
+		<skill name="Soul Shield" id="45145" level="4" required-level="76" sp="8000000">
+			<item id="94136" count="1" /> <!-- Master's Book: Shield -->
+		</skill>
+		<!-- Acumen Lv. 4 -->
+		<skill name="Soul Acumen" id="45146" level="4" required-level="76" sp="8000000">
+			<item id="94370" count="1" /> <!-- Master's Book: Acumen -->
+		</skill>
+		<!-- Empower Lv. 4 -->
+		<skill name="Soul Empower" id="45147" level="4" required-level="76" sp="8000000">
+			<item id="94361" count="1" /> <!-- Master's Book: Empower -->
+		</skill>
+		<!-- Wild Magic Lv. 3 -->
+		<skill name="Soul Wild Magic" id="45148" level="3" required-level="76" sp="8000000">
+			<item id="94368" count="1" /> <!-- Master's Book: Wild Magic -->
+		</skill>
+		<!-- Wind Walk Lv. 3 -->
+		<skill name="Soul Wind Walk" id="45142" level="3" required-level="76" sp="8000000">
+			<item id="94365" count="1" /> <!-- Master's Book: Wind Walk -->
+		</skill>
+		<!-- Magic Barrier Lv. 3 -->
+		<skill name="Soul Magic Barrier" id="45143" level="3" required-level="76" sp="8000000">
+			<item id="94362" count="1" /> <!-- Master's Book: Magic Barrier -->
+		</skill>
+		<!-- Focus Lv. 4 -->
+		<skill name="Soul Focus" id="45139" level="4" required-level="76" sp="8000000">
+			<item id="94363" count="1" /> <!-- Master's Book: Focus -->
+		</skill>
+		<!-- Death Whisper Lv. 4 -->
+		<skill name="Soul Death Whisper" id="45140" level="4" required-level="76" sp="8000000">
+			<item id="94364" count="1" /> <!-- Master's Book: Death Whisper -->
+		</skill>
+		<!-- Haste Lv. 3 -->
+		<skill name="Soul Haste" id="45141" level="3" required-level="76" sp="8000000">
+			<item id="94369" count="1" /> <!-- Master's Book: Haste -->
+		</skill>
+		<!-- Berserker Spirit Lv. 3 -->
+		<skill name="Soul Berserker Spirit" id="45149" level="3" required-level="76" sp="8000000">
+			<item id="94366" count="1" /> <!-- Master's Book: Berserker Spirit -->
+		</skill>
+		<!-- Clarity Lv. 4 -->
+		<skill name="Soul Clarity" id="45150" level="4" required-level="76" sp="8000000">
+			<item id="94367" count="1" /> <!-- Master's Book: Clarity -->
+		</skill>
+		<skill name="Detection" id="45190" level="1" required-level="76" sp="8000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Final Secret" id="917" level="1" required-level="76" sp="8000000">
+			<item id="90080" count="1" /> <!-- Scroll: Final Secret -->
+		</skill>
+		<skill name="Mount Griffin" id="62002" level="1" required-level="76">
+			<item id="91946" count="1" /> <!-- Spellbook - Mount Griffin -->
+		</skill>
+		<skill name="Disarm" id="485" level="1" required-level="76" sp="8000000">
+			<item id="91921" count="1" /> <!-- Scroll: Disarm -->
+		</skill>
+		<skill name="Collect Light Souls" id="45151" level="2" required-level="76" sp="8000000">
+			<item id="4347" count="1" /> <!-- Crystal of Light -->
+		</skill>
+		<skill name="Collect Shadow Souls" id="45152" level="2" required-level="76" sp="8000000">
+			<item id="91943" count="1" /> <!-- Crystal of Shadows -->
+		</skill>
+		<skill name="Magic Break" id="501" level="1" required-level="76" sp="8000000">
+			<item id="91920" count="1" /> <!-- Scroll: Magic Break -->
+		</skill>
+		<skill name="Rush" id="994" level="3" required-level="76" sp="8000000" />
+		<skill name="Increase Power" id="1432" level="3" required-level="76" sp="8000000" />
+		<skill name="Enhanced Assault" id="45251" level="1" required-level="76" sp="8000000">
+			<item id="57" count="3000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="46" required-level="76" sp="8000000" />
 
-        <skill name="Critical Sense" id="626" level="4" required-level="78" sp="12000000" />
-        <skill name="Death Mark" id="1435" level="4" required-level="78" sp="12000000">
-            <item id="57" count="1000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Disarm" id="485" level="2" required-level="78" sp="12000000"/>
-        <skill name="Magic Break" id="501" level="2" required-level="78" sp="12000000"/>
-        <skill name="Increase Power" id="1432" level="4" required-level="78" sp="12000000" />
+		<skill name="Emergency Rescue" id="70" level="47" required-level="77" sp="10000000" />
 
-        <skill name="Ancient Sword Mastery" id="472" level="8" required-level="80" sp="18000000">
-            <item id="57" count="1000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Light Armor Mastery" id="465" level="8" required-level="80" sp="18000000">
-            <item id="57" count="1000000"/>
-        </skill>
-        <skill name="Heavy Armor Mastery" id="399" level="8" required-level="80" sp="18000000">
-            <item id="57" count="1000000"/>
-        </skill>
-        <skill name="Soul Impulse" id="45155" level="6" required-level="80" sp="18000000">
-            <item id="57" count="1000000"/>
-        </skill>
-        <skill name="Soul Barrier" id="1514" level="2" required-level="80" sp="18000000" />
-        <skill name="Disarm" id="485" level="3" required-level="80" sp="18000000"/>
-        <skill name="Magic Break" id="501" level="3" required-level="80" sp="18000000"/>
-        <skill name="Soul Smash" id="477" level="8" required-level="80" sp="18000000">
-            <item id="57" count="1000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Rush Impact" id="45159" level="3" required-level="80" sp="18000000" />
-        <skill name="Increase Power" id="1432" level="5" required-level="80" sp="18000000" />
-        <skill name="Enuma Elish" id="45157" level="4" required-level="80" sp="18000000">
-            <item id="57" count="1000000"/> <!-- Adena -->
-        </skill>
+		<skill name="Critical Sense" id="626" level="4" required-level="78" sp="12000000" />
+		<skill name="Death Mark" id="1435" level="4" required-level="78" sp="12000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Disarm" id="485" level="2" required-level="78" sp="12000000" />
+		<skill name="Magic Break" id="501" level="2" required-level="78" sp="12000000" />
+		<skill name="Increase Power" id="1432" level="4" required-level="78" sp="12000000" />
+		<skill name="Emergency Rescue" id="70" level="48" required-level="78" sp="12000000" />
 
-        <skill name="Disarm" id="485" level="4" required-level="82" sp="170000000"/>
-        <skill name="Magic Break" id="501" level="4" required-level="82" sp="170000000"/>
+		<skill name="Emergency Rescue" id="70" level="49" required-level="79" sp="15000000" />
 
-        <skill name="Disarm" id="485" level="5" required-level="84" sp="240000000"/>
-        <skill name="Magic Break" id="501" level="5" required-level="84" sp="240000000"/>
+		<skill name="Ancient Sword Mastery" id="472" level="8" required-level="80" sp="18000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Light Armor Mastery" id="465" level="8" required-level="80" sp="18000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Heavy Armor Mastery" id="399" level="8" required-level="80" sp="18000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Soul Impulse" id="45155" level="6" required-level="80" sp="18000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Master of Combat" id="430" level="2" required-level="80" sp="18000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Evolution Power" id="45189" level="1" required-level="80">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Soul Barrier" id="1514" level="2" required-level="80" sp="18000000" />
+		<skill name="Disarm" id="485" level="3" required-level="80" sp="18000000" />
+		<skill name="Magic Break" id="501" level="3" required-level="80" sp="18000000" />
+		<skill name="Soul Smash" id="477" level="8" required-level="80" sp="18000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Rush Impact" id="45159" level="3" required-level="80" sp="18000000" />
+		<skill name="Increase Power" id="1432" level="5" required-level="80" sp="18000000" />
+		<skill name="Emergency Rescue" id="70" level="50" required-level="80" sp="18000000" />
+		<skill name="Enuma Elish" id="45157" level="4" required-level="80" sp="18000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
 
+		<skill name="Emergency Rescue" id="70" level="51" required-level="81" sp="160000000" />
 
-        <skill name="Armor Mastery" id="464" level="5" required-level="85" sp="840000000">
-            <item id="57" count="2000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Ancient Sword Mastery" id="472" level="9" required-level="85" sp="840000000">
-            <item id="57" count="5000000"/> <!-- Adena -->
-        </skill>
-       <skill name="Ancient Sword Mastery" id="472" level="10" required-level="90" sp="1680000000">
-            <item id="57" count="10000000"/> <!-- Adena -->
-        </skill>	
-        <skill name="Light Armor Mastery" id="465" level="9" required-level="85" sp="840000000">
-            <item id="57" count="5000000"/>
-        </skill>
-        <skill name="Light Armor Mastery" id="465" level="10" required-level="90" sp="1680000000">
-            <item id="57" count="10000000"/>
-        </skill>	
-        <skill name="Weapon Mastery" id="463" level="5" required-level="85" sp="840000000">
-            <item id="57" count="2000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Heavy Armor Mastery" id="399" level="9" required-level="85" sp="840000000">
-            <item id="57" count="5000000"/>
-        </skill>
-        <skill name="Heavy Armor Mastery" id="399" level="10" required-level="90" sp="1680000000">
-            <item id="57" count="10000000"/>
-        </skill>	
-        <skill name="Soul Impulse" id="45155" level="7" required-level="85" sp="840000000">
-            <item id="57" count="5000000"/>
-        </skill>
-        <skill name="Soul Impulse" id="45155" level="8" required-level="90" sp="1680000000">
-            <item id="57" count="10000000"/>
-        </skill>	
-        <skill name="Critical Sense" id="626" level="5" required-level="85" sp="840000000" />
-        <skill name="Death Mark" id="1435" level="5" required-level="85" sp="840000000">
-            <item id="57" count="2000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Soul Smash" id="477" level="9" required-level="85" sp="840000000">
-            <item id="57" count="5000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Soul Smash" id="477" level="10" required-level="90" sp="1680000000">
-            <item id="57" count="10000000"/> <!-- Adena -->
-        </skill>	
-        <skill name="Enuma Elish" id="45157" level="5" required-level="85" sp="840000000">
-            <item id="57" count="5000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Enuma Elish" id="45157" level="6" required-level="90" sp="1680000000">
-            <item id="57" count="10000000"/> <!-- Adena -->
-        </skill>	
-        
-    </skillTree>
+		<skill name="Disarm" id="485" level="4" required-level="82" sp="170000000" />
+		<skill name="Magic Break" id="501" level="4" required-level="82" sp="170000000" />
+		<skill name="Emergency Rescue" id="70" level="52" required-level="82" sp="170000000" />
+
+		<skill name="Emergency Rescue" id="70" level="53" required-level="83" sp="240000000" />
+
+		<skill name="Disarm" id="485" level="5" required-level="84" sp="240000000" />
+		<skill name="Magic Break" id="501" level="5" required-level="84" sp="240000000" />
+		<skill name="Emergency Rescue" id="70" level="54" required-level="84" sp="240000000" />
+
+		<skill name="Armor Mastery" id="464" level="5" required-level="85" sp="840000000">
+			<item id="57" count="2000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Ancient Sword Mastery" id="472" level="9" required-level="85" sp="840000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Light Armor Mastery" id="465" level="9" required-level="85" sp="840000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Weapon Mastery" id="463" level="5" required-level="85" sp="840000000">
+			<item id="57" count="2000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Heavy Armor Mastery" id="399" level="9" required-level="85" sp="840000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Soul Impulse" id="45155" level="7" required-level="85" sp="840000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Critical Sense" id="626" level="5" required-level="85" sp="840000000" />
+		<skill name="Death Mark" id="1435" level="5" required-level="85" sp="840000000">
+			<item id="57" count="2000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Soul Smash" id="477" level="9" required-level="85" sp="840000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="55" required-level="85" sp="840000000" />
+		<skill name="Enuma Elish" id="45157" level="5" required-level="85" sp="840000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+
+		<skill name="Emergency Rescue" id="70" level="56" required-level="86" sp="840000000" />
+
+		<skill name="Emergency Rescue" id="70" level="57" required-level="87" sp="840000000" />
+
+		<skill name="Emergency Rescue" id="70" level="58" required-level="88" sp="840000000" />
+
+		<skill name="Emergency Rescue" id="70" level="59" required-level="89" sp="840000000" />
+
+		<skill name="Ancient Sword Mastery" id="472" level="10" required-level="90" sp="840000000">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Light Armor Mastery" id="465" level="10" required-level="90" sp="840000000">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Heavy Armor Mastery" id="399" level="10" required-level="90" sp="840000000">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Soul Impulse" id="45155" level="8" required-level="90" sp="840000000">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Soul Smash" id="477" level="10" required-level="90" sp="840000000">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="60" required-level="90" sp="840000000" />
+		<skill name="Enuma Elish" id="45157" level="6" required-level="90" sp="840000000">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+
+	</skillTree>
 </list>

--- a/data/skillTrees/3rdClass/Doomcryer.xml
+++ b/data/skillTrees/3rdClass/Doomcryer.xml
@@ -1,78 +1,131 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="116" parentClassId="52">
-		<skill name="White Guardian" id="54102" level="1" required-level="80" >
-			<item id="92401"/>
-		</skill>
+
 		<skill name="Anti Magic" id="146" level="46" required-level="76" sp="6700000" />
+		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="6700000">
+			<item id="8620" count="1" /> <!-- Buff Expansion Book Lv. 3 -->
+		</skill>
+		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="6700000">
+			<item id="8621" count="1" /> <!-- Buff Expansion Book Lv. 4 -->
+		</skill>
 		<skill name="Light Armor Mastery" id="252" level="46" required-level="76" sp="6700000" />
 		<skill name="Robe Mastery" id="251" level="46" required-level="76" sp="6700000" />
 		<skill name="Weapon Mastery" id="250" level="43" required-level="76" sp="6700000" />
 		<skill name="Heavy Armor Mastery" id="253" level="44" required-level="76" sp="6700000" />
 		<skill name="Freezing Flame" id="1244" level="5" required-level="76" sp="6700000" />
+		<skill name="Evolution Defense" id="45188" level="1" required-level="76">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Steal Essence" id="1245" level="15" required-level="76" sp="6700000" />
 		<skill name="Chant of Life" id="1229" level="19" required-level="76" sp="6700000" />
-		<skill name="Power Crush" id="260" level="38" required-level="76" sp="6700000" />
+		<!-- Might Lv. 4 -->
+		<skill name="Chant of Might" id="45126" level="4" required-level="76" sp="6700000">
+			<item id="94135" count="1" /> <!-- Master's Book: Might -->
+		</skill>
+		<!-- Shield Lv. 4 -->
+		<skill name="Chant of Shield" id="45127" level="4" required-level="76" sp="6700000">
+			<item id="94136" count="1" /> <!-- Master's Book: Shield -->
+		</skill>
+		<!-- Acumen Lv. 4 -->
+		<skill name="Chant of Acumen" id="45135" level="4" required-level="76" sp="6700000">
+			<item id="94370" count="1" /> <!-- Master's Book: Acumen -->
+		</skill>
+		<!-- Empower Lv. 4 -->
+		<skill name="Chant of Empower" id="45136" level="4" required-level="76" sp="6700000">
+			<item id="94361" count="1" /> <!-- Master's Book: Empower -->
+		</skill>
+		<!-- Wild Magic Lv. 3 -->
+		<skill name="Chant of Wild Magic" id="45137" level="3" required-level="76" sp="6700000">
+			<item id="94368" count="1" /> <!-- Master's Book: Wild Magic -->
+		</skill>
+		<!-- Wind Walk Lv. 3 -->
+		<skill name="Chant of Wind Walk" id="45124" level="3" required-level="76" sp="6700000">
+			<item id="94365" count="1" /> <!-- Master's Book: Wind Walk -->
+		</skill>
+		<!-- Magic Barrier Lv. 3 -->
+		<skill name="Chant Of Magic Barrier" id="45125" level="3" required-level="76" sp="6700000">
+			<item id="94362" count="1" /> <!-- Master's Book: Magic Barrier -->
+		</skill>
+		<!-- Focus Lv. 4 -->
+		<skill name="Chant Of Focus" id="45121" level="4" required-level="76" sp="6700000">
+			<item id="94363" count="1" /> <!-- Master's Book: Focus -->
+		</skill>
+		<!-- Death Whisper Lv. 4 -->
+		<skill name="Chant Of Death Whisper" id="45122" level="4" required-level="76" sp="6700000">
+			<item id="94364" count="1" /> <!-- Master's Book: Death Whisper -->
+		</skill>
+		<!-- Haste Lv. 3 -->
+		<skill name="Chant of Haste" id="45123" level="3" required-level="76" sp="6700000">
+			<item id="94369" count="1" /> <!-- Master's Book: Haste -->
+		</skill>
+		<!-- Berserker Spirit Lv. 3 -->
+		<skill name="Chant Of Berserker Spirit" id="45128" level="3" required-level="76" sp="6700000">
+			<item id="94366" count="1" /> <!-- Master's Book: Berserker Spirit -->
+		</skill>
+		<!-- Clarity Lv. 4 -->
+		<skill name="Chant Of Clarity" id="45129" level="4" required-level="76" sp="6700000">
+			<item id="94367" count="1" /> <!-- Master's Book: Clarity -->
+		</skill>
+
+		<skill name="Detection" id="45190" level="1" required-level="76" sp="6700000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Mount Black Bear" id="1837" level="1" required-level="76">
+			<item id="90042" count="1" /> <!-- Spellbook - Mount Black Bear -->
+		</skill>
+		<skill name="Mana Gain" id="1460" level="1" required-level="76" sp="6700000">
+			<item id="90106" count="1" /> <!-- Scroll: Mana Gain -->
+		</skill>
+		<skill name="Prophecy of Victory" id="1363" level="1" required-level="76" sp="6700000">
+			<item id="90112" count="1" /> <!-- Scroll: Prophecy of Victory -->
+		</skill>
+		<skill name="Power Break" id="260" level="38" required-level="76" sp="6700000" />
 		<skill name="Dreaming Spirit" id="1097" level="21" required-level="76" sp="6700000" />
 		<skill name="Life Rescue" id="1610" level="21" required-level="76" sp="6700000" />
 		<skill name="Fear" id="1092" level="20" required-level="76" sp="6700000" />
-		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="6700000">
-			<item id="8620"/> <!-- Ancient Book: Divine Inspiration (Manuscript) -->
-		</skill>
-		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="6700000">
-			<item id="8621"/> <!-- Ancient Book: Divine Inspiration (Original Version) -->
-		</skill>
-		<skill name="Chant of Victory" id="1363" level="1" required-level="76" sp="6700000">
-			<item id="90112"/>
-		</skill>
-		<skill name="Mount Black Bear" id="1837" level="1" required-level="76">
-			<item id="90042"/> <!--  Spellbook: Mount Black Bear -->
-		</skill>
-		<skill name="Glory Ability" id="45361" level="1" required-level="86">
-			<item id="94046"/> <!-- Spellbook: Glory Ability Lv. 1 -->
-		</skill>
-		<skill name="Mount White Wings" id="54200" level="1" required-level="87">
-			<item id="93059"/> <!-- Spellbook: Summon White Wings -->
-		</skill>	
-		<skill name="Mount Shining Lady" id="54202" level="1" required-level="89">
-			<item id="93061"/> <!-- Spellbook: Summon Silver Saint -->
-		</skill>
-		
+		<skill name="Fatal Strike" id="190" level="38" required-level="76" sp="6700000" />
+
 		<skill name="Anti Magic" id="146" level="47" required-level="77" sp="6700000" />
 		<skill name="Light Armor Mastery" id="252" level="47" required-level="77" sp="6700000" />
 		<skill name="Robe Mastery" id="251" level="47" required-level="77" sp="6700000" />
 		<skill name="Weapon Mastery" id="250" level="44" required-level="77" sp="6700000" />
 		<skill name="Heavy Armor Mastery" id="253" level="45" required-level="77" sp="6700000" />
 		<skill name="Freezing Flame" id="1244" level="6" required-level="77" sp="6700000" />
-		<skill name="Power Crush" id="260" level="39" required-level="77" sp="6700000" />
-		<skill name="Life Rescue" id="1610" level="22" required-level="77" sp="6700000" />
 		<skill name="Chant of Spirit" id="1362" level="1" required-level="77" sp="6700000">
-			<item id="90113"/>
+			<item id="90113" count="1" /> <!-- Scroll: Chant of Spirit -->
 		</skill>
-		
+		<skill name="Mana Gain" id="1460" level="2" required-level="77" sp="6700000" />
+		<skill name="Power Break" id="260" level="39" required-level="77" sp="6700000" />
+		<skill name="Life Rescue" id="1610" level="22" required-level="77" sp="6700000" />
+		<skill name="Fatal Strike" id="190" level="39" required-level="77" sp="6700000" />
+
 		<skill name="Anti Magic" id="146" level="48" required-level="78" sp="14800000" />
+		<skill name="Battle Cry" id="1001" level="11" required-level="78" sp="14800000" />
 		<skill name="Light Armor Mastery" id="252" level="48" required-level="78" sp="14800000" />
 		<skill name="Robe Mastery" id="251" level="48" required-level="78" sp="14800000" />
 		<skill name="Weapon Mastery" id="250" level="45" required-level="78" sp="14800000" />
 		<skill name="Heavy Armor Mastery" id="253" level="46" required-level="78" sp="14800000" />
 		<skill name="Freezing Flame" id="1244" level="7" required-level="78" sp="14800000" />
 		<skill name="Steal Essence" id="1245" level="16" required-level="78" sp="14800000" />
-		<skill name="Soul Cry" id="1001" level="11" required-level="78" sp="14800000" />
+		<skill name="Chant of Gate" id="1429" level="1" required-level="78" sp="14800000">
+			<item id="90114" count="1" /> <!-- Scroll: Chant of Gate -->
+		</skill>
 		<skill name="Chant of Life" id="1229" level="20" required-level="78" sp="14800000" />
-		<skill name="Power Crush" id="260" level="40" required-level="78" sp="14800000" />
+		<skill name="Mana Gain" id="1460" level="3" required-level="78" sp="14800000" />
+		<skill name="Power Break" id="260" level="40" required-level="78" sp="14800000" />
 		<skill name="Dreaming Spirit" id="1097" level="22" required-level="78" sp="14800000" />
 		<skill name="Life Rescue" id="1610" level="23" required-level="78" sp="14800000" />
 		<skill name="Fear" id="1092" level="21" required-level="78" sp="14800000" />
-		<skill name="Chant of Gate" id="1429" level="1" required-level="78" sp="14800000">
-			<item id="90114"/> <!-- Scroll: Chant of Gate -->
-		</skill>
-		
+		<skill name="Fatal Strike" id="190" level="40" required-level="78" sp="14800000" />
+
 		<skill name="Freezing Flame" id="1244" level="8" required-level="79" sp="14800000" />
-		<skill name="Life Rescue" id="1610" level="24" required-level="79" sp="14800000" />
 		<skill name="Chant of Protection" id="1461" level="1" required-level="79" sp="14800000">
-			<item id="90115"/> <!-- Scroll: Chant of Protection -->
+			<item id="90115" count="1" /> <!-- Scroll: Chant of Protection -->
 		</skill>
-		
+		<skill name="Mana Gain" id="1460" level="4" required-level="79" sp="14800000" />
+		<skill name="Life Rescue" id="1610" level="24" required-level="79" sp="14800000" />
+
 		<skill name="Anti Magic" id="146" level="49" required-level="80" sp="14800000" />
 		<skill name="Light Armor Mastery" id="252" level="49" required-level="80" sp="14800000" />
 		<skill name="Robe Mastery" id="251" level="49" required-level="80" sp="14800000" />
@@ -80,12 +133,24 @@
 		<skill name="Heavy Armor Mastery" id="253" level="47" required-level="80" sp="14800000" />
 		<skill name="Freezing Flame" id="1244" level="9" required-level="80" sp="14800000" />
 		<skill name="Steal Essence" id="1245" level="17" required-level="80" sp="14800000" />
+		<skill name="Spell Master" id="1832" level="4" required-level="80" sp="2400000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Evolution Power" id="45189" level="1" required-level="80">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Chant of Life" id="1229" level="21" required-level="80" sp="14800000" />
+		<skill name="Great Fury" id="1543" level="1" required-level="80" sp="14800000">
+			<item id="90116" count="1" /> <!-- Scroll: Great Fury -->
+		</skill>
+		<skill name="Mana Gain" id="1460" level="5" required-level="80" sp="14800000" />
+		<skill name="Swap Defense" id="1392" level="4" required-level="80" sp="10000000" />
 		<skill name="Dreaming Spirit" id="1097" level="23" required-level="80" sp="14800000" />
 		<skill name="Life Rescue" id="1610" level="25" required-level="80" sp="14800000" />
-		<skill name="Great Fury" id="1543" level="1" required-level="80" sp="14800000">
-			<item id="90116"/> <!-- Scroll: Great Fury -->
+		<skill name="White Guardian Transformation" id="54102" level="1" required-level="80">
+			<item id="92401" count="1" /> <!-- Spellbook - White Guardian -->
 		</skill>
+		<skill name="Fatal Strike" id="190" level="41" required-level="80" sp="14800000" />
 
 		<skill name="Anti Magic" id="146" level="50" required-level="81" sp="160000000" />
 		<skill name="Light Armor Mastery" id="252" level="50" required-level="81" sp="160000000" />
@@ -93,7 +158,9 @@
 		<skill name="Weapon Mastery" id="250" level="47" required-level="81" sp="160000000" />
 		<skill name="Heavy Armor Mastery" id="253" level="48" required-level="81" sp="160000000" />
 		<skill name="Freezing Flame" id="1244" level="10" required-level="81" sp="160000000" />
+		<skill name="Mana Gain" id="1460" level="6" required-level="81" sp="160000000" />
 		<skill name="Life Rescue" id="1610" level="26" required-level="81" sp="160000000" />
+		<skill name="Fatal Strike" id="190" level="42" required-level="81" sp="160000000" />
 
 		<skill name="Anti Magic" id="146" level="51" required-level="82" sp="170000000" />
 		<skill name="Light Armor Mastery" id="252" level="51" required-level="82" sp="170000000" />
@@ -103,9 +170,11 @@
 		<skill name="Freezing Flame" id="1244" level="11" required-level="82" sp="170000000" />
 		<skill name="Steal Essence" id="1245" level="18" required-level="82" sp="170000000" />
 		<skill name="Chant of Life" id="1229" level="22" required-level="82" sp="170000000" />
-		<skill name="Chant of Victory" id="1363" level="2" required-level="82" sp="170000000" />
+		<skill name="Mana Gain" id="1460" level="7" required-level="82" sp="170000000" />
+		<skill name="Prophecy of Victory" id="1363" level="2" required-level="82" sp="170000000" />
 		<skill name="Dreaming Spirit" id="1097" level="24" required-level="82" sp="170000000" />
 		<skill name="Life Rescue" id="1610" level="27" required-level="82" sp="170000000" />
+		<skill name="Fatal Strike" id="190" level="43" required-level="82" sp="170000000" />
 
 		<skill name="Anti Magic" id="146" level="52" required-level="83" sp="240000000" />
 		<skill name="Light Armor Mastery" id="252" level="52" required-level="83" sp="240000000" />
@@ -113,7 +182,9 @@
 		<skill name="Weapon Mastery" id="250" level="49" required-level="83" sp="240000000" />
 		<skill name="Heavy Armor Mastery" id="253" level="50" required-level="83" sp="240000000" />
 		<skill name="Freezing Flame" id="1244" level="12" required-level="83" sp="240000000" />
+		<skill name="Mana Gain" id="1460" level="8" required-level="83" sp="240000000" />
 		<skill name="Life Rescue" id="1610" level="28" required-level="83" sp="240000000" />
+		<skill name="Fatal Strike" id="190" level="44" required-level="83" sp="240000000" />
 
 		<skill name="Anti Magic" id="146" level="53" required-level="84" sp="240000000" />
 		<skill name="Light Armor Mastery" id="252" level="53" required-level="84" sp="240000000" />
@@ -123,38 +194,52 @@
 		<skill name="Freezing Flame" id="1244" level="13" required-level="84" sp="240000000" />
 		<skill name="Steal Essence" id="1245" level="19" required-level="84" sp="240000000" />
 		<skill name="Chant of Life" id="1229" level="23" required-level="84" sp="240000000" />
+		<skill name="Mana Gain" id="1460" level="9" required-level="84" sp="240000000" />
 		<skill name="Dreaming Spirit" id="1097" level="25" required-level="84" sp="240000000" />
 		<skill name="Life Rescue" id="1610" level="29" required-level="84" sp="240000000" />
-		
+		<skill name="Fatal Strike" id="190" level="45" required-level="84" sp="240000000" />
+
 		<skill name="Anti Magic" id="146" level="54" required-level="85" sp="840000000" />
-		<skill name="Anti Magic" id="146" level="55" required-level="86" sp="924000000" />
-		<skill name="Anti Magic" id="146" level="56" required-level="87" sp="1016400000" />
-		<skill name="Anti Magic" id="146" level="57" required-level="88" sp="1118040000" />
-		<skill name="Anti Magic" id="146" level="58" required-level="89" sp="1229844000" />
-		<skill name="Anti Magic" id="146" level="59" required-level="90" sp="1352828400" />
 		<skill name="Light Armor Mastery" id="252" level="54" required-level="85" sp="840000000" />
-		<skill name="Light Armor Mastery" id="252" level="55" required-level="86" sp="924000000" />
-		<skill name="Light Armor Mastery" id="252" level="56" required-level="87" sp="1016400000" />
-		<skill name="Light Armor Mastery" id="252" level="57" required-level="88" sp="1118040000" />
-		<skill name="Light Armor Mastery" id="252" level="58" required-level="89" sp="1229844000" />
-		<skill name="Light Armor Mastery" id="252" level="59" required-level="90" sp="1352828400" />
 		<skill name="Robe Mastery" id="251" level="54" required-level="85" sp="840000000" />
-		<skill name="Robe Mastery" id="251" level="55" required-level="86" sp="924000000" />
-		<skill name="Robe Mastery" id="251" level="56" required-level="87" sp="1016400000" />
-		<skill name="Robe Mastery" id="251" level="57" required-level="88" sp="1118040000" />
-		<skill name="Robe Mastery" id="251" level="58" required-level="89" sp="1229844000" />
-		<skill name="Robe Mastery" id="251" level="59" required-level="90" sp="1352828400" />
 		<skill name="Weapon Mastery" id="250" level="51" required-level="85" sp="840000000" />
-		<skill name="Weapon Mastery" id="250" level="52" required-level="86" sp="924000000" />
-		<skill name="Weapon Mastery" id="250" level="53" required-level="87" sp="1016400000" />
-		<skill name="Weapon Mastery" id="250" level="54" required-level="88" sp="1118040000" />
-		<skill name="Weapon Mastery" id="250" level="55" required-level="89" sp="1229844000" />
-		<skill name="Weapon Mastery" id="250" level="56" required-level="90" sp="1352828400" />
 		<skill name="Heavy Armor Mastery" id="253" level="52" required-level="85" sp="840000000" />
-		<skill name="Heavy Armor Mastery" id="253" level="53" required-level="86" sp="924000000" />
-		<skill name="Heavy Armor Mastery" id="253" level="54" required-level="87" sp="1016400000" />
-		<skill name="Heavy Armor Mastery" id="253" level="55" required-level="88" sp="1118040000" />
-		<skill name="Heavy Armor Mastery" id="253" level="56" required-level="89" sp="1229844000" />
-		<skill name="Heavy Armor Mastery" id="253" level="57" required-level="90" sp="1352828400" />
+		<skill name="Steal Essence" id="1245" level="20" required-level="85" sp="840000000" />
+		<skill name="Mana Gain" id="1460" level="10" required-level="85" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="55" required-level="86" sp="840000000" />
+		<skill name="Light Armor Mastery" id="252" level="55" required-level="86" sp="840000000" />
+		<skill name="Robe Mastery" id="251" level="55" required-level="86" sp="840000000" />
+		<skill name="Weapon Mastery" id="250" level="52" required-level="86" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="253" level="53" required-level="86" sp="840000000" />
+		<skill name="Steal Essence" id="1245" level="21" required-level="86" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="56" required-level="87" sp="840000000" />
+		<skill name="Light Armor Mastery" id="252" level="56" required-level="87" sp="840000000" />
+		<skill name="Robe Mastery" id="251" level="56" required-level="87" sp="840000000" />
+		<skill name="Weapon Mastery" id="250" level="53" required-level="87" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="253" level="54" required-level="87" sp="840000000" />
+		<skill name="Steal Essence" id="1245" level="22" required-level="87" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="57" required-level="88" sp="840000000" />
+		<skill name="Light Armor Mastery" id="252" level="57" required-level="88" sp="840000000" />
+		<skill name="Robe Mastery" id="251" level="57" required-level="88" sp="840000000" />
+		<skill name="Weapon Mastery" id="250" level="54" required-level="88" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="253" level="55" required-level="88" sp="840000000" />
+		<skill name="Steal Essence" id="1245" level="23" required-level="88" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="58" required-level="89" sp="840000000" />
+		<skill name="Light Armor Mastery" id="252" level="58" required-level="89" sp="840000000" />
+		<skill name="Robe Mastery" id="251" level="58" required-level="89" sp="840000000" />
+		<skill name="Weapon Mastery" id="250" level="55" required-level="89" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="253" level="56" required-level="89" sp="840000000" />
+		<skill name="Steal Essence" id="1245" level="24" required-level="89" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="59" required-level="90" sp="840000000" />
+		<skill name="Light Armor Mastery" id="252" level="59" required-level="90" sp="840000000" />
+		<skill name="Robe Mastery" id="251" level="59" required-level="90" sp="840000000" />
+		<skill name="Weapon Mastery" id="250" level="56" required-level="90" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="253" level="57" required-level="90" sp="840000000" />
+		<skill name="Steal Essence" id="1245" level="25" required-level="90" sp="840000000" />
 	</skillTree>
 </list>

--- a/data/skillTrees/3rdClass/Dreadnought.xml
+++ b/data/skillTrees/3rdClass/Dreadnought.xml
@@ -1,118 +1,298 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="89" parentClassId="3">
-		<skill name="White Guardian" id="54102" level="1" required-level="80" >
-			<item id="92401"/>
-		</skill>
 
-		<skill name="Spinning Slasher" id="36" level="38" required-level="76" sp="7200000" />
-		<skill name="Polearm Mastery" id="216" level="46" required-level="76" sp="7200000" />
-		<skill name="Light Armor Mastery" id="227" level="51" required-level="76" sp="7200000" />
-		<skill name="Heavy Armor Mastery" id="231" level="51" required-level="76" sp="7200000" />
-		<skill name="Howl" id="116" level="15" required-level="76" sp="7200000" />
-		<skill name="Thunder Storm" id="48" level="38" required-level="76" sp="7200000" />
-		<skill name="Spike Thrust" id="921" level="1" required-level="76" sp="7200000" />
-		<skill name="Focus Attack" id="317" level="6" required-level="76" sp="7200000" />
 		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="7200000">
-			<item id="8620"/> <!-- Ancient Book: Divine Inspiration (Manuscript) -->
+			<item id="8620" count="1" /> <!-- Buff Expansion Book Lv. 3 -->
 		</skill>
 		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="7200000">
-			<item id="8621"/> <!-- Ancient Book: Divine Inspiration (Original Version) -->
+			<item id="8621" count="1" /> <!-- Buff Expansion Book Lv. 4 -->
 		</skill>
-		<skill name="Mount Gold Maned Lion" id="1833" level="1" required-level="76">
-			<item id="90038"/> <!-- Spellbook: Mount Golden Lion -->
+		<skill name="Spinning Slasher" id="36" level="41" required-level="76" sp="7200000" />
+		<skill name="Polearm Mastery" id="216" level="46" required-level="76" sp="7200000" />
+		<skill name="Light Armor Mastery" id="227" level="51" required-level="76" sp="7200000" />
+		<skill name="Weapon Mastery" id="141" level="5" required-level="76" sp="7200000" />
+		<skill name="Amazing Thunder Storm Mastery" id="45367" level="1" required-level="76" sp="7200000">
+			<item id="93867" count="1" /> <!-- Spellbook: Amazing Thunder Storm Mastery -->
 		</skill>
-		<skill name="Glory Ability" id="45361" level="1" required-level="86">
-			<item id="94046"/> <!-- Spellbook: Glory Ability Lv. 1 -->
+		<skill name="Amazing Spike Thrust Mastery" id="45383" level="1" required-level="76" sp="7200000">
+			<item id="94134" count="1" /> <!-- Spellbook: Amazing Spike Thrust Mastery -->
 		</skill>
-		<skill name="Mount White Wings" id="54200" level="1" required-level="87">
-			<item id="93059"/> <!-- Spellbook: Summon White Wings -->
-		</skill>	
-		<skill name="Mount Shining Lady" id="54202" level="1" required-level="89">
-			<item id="93061"/> <!-- Spellbook: Summon Silver Saint -->
+		<skill name="Heavy Armor Mastery" id="231" level="51" required-level="76" sp="7200000" />
+		<skill name="Howl" id="116" level="16" required-level="76" sp="7200000">
+			<item id="57" count="500000" /> <!-- Adena -->
 		</skill>
-		
-		<skill name="Spinning Slasher" id="36" level="39" required-level="77" sp="7200000" />
+		<skill name="Thunder Storm" id="48" level="41" required-level="76" sp="7200000" />
+		<skill name="Evolution Defense" id="45188" level="1" required-level="76">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Master of Combat" id="430" level="1" required-level="76" sp="7200000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<!-- Might Lv. 4 -->
+		<skill name="Might" id="1068" level="4" required-level="76" sp="7200000">
+			<item id="94135" count="1" /> <!-- Master's Book: Might -->
+		</skill>
+		<!-- Shield Lv. 4 -->
+		<skill name="Shield" id="1040" level="4" required-level="76" sp="7200000">
+			<item id="94136" count="1" /> <!-- Master's Book: Shield -->
+		</skill>
+		<!-- Acumen Lv. 4 -->
+		<skill name="Acumen" id="45104" level="4" required-level="76" sp="7200000">
+			<item id="94370" count="1" /> <!-- Master's Book: Acumen -->
+		</skill>
+		<!-- Empower Lv. 4 -->
+		<skill name="Empower" id="45105" level="4" required-level="76" sp="7200000">
+			<item id="94361" count="1" /> <!-- Master's Book: Empower -->
+		</skill>
+		<!-- Wild Magic Lv. 3 -->
+		<skill name="Wild Magic" id="45106" level="3" required-level="76" sp="7200000">
+			<item id="94368" count="1" /> <!-- Master's Book: Wild Magic -->
+		</skill>
+		<!-- Wind Walk Lv. 3 -->
+		<skill name="Wind Walk" id="45107" level="3" required-level="76" sp="7200000">
+			<item id="94365" count="1" /> <!-- Master's Book: Wind Walk -->
+		</skill>
+		<!-- Magic Barrier Lv. 3 -->
+		<skill name="Magic Barrier" id="45108" level="3" required-level="76" sp="7200000">
+			<item id="94362" count="1" /> <!-- Master's Book: Magic Barrier -->
+		</skill>
+		<!-- Focus Lv. 4 -->
+		<skill name="Focus" id="45109" level="4" required-level="76" sp="7200000">
+			<item id="94363" count="1" /> <!-- Master's Book: Focus -->
+		</skill>
+		<!-- Death Whisper Lv. 4 -->
+		<skill name="Death Whisper" id="45110" level="4" required-level="76" sp="7200000">
+			<item id="94364" count="1" /> <!-- Master's Book: Death Whisper -->
+		</skill>
+		<!-- Haste Lv. 3 -->
+		<skill name="Haste" id="45111" level="3" required-level="76" sp="7200000">
+			<item id="94369" count="1" /> <!-- Master's Book: Haste -->
+		</skill>
+		<!-- Berserker Spirit Lv. 3 -->
+		<skill name="Berserker Spirit" id="45112" level="3" required-level="76" sp="7200000">
+			<item id="94366" count="1" /> <!-- Master's Book: Berserker Spirit -->
+		</skill>
+		<!-- Clarity Lv. 4 -->
+		<skill name="Clarity" id="45113" level="4" required-level="76" sp="7200000">
+			<item id="94367" count="1" /> <!-- Master's Book: Clarity -->
+		</skill>
+		<skill name="Detection" id="45190" level="1" required-level="76" sp="7200000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Final Secret" id="917" level="1" required-level="76" sp="7200000">
+			<item id="90080" count="1" /> <!-- Scroll: Final Secret -->
+		</skill>
+		<skill name="Mount Golden Lion" id="1833" level="1" required-level="76">
+			<item id="90038" count="1" /> <!-- Spellbook - Ride Golden Lion -->
+		</skill>
+		<skill name="Power Break" id="260" level="38" required-level="76" sp="7200000" />
+		<skill name="Rush" id="994" level="3" required-level="76" sp="7200000" />
+		<skill name="Spike Thrust" id="921" level="1" required-level="76" sp="7200000" />
+		<skill name="Fatal Strike" id="190" level="41" required-level="76" sp="7200000" />
+		<skill name="Focus Attack" id="317" level="6" required-level="76" sp="7200000" />
+		<skill name="Emergency Rescue" id="70" level="46" required-level="76" sp="7200000" />
+
+		<skill name="Spinning Slasher" id="36" level="42" required-level="77" sp="7200000" />
 		<skill name="Polearm Mastery" id="216" level="47" required-level="77" sp="7200000" />
 		<skill name="Light Armor Mastery" id="227" level="52" required-level="77" sp="7200000" />
 		<skill name="Heavy Armor Mastery" id="231" level="52" required-level="77" sp="7200000" />
-		<skill name="Thunder Storm" id="48" level="39" required-level="77" sp="7200000" />
-		<skill name="Stun Burst" id="361" level="1" required-level="77" sp="7200000" >
-			<item id="90076"/> <!-- Scroll: Stun Blast -->
+		<skill name="Howl" id="116" level="17" required-level="77" sp="7200000" />
+		<skill name="Thunder Storm" id="48" level="42" required-level="77" sp="7200000" />
+		<skill name="Stun Burst" id="361" level="1" required-level="77" sp="7200000">
+			<item id="90076" count="1" /> <!-- Scroll: Stun Burst -->
 		</skill>
-		
+		<skill name="Power Break" id="260" level="39" required-level="77" sp="7200000" />
+		<skill name="Buff Thief" id="45390" level="1" required-level="77" sp="7200000">
+			<item id="94141" count="1" /> <!-- Spellbook: Buff Thief -->
+		</skill>
+		<skill name="Spike Thrust" id="921" level="2" required-level="77" sp="7200000" />
+		<skill name="Fatal Strike" id="190" level="42" required-level="77" sp="7200000" />
+		<skill name="Emergency Rescue" id="70" level="47" required-level="77" sp="7200000" />
+
 		<skill name="Throwing Spear" id="1625" level="1" required-level="78" sp="16800000" />
-		<skill name="Spinning Slasher" id="36" level="40" required-level="78" sp="16800000" />
+		<skill name="Spinning Slasher" id="36" level="43" required-level="78" sp="16800000" />
 		<skill name="Polearm Mastery" id="216" level="48" required-level="78" sp="16800000" />
 		<skill name="Light Armor Mastery" id="227" level="53" required-level="78" sp="16800000" />
 		<skill name="Heavy Armor Mastery" id="231" level="53" required-level="78" sp="16800000" />
-		<skill name="Howl" id="116" level="16" required-level="78" sp="16800000" />
-		<skill name="Thunder Storm" id="48" level="40" required-level="78" sp="16800000" />
-		<skill name="Master of Combat" id="430" level="1" required-level="78" sp="16800000" />
+		<skill name="Howl" id="116" level="18" required-level="78" sp="16800000" />
+		<skill name="Thunder Storm" id="48" level="43" required-level="78" sp="16800000" />
 		<skill name="Quick Spear" id="1606" level="10" required-level="78" sp="16800000" />
 		<skill name="Provoke" id="286" level="8" required-level="78" sp="16800000" />
-		<skill name="Rush" id="994" level="1" required-level="78" sp="16800000" >
-			<item id="90071"/> <!-- Scroll: Rush -->
-		</skill>
+		<skill name="Power Break" id="260" level="40" required-level="78" sp="16800000" />
+		<skill name="Spike Thrust" id="921" level="3" required-level="78" sp="16800000" />
+		<skill name="Fatal Strike" id="190" level="43" required-level="78" sp="16800000" />
 		<skill name="Braveheart" id="440" level="1" required-level="78" sp="16800000" />
-		
+		<skill name="Emergency Rescue" id="70" level="48" required-level="78" sp="16800000" />
+
+		<skill name="Spinning Slasher" id="36" level="44" required-level="79" sp="16800000" />
 		<skill name="Revival" id="181" level="2" required-level="79" sp="16800000" />
-		<skill name="Final Secret" id="917" level="1" required-level="79" sp="16800000">
-			<item id="90080"/> <!-- Scroll: Final Secret -->
+		<skill name="Howl" id="116" level="19" required-level="79" sp="16800000" />
+		<skill name="Thunder Storm" id="48" level="44" required-level="79" sp="16800000" />
+		<skill name="Final Frenzy" id="290" level="15" required-level="79" sp="16800000">
+			<item id="57" count="500000" /> <!-- Adena -->
 		</skill>
-		
+		<skill name="Spike Thrust" id="921" level="4" required-level="79" sp="16800000" />
+		<skill name="Fatal Strike" id="190" level="44" required-level="79" sp="16800000" />
+		<skill name="Emergency Rescue" id="70" level="49" required-level="79" sp="16800000" />
+
+		<skill name="Spinning Slasher" id="36" level="45" required-level="80" sp="16800000" />
 		<skill name="Polearm Mastery" id="216" level="49" required-level="80" sp="16800000" />
 		<skill name="Light Armor Mastery" id="227" level="54" required-level="80" sp="16800000" />
 		<skill name="Heavy Armor Mastery" id="231" level="54" required-level="80" sp="16800000" />
-		<skill name="Thunder Storm" id="48" level="41" required-level="80" sp="16800000" />
+		<skill name="Howl" id="116" level="20" required-level="80" sp="16800000" />
+		<skill name="Thunder Storm" id="48" level="45" required-level="80" sp="16800000" />
 		<skill name="War Cry" id="78" level="3" required-level="80" sp="16800000" />
+		<skill name="Master of Combat" id="430" level="2" required-level="80" sp="16800000" />
+		<skill name="Evolution Power" id="45189" level="1" required-level="80">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Stun Burst" id="361" level="2" required-level="80" sp="16800000" />
 		<skill name="Provoke" id="286" level="9" required-level="80" sp="16800000" />
 		<skill name="Spear Howl" id="1626" level="1" required-level="80" sp="16800000">
-			<item id="90077"/> <!-- Scroll: Spear Howl -->
+			<item id="90077" count="1" /> <!-- Scroll: Spear Howl -->
 		</skill>
+		<skill name="Power Break" id="260" level="41" required-level="80" sp="16800000" />
+		<skill name="Buff Thief" id="45390" level="2" required-level="80" sp="16800000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="White Guardian Transformation" id="54102" level="1" required-level="80">
+			<item id="92401" count="1" /> <!-- Spellbook - White Guardian -->
+		</skill>
+		<skill name="Spike Thrust" id="921" level="5" required-level="80" sp="16800000" />
+		<skill name="Fatal Strike" id="190" level="45" required-level="80" sp="16800000" />
+		<skill name="Focus Attack" id="317" level="7" required-level="80" sp="16800000" />
+		<skill name="Emergency Rescue" id="70" level="50" required-level="80" sp="16800000" />
 
+		<skill name="Spinning Slasher" id="36" level="46" required-level="81" sp="303000000" />
 		<skill name="Polearm Mastery" id="216" level="50" required-level="81" sp="303000000" />
 		<skill name="Light Armor Mastery" id="227" level="55" required-level="81" sp="303000000" />
 		<skill name="Heavy Armor Mastery" id="231" level="55" required-level="81" sp="303000000" />
-		<skill name="Thunder Storm" id="48" level="42" required-level="81" sp="303000000" />
+		<skill name="Howl" id="116" level="21" required-level="81" sp="303000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Thunder Storm" id="48" level="46" required-level="81" sp="303000000" />
+		<skill name="Power Break" id="260" level="42" required-level="81" sp="303000000" />
+		<skill name="Spike Thrust" id="921" level="6" required-level="81" sp="303000000" />
+		<skill name="Fatal Strike" id="190" level="46" required-level="81" sp="303000000" />
+		<skill name="Emergency Rescue" id="70" level="51" required-level="81" sp="303000000" />
 
+		<skill name="Spinning Slasher" id="36" level="47" required-level="82" sp="311000000" />
 		<skill name="Polearm Mastery" id="216" level="51" required-level="82" sp="311000000" />
 		<skill name="Light Armor Mastery" id="227" level="56" required-level="82" sp="311000000" />
 		<skill name="Heavy Armor Mastery" id="231" level="56" required-level="82" sp="311000000" />
-		<skill name="Thunder Storm" id="48" level="43" required-level="82" sp="311000000" />
+		<skill name="Howl" id="116" level="22" required-level="82" sp="311000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Thunder Storm" id="48" level="47" required-level="82" sp="311000000" />
 		<skill name="Provoke" id="286" level="10" required-level="82" sp="311000000" />
+		<skill name="Power Break" id="260" level="43" required-level="82" sp="311000000" />
+		<skill name="Spike Thrust" id="921" level="7" required-level="82" sp="311000000" />
+		<skill name="Fatal Strike" id="190" level="47" required-level="82" sp="311000000" />
+		<skill name="Emergency Rescue" id="70" level="52" required-level="82" sp="311000000" />
 
+		<skill name="Spinning Slasher" id="36" level="48" required-level="83" sp="425000000" />
 		<skill name="Polearm Mastery" id="216" level="52" required-level="83" sp="425000000" />
 		<skill name="Light Armor Mastery" id="227" level="57" required-level="83" sp="425000000" />
 		<skill name="Heavy Armor Mastery" id="231" level="57" required-level="83" sp="425000000" />
-		<skill name="Thunder Storm" id="48" level="44" required-level="83" sp="425000000" />
+		<skill name="Howl" id="116" level="23" required-level="83" sp="425000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Thunder Storm" id="48" level="48" required-level="83" sp="425000000" />
 		<skill name="War Cry" id="78" level="4" required-level="83" sp="425000000" />
 		<skill name="Stun Burst" id="361" level="3" required-level="83" sp="425000000" />
+		<skill name="Power Break" id="260" level="44" required-level="83" sp="425000000" />
+		<skill name="Spike Thrust" id="921" level="8" required-level="83" sp="425000000" />
+		<skill name="Fatal Strike" id="190" level="48" required-level="83" sp="425000000" />
+		<skill name="Emergency Rescue" id="70" level="53" required-level="83" sp="425000000" />
 
+		<skill name="Spinning Slasher" id="36" level="49" required-level="84" sp="457000000" />
 		<skill name="Polearm Mastery" id="216" level="53" required-level="84" sp="457000000" />
 		<skill name="Light Armor Mastery" id="227" level="58" required-level="84" sp="457000000" />
 		<skill name="Heavy Armor Mastery" id="231" level="58" required-level="84" sp="457000000" />
-		<skill name="Thunder Storm" id="48" level="45" required-level="84" sp="457000000" />
+		<skill name="Howl" id="116" level="24" required-level="84" sp="457000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Thunder Storm" id="48" level="49" required-level="84" sp="457000000" />
 		<skill name="Provoke" id="286" level="11" required-level="84" sp="457000000" />
-		
+		<skill name="Power Break" id="260" level="45" required-level="84" sp="457000000" />
+		<skill name="Spike Thrust" id="921" level="9" required-level="84" sp="457000000" />
+		<skill name="Fatal Strike" id="190" level="49" required-level="84" sp="457000000" />
+		<skill name="Emergency Rescue" id="70" level="54" required-level="84" sp="457000000" />
+
+		<skill name="Spinning Slasher" id="36" level="50" required-level="85" sp="840000000" />
 		<skill name="Polearm Mastery" id="216" level="54" required-level="85" sp="840000000" />
-		<skill name="Polearm Mastery" id="216" level="55" required-level="86" sp="924000000" />
-		<skill name="Polearm Mastery" id="216" level="56" required-level="87" sp="1016400000" />
-		<skill name="Polearm Mastery" id="216" level="57" required-level="88" sp="1118040000" />
-		<skill name="Polearm Mastery" id="216" level="58" required-level="89" sp="1229844000" />
-		<skill name="Polearm Mastery" id="216" level="59" required-level="90" sp="1352828400" />
 		<skill name="Light Armor Mastery" id="227" level="59" required-level="85" sp="840000000" />
-		<skill name="Light Armor Mastery" id="227" level="60" required-level="86" sp="924000000" />
-		<skill name="Light Armor Mastery" id="227" level="61" required-level="87" sp="1016400000" />
-		<skill name="Light Armor Mastery" id="227" level="62" required-level="88" sp="1118040000" />
-		<skill name="Light Armor Mastery" id="227" level="63" required-level="89" sp="1229844000" />
-		<skill name="Light Armor Mastery" id="227" level="64" required-level="90" sp="1352828400" />
 		<skill name="Heavy Armor Mastery" id="231" level="59" required-level="85" sp="840000000" />
-		<skill name="Heavy Armor Mastery" id="231" level="60" required-level="86" sp="924000000" />
-		<skill name="Heavy Armor Mastery" id="231" level="61" required-level="87" sp="1016400000" />
-		<skill name="Heavy Armor Mastery" id="231" level="62" required-level="88" sp="1118040000" />
-		<skill name="Heavy Armor Mastery" id="231" level="63" required-level="89" sp="1229844000" />
-		<skill name="Heavy Armor Mastery" id="231" level="64" required-level="90" sp="1352828400" />
+		<skill name="Howl" id="116" level="25" required-level="85" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Thunder Storm" id="48" level="50" required-level="85" sp="840000000" />
+		<skill name="War Cry" id="78" level="5" required-level="85" sp="840000000" />
+		<skill name="Spike Thrust" id="921" level="10" required-level="85" sp="840000000" />
+		<skill name="Fatal Strike" id="190" level="50" required-level="85" sp="840000000" />
+		<skill name="Focus Attack" id="317" level="8" required-level="85" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="55" required-level="85" sp="840000000" />
+
+		<skill name="Spinning Slasher" id="36" level="51" required-level="86" sp="840000000" />
+		<skill name="Polearm Mastery" id="216" level="55" required-level="86" sp="840000000" />
+		<skill name="Light Armor Mastery" id="227" level="60" required-level="86" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="231" level="60" required-level="86" sp="840000000" />
+		<skill name="Howl" id="116" level="26" required-level="86" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Thunder Storm" id="48" level="51" required-level="86" sp="840000000" />
+		<skill name="Spike Thrust" id="921" level="11" required-level="86" sp="840000000" />
+		<skill name="Fatal Strike" id="190" level="51" required-level="86" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="56" required-level="86" sp="840000000" />
+
+		<skill name="Spinning Slasher" id="36" level="52" required-level="87" sp="840000000" />
+		<skill name="Polearm Mastery" id="216" level="56" required-level="87" sp="840000000" />
+		<skill name="Light Armor Mastery" id="227" level="61" required-level="87" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="231" level="61" required-level="87" sp="840000000" />
+		<skill name="Howl" id="116" level="27" required-level="87" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Thunder Storm" id="48" level="52" required-level="87" sp="840000000" />
+		<skill name="Spike Thrust" id="921" level="12" required-level="87" sp="840000000" />
+		<skill name="Fatal Strike" id="190" level="52" required-level="87" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="57" required-level="87" sp="840000000" />
+
+		<skill name="Spinning Slasher" id="36" level="53" required-level="88" sp="840000000" />
+		<skill name="Polearm Mastery" id="216" level="57" required-level="88" sp="840000000" />
+		<skill name="Light Armor Mastery" id="227" level="62" required-level="88" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="231" level="62" required-level="88" sp="840000000" />
+		<skill name="Howl" id="116" level="28" required-level="88" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Thunder Storm" id="48" level="53" required-level="88" sp="840000000" />
+		<skill name="Spike Thrust" id="921" level="13" required-level="88" sp="840000000" />
+		<skill name="Fatal Strike" id="190" level="53" required-level="88" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="58" required-level="88" sp="840000000" />
+
+		<skill name="Spinning Slasher" id="36" level="54" required-level="89" sp="840000000" />
+		<skill name="Polearm Mastery" id="216" level="58" required-level="89" sp="840000000" />
+		<skill name="Light Armor Mastery" id="227" level="63" required-level="89" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="231" level="63" required-level="89" sp="840000000" />
+		<skill name="Howl" id="116" level="29" required-level="89" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Thunder Storm" id="48" level="54" required-level="89" sp="840000000" />
+		<skill name="Spike Thrust" id="921" level="14" required-level="89" sp="840000000" />
+		<skill name="Fatal Strike" id="190" level="54" required-level="89" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="59" required-level="89" sp="840000000" />
+
+		<skill name="Spinning Slasher" id="36" level="55" required-level="90" sp="840000000" />
+		<skill name="Polearm Mastery" id="216" level="59" required-level="90" sp="840000000" />
+		<skill name="Light Armor Mastery" id="227" level="64" required-level="90" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="231" level="64" required-level="90" sp="840000000" />
+		<skill name="Howl" id="116" level="30" required-level="90" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Thunder Storm" id="48" level="55" required-level="90" sp="840000000" />
+		<skill name="Spike Thrust" id="921" level="15" required-level="90" sp="840000000" />
+		<skill name="Fatal Strike" id="190" level="55" required-level="90" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="60" required-level="90" sp="840000000" />
+
 	</skillTree>
 </list>

--- a/data/skillTrees/3rdClass/Duelist.xml
+++ b/data/skillTrees/3rdClass/Duelist.xml
@@ -1,169 +1,282 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="88" parentClassId="2">
-		<skill name="White Guardian" id="54102" level="1" required-level="80" >
-			<item id="92401"/>
+
+		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="4800000">
+			<item id="8620" count="1" /> <!-- Buff Expansion Book Lv. 3 -->
 		</skill>
-		<skill name="Power Crush" id="260" level="38" required-level="76" sp="4800000" />
-		<skill name="Fatal Strike" id="190" level="38" required-level="76" sp="4800000" />
+		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="4800000">
+			<item id="8621" count="1" /> <!-- Buff Expansion Book Lv. 4 -->
+		</skill>
 		<skill name="Light Armor Mastery" id="227" level="51" required-level="76" sp="4800000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="46" required-level="76" sp="4800000" />
-		<skill name="Dual Weapon Mastery" id="144" level="38" required-level="76" sp="4800000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="46" required-level="76" sp="4800000" />
+		<skill name="Weapon Mastery" id="141" level="5" required-level="76" sp="4800000" />
+		<skill name="Dual Sword Mastery" id="144" level="38" required-level="76" sp="4800000" />
+		<skill name="Amazing Rising Attack Mastery" id="45363" level="1" required-level="76" sp="4800000">
+			<item id="93866" count="1" /> <!-- Scroll: Amazing Rising Attack Mastery -->
+		</skill>
 		<skill name="Heavy Armor Mastery" id="231" level="51" required-level="76" sp="4800000" />
-		<skill name="Double Sonic Slash" id="5" level="32" required-level="76" sp="4800000" />
+		<skill name="Rising Attack" id="1" level="41" required-level="76" sp="4800000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Double Sonic Slash" id="5" level="36" required-level="76" sp="4800000" />
+		<skill name="Evolution Defense" id="45188" level="1" required-level="76">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Sonic Buster" id="9" level="35" required-level="76" sp="4800000" />
 		<skill name="Sonic Rage" id="345" level="1" required-level="76" sp="4800000" />
 		<skill name="Sonic Blaster" id="6" level="38" required-level="76" sp="4800000" />
 		<skill name="Sonic Storm" id="7" level="29" required-level="76" sp="4800000" />
-		<skill name="Triple Sonic Slash" id="261" level="23" required-level="76" sp="4800000" />
-		<skill name="Triple Slash" id="1" level="38" required-level="76" sp="4800000" />
-		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="4800000">
-			<item id="8620"/> <!-- Ancient Book: Divine Inspiration (Manuscript) -->
+		<skill name="Master of Combat" id="430" level="1" required-level="76" sp="4800000">
+			<item id="57" count="500000" /> <!-- Adena -->
 		</skill>
-		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="4800000">
-			<item id="8621"/> <!-- Ancient Book: Divine Inspiration (Original Version) -->
+		<!-- Might Lv. 4 -->
+		<skill name="Might" id="1068" level="4" required-level="76" sp="4800000">
+			<item id="94135" count="1" /> <!-- Master's Book: Might -->
 		</skill>
-		<skill name="Mount Gold Maned Lion" id="1833" level="1" required-level="76">
-			<item id="90038"/> <!-- Spellbook: Mount Golden Lion -->
+		<!-- Shield Lv. 4 -->
+		<skill name="Shield" id="1040" level="4" required-level="76" sp="4800000">
+			<item id="94136" count="1" /> <!-- Master's Book: Shield -->
 		</skill>
-		<skill name="Glory Ability" id="45361" level="1" required-level="86">
-			<item id="94046"/> <!-- Spellbook: Glory Ability Lv. 1 -->
+		<!-- Acumen Lv. 4 -->
+		<skill name="Acumen" id="45104" level="4" required-level="76" sp="4800000">
+			<item id="94370" count="1" /> <!-- Master's Book: Acumen -->
 		</skill>
-		<skill name="Mount White Wings" id="54200" level="1" required-level="87">
-			<item id="93059"/> <!-- Spellbook: Summon White Wings -->
-		</skill>	
-		<skill name="Mount Shining Lady" id="54202" level="1" required-level="89">
-			<item id="93061"/> <!-- Spellbook: Summon Silver Saint -->
+		<!-- Empower Lv. 4 -->
+		<skill name="Empower" id="45105" level="4" required-level="76" sp="4800000">
+			<item id="94361" count="1" /> <!-- Master's Book: Empower -->
 		</skill>
-		
-		<skill name="Power Crush" id="260" level="39" required-level="77" sp="4800000" />
-		<skill name="Fatal Strike" id="190" level="39" required-level="77" sp="4800000" />
+		<!-- Wild Magic Lv. 3 -->
+		<skill name="Wild Magic" id="45106" level="3" required-level="76" sp="4800000">
+			<item id="94368" count="1" /> <!-- Master's Book: Wild Magic -->
+		</skill>
+		<!-- Wind Walk Lv. 3 -->
+		<skill name="Wind Walk" id="45107" level="3" required-level="76" sp="4800000">
+			<item id="94365" count="1" /> <!-- Master's Book: Wind Walk -->
+		</skill>
+		<!-- Magic Barrier Lv. 3 -->
+		<skill name="Magic Barrier" id="45108" level="3" required-level="76" sp="4800000">
+			<item id="94362" count="1" /> <!-- Master's Book: Magic Barrier -->
+		</skill>
+		<!-- Focus Lv. 4 -->
+		<skill name="Focus" id="45109" level="4" required-level="76" sp="4800000">
+			<item id="94363" count="1" /> <!-- Master's Book: Focus -->
+		</skill>
+		<!-- Death Whisper Lv. 4 -->
+		<skill name="Death Whisper" id="45110" level="4" required-level="76" sp="4800000">
+			<item id="94364" count="1" /> <!-- Master's Book: Death Whisper -->
+		</skill>
+		<!-- Haste Lv. 3 -->
+		<skill name="Haste" id="45111" level="3" required-level="76" sp="4800000">
+			<item id="94369" count="1" /> <!-- Master's Book: Haste -->
+		</skill>
+		<!-- Berserker Spirit Lv. 3 -->
+		<skill name="Berserker Spirit" id="45112" level="3" required-level="76" sp="4800000">
+			<item id="94366" count="1" /> <!-- Master's Book: Berserker Spirit -->
+		</skill>
+		<!-- Clarity Lv. 4 -->
+		<skill name="Clarity" id="45113" level="4" required-level="76" sp="4800000">
+			<item id="94367" count="1" /> <!-- Master's Book: Clarity -->
+		</skill>
+		<skill name="Detection" id="45190" level="1" required-level="76" sp="4800000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Final Secret" id="917" level="1" required-level="76" sp="4800000">
+			<item id="90080" count="1" /> <!-- Scroll: Final Secret -->
+		</skill>
+		<skill name="Mount Golden Lion" id="1833" level="1" required-level="76">
+			<item id="90038" count="1" /> <!-- Spellbook - Ride Golden Lion -->
+		</skill>
+		<skill name="Rush" id="994" level="3" required-level="76" sp="4800000" />
+		<skill name="Triple Sonic Slash" id="261" level="26" required-level="76" sp="4800000" />
+		<skill name="Fatal Strike" id="190" level="41" required-level="76" sp="4800000" />
+		<skill name="Emergency Rescue" id="70" level="46" required-level="76" sp="4800000" />
+
 		<skill name="Light Armor Mastery" id="227" level="52" required-level="77" sp="4800000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="47" required-level="77" sp="4800000" />
-		<skill name="Dual Weapon Mastery" id="144" level="39" required-level="77" sp="4800000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="47" required-level="77" sp="4800000" />
+		<skill name="Dual Sword Mastery" id="144" level="39" required-level="77" sp="4800000" />
 		<skill name="Heavy Armor Mastery" id="231" level="52" required-level="77" sp="4800000" />
-		<skill name="Double Sonic Slash" id="5" level="33" required-level="77" sp="4800000" />
+		<skill name="Rising Attack" id="1" level="42" required-level="77" sp="4800000" />
+		<skill name="Double Sonic Slash" id="5" level="37" required-level="77" sp="4800000" />
 		<skill name="Sonic Buster" id="9" level="36" required-level="77" sp="4800000" />
+		<skill name="Sonic Barrier" id="442" level="1" required-level="77" sp="4800000">
+			<item id="90067" count="1" /> <!-- Scroll: Sonic Barrier -->
+		</skill>
 		<skill name="Sonic Blaster" id="6" level="39" required-level="77" sp="4800000" />
 		<skill name="Sonic Storm" id="7" level="30" required-level="77" sp="4800000" />
-		<skill name="Triple Sonic Slash" id="261" level="24" required-level="77" sp="4800000" />
-		<skill name="Triple Slash" id="1" level="39" required-level="77" sp="4800000" />
-		<skill name="Sonic Barier" id="442" level="1" required-level="77" sp="4800000">
-			<item id="90067"/> <!-- Scroll: Sonic Barier -->
-		</skill>
-		
-		<skill name="Power Crush" id="260" level="40" required-level="78" sp="11300000" />
-		<skill name="Fatal Strike" id="190" level="40" required-level="78" sp="11300000" />
+		<skill name="Triple Sonic Slash" id="261" level="27" required-level="77" sp="4800000" />
+		<skill name="Fatal Strike" id="190" level="42" required-level="77" sp="4800000" />
+		<skill name="Emergency Rescue" id="70" level="47" required-level="77" sp="4800000" />
+
 		<skill name="Light Armor Mastery" id="227" level="53" required-level="78" sp="11300000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="48" required-level="78" sp="11300000" />
-		<skill name="Dual Weapon Mastery" id="144" level="40" required-level="78" sp="11300000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="48" required-level="78" sp="11300000" />
+		<skill name="Dual Sword Mastery" id="144" level="40" required-level="78" sp="11300000" />
 		<skill name="Heavy Armor Mastery" id="231" level="53" required-level="78" sp="11300000" />
-		<skill name="Double Sonic Slash" id="5" level="34" required-level="78" sp="11300000" />
+		<skill name="Rising Attack" id="1" level="43" required-level="78" sp="11300000" />
+		<skill name="Double Sonic Slash" id="5" level="38" required-level="78" sp="11300000" />
 		<skill name="Sonic Buster" id="9" level="37" required-level="78" sp="11300000" />
 		<skill name="Sonic Rage" id="345" level="2" required-level="78" sp="11300000" />
 		<skill name="Sonic Blaster" id="6" level="40" required-level="78" sp="11300000" />
 		<skill name="Sonic Storm" id="7" level="31" required-level="78" sp="11300000" />
-		<skill name="Master of Combat" id="430" level="1" required-level="78" sp="11300000" />
-		<skill name="Rush" id="994" level="1" required-level="78" sp="11300000" />
-		<skill name="Triple Sonic Slash" id="261" level="25" required-level="78" sp="11300000" />
-		<skill name="Triple Slash" id="1" level="40" required-level="78" sp="11300000" />
-		<skill name="Braveheart" id="440" level="1" required-level="78" sp="11300000" />
 		<skill name="Indestructible Sound" id="1624" level="1" required-level="78" sp="11300000">
-			<item id="90068"/> <!-- Scroll: Indestructible Sound -->
+			<item id="90068" count="1" /> <!-- Scroll: Indestructible Sound -->
 		</skill>
-		
+		<skill name="Triple Sonic Slash" id="261" level="28" required-level="78" sp="11300000" />
+		<skill name="Fatal Strike" id="190" level="43" required-level="78" sp="11300000" />
+		<skill name="Braveheart" id="440" level="1" required-level="78" sp="11300000" />
+		<skill name="Emergency Rescue" id="70" level="48" required-level="78" sp="11300000" />
+
 		<skill name="Sonic Mastery" id="992" level="8" required-level="79" sp="11300000" />
+		<skill name="Rising Attack" id="1" level="44" required-level="79" sp="11300000" />
+		<skill name="Double Sonic Slash" id="5" level="39" required-level="79" sp="11300000" />
 		<skill name="Sonic Move" id="451" level="4" required-level="79" sp="11300000" />
-		<skill name="Final Secret" id="917" level="1" required-level="79" sp="11300000">
-			<item id="90080"/> <!-- Scroll: Final Secret -->
+		<skill name="Final Frenzy" id="290" level="15" required-level="79" sp="11300000">
+			<item id="57" count="500000" /> <!-- Adena -->
 		</skill>
-		
-		<skill name="Power Crush" id="260" level="41" required-level="80" sp="11300000" />
-		<skill name="Fatal Strike" id="190" level="41" required-level="80" sp="11300000" />
+		<skill name="Triple Sonic Slash" id="261" level="29" required-level="79" sp="11300000" />
+		<skill name="Fatal Strike" id="190" level="44" required-level="79" sp="11300000" />
+		<skill name="Emergency Rescue" id="70" level="49" required-level="79" sp="11300000" />
+
 		<skill name="Light Armor Mastery" id="227" level="54" required-level="80" sp="11300000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="49" required-level="80" sp="11300000" />
-		<skill name="Dual Weapon Mastery" id="144" level="41" required-level="80" sp="11300000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="49" required-level="80" sp="11300000" />
+		<skill name="Dual Sword Mastery" id="144" level="41" required-level="80" sp="11300000" />
 		<skill name="Heavy Armor Mastery" id="231" level="54" required-level="80" sp="11300000" />
+		<skill name="Rising Attack" id="1" level="45" required-level="80" sp="11300000" />
+		<skill name="Double Sonic Slash" id="5" level="40" required-level="80" sp="11300000" />
 		<skill name="Sonic Rage" id="345" level="3" required-level="80" sp="11300000" />
 		<skill name="Sonic Blaster" id="6" level="41" required-level="80" sp="11300000" />
 		<skill name="War Cry" id="78" level="3" required-level="80" sp="11300000" />
+		<skill name="Master of Combat" id="430" level="2" required-level="80" sp="11300000" />
+		<skill name="Evolution Power" id="45189" level="1" required-level="80">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Indestructible Sound" id="1624" level="2" required-level="80" sp="11300000" />
 		<skill name="Maximum Sonic Focus" id="919" level="1" required-level="80" sp="11300000">
-			<item id="90069"/> <!-- Scroll: Maximum Sonic Focus -->
+			<item id="90069" count="1" /> <!-- Scroll: Maximum Sonic Focus -->
 		</skill>
-		<skill name="Triple Sonic Slash" id="261" level="26" required-level="80" sp="11300000" />
-		<skill name="Triple Slash" id="1" level="41" required-level="80" sp="11300000" />
+		<skill name="White Guardian Transformation" id="54102" level="1" required-level="80">
+			<item id="92401" count="1" /> <!-- Spellbook - White Guardian -->
+		</skill>
+		<skill name="Triple Sonic Slash" id="261" level="30" required-level="80" sp="11300000" />
+		<skill name="Fatal Strike" id="190" level="45" required-level="80" sp="11300000" />
+		<skill name="Emergency Rescue" id="70" level="50" required-level="80" sp="11300000" />
 
-		<skill name="Power Crush" id="260" level="42" required-level="81" sp="160000000" />
-		<skill name="Fatal Strike" id="190" level="42" required-level="81" sp="160000000" />
 		<skill name="Light Armor Mastery" id="227" level="55" required-level="81" sp="160000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="50" required-level="81" sp="160000000" />
-		<skill name="Dual Weapon Mastery" id="144" level="42" required-level="81" sp="160000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="50" required-level="81" sp="160000000" />
+		<skill name="Dual Sword Mastery" id="144" level="42" required-level="81" sp="160000000" />
 		<skill name="Heavy Armor Mastery" id="231" level="55" required-level="81" sp="160000000" />
+		<skill name="Double Sonic Slash" id="5" level="41" required-level="81" sp="160000000" />
 		<skill name="Sonic Move" id="451" level="5" required-level="81" sp="160000000" />
 		<skill name="Sonic Blaster" id="6" level="42" required-level="81" sp="160000000" />
-		<skill name="Triple Sonic Slash" id="261" level="27" required-level="81" sp="160000000" />
-		<skill name="Triple Slash" id="1" level="42" required-level="81" sp="160000000" />
+		<skill name="Triple Sonic Slash" id="261" level="31" required-level="81" sp="160000000" />
+		<skill name="Fatal Strike" id="190" level="46" required-level="81" sp="160000000" />
+		<skill name="Emergency Rescue" id="70" level="51" required-level="81" sp="160000000" />
 
-		<skill name="Power Crush" id="260" level="43" required-level="82" sp="170000000" />
-		<skill name="Fatal Strike" id="190" level="43" required-level="82" sp="170000000" />
 		<skill name="Light Armor Mastery" id="227" level="56" required-level="82" sp="170000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="51" required-level="82" sp="170000000" />
-		<skill name="Dual Weapon Mastery" id="144" level="43" required-level="82" sp="170000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="51" required-level="82" sp="170000000" />
+		<skill name="Dual Sword Mastery" id="144" level="43" required-level="82" sp="170000000" />
 		<skill name="Heavy Armor Mastery" id="231" level="56" required-level="82" sp="170000000" />
+		<skill name="Rising Attack" id="1" level="46" required-level="82" sp="170000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Double Sonic Slash" id="5" level="42" required-level="82" sp="170000000" />
 		<skill name="Duelist Spirit" id="297" level="3" required-level="82" sp="170000000" />
 		<skill name="Sonic Rage" id="345" level="4" required-level="82" sp="170000000" />
 		<skill name="Sonic Blaster" id="6" level="43" required-level="82" sp="170000000" />
 		<skill name="Indestructible Sound" id="1624" level="3" required-level="82" sp="170000000" />
-		<skill name="Triple Sonic Slash" id="261" level="28" required-level="82" sp="170000000" />
-		<skill name="Triple Slash" id="1" level="43" required-level="82" sp="170000000" />
+		<skill name="Triple Sonic Slash" id="261" level="32" required-level="82" sp="170000000" />
+		<skill name="Fatal Strike" id="190" level="47" required-level="82" sp="170000000" />
+		<skill name="Emergency Rescue" id="70" level="52" required-level="82" sp="170000000" />
 
-		<skill name="Power Crush" id="260" level="44" required-level="83" sp="240000000" />
-		<skill name="Fatal Strike" id="190" level="44" required-level="83" sp="240000000" />
 		<skill name="Light Armor Mastery" id="227" level="57" required-level="83" sp="240000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="52" required-level="83" sp="240000000" />
-		<skill name="Dual Weapon Mastery" id="144" level="44" required-level="83" sp="240000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="52" required-level="83" sp="240000000" />
+		<skill name="Dual Sword Mastery" id="144" level="44" required-level="83" sp="240000000" />
 		<skill name="Heavy Armor Mastery" id="231" level="57" required-level="83" sp="240000000" />
+		<skill name="Double Sonic Slash" id="5" level="43" required-level="83" sp="240000000" />
 		<skill name="Sonic Blaster" id="6" level="44" required-level="83" sp="240000000" />
 		<skill name="War Cry" id="78" level="4" required-level="83" sp="240000000" />
-		<skill name="Triple Sonic Slash" id="261" level="29" required-level="83" sp="240000000" />
-		<skill name="Triple Slash" id="1" level="44" required-level="83" sp="240000000" />
+		<skill name="Triple Sonic Slash" id="261" level="33" required-level="83" sp="240000000" />
+		<skill name="Fatal Strike" id="190" level="48" required-level="83" sp="240000000" />
+		<skill name="Emergency Rescue" id="70" level="53" required-level="83" sp="240000000" />
 
-		<skill name="Power Crush" id="260" level="45" required-level="84" sp="240000000" />
-		<skill name="Fatal Strike" id="190" level="45" required-level="84" sp="240000000" />
 		<skill name="Light Armor Mastery" id="227" level="58" required-level="84" sp="240000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="53" required-level="84" sp="240000000" />
-		<skill name="Dual Weapon Mastery" id="144" level="45" required-level="84" sp="240000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="53" required-level="84" sp="240000000" />
+		<skill name="Dual Sword Mastery" id="144" level="45" required-level="84" sp="240000000" />
 		<skill name="Heavy Armor Mastery" id="231" level="58" required-level="84" sp="240000000" />
+		<skill name="Rising Attack" id="1" level="47" required-level="84" sp="240000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Double Sonic Slash" id="5" level="44" required-level="84" sp="240000000" />
 		<skill name="Sonic Rage" id="345" level="5" required-level="84" sp="240000000" />
 		<skill name="Sonic Blaster" id="6" level="45" required-level="84" sp="240000000" />
 		<skill name="Indestructible Sound" id="1624" level="4" required-level="84" sp="240000000" />
-		<skill name="Triple Sonic Slash" id="261" level="30" required-level="84" sp="240000000" />
-		<skill name="Triple Slash" id="1" level="45" required-level="84" sp="240000000" />
-		
+		<skill name="Triple Sonic Slash" id="261" level="34" required-level="84" sp="240000000" />
+		<skill name="Fatal Strike" id="190" level="49" required-level="84" sp="240000000" />
+		<skill name="Emergency Rescue" id="70" level="54" required-level="84" sp="240000000" />
+
 		<skill name="Light Armor Mastery" id="227" level="59" required-level="85" sp="840000000" />
-		<skill name="Light Armor Mastery" id="227" level="60" required-level="86" sp="924000000" />
-		<skill name="Light Armor Mastery" id="227" level="61" required-level="87" sp="1016400000" />
-		<skill name="Light Armor Mastery" id="227" level="62" required-level="88" sp="1118040000" />
-		<skill name="Light Armor Mastery" id="227" level="63" required-level="89" sp="1229844000" />
-		<skill name="Light Armor Mastery" id="227" level="64" required-level="90" sp="1352828400" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="54" required-level="85" sp="840000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="55" required-level="86" sp="924000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="56" required-level="87" sp="1016400000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="57" required-level="88" sp="1118040000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="58" required-level="89" sp="1229844000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="59" required-level="90" sp="1352828400" />
-		<skill name="Dual Weapon Mastery" id="144" level="46" required-level="85" sp="840000000" />
-		<skill name="Dual Weapon Mastery" id="144" level="47" required-level="86" sp="924000000" />
-		<skill name="Dual Weapon Mastery" id="144" level="48" required-level="87" sp="1016400000" />
-		<skill name="Dual Weapon Mastery" id="144" level="49" required-level="88" sp="1118040000" />
-		<skill name="Dual Weapon Mastery" id="144" level="50" required-level="89" sp="1229844000" />
-		<skill name="Dual Weapon Mastery" id="144" level="51" required-level="90" sp="1352828400" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="54" required-level="85" sp="840000000" />
+		<skill name="Dual Sword Mastery" id="144" level="46" required-level="85" sp="840000000" />
 		<skill name="Heavy Armor Mastery" id="231" level="59" required-level="85" sp="840000000" />
-		<skill name="Heavy Armor Mastery" id="231" level="60" required-level="86" sp="924000000" />
-		<skill name="Heavy Armor Mastery" id="231" level="61" required-level="87" sp="1016400000" />
-		<skill name="Heavy Armor Mastery" id="231" level="62" required-level="88" sp="1118040000" />
-		<skill name="Heavy Armor Mastery" id="231" level="63" required-level="89" sp="1229844000" />
-		<skill name="Heavy Armor Mastery" id="231" level="64" required-level="90" sp="1352828400" />
+		<skill name="Double Sonic Slash" id="5" level="45" required-level="85" sp="840000000" />
+		<skill name="War Cry" id="78" level="5" required-level="85" sp="840000000" />
+		<skill name="Triple Sonic Slash" id="261" level="35" required-level="85" sp="840000000" />
+		<skill name="Fatal Strike" id="190" level="50" required-level="85" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="55" required-level="85" sp="840000000" />
+
+		<skill name="Light Armor Mastery" id="227" level="60" required-level="86" sp="840000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="55" required-level="86" sp="840000000" />
+		<skill name="Dual Sword Mastery" id="144" level="47" required-level="86" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="231" level="60" required-level="86" sp="840000000" />
+		<skill name="Rising Attack" id="1" level="48" required-level="86" sp="840000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Double Sonic Slash" id="5" level="46" required-level="86" sp="840000000" />
+		<skill name="Triple Sonic Slash" id="261" level="36" required-level="86" sp="840000000" />
+		<skill name="Fatal Strike" id="190" level="51" required-level="86" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="56" required-level="86" sp="840000000" />
+
+		<skill name="Light Armor Mastery" id="227" level="61" required-level="87" sp="840000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="56" required-level="87" sp="840000000" />
+		<skill name="Dual Sword Mastery" id="144" level="48" required-level="87" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="231" level="61" required-level="87" sp="840000000" />
+		<skill name="Double Sonic Slash" id="5" level="47" required-level="87" sp="840000000" />
+		<skill name="Triple Sonic Slash" id="261" level="37" required-level="87" sp="840000000" />
+		<skill name="Fatal Strike" id="190" level="52" required-level="87" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="57" required-level="87" sp="840000000" />
+
+		<skill name="Light Armor Mastery" id="227" level="62" required-level="88" sp="840000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="57" required-level="88" sp="840000000" />
+		<skill name="Dual Sword Mastery" id="144" level="49" required-level="88" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="231" level="62" required-level="88" sp="840000000" />
+		<skill name="Rising Attack" id="1" level="49" required-level="88" sp="840000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Double Sonic Slash" id="5" level="48" required-level="88" sp="840000000" />
+		<skill name="Triple Sonic Slash" id="261" level="38" required-level="88" sp="840000000" />
+		<skill name="Fatal Strike" id="190" level="53" required-level="88" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="58" required-level="88" sp="840000000" />
+
+		<skill name="Light Armor Mastery" id="227" level="63" required-level="89" sp="840000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="58" required-level="89" sp="840000000" />
+		<skill name="Dual Sword Mastery" id="144" level="50" required-level="89" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="231" level="63" required-level="89" sp="840000000" />
+		<skill name="Double Sonic Slash" id="5" level="49" required-level="89" sp="840000000" />
+		<skill name="Triple Sonic Slash" id="261" level="39" required-level="89" sp="840000000" />
+		<skill name="Fatal Strike" id="190" level="54" required-level="89" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="59" required-level="89" sp="840000000" />
+
+		<skill name="Light Armor Mastery" id="227" level="64" required-level="90" sp="840000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="59" required-level="90" sp="840000000" />
+		<skill name="Dual Sword Mastery" id="144" level="51" required-level="90" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="231" level="64" required-level="90" sp="840000000" />
+		<skill name="Rising Attack" id="1" level="50" required-level="90" sp="840000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Double Sonic Slash" id="5" level="50" required-level="90" sp="840000000" />
+		<skill name="Triple Sonic Slash" id="261" level="40" required-level="90" sp="840000000" />
+		<skill name="Fatal Strike" id="190" level="55" required-level="90" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="60" required-level="90" sp="840000000" />
+
 	</skillTree>
 </list>

--- a/data/skillTrees/3rdClass/ElementalMaster.xml
+++ b/data/skillTrees/3rdClass/ElementalMaster.xml
@@ -1,42 +1,89 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="104" parentClassId="28">
-		<skill name="White Guardian" id="54102" level="1" required-level="80" >
-			<item id="92401"/>
-		</skill>
+
 		<skill name="Anti Magic" id="146" level="46" required-level="76" sp="8100000" />
 		<skill name="Warrior Bane" id="1350" level="1" required-level="76" sp="8100000" />
 		<skill name="Mage Bane" id="1351" level="1" required-level="76" sp="8100000" />
+		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="8100000">
+			<item id="8620" count="1" /> <!-- Buff Expansion Book Lv. 3 -->
+		</skill>
+		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="8100000">
+			<item id="8621" count="1" /> <!-- Buff Expansion Book Lv. 4 -->
+		</skill>
 		<skill name="Light Armor Mastery" id="258" level="34" required-level="76" sp="8100000" />
 		<skill name="Robe Mastery" id="234" level="42" required-level="76" sp="8100000" />
 		<skill name="Weapon Mastery" id="249" level="43" required-level="76" sp="8100000" />
 		<skill name="Aqua Swirl" id="1175" level="27" required-level="76" sp="8100000" />
+		<skill name="Evolution Defense" id="45188" level="1" required-level="76">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Servitor Heal" id="1127" level="46" required-level="76" sp="8100000" />
+		<!-- Might Lv. 4 -->
+		<skill name="Might" id="1068" level="4" required-level="76" sp="8100000">
+			<item id="94135" count="1" /> <!-- Master's Book: Might -->
+		</skill>
+		<!-- Shield Lv. 4 -->
+		<skill name="Shield" id="1040" level="4" required-level="76" sp="8100000">
+			<item id="94136" count="1" /> <!-- Master's Book: Shield -->
+		</skill>
+		<!-- Acumen Lv. 4 -->
+		<skill name="Acumen" id="45104" level="4" required-level="76" sp="8100000">
+			<item id="94370" count="1" /> <!-- Master's Book: Acumen -->
+		</skill>
+		<!-- Empower Lv. 4 -->
+		<skill name="Empower" id="45105" level="4" required-level="76" sp="8100000">
+			<item id="94361" count="1" /> <!-- Master's Book: Empower -->
+		</skill>
+		<!-- Wild Magic Lv. 3 -->
+		<skill name="Wild Magic" id="45106" level="3" required-level="76" sp="8100000">
+			<item id="94368" count="1" /> <!-- Master's Book: Wild Magic -->
+		</skill>
+		<!-- Wind Walk Lv. 3 -->
+		<skill name="Wind Walk" id="45107" level="3" required-level="76" sp="8100000">
+			<item id="94365" count="1" /> <!-- Master's Book: Wind Walk -->
+		</skill>
+		<!-- Magic Barrier Lv. 3 -->
+		<skill name="Magic Barrier" id="45108" level="3" required-level="76" sp="8100000">
+			<item id="94362" count="1" /> <!-- Master's Book: Magic Barrier -->
+		</skill>
+		<!-- Focus Lv. 4 -->
+		<skill name="Focus" id="45109" level="4" required-level="76" sp="8100000">
+			<item id="94363" count="1" /> <!-- Master's Book: Focus -->
+		</skill>
+		<!-- Death Whisper Lv. 4 -->
+		<skill name="Death Whisper" id="45110" level="4" required-level="76" sp="8100000">
+			<item id="94364" count="1" /> <!-- Master's Book: Death Whisper -->
+		</skill>
+		<!-- Haste Lv. 3 -->
+		<skill name="Haste" id="45111" level="3" required-level="76" sp="8100000">
+			<item id="94369" count="1" /> <!-- Master's Book: Haste -->
+		</skill>
+		<!-- Berserker Spirit Lv. 3 -->
+		<skill name="Berserker Spirit" id="45112" level="3" required-level="76" sp="8100000">
+			<item id="94366" count="1" /> <!-- Master's Book: Berserker Spirit -->
+		</skill>
+		<!-- Clarity Lv. 4 -->
+		<skill name="Clarity" id="45113" level="4" required-level="76" sp="8100000">
+			<item id="94367" count="1" /> <!-- Master's Book: Clarity -->
+		</skill>
+		<skill name="Detection" id="45190" level="1" required-level="76" sp="8100000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Wind Shackle" id="1206" level="20" required-level="76" sp="6800000" />
+		<skill name="Mount Pegasus" id="1834" level="1" required-level="76">
+			<item id="90039" count="1" /> <!-- Spellbook - Ride Pegasus -->
+		</skill>
 		<skill name="Servitor Recharge" id="1126" level="35" required-level="76" sp="8100000" />
 		<skill name="Summon Aqua Cubic" id="1280" level="10" required-level="76" sp="8100000" />
 		<skill name="Summon Life Cubic" id="67" level="9" required-level="76" sp="8100000" />
 		<skill name="Servitor Share" id="1557" level="1" required-level="76" sp="8100000">
-			<item id="90131"/> <!-- Scroll: Servitor Share -->
+			<item id="90131" count="1" /> <!-- Scroll: Servitor Share -->
 		</skill>
-		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="8100000">
-			<item id="8620"/> <!-- Ancient Book: Divine Inspiration (Manuscript) -->
-		</skill>
-		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="8100000">
-			<item id="8621"/> <!-- Ancient Book: Divine Inspiration (Original Version) -->
-		</skill>
-		<skill name="Mount Pegasus" id="1834" level="1" required-level="76">
-			<item id="90039"/> <!-- Spellbook: Mount Pegasus -->
-		</skill>
-		<skill name="Glory Ability" id="45361" level="1" required-level="86">
-			<item id="94046"/> <!-- Spellbook: Glory Ability Lv. 1 -->
-		</skill>
-		<skill name="Mount White Wings" id="54200" level="1" required-level="87">
-			<item id="93059"/> <!-- Spellbook: Summon White Wings -->
-		</skill>	
-		<skill name="Mount Shining Lady" id="54202" level="1" required-level="89">
-			<item id="93061"/> <!-- Spellbook: Summon Silver Saint -->
-		</skill>
-		
+		<skill name="Weakness" id="1164" level="20" required-level="76" sp="6100000" />
+		<skill name="Swift Servitor Heal" id="45362" level="46" required-level="76" sp="8100000" />
+		<skill name="Ethereal Strike" id="45377" level="1" required-level="76" sp="8100000" />
+
 		<skill name="Anti Magic" id="146" level="47" required-level="77" sp="8100000" />
 		<skill name="Light Armor Mastery" id="258" level="35" required-level="77" sp="8100000" />
 		<skill name="Robe Mastery" id="234" level="43" required-level="77" sp="8100000" />
@@ -45,9 +92,11 @@
 		<skill name="Servitor Recharge" id="1126" level="36" required-level="77" sp="8100000" />
 		<skill name="Summon Magnus the Unicorn" id="1407" level="1" required-level="77" sp="8100000" />
 		<skill name="Summon Seraphim the Unicorn" id="1332" level="1" required-level="77" sp="8100000">
-			<item id="91204"/> <!-- Scroll: Summon Seraphim the Unicorn -->
+			<item id="91204" count="1" /> <!-- Scroll: Summon Seraphim the Unicorn -->
 		</skill>
-		
+		<skill name="Swift Servitor Heal" id="45362" level="47" required-level="77" sp="8100000" />
+		<skill name="Ethereal Strike" id="45377" level="2" required-level="77" sp="8100000" />
+
 		<skill name="Anti Magic" id="146" level="48" required-level="78" sp="17900000" />
 		<skill name="Warrior Bane" id="1350" level="2" required-level="78" sp="17900000" />
 		<skill name="Mage Bane" id="1351" level="2" required-level="78" sp="17900000" />
@@ -56,68 +105,100 @@
 		<skill name="Weapon Mastery" id="249" level="45" required-level="78" sp="17900000" />
 		<skill name="Aqua Swirl" id="1175" level="28" required-level="78" sp="17900000" />
 		<skill name="Servitor Heal" id="1127" level="48" required-level="78" sp="17900000" />
+		<skill name="Wind Shackle" id="1206" level="21" required-level="78" sp="14900000" />
 		<skill name="Servitor Recharge" id="1126" level="37" required-level="78" sp="17900000" />
 		<skill name="Summon Aqua Cubic" id="1280" level="11" required-level="78" sp="17900000" />
 		<skill name="Summon Life Cubic" id="67" level="10" required-level="78" sp="17900000" />
 		<skill name="Spirit Sharing" id="1547" level="4" required-level="78" sp="17900000" />
 		<skill name="Servitor Share" id="1557" level="2" required-level="78" sp="17900000" />
+		<skill name="Weakness" id="1164" level="21" required-level="78" sp="13500000" />
 		<skill name="Wizard Servitor" id="1347" level="1" required-level="78" sp="17900000">
-			<item id="90128"/> <!-- Scroll: Wizard Servitor -->
+			<item id="90128" count="1" /> <!-- Scroll: Wizard Servitor -->
 		</skill>
-		
+		<skill name="Swift Servitor Heal" id="45362" level="48" required-level="78" sp="17900000" />
+		<skill name="Ethereal Strike" id="45377" level="3" required-level="78" sp="17900000" />
+
+		<skill name="Aqua Swirl" id="1175" level="29" required-level="79" sp="17900000" />
+		<skill name="Wind Shackle" id="1206" level="22" required-level="79" sp="14900000" />
 		<skill name="Summon Seraphim the Unicorn" id="1332" level="2" required-level="79" sp="17900000" />
 		<skill name="Final Servitor" id="1349" level="1" required-level="79" sp="17900000">
-			<item id="90130"/>
+			<item id="90130" count="1" /> <!-- Scroll: Final Servitor -->
 		</skill>
-		
+		<skill name="Ethereal Strike" id="45377" level="4" required-level="79" sp="17900000" />
+
 		<skill name="Anti Magic" id="146" level="49" required-level="80" sp="17900000" />
 		<skill name="Warrior Bane" id="1350" level="3" required-level="80" sp="17900000" />
 		<skill name="Mage Bane" id="1351" level="3" required-level="80" sp="17900000" />
 		<skill name="Light Armor Mastery" id="258" level="37" required-level="80" sp="17900000" />
 		<skill name="Robe Mastery" id="234" level="45" required-level="80" sp="17900000" />
 		<skill name="Weapon Mastery" id="249" level="46" required-level="80" sp="17900000" />
-		<skill name="Aqua Swirl" id="1175" level="29" required-level="80" sp="17900000" />
+		<skill name="Aqua Swirl" id="1175" level="30" required-level="80" sp="17900000" />
 		<skill name="Servitor Heal" id="1127" level="49" required-level="80" sp="17900000" />
+		<skill name="Spell Master" id="1830" level="4" required-level="80" sp="2400000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Evolution Power" id="45189" level="1" required-level="80">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Wind Shackle" id="1206" level="23" required-level="80" sp="14900000" />
 		<skill name="Servitor Recharge" id="1126" level="38" required-level="80" sp="17900000" />
 		<skill name="Power Supremacy" id="1611" level="5" required-level="80" sp="17900000" />
 		<skill name="Summon Aqua Cubic" id="1280" level="12" required-level="80" sp="17900000" />
 		<skill name="Summon Life Cubic" id="67" level="11" required-level="80" sp="17900000" />
 		<skill name="Servitor Share" id="1557" level="3" required-level="80" sp="17900000" />
-		
+		<skill name="Weakness" id="1164" level="22" required-level="80" sp="13500000" />
+		<skill name="White Guardian Transformation" id="54102" level="1" required-level="80">
+			<item id="92401" count="1" /> <!-- Spellbook - White Guardian -->
+		</skill>
+		<skill name="Swift Servitor Heal" id="45362" level="49" required-level="80" sp="17900000" />
+		<skill name="Ethereal Strike" id="45377" level="5" required-level="80" sp="17900000" />
+
 		<skill name="Anti Magic" id="146" level="50" required-level="81" sp="160000000" />
 		<skill name="Light Armor Mastery" id="258" level="38" required-level="81" sp="160000000" />
 		<skill name="Robe Mastery" id="234" level="46" required-level="81" sp="160000000" />
 		<skill name="Weapon Mastery" id="249" level="47" required-level="81" sp="160000000" />
-		<skill name="Aqua Swirl" id="1175" level="30" required-level="81" sp="160000000" />
+		<skill name="Aqua Swirl" id="1175" level="31" required-level="81" sp="160000000" />
 		<skill name="Servitor Heal" id="1127" level="50" required-level="81" sp="160000000" />
+		<skill name="Wind Shackle" id="1206" level="24" required-level="81" sp="160000000" />
 		<skill name="Servitor Recharge" id="1126" level="39" required-level="81" sp="160000000" />
 		<skill name="Summon Magnus the Unicorn" id="1407" level="2" required-level="81" sp="160000000" />
 		<skill name="Summon Seraphim the Unicorn" id="1332" level="3" required-level="81" sp="160000000" />
-	
+		<skill name="Weakness" id="1164" level="23" required-level="81" sp="160000000" />
+		<skill name="Swift Servitor Heal" id="45362" level="50" required-level="81" sp="160000000" />
+		<skill name="Ethereal Strike" id="45377" level="6" required-level="81" sp="160000000" />
+
 		<skill name="Anti Magic" id="146" level="51" required-level="82" sp="170000000" />
 		<skill name="Warrior Bane" id="1350" level="4" required-level="82" sp="170000000" />
 		<skill name="Mage Bane" id="1351" level="4" required-level="82" sp="170000000" />
 		<skill name="Light Armor Mastery" id="258" level="39" required-level="82" sp="170000000" />
 		<skill name="Robe Mastery" id="234" level="47" required-level="82" sp="170000000" />
 		<skill name="Weapon Mastery" id="249" level="48" required-level="82" sp="170000000" />
-		<skill name="Aqua Swirl" id="1175" level="31" required-level="82" sp="170000000" />
+		<skill name="Aqua Swirl" id="1175" level="32" required-level="82" sp="170000000" />
 		<skill name="Servitor Heal" id="1127" level="51" required-level="82" sp="170000000" />
+		<skill name="Wind Shackle" id="1206" level="25" required-level="82" sp="170000000" />
 		<skill name="Servitor Recharge" id="1126" level="40" required-level="82" sp="170000000" />
 		<skill name="Summon Aqua Cubic" id="1280" level="13" required-level="82" sp="170000000" />
 		<skill name="Summon Magnus the Unicorn" id="1407" level="3" required-level="82" sp="170000000" />
 		<skill name="Summon Life Cubic" id="67" level="12" required-level="82" sp="170000000" />
 		<skill name="Spirit Sharing" id="1547" level="5" required-level="82" sp="170000000" />
 		<skill name="Servitor Share" id="1557" level="4" required-level="82" sp="170000000" />
+		<skill name="Weakness" id="1164" level="24" required-level="82" sp="170000000" />
+		<skill name="Swift Servitor Heal" id="45362" level="51" required-level="82" sp="170000000" />
+		<skill name="Ethereal Strike" id="45377" level="7" required-level="82" sp="170000000" />
 
 		<skill name="Anti Magic" id="146" level="52" required-level="83" sp="240000000" />
 		<skill name="Light Armor Mastery" id="258" level="40" required-level="83" sp="240000000" />
 		<skill name="Robe Mastery" id="234" level="48" required-level="83" sp="240000000" />
 		<skill name="Weapon Mastery" id="249" level="49" required-level="83" sp="240000000" />
-		<skill name="Aqua Swirl" id="1175" level="32" required-level="83" sp="240000000" />
+		<skill name="Aqua Swirl" id="1175" level="33" required-level="83" sp="240000000" />
 		<skill name="Servitor Heal" id="1127" level="52" required-level="83" sp="240000000" />
+		<skill name="Wind Shackle" id="1206" level="26" required-level="83" sp="240000000" />
 		<skill name="Servitor Recharge" id="1126" level="41" required-level="83" sp="240000000" />
 		<skill name="Summon Magnus the Unicorn" id="1407" level="4" required-level="83" sp="240000000" />
 		<skill name="Summon Seraphim the Unicorn" id="1332" level="4" required-level="83" sp="240000000" />
+		<skill name="Weakness" id="1164" level="25" required-level="83" sp="240000000" />
+		<skill name="Swift Servitor Heal" id="45362" level="52" required-level="83" sp="240000000" />
+		<skill name="Ethereal Strike" id="45377" level="8" required-level="83" sp="240000000" />
 
 		<skill name="Anti Magic" id="146" level="53" required-level="84" sp="240000000" />
 		<skill name="Warrior Bane" id="1350" level="5" required-level="84" sp="240000000" />
@@ -125,8 +206,9 @@
 		<skill name="Light Armor Mastery" id="258" level="41" required-level="84" sp="240000000" />
 		<skill name="Robe Mastery" id="234" level="49" required-level="84" sp="240000000" />
 		<skill name="Weapon Mastery" id="249" level="50" required-level="84" sp="240000000" />
-		<skill name="Aqua Swirl" id="1175" level="33" required-level="84" sp="240000000" />
+		<skill name="Aqua Swirl" id="1175" level="34" required-level="84" sp="240000000" />
 		<skill name="Servitor Heal" id="1127" level="53" required-level="84" sp="240000000" />
+		<skill name="Wind Shackle" id="1206" level="27" required-level="84" sp="240000000" />
 		<skill name="Servitor Recharge" id="1126" level="42" required-level="84" sp="240000000" />
 		<skill name="Power Supremacy" id="1611" level="6" required-level="84" sp="240000000" />
 		<skill name="Summon Aqua Cubic" id="1280" level="14" required-level="84" sp="240000000" />
@@ -134,32 +216,52 @@
 		<skill name="Summon Life Cubic" id="67" level="13" required-level="84" sp="240000000" />
 		<skill name="Summon Seraphim the Unicorn" id="1332" level="5" required-level="84" sp="240000000" />
 		<skill name="Servitor Share" id="1557" level="5" required-level="84" sp="240000000" />
-		
+		<skill name="Weakness" id="1164" level="26" required-level="84" sp="240000000" />
+		<skill name="Swift Servitor Heal" id="45362" level="53" required-level="84" sp="240000000" />
+		<skill name="Ethereal Strike" id="45377" level="9" required-level="84" sp="240000000" />
+
 		<skill name="Anti Magic" id="146" level="54" required-level="85" sp="840000000" />
-		<skill name="Anti Magic" id="146" level="55" required-level="86" sp="924000000" />
-		<skill name="Anti Magic" id="146" level="56" required-level="87" sp="1016400000" />
-		<skill name="Anti Magic" id="146" level="57" required-level="88" sp="1118040000" />
-		<skill name="Anti Magic" id="146" level="58" required-level="89" sp="1229844000" />
-		<skill name="Anti Magic" id="146" level="59" required-level="90" sp="1352828400" />
 		<skill name="Light Armor Mastery" id="258" level="42" required-level="85" sp="840000000" />
-		<skill name="Light Armor Mastery" id="258" level="43" required-level="86" sp="924000000" />
-		<skill name="Light Armor Mastery" id="258" level="44" required-level="87" sp="1016400000" />
-		<skill name="Light Armor Mastery" id="258" level="45" required-level="88" sp="1118040000" />
-		<skill name="Light Armor Mastery" id="258" level="46" required-level="89" sp="1229844000" />
-		<skill name="Light Armor Mastery" id="258" level="47" required-level="90" sp="1352828400" />
 		<skill name="Robe Mastery" id="234" level="50" required-level="85" sp="840000000" />
-		<skill name="Robe Mastery" id="234" level="51" required-level="86" sp="924000000" />
-		<skill name="Robe Mastery" id="234" level="52" required-level="87" sp="1016400000" />
-		<skill name="Robe Mastery" id="234" level="53" required-level="88" sp="1118040000" />
-		<skill name="Robe Mastery" id="234" level="54" required-level="89" sp="1229844000" />
-		<skill name="Robe Mastery" id="234" level="55" required-level="90" sp="1352828400" />
 		<skill name="Weapon Mastery" id="249" level="51" required-level="85" sp="840000000" />
-		<skill name="Weapon Mastery" id="249" level="52" required-level="86" sp="924000000" />
-		<skill name="Weapon Mastery" id="249" level="53" required-level="87" sp="1016400000" />
-		<skill name="Weapon Mastery" id="249" level="54" required-level="88" sp="1118040000" />
-		<skill name="Weapon Mastery" id="249" level="55" required-level="89" sp="1229844000" />
-		<skill name="Weapon Mastery" id="249" level="56" required-level="90" sp="1352828400" />
+		<skill name="Aqua Swirl" id="1175" level="35" required-level="85" sp="840000000" />
 		<skill name="Summon Magnus the Unicorn" id="1407" level="6" required-level="85" sp="840000000" />
 		<skill name="Summon Seraphim the Unicorn" id="1332" level="6" required-level="85" sp="840000000" />
+		<skill name="Ethereal Strike" id="45377" level="10" required-level="85" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="55" required-level="86" sp="840000000" />
+		<skill name="Light Armor Mastery" id="258" level="43" required-level="86" sp="840000000" />
+		<skill name="Robe Mastery" id="234" level="51" required-level="86" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="52" required-level="86" sp="840000000" />
+		<skill name="Aqua Swirl" id="1175" level="36" required-level="86" sp="840000000" />
+		<skill name="Ethereal Strike" id="45377" level="11" required-level="86" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="56" required-level="87" sp="840000000" />
+		<skill name="Light Armor Mastery" id="258" level="44" required-level="87" sp="840000000" />
+		<skill name="Robe Mastery" id="234" level="52" required-level="87" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="53" required-level="87" sp="840000000" />
+		<skill name="Aqua Swirl" id="1175" level="37" required-level="87" sp="840000000" />
+		<skill name="Ethereal Strike" id="45377" level="12" required-level="87" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="57" required-level="88" sp="840000000" />
+		<skill name="Light Armor Mastery" id="258" level="45" required-level="88" sp="840000000" />
+		<skill name="Robe Mastery" id="234" level="53" required-level="88" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="54" required-level="88" sp="840000000" />
+		<skill name="Aqua Swirl" id="1175" level="38" required-level="88" sp="840000000" />
+		<skill name="Ethereal Strike" id="45377" level="13" required-level="88" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="58" required-level="89" sp="840000000" />
+		<skill name="Light Armor Mastery" id="258" level="46" required-level="89" sp="840000000" />
+		<skill name="Robe Mastery" id="234" level="54" required-level="89" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="55" required-level="89" sp="840000000" />
+		<skill name="Aqua Swirl" id="1175" level="39" required-level="89" sp="840000000" />
+		<skill name="Ethereal Strike" id="45377" level="14" required-level="89" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="59" required-level="90" sp="840000000" />
+		<skill name="Light Armor Mastery" id="258" level="47" required-level="90" sp="840000000" />
+		<skill name="Robe Mastery" id="234" level="55" required-level="90" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="56" required-level="90" sp="840000000" />
+		<skill name="Aqua Swirl" id="1175" level="40" required-level="90" sp="840000000" />
+		<skill name="Ethereal Strike" id="45377" level="15" required-level="90" sp="840000000" />
 	</skillTree>
 </list>

--- a/data/skillTrees/3rdClass/ElfDeathKnight.xml
+++ b/data/skillTrees/3rdClass/ElfDeathKnight.xml
@@ -1,0 +1,233 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
+	<skillTree type="classSkillTree" classId="203" parentClassId="202">
+
+		<skill name="Slowdown" id="15" level="53" required-level="76" sp="8000000" />
+		<skill name="Entangle" id="102" level="17" required-level="76" sp="8000000" />
+		<skill name="Hellfire" id="45312" level="1" required-level="76" sp="8000000">
+			<item id="93631" count="1" /> <!-- Spellbook - Hellfire -->
+		</skill>
+		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="8000000">
+			<item id="8620" count="1" /> <!-- Buff Expansion Book Lv. 3 -->
+		</skill>
+		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="8000000">
+			<item id="8621" count="1" /> <!-- Buff Expansion Book Lv. 4 -->
+		</skill>
+		<skill name="Death Armor Mastery" id="45354" level="23" required-level="76" sp="8000000" />
+		<skill name="Death Sword Mastery" id="45353" level="23" required-level="76" sp="8000000" />
+		<skill name="Evolution Defense" id="45188" level="1" required-level="76">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Death Guard" id="45329" level="2" required-level="76" sp="8000000">
+			<item id="93388" count="1" /> <!-- Spellbook: Death Guard -->
+		</skill>
+		<skill name="Fist of Fury" id="45307" level="10" required-level="76" sp="8000000" />
+		<skill name="Might" id="1068" level="4" required-level="76" sp="8000000">
+			<item id="94135" count="1" /> <!-- Master's Book: Might -->
+		</skill>
+		<skill name="Ultimate Death Knight Transformation" id="54206" level="1" required-level="76" sp="8000000">
+			<item id="93387" count="1" /> <!-- Spellbook - Ultimate Death Knight Form -->
+		</skill>
+		<skill name="Detection" id="45190" level="1" required-level="76" sp="8000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Mount Night Mare" id="54207" level="1" required-level="76">
+			<item id="93383" count="1" /> <!-- Spellbook - Mount Nightmare Steed -->
+		</skill>
+		<skill name="Death Points" id="45352" level="3" required-level="76" auto-learn="true" />
+		<skill name="Devour" id="45389" level="1" required-level="76" sp="8000000">
+			<item id="94137" count="1" /> <!-- Spellbook: Devour -->
+		</skill>
+		<skill name="Deadly Ligament Rupture" id="45343" level="1" required-level="76" sp="8000000" />
+		<skill name="Death Blind" id="45342" level="11" required-level="76" sp="8000000" />
+		<skill name="Shield" id="1040" level="4" required-level="76" sp="8000000">
+			<item id="94136" count="1" /> <!-- Master's Book: Shield -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="46" required-level="76" sp="8000000" />
+
+		<skill name="Hellfire" id="45312" level="2" required-level="77" sp="10000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="2" required-level="77" sp="10000000" />
+		<skill name="Death Blind" id="45342" level="12" required-level="77" sp="10000000" />
+		<skill name="Emergency Rescue" id="70" level="47" required-level="77" sp="10000000" />
+
+		<skill name="Slowdown" id="15" level="54" required-level="78" sp="12000000" />
+		<skill name="Entangle" id="102" level="18" required-level="78" sp="12000000" />
+		<skill name="Hellfire" id="45312" level="3" required-level="78" sp="12000000" />
+		<skill name="Death Armor Mastery" id="45354" level="24" required-level="78" sp="12000000" />
+		<skill name="Death Sword Mastery" id="45353" level="24" required-level="78" sp="12000000" />
+		<skill name="Punishment" id="45301" level="15" required-level="78" sp="12000000" />
+		<skill name="Fist of Fury" id="45307" level="11" required-level="78" sp="12000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="3" required-level="78" sp="12000000" />
+		<skill name="Death Blind" id="45342" level="13" required-level="78" sp="12000000" />
+		<skill name="Emergency Rescue" id="70" level="48" required-level="78" sp="12000000" />
+
+		<skill name="Entangle" id="102" level="19" required-level="79" sp="15000000" />
+		<skill name="Hellfire" id="45312" level="4" required-level="79" sp="15000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="4" required-level="79" sp="15000000" />
+		<skill name="Death Blind" id="45342" level="14" required-level="79" sp="15000000" />
+		<skill name="Emergency Rescue" id="70" level="49" required-level="79" sp="15000000" />
+
+		<skill name="Slowdown" id="15" level="55" required-level="80" sp="18000000" />
+		<skill name="Hellfire" id="45312" level="5" required-level="80" sp="18000000" />
+		<skill name="Death Armor Mastery" id="45354" level="25" required-level="80" sp="18000000" />
+		<skill name="Death Sword Mastery" id="45353" level="25" required-level="80" sp="18000000" />
+		<skill name="Frozen Field" id="45316" level="1" required-level="80" sp="18000000">
+			<item id="93385" count="1" /> <!-- Spellbook: Frozen Field -->
+		</skill>
+		<skill name="Bone Cage" id="45338" level="5" required-level="80" sp="18000000" />
+		<skill name="Soul Steal" id="45335" level="4" required-level="80" sp="18000000" />
+		<skill name="Fist of Fury" id="45307" level="12" required-level="80" sp="18000000" />
+		<skill name="Evolution Power" id="45189" level="1" required-level="80">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Flaming Body" id="45332" level="3" required-level="80" sp="18000000" />
+		<skill name="Wipeout" id="45303" level="8" required-level="80" sp="18000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="5" required-level="80" sp="18000000" />
+		<skill name="Roar of Death" id="45328" level="4" required-level="80" sp="18000000" />
+		<skill name="Undying Body" id="45350" level="5" required-level="80" auto-learn="true" />
+		<skill name="Death Blind" id="45342" level="15" required-level="80" sp="18000000" />
+		<skill name="Deadly Pull" id="45311" level="8" required-level="80" sp="18000000" />
+		<skill name="Emergency Rescue" id="70" level="50" required-level="80" sp="18000000" />
+		<skill name="Entangle" id="102" level="20" required-level="80" sp="18000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+
+		<skill name="Slowdown" id="15" level="56" required-level="81" sp="160000000" />
+		<skill name="Hellfire" id="45312" level="6" required-level="81" sp="160000000" />
+		<skill name="Death Armor Mastery" id="45354" level="26" required-level="81" sp="160000000" />
+		<skill name="Death Sword Mastery" id="45353" level="26" required-level="81" sp="160000000" />
+		<skill name="Punishment" id="45301" level="16" required-level="81" sp="160000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="6" required-level="81" sp="160000000" />
+		<skill name="Death Blind" id="45342" level="16" required-level="81" sp="160000000" />
+		<skill name="Emergency Rescue" id="70" level="51" required-level="81" sp="160000000" />
+		<skill name="Entangle" id="102" level="21" required-level="81" sp="160000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+
+		<skill name="Slowdown" id="15" level="57" required-level="82" sp="170000000" />
+		<skill name="Hellfire" id="45312" level="7" required-level="82" sp="170000000" />
+		<skill name="Death Armor Mastery" id="45354" level="27" required-level="82" sp="170000000" />
+		<skill name="Death Sword Mastery" id="45353" level="27" required-level="82" sp="170000000" />
+		<skill name="Bone Cage" id="45338" level="6" required-level="82" sp="170000000" />
+		<skill name="Fist of Fury" id="45307" level="13" required-level="82" sp="170000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="7" required-level="82" sp="170000000" />
+		<skill name="Death Blind" id="45342" level="17" required-level="82" sp="170000000" />
+		<skill name="Emergency Rescue" id="70" level="52" required-level="82" sp="170000000" />
+		<skill name="Entangle" id="102" level="22" required-level="82" sp="170000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+
+		<skill name="Slowdown" id="15" level="58" required-level="83" sp="240000000" />
+		<skill name="Hellfire" id="45312" level="8" required-level="83" sp="240000000" />
+		<skill name="Death Armor Mastery" id="45354" level="28" required-level="83" sp="240000000" />
+		<skill name="Death Sword Mastery" id="45353" level="28" required-level="83" sp="240000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="8" required-level="83" sp="240000000" />
+		<skill name="Death Blind" id="45342" level="18" required-level="83" sp="240000000" />
+		<skill name="Emergency Rescue" id="70" level="53" required-level="83" sp="240000000" />
+		<skill name="Entangle" id="102" level="23" required-level="83" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+
+		<skill name="Slowdown" id="15" level="59" required-level="84" sp="240000000" />
+		<skill name="Hellfire" id="45312" level="9" required-level="84" sp="240000000" />
+		<skill name="Death Armor Mastery" id="45354" level="29" required-level="84" sp="240000000" />
+		<skill name="Death Sword Mastery" id="45353" level="29" required-level="84" sp="240000000" />
+		<skill name="Bone Cage" id="45338" level="7" required-level="84" sp="240000000" />
+		<skill name="Fist of Fury" id="45307" level="14" required-level="84" sp="240000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="9" required-level="84" sp="240000000" />
+		<skill name="Death Blind" id="45342" level="19" required-level="84" sp="240000000" />
+		<skill name="Emergency Rescue" id="70" level="54" required-level="84" sp="240000000" />
+		<skill name="Entangle" id="102" level="24" required-level="84" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+
+		<skill name="Slowdown" id="15" level="60" required-level="85" sp="840000000" />
+		<skill name="Hellfire" id="45312" level="10" required-level="85" sp="840000000" />
+		<skill name="Death Armor Mastery" id="45354" level="30" required-level="85" sp="840000000" />
+		<skill name="Death Sword Mastery" id="45353" level="30" required-level="85" sp="840000000" />
+		<skill name="Frozen Field" id="45316" level="2" required-level="85" sp="840000000" />
+		<skill name="Punishment" id="45301" level="17" required-level="85" sp="840000000" />
+		<skill name="Fist of Fury" id="45307" level="15" required-level="85" sp="840000000" />
+		<skill name="Flaming Body" id="45332" level="4" required-level="85" sp="840000000" />
+		<skill name="Wipeout" id="45303" level="9" required-level="85" sp="840000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="10" required-level="85" sp="840000000" />
+		<skill name="Death Blind" id="45342" level="20" required-level="85" sp="840000000" />
+		<skill name="Deadly Pull" id="45311" level="9" required-level="85" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="55" required-level="85" sp="840000000" />
+		<skill name="Entangle" id="102" level="25" required-level="85" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+
+		<skill name="Slowdown" id="15" level="61" required-level="86" sp="840000000" />
+		<skill name="Hellfire" id="45312" level="11" required-level="86" sp="840000000" />
+		<skill name="Death Armor Mastery" id="45354" level="31" required-level="86" sp="840000000" />
+		<skill name="Death Sword Mastery" id="45353" level="31" required-level="86" sp="840000000" />
+		<skill name="Bone Cage" id="45338" level="8" required-level="86" sp="840000000" />
+		<skill name="Fist of Fury" id="45307" level="16" required-level="86" sp="840000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="11" required-level="86" sp="840000000" />
+		<skill name="Death Blind" id="45342" level="21" required-level="86" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="56" required-level="86" sp="840000000" />
+		<skill name="Entangle" id="102" level="26" required-level="86" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+
+		<skill name="Slowdown" id="15" level="62" required-level="87" sp="840000000" />
+		<skill name="Hellfire" id="45312" level="12" required-level="87" sp="840000000" />
+		<skill name="Death Armor Mastery" id="45354" level="32" required-level="87" sp="840000000" />
+		<skill name="Death Sword Mastery" id="45353" level="32" required-level="87" sp="840000000" />
+		<skill name="Punishment" id="45301" level="18" required-level="87" sp="840000000" />
+		<skill name="Fist of Fury" id="45307" level="17" required-level="87" sp="840000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="12" required-level="87" sp="840000000" />
+		<skill name="Death Blind" id="45342" level="22" required-level="87" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="57" required-level="87" sp="840000000" />
+		<skill name="Entangle" id="102" level="27" required-level="87" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+
+		<skill name="Slowdown" id="15" level="63" required-level="88" sp="840000000" />
+		<skill name="Hellfire" id="45312" level="13" required-level="88" sp="840000000" />
+		<skill name="Death Armor Mastery" id="45354" level="33" required-level="88" sp="840000000" />
+		<skill name="Death Sword Mastery" id="45353" level="33" required-level="88" sp="840000000" />
+		<skill name="Bone Cage" id="45338" level="9" required-level="88" sp="840000000" />
+		<skill name="Fist of Fury" id="45307" level="18" required-level="88" sp="840000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="13" required-level="88" sp="840000000" />
+		<skill name="Death Blind" id="45342" level="23" required-level="88" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="58" required-level="88" sp="840000000" />
+		<skill name="Entangle" id="102" level="28" required-level="88" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+
+		<skill name="Slowdown" id="15" level="64" required-level="89" sp="840000000" />
+		<skill name="Hellfire" id="45312" level="14" required-level="89" sp="840000000" />
+		<skill name="Death Armor Mastery" id="45354" level="34" required-level="89" sp="840000000" />
+		<skill name="Death Sword Mastery" id="45353" level="34" required-level="89" sp="840000000" />
+		<skill name="Punishment" id="45301" level="19" required-level="89" sp="840000000" />
+		<skill name="Fist of Fury" id="45307" level="19" required-level="89" sp="840000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="14" required-level="89" sp="840000000" />
+		<skill name="Death Blind" id="45342" level="24" required-level="89" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="59" required-level="89" sp="840000000" />
+		<skill name="Entangle" id="102" level="29" required-level="89" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+
+		<skill name="Slowdown" id="15" level="65" required-level="90" sp="840000000" />
+		<skill name="Hellfire" id="45312" level="15" required-level="90" sp="840000000" />
+		<skill name="Death Armor Mastery" id="45354" level="35" required-level="90" sp="840000000" />
+		<skill name="Death Sword Mastery" id="45353" level="35" required-level="90" sp="840000000" />
+		<skill name="Frozen Field" id="45316" level="3" required-level="90" sp="840000000" />
+		<skill name="Punishment" id="45301" level="20" required-level="90" sp="840000000" />
+		<skill name="Bone Cage" id="45338" level="10" required-level="90" sp="840000000" />
+		<skill name="Soul Steal" id="45335" level="5" required-level="90" sp="840000000" />
+		<skill name="Fist of Fury" id="45307" level="20" required-level="90" sp="840000000" />
+		<skill name="Flaming Body" id="45332" level="5" required-level="90" sp="840000000" />
+		<skill name="Wipeout" id="45303" level="10" required-level="90" sp="840000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="15" required-level="90" sp="840000000" />
+		<skill name="Roar of Death" id="45328" level="5" required-level="90" sp="840000000" />
+		<skill name="Death Blind" id="45342" level="25" required-level="90" sp="840000000" />
+		<skill name="Deadly Pull" id="45311" level="10" required-level="90" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="60" required-level="90" sp="840000000" />
+		<skill name="Entangle" id="102" level="30" required-level="90" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+	</skillTree>
+</list>

--- a/data/skillTrees/3rdClass/EvaSaint.xml
+++ b/data/skillTrees/3rdClass/EvaSaint.xml
@@ -1,132 +1,286 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="105" parentClassId="30">
-		<skill name="White Guardian" id="54102" level="1" required-level="80" >
-			<item id="92401"/>
-		</skill>
-		<skill name="Might" id="1068" level="4" required-level="76" sp="8000000">
-			<item id="99046" count="1" /> <!-- Master's Book: Might -->
-		</skill>
-		<skill name="Shield" id="1040" level="4" required-level="76" sp="8000000">
-			<item id="99047" count="1" /> <!-- Master's Book: Shield -->
-		</skill>
+
 		<skill name="Anti Magic" id="146" level="46" required-level="76" sp="6800000" />
+		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="6800000">
+			<item id="8620" count="1" /> <!-- Buff Expansion Book Lv. 3 -->
+		</skill>
+		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="6800000">
+			<item id="8621" count="1" /> <!-- Buff Expansion Book Lv. 4 -->
+		</skill>
+		<skill name="Root Mastery" id="45238" level="1" required-level="76" sp="6800000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Light Armor Mastery" id="236" level="42" required-level="76" sp="6800000" />
 		<skill name="Robe Mastery" id="235" level="42" required-level="76" sp="6800000" />
 		<skill name="Weapon Mastery" id="249" level="43" required-level="76" sp="6800000" />
+		<skill name="Sleep Mastery" id="45239" level="1" required-level="76" sp="6800000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Evolution Defense" id="45188" level="1" required-level="76">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Dryad Root" id="1201" level="33" required-level="76" sp="6800000" />
+		<skill name="Mass Cure" id="1550" level="1" required-level="76" sp="6800000">
+			<item id="90104" count="1" /> <!-- Scroll: Mass Cure -->
+		</skill>
+		<skill name="Mass Vitalize" id="1552" level="1" required-level="76" sp="6800000">
+			<item id="90105" count="1" /> <!-- Scroll: Mass Vitalize -->
+		</skill>
+		<!-- Might Lv. 4 -->
+		<skill name="Might" id="1068" level="4" required-level="76" sp="6800000">
+			<item id="94135" count="1" /> <!-- Master's Book: Might -->
+		</skill>
+		<!-- Shield Lv. 4 -->
+		<skill name="Shield" id="1040" level="4" required-level="76" sp="6800000">
+			<item id="94136" count="1" /> <!-- Master's Book: Shield -->
+		</skill>
+		<!-- Acumen Lv. 4 -->
+		<skill name="Acumen" id="45104" level="4" required-level="76" sp="6800000">
+			<item id="94370" count="1" /> <!-- Master's Book: Acumen -->
+		</skill>
+		<!-- Empower Lv. 4 -->
+		<skill name="Empower" id="45105" level="4" required-level="76" sp="6800000">
+			<item id="94361" count="1" /> <!-- Master's Book: Empower -->
+		</skill>
+		<!-- Wild Magic Lv. 3 -->
+		<skill name="Wild Magic" id="45106" level="3" required-level="76" sp="6800000">
+			<item id="94368" count="1" /> <!-- Master's Book: Wild Magic -->
+		</skill>
+		<!-- Wind Walk Lv. 3 -->
+		<skill name="Wind Walk" id="45107" level="3" required-level="76" sp="6800000">
+			<item id="94365" count="1" /> <!-- Master's Book: Wind Walk -->
+		</skill>
+		<!-- Magic Barrier Lv. 3 -->
+		<skill name="Magic Barrier" id="45108" level="3" required-level="76" sp="6800000">
+			<item id="94362" count="1" /> <!-- Master's Book: Magic Barrier -->
+		</skill>
+		<!-- Focus Lv. 4 -->
+		<skill name="Focus" id="45109" level="4" required-level="76" sp="6800000">
+			<item id="94363" count="1" /> <!-- Master's Book: Focus -->
+		</skill>
+		<!-- Death Whisper Lv. 4 -->
+		<skill name="Death Whisper" id="45110" level="4" required-level="76" sp="6800000">
+			<item id="94364" count="1" /> <!-- Master's Book: Death Whisper -->
+		</skill>
+		<!-- Haste Lv. 3 -->
+		<skill name="Haste" id="45111" level="3" required-level="76" sp="6800000">
+			<item id="94369" count="1" /> <!-- Master's Book: Haste -->
+		</skill>
+		<!-- Berserker Spirit Lv. 3 -->
+		<skill name="Berserker Spirit" id="45112" level="3" required-level="76" sp="6800000">
+			<item id="94366" count="1" /> <!-- Master's Book: Berserker Spirit -->
+		</skill>
+		<!-- Clarity Lv. 4 -->
+		<skill name="Clarity" id="45113" level="4" required-level="76" sp="6800000">
+			<item id="94367" count="1" /> <!-- Master's Book: Clarity -->
+		</skill>
+		<skill name="Detection" id="45190" level="1" required-level="76" sp="6800000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Wind Shackle" id="1206" level="20" required-level="76" sp="6800000" />
-		<skill name="Recharge" id="1013" level="33" required-level="76" sp="6800000" />
-		<skill name="Eva's Serenade" id="1273" level="14" required-level="76" sp="6800000" />
-		<skill name="Might of Heaven" id="1028" level="20" required-level="76" sp="6800000" />
-		<skill name="Sleep" id="1069" level="43" required-level="76" sp="6800000" />
-		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="6800000">
-			<item id="8620"/> <!-- Ancient Book: Divine Inspiration (Manuscript) -->
-		</skill>
-		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="6800000">
-			<item id="8621"/> <!-- Ancient Book: Divine Inspiration (Original Version) -->
-		</skill>
 		<skill name="Mount Pegasus" id="1834" level="1" required-level="76">
-			<item id="90039"/> <!-- Spellbook: Mount Pegasus -->
+			<item id="90039" count="1" /> <!-- Spellbook - Ride Pegasus -->
 		</skill>
-		<skill name="Glory Ability" id="45361" level="1" required-level="86">
-			<item id="94046"/> <!-- Spellbook: Glory Ability Lv. 1 -->
-		</skill>
-		<skill name="Mount White Wings" id="54200" level="1" required-level="87">
-			<item id="93059"/> <!-- Spellbook: Summon White Wings -->
-		</skill>	
-		<skill name="Mount Shining Lady" id="54202" level="1" required-level="89">
-			<item id="93061"/> <!-- Spellbook: Summon Silver Saint -->
+		<skill name="Mana Gain" id="1460" level="1" required-level="76" sp="6800000">
+			<item id="90106" count="1" /> <!-- Scroll: Mana Gain -->
 		</skill>
 		<skill name="Prophecy of Water" id="1355" level="1" required-level="76" sp="6800000">
-			<item id="90103"/> <!-- Scroll: Prophecy of Water -->
+			<item id="90103" count="1" /> <!-- Scroll: Prophecy of Water -->
 		</skill>
-		
+		<skill name="Divine Beam" id="45241" level="1" required-level="76" sp="6800000">
+			<item id="93103" count="1" /> <!-- Spellbook: Divine Beam -->
+		</skill>
+		<skill name="Eva's Serenade" id="1273" level="14" required-level="76" sp="6800000" />
+		<skill name="Might of Heaven" id="1028" level="21" required-level="76" sp="6800000" />
+		<skill name="Weakness" id="1164" level="20" required-level="76" sp="6800000" />
+		<skill name="Boost Mana" id="1013" level="33" required-level="76" sp="6800000" />
+		<skill name="Sleep" id="1069" level="46" required-level="76" sp="6800000" />
 		<skill name="Anti Magic" id="146" level="47" required-level="77" sp="6800000" />
 		<skill name="Light Armor Mastery" id="236" level="43" required-level="77" sp="6800000" />
 		<skill name="Robe Mastery" id="235" level="43" required-level="77" sp="6800000" />
 		<skill name="Weapon Mastery" id="249" level="44" required-level="77" sp="6800000" />
-		<skill name="Sleep" id="1069" level="44" required-level="77" sp="6800000" />
-		<skill name="Mass Vitalize" id="1552" level="1" required-level="77" sp="6800000">
-			<item id="90105"/> <!-- Scroll: Mass Vitalize -->
-		</skill>
-		<skill name="Mass Cure Poison" id="1550" level="1" required-level="77" sp="6800000">
-			<item id="90104"/> <!-- Scroll: Mass Cure Poison -->
-		</skill>
-		
+		<skill name="Mana Gain" id="1460" level="2" required-level="77" sp="6800000" />
+		<skill name="Divine Beam" id="45241" level="2" required-level="77" sp="6800000" />
+		<skill name="Might of Heaven" id="1028" level="22" required-level="77" sp="6800000" />
+		<skill name="Sleep" id="1069" level="47" required-level="77" sp="6800000" />
+
 		<skill name="Anti Magic" id="146" level="48" required-level="78" sp="14900000" />
 		<skill name="Light Armor Mastery" id="236" level="44" required-level="78" sp="14900000" />
 		<skill name="Robe Mastery" id="235" level="44" required-level="78" sp="14900000" />
 		<skill name="Weapon Mastery" id="249" level="45" required-level="78" sp="14900000" />
+		<skill name="Dryad Root" id="1201" level="34" required-level="78" sp="14900000" />
 		<skill name="Wind Shackle" id="1206" level="21" required-level="78" sp="14900000" />
-		<skill name="Recharge" id="1013" level="34" required-level="78" sp="14900000" />
-		<skill name="Eva's Serenade" id="1273" level="15" required-level="78" sp="14900000" />
-		<skill name="Might of Heaven" id="1028" level="21" required-level="78" sp="14900000" />
-		<skill name="Sleep" id="1069" level="45" required-level="78" sp="14900000" />
+		<skill name="Mana Gain" id="1460" level="3" required-level="78" sp="14900000" />
 		<skill name="Enlightenment" id="1533" level="1" required-level="78" sp="14900000">
-			<item id="90111"/> <!-- Scroll: Enlightenment -->
+			<item id="90111" count="1" /> <!-- Scroll: Enlightenment -->
 		</skill>
-		
+		<skill name="Divine Beam" id="45241" level="3" required-level="78" sp="14900000" />
+		<skill name="Eva's Serenade" id="1273" level="15" required-level="78" sp="14900000" />
+		<skill name="Might of Heaven" id="1028" level="23" required-level="78" sp="14900000" />
+		<skill name="Weakness" id="1164" level="21" required-level="78" sp="14900000" />
+		<skill name="Boost Mana" id="1013" level="34" required-level="78" sp="14900000" />
+		<skill name="Sleep" id="1069" level="48" required-level="78" sp="14900000" />
+
+		<skill name="Root Mastery" id="45238" level="2" required-level="79" sp="14900000">
+			<item id="57" count="2000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Sleep Mastery" id="45239" level="2" required-level="79" sp="14900000">
+			<item id="57" count="2000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Wind Shackle" id="1206" level="22" required-level="79" sp="14900000" />
-		<skill name="Sleep" id="1069" level="46" required-level="79" sp="14900000" />
-		<skill name="Mana Gain" id="1460" level="1" required-level="79" sp="14900000">
-			<item id="90106"/> <!-- Scroll: Mana Gain -->
-		</skill>
+		<skill name="Mana Gain" id="1460" level="4" required-level="79" sp="14900000" />
+		<skill name="Divine Beam" id="45241" level="4" required-level="79" sp="14900000" />
+		<skill name="Might of Heaven" id="1028" level="24" required-level="79" sp="14900000" />
+		<skill name="Sleep" id="1069" level="49" required-level="79" sp="14900000" />
 
 		<skill name="Anti Magic" id="146" level="49" required-level="80" sp="14900000" />
+		<skill name="Blessing of Eva" id="1506" level="1" required-level="80" sp="14900000">
+			<item id="90107" count="1" /> <!-- Scroll: Blessing of Eva -->
+		</skill>
 		<skill name="Light Armor Mastery" id="236" level="45" required-level="80" sp="14900000" />
 		<skill name="Robe Mastery" id="235" level="45" required-level="80" sp="14900000" />
 		<skill name="Weapon Mastery" id="249" level="46" required-level="80" sp="14900000" />
-		<skill name="Wind Shackle" id="1206" level="23" required-level="80" sp="14900000" />
-		<skill name="Recharge" id="1013" level="35" required-level="80" sp="14900000" />
-		<skill name="Mana Gain" id="1460" level="2" required-level="80" sp="14900000" />
-		<skill name="Might of Heaven" id="1028" level="22" required-level="80" sp="14900000" />
-		<skill name="Sleep" id="1069" level="47" required-level="80" sp="14900000" />
-		<skill name="Blessing of Eva" id="1506" level="1" required-level="80" sp="14900000">
-			<item id="90107"/> <!-- Scroll: Blessing of Eva -->
+		<skill name="Dryad Root" id="1201" level="35" required-level="80" sp="14900000" />
+		<skill name="Swap Defense" id="1392" level="4" required-level="80" sp="10000000" />
+		<skill name="Mass Cure" id="1550" level="2" required-level="80" sp="14900000" />
+		<skill name="Mass Vitalize" id="1552" level="2" required-level="80" sp="14900000" />
+		<skill name="Spell Master" id="1830" level="4" required-level="80" sp="2400000">
+			<item id="57" count="500000" /> <!-- Adena -->
 		</skill>
-		
+		<skill name="Evolution Power" id="45189" level="1" required-level="80">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Wind Shackle" id="1206" level="23" required-level="80" sp="14900000" />
+		<skill name="Mana Gain" id="1460" level="5" required-level="80" sp="14900000" />
+		<skill name="Divine Beam" id="45241" level="5" required-level="80" sp="14900000" />
+		<skill name="Might of Heaven" id="1028" level="25" required-level="80" sp="14900000" />
+		<skill name="Weakness" id="1164" level="22" required-level="80" sp="14900000" />
+		<skill name="White Guardian Transformation" id="54102" level="1" required-level="80">
+			<item id="92401" count="1" /> <!-- Spellbook - White Guardian -->
+		</skill>
+		<skill name="Boost Mana" id="1013" level="35" required-level="80" sp="14900000" />
+		<skill name="Sleep" id="1069" level="50" required-level="80" sp="14900000" />
+
 		<skill name="Anti Magic" id="146" level="50" required-level="81" sp="160000000" />
 		<skill name="Light Armor Mastery" id="236" level="46" required-level="81" sp="160000000" />
 		<skill name="Robe Mastery" id="235" level="46" required-level="81" sp="160000000" />
 		<skill name="Weapon Mastery" id="249" level="47" required-level="81" sp="160000000" />
-		<skill name="Mass Vitalize" id="1552" level="2" required-level="81" sp="160000000" />
+		<skill name="Dryad Root" id="1201" level="36" required-level="81" sp="160000000" />
 		<skill name="Wind Shackle" id="1206" level="24" required-level="81" sp="160000000" />
-		<skill name="Recharge" id="1013" level="36" required-level="81" sp="160000000" />
-		<skill name="Mana Gain" id="1460" level="3" required-level="81" sp="160000000" />
-		<skill name="Might of Heaven" id="1028" level="23" required-level="81" sp="160000000" />
-		<skill name="Sleep" id="1069" level="48" required-level="81" sp="160000000" />
+		<skill name="Mana Gain" id="1460" level="6" required-level="81" sp="160000000" />
+		<skill name="Divine Beam" id="45241" level="6" required-level="81" sp="160000000" />
+		<skill name="Might of Heaven" id="1028" level="26" required-level="81" sp="160000000" />
+		<skill name="Weakness" id="1164" level="23" required-level="81" sp="160000000" />
+		<skill name="Boost Mana" id="1013" level="36" required-level="81" sp="160000000" />
+		<skill name="Sleep" id="1069" level="51" required-level="81" sp="160000000" />
 
 		<skill name="Anti Magic" id="146" level="51" required-level="82" sp="170000000" />
+		<skill name="Root Mastery" id="45238" level="3" required-level="82" sp="170000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Light Armor Mastery" id="236" level="47" required-level="82" sp="170000000" />
 		<skill name="Robe Mastery" id="235" level="47" required-level="82" sp="170000000" />
 		<skill name="Weapon Mastery" id="249" level="48" required-level="82" sp="170000000" />
+		<skill name="Sleep Mastery" id="45239" level="3" required-level="82" sp="170000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Dryad Root" id="1201" level="37" required-level="82" sp="170000000" />
 		<skill name="Wind Shackle" id="1206" level="25" required-level="82" sp="170000000" />
-		<skill name="Recharge" id="1013" level="37" required-level="82" sp="170000000" />
+		<skill name="Mana Gain" id="1460" level="7" required-level="82" sp="170000000" />
 		<skill name="Prophecy of Water" id="1355" level="2" required-level="82" sp="170000000" />
-		<skill name="Might of Heaven" id="1028" level="24" required-level="82" sp="170000000" />
-		<skill name="Sleep" id="1069" level="49" required-level="82" sp="170000000" />
+		<skill name="Divine Beam" id="45241" level="7" required-level="82" sp="170000000" />
+		<skill name="Might of Heaven" id="1028" level="27" required-level="82" sp="170000000" />
+		<skill name="Weakness" id="1164" level="24" required-level="82" sp="170000000" />
+		<skill name="Boost Mana" id="1013" level="37" required-level="82" sp="170000000" />
+		<skill name="Sleep" id="1069" level="52" required-level="82" sp="170000000" />
 
 		<skill name="Anti Magic" id="146" level="52" required-level="83" sp="240000000" />
 		<skill name="Light Armor Mastery" id="236" level="48" required-level="83" sp="240000000" />
 		<skill name="Robe Mastery" id="235" level="48" required-level="83" sp="240000000" />
 		<skill name="Weapon Mastery" id="249" level="49" required-level="83" sp="240000000" />
+		<skill name="Dryad Root" id="1201" level="38" required-level="83" sp="240000000" />
 		<skill name="Wind Shackle" id="1206" level="26" required-level="83" sp="240000000" />
-		<skill name="Recharge" id="1013" level="38" required-level="83" sp="240000000" />
-		<skill name="Might of Heaven" id="1028" level="25" required-level="83" sp="240000000" />
-		<skill name="Sleep" id="1069" level="50" required-level="83" sp="240000000" />
+		<skill name="Mana Gain" id="1460" level="8" required-level="83" sp="240000000" />
+		<skill name="Divine Beam" id="45241" level="8" required-level="83" sp="240000000" />
+		<skill name="Might of Heaven" id="1028" level="28" required-level="83" sp="240000000" />
+		<skill name="Weakness" id="1164" level="25" required-level="83" sp="240000000" />
+		<skill name="Boost Mana" id="1013" level="38" required-level="83" sp="240000000" />
+		<skill name="Sleep" id="1069" level="53" required-level="83" sp="240000000" />
 
 		<skill name="Anti Magic" id="146" level="53" required-level="84" sp="240000000" />
 		<skill name="Light Armor Mastery" id="236" level="49" required-level="84" sp="240000000" />
 		<skill name="Robe Mastery" id="235" level="49" required-level="84" sp="240000000" />
 		<skill name="Weapon Mastery" id="249" level="50" required-level="84" sp="240000000" />
+		<skill name="Dryad Root" id="1201" level="39" required-level="84" sp="240000000" />
 		<skill name="Wind Shackle" id="1206" level="27" required-level="84" sp="240000000" />
-		<skill name="Recharge" id="1013" level="39" required-level="84" sp="240000000" />
-		<skill name="Might of Heaven" id="1028" level="26" required-level="84" sp="240000000" />
-		<skill name="Sleep" id="1069" level="51" required-level="84" sp="240000000" />
-		
+		<skill name="Mana Gain" id="1460" level="9" required-level="84" sp="240000000" />
+		<skill name="Divine Beam" id="45241" level="9" required-level="84" sp="240000000" />
+		<skill name="Might of Heaven" id="1028" level="29" required-level="84" sp="240000000" />
+		<skill name="Weakness" id="1164" level="26" required-level="84" sp="240000000" />
+		<skill name="Boost Mana" id="1013" level="39" required-level="84" sp="240000000" />
+		<skill name="Sleep" id="1069" level="54" required-level="84" sp="240000000" />
+
 		<skill name="Anti Magic" id="146" level="54" required-level="85" sp="840000000" />
+		<skill name="Root Mastery" id="45238" level="4" required-level="85" sp="840000000">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Light Armor Mastery" id="236" level="50" required-level="85" sp="840000000" />
 		<skill name="Robe Mastery" id="235" level="50" required-level="85" sp="840000000" />
 		<skill name="Weapon Mastery" id="249" level="51" required-level="85" sp="840000000" />
+		<skill name="Sleep Mastery" id="45239" level="4" required-level="85" sp="840000000">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Dryad Root" id="1201" level="40" required-level="85" sp="840000000" />
+		<skill name="Mana Gain" id="1460" level="10" required-level="85" sp="840000000" />
+		<skill name="Divine Beam" id="45241" level="10" required-level="85" sp="840000000" />
+		<skill name="Might of Heaven" id="1028" level="30" required-level="85" sp="840000000" />
+		<skill name="Sleep" id="1069" level="55" required-level="85" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="55" required-level="86" sp="840000000" />
+		<skill name="Light Armor Mastery" id="236" level="51" required-level="86" sp="840000000" />
+		<skill name="Robe Mastery" id="235" level="51" required-level="86" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="52" required-level="86" sp="840000000" />
+		<skill name="Dryad Root" id="1201" level="41" required-level="86" sp="840000000" />
+		<skill name="Divine Beam" id="45241" level="11" required-level="86" sp="840000000" />
+		<skill name="Might of Heaven" id="1028" level="31" required-level="86" sp="840000000" />
+		<skill name="Sleep" id="1069" level="56" required-level="86" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="56" required-level="87" sp="840000000" />
+		<skill name="Light Armor Mastery" id="236" level="52" required-level="87" sp="840000000" />
+		<skill name="Robe Mastery" id="235" level="52" required-level="87" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="53" required-level="87" sp="840000000" />
+		<skill name="Dryad Root" id="1201" level="42" required-level="87" sp="840000000" />
+		<skill name="Divine Beam" id="45241" level="12" required-level="87" sp="840000000" />
+		<skill name="Might of Heaven" id="1028" level="32" required-level="87" sp="840000000" />
+		<skill name="Sleep" id="1069" level="57" required-level="87" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="57" required-level="88" sp="840000000" />
+		<skill name="Light Armor Mastery" id="236" level="53" required-level="88" sp="840000000" />
+		<skill name="Robe Mastery" id="235" level="53" required-level="88" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="54" required-level="88" sp="840000000" />
+		<skill name="Dryad Root" id="1201" level="43" required-level="88" sp="840000000" />
+		<skill name="Divine Beam" id="45241" level="13" required-level="88" sp="840000000" />
+		<skill name="Might of Heaven" id="1028" level="33" required-level="88" sp="840000000" />
+		<skill name="Sleep" id="1069" level="58" required-level="88" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="58" required-level="89" sp="840000000" />
+		<skill name="Light Armor Mastery" id="236" level="54" required-level="89" sp="840000000" />
+		<skill name="Robe Mastery" id="235" level="54" required-level="89" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="55" required-level="89" sp="840000000" />
+		<skill name="Dryad Root" id="1201" level="44" required-level="89" sp="840000000" />
+		<skill name="Divine Beam" id="45241" level="14" required-level="89" sp="840000000" />
+		<skill name="Might of Heaven" id="1028" level="34" required-level="89" sp="840000000" />
+		<skill name="Sleep" id="1069" level="59" required-level="89" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="59" required-level="90" sp="840000000" />
+		<skill name="Light Armor Mastery" id="236" level="55" required-level="90" sp="840000000" />
+		<skill name="Robe Mastery" id="235" level="55" required-level="90" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="56" required-level="90" sp="840000000" />
+		<skill name="Dryad Root" id="1201" level="45" required-level="90" sp="840000000" />
+		<skill name="Divine Beam" id="45241" level="15" required-level="90" sp="840000000" />
+		<skill name="Might of Heaven" id="1028" level="35" required-level="90" sp="840000000" />
+		<skill name="Sleep" id="1069" level="60" required-level="90" sp="840000000" />
 	</skillTree>
 </list>

--- a/data/skillTrees/3rdClass/EvaTemplar.xml
+++ b/data/skillTrees/3rdClass/EvaTemplar.xml
@@ -1,18 +1,87 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="99" parentClassId="20">
-		<skill name="White Guardian" id="54102" level="1" required-level="80" >
-			<item id="92401"/>
-		</skill>
+
 		<skill name="Aggression" id="28" level="50" required-level="76" sp="5800000" />
-		<skill name="Arrest" id="402" level="11" required-level="76" sp="5800000" />
 		<skill name="Aggression Aura" id="18" level="38" required-level="76" sp="5800000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="46" required-level="76" sp="5800000" />
+		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="5800000">
+			<item id="8620" count="1" /> <!-- Buff Expansion Book Lv. 3 -->
+		</skill>
+		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="5800000">
+			<item id="8621" count="1" /> <!-- Buff Expansion Book Lv. 4 -->
+		</skill>
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="46" required-level="76" sp="5800000" />
+		<skill name="Weapon Mastery" id="141" level="5" required-level="76" sp="5800000" />
 		<skill name="Heavy Armor Mastery" id="232" level="53" required-level="76" sp="5800000" />
 		<skill name="Shield Charge" id="1898" level="1" required-level="76" sp="5800000" />
+		<skill name="Evolution Defense" id="45188" level="1" required-level="76">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Shackle" id="402" level="11" required-level="76" sp="5800000" />
 		<skill name="Magic Resistance" id="147" level="52" required-level="76" sp="5800000" />
+		<skill name="Mass Shackling" id="404" level="6" required-level="76" sp="5800000" />
+
+		<!-- Might Lv. 4 -->
+
+		<skill name="Might" id="1068" level="4" required-level="76" sp="5800000">
+			<item id="94135" count="1" /> <!-- Master's Book: Might -->
+		</skill>
+
+		<!-- Shield Lv. 4 -->
+		<skill name="Shield" id="1040" level="4" required-level="76" sp="5800000">
+			<item id="94136" count="1" /> <!-- Master's Book: Shield -->
+		</skill>
+		<!-- Acumen Lv. 4 -->
+		<skill name="Acumen" id="45104" level="4" required-level="76" sp="5800000">
+			<item id="94370" count="1" /> <!-- Master's Book: Acumen -->
+		</skill>
+		<!-- Empower Lv. 4 -->
+		<skill name="Empower" id="45105" level="4" required-level="76" sp="5800000">
+			<item id="94361" count="1" /> <!-- Master's Book: Empower -->
+		</skill>
+		<!-- Wild Magic Lv. 3 -->
+		<skill name="Wild Magic" id="45106" level="3" required-level="76" sp="5800000">
+			<item id="94368" count="1" /> <!-- Master's Book: Wild Magic -->
+		</skill>
+		<!-- Wind Walk Lv. 3 -->
+		<skill name="Wind Walk" id="45107" level="3" required-level="76" sp="5800000">
+			<item id="94365" count="1" /> <!-- Master's Book: Wind Walk -->
+		</skill>
+		<!-- Magic Barrier Lv. 3 -->
+		<skill name="Magic Barrier" id="45108" level="3" required-level="76" sp="5800000">
+			<item id="94362" count="1" /> <!-- Master's Book: Magic Barrier -->
+		</skill>
+		<!-- Focus Lv. 4 -->
+		<skill name="Focus" id="45109" level="4" required-level="76" sp="5800000">
+			<item id="94363" count="1" /> <!-- Master's Book: Focus -->
+		</skill>
+		<!-- Death Whisper Lv. 4 -->
+		<skill name="Death Whisper" id="45110" level="4" required-level="76" sp="5800000">
+			<item id="94364" count="1" /> <!-- Master's Book: Death Whisper -->
+		</skill>
+		<!-- Haste Lv. 3 -->
+		<skill name="Haste" id="45111" level="3" required-level="76" sp="5800000">
+			<item id="94369" count="1" /> <!-- Master's Book: Haste -->
+		</skill>
+		<!-- Berserker Spirit Lv. 3 -->
+		<skill name="Berserker Spirit" id="45112" level="3" required-level="76" sp="5800000">
+			<item id="94366" count="1" /> <!-- Master's Book: Berserker Spirit -->
+		</skill>
+		<!-- Clarity Lv. 4 -->
+		<skill name="Clarity" id="45113" level="4" required-level="76" sp="5800000">
+			<item id="94367" count="1" /> <!-- Master's Book: Clarity -->
+		</skill>
+		<skill name="Detection" id="45190" level="1" required-level="76" sp="5800000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Entangle" id="102" level="17" required-level="76" sp="5800000" />
-		<skill name="Charm" id="15" level="53" required-level="76" sp="5800000" />
+		<skill name="Mount Pegasus" id="1834" level="1" required-level="76">
+			<item id="90039" count="1" /> <!-- Spellbook - Ride Pegasus -->
+		</skill>
+		<skill name="Slowdown" id="15" level="53" required-level="76" sp="5800000" />
+		<skill name="Power of Eva" id="45371" level="1" required-level="76" sp="5800000">
+			<item id="93871" count="1" /> <!-- Spellbook: Knight's Help -->
+		</skill>
 		<skill name="Final Fortress" id="291" level="12" required-level="76" sp="5800000" />
 		<skill name="Summon Attractive Cubic" id="449" level="5" required-level="76" sp="5800000" />
 		<skill name="Summon Life Cubic" id="67" level="9" required-level="76" sp="5800000" />
@@ -21,173 +90,316 @@
 		<skill name="Fortitude" id="335" level="1" required-level="76" sp="5800000" />
 		<skill name="Tribunal" id="400" level="16" required-level="76" sp="5800000" />
 		<skill name="Shield Bash" id="352" level="6" required-level="76" sp="5800000" />
-		<skill name="Critical Vulnerability Decrease" id="53004" level="1" required-level="76" sp="5800000" />
+		<skill name="Critical Vulnerability Decrease" id="53004" level="1" required-level="76" sp="5800000">
+			<item id="91485" count="1" /> <!-- Scroll: Critical Vulnerability Decrease -->
+		</skill>
 		<skill name="Chain Strike" id="10015" level="1" required-level="76" sp="5800000" />
-		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="5800000">
-			<item id="8620"/> <!-- Ancient Book: Divine Inspiration (Manuscript) -->
-		</skill>
-		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="5800000">
-			<item id="8621"/> <!-- Ancient Book: Divine Inspiration (Original Version) -->
-		</skill>
-		<skill name="Mount Pegasus" id="1834" level="1" required-level="76">
-			<item id="90039"/> <!-- Spellbook: Mount Pegasus -->
-		</skill>
-		<skill name="Glory Ability" id="45361" level="1" required-level="86">
-			<item id="94046"/> <!-- Spellbook: Glory Ability Lv. 1 -->
-		</skill>
-		<skill name="Mount White Wings" id="54200" level="1" required-level="87">
-			<item id="93059"/> <!-- Spellbook: Summon White Wings -->
-		</skill>	
-		<skill name="Mount Shining Lady" id="54202" level="1" required-level="89">
-			<item id="93061"/> <!-- Spellbook: Summon Silver Saint -->
-		</skill>
-		
+		<skill name="Emergency Rescue" id="70" level="46" required-level="76" sp="5800000" />
+
 		<skill name="Aggression" id="28" level="51" required-level="77" sp="5800000" />
 		<skill name="Aggression Aura" id="18" level="39" required-level="77" sp="5800000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="47" required-level="77" sp="5800000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="47" required-level="77" sp="5800000" />
 		<skill name="Heavy Armor Mastery" id="232" level="54" required-level="77" sp="5800000" />
 		<skill name="Shield Charge" id="1898" level="2" required-level="77" sp="5800000" />
+		<skill name="Shackle" id="402" level="12" required-level="77" sp="5800000" />
 		<skill name="Magic Resistance" id="147" level="53" required-level="77" sp="5800000" />
+		<skill name="Mass Shackling" id="404" level="7" required-level="77" sp="5800000" />
+		<skill name="Vengeance" id="368" level="1" required-level="77" sp="5800000">
+			<item id="90046" count="1" /> <!-- Scroll: Vengeance -->
+		</skill>
 		<skill name="Deflect Magic" id="913" level="1" required-level="77" sp="5800000" />
 		<skill name="Final Fortress" id="291" level="13" required-level="77" sp="5800000" />
-		<skill name="Vengeance" id="368" level="1" required-level="77" sp="5800000">
-			<item id="90046"/> <!-- Scroll: Vengeance -->
-		</skill>
-		
+		<skill name="Holy Aura" id="107" level="11" required-level="77" sp="5800000" />
+		<skill name="Tribunal" id="400" level="17" required-level="77" sp="5800000" />
+		<skill name="Emergency Rescue" id="70" level="47" required-level="77" sp="5800000" />
+
 		<skill name="Aggression" id="28" level="52" required-level="78" sp="13600000" />
-		<skill name="Arrest" id="402" level="12" required-level="78" sp="13600000" />
 		<skill name="Aggression Aura" id="18" level="40" required-level="78" sp="13600000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="48" required-level="78" sp="13600000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="48" required-level="78" sp="13600000" />
 		<skill name="Heavy Armor Mastery" id="232" level="55" required-level="78" sp="13600000" />
 		<skill name="Shield Charge" id="1898" level="3" required-level="78" sp="13600000" />
+		<skill name="Shackle" id="402" level="13" required-level="78" sp="13600000" />
 		<skill name="Magic Resistance" id="147" level="54" required-level="78" sp="13600000" />
-		<skill name="Mass Chain Strike" id="53003" level="1" required-level="78" sp="13600000" />
+		<skill name="Mass Shackling" id="404" level="8" required-level="78" sp="13600000" />
+		<skill name="Mass Chain Strike" id="53003" level="1" required-level="78" sp="13600000">
+			<item id="91484" count="1" /> <!-- Scroll: Mass Chain Strike -->
+		</skill>
 		<skill name="Entangle" id="102" level="18" required-level="78" sp="13600000" />
-		<skill name="Charm" id="15" level="54" required-level="78" sp="13600000" />
+		<skill name="Slowdown" id="15" level="54" required-level="78" sp="13600000" />
 		<skill name="Final Fortress" id="291" level="14" required-level="78" sp="13600000" />
 		<skill name="Summon Attractive Cubic" id="449" level="6" required-level="78" sp="13600000" />
 		<skill name="Summon Life Cubic" id="67" level="10" required-level="78" sp="13600000" />
 		<skill name="Summon Storm Cubic" id="10" level="10" required-level="78" sp="13600000" />
+		<skill name="Touch of Life" id="341" level="1" required-level="78" sp="13600000">
+			<item id="90047" count="1" /> <!-- Scroll: Touch of Life -->
+		</skill>
 		<skill name="Knighthood" id="429" level="1" required-level="78" sp="13600000" />
-		<skill name="Holy Aura" id="107" level="11" required-level="78" sp="13600000" />
-		<skill name="Tribunal" id="400" level="17" required-level="78" sp="13600000" />
+		<skill name="Holy Aura" id="107" level="12" required-level="78" sp="13600000" />
+		<skill name="Tribunal" id="400" level="18" required-level="78" sp="13600000" />
 		<skill name="Shield Bash" id="352" level="7" required-level="78" sp="13600000" />
 		<skill name="Critical Vulnerability Decrease" id="53004" level="2" required-level="78" sp="13600000" />
-		<skill name="Touch of Life" id="341" level="1" required-level="78" sp="13600000">
-			<item id="90047"/> <!-- Scroll: Touch of Life -->
-		</skill>
-		
+		<skill name="Emergency Rescue" id="70" level="48" required-level="78" sp="13600000" />
+
 		<skill name="Shield Charge" id="1898" level="4" required-level="79" sp="13600000" />
+		<skill name="Shackle" id="402" level="14" required-level="79" sp="13600000" />
+		<skill name="Mass Shackling" id="404" level="9" required-level="79" sp="13600000" />
+		<skill name="Entangle" id="102" level="19" required-level="79" sp="13600000" />
 		<skill name="Final Fortress" id="291" level="15" required-level="79" sp="13600000" />
 		<skill name="Knighthood" id="429" level="2" required-level="79" sp="13600000" />
+		<skill name="Tribunal" id="400" level="19" required-level="79" sp="13600000" />
 		<skill name="Shield of Faith" id="528" level="1" required-level="79" sp="13600000">
-			<item id="90049"/> <!-- Scroll: Shield of Faith -->
+			<item id="90049" count="1" /> <!-- Scroll: Shield of Faith -->
 		</skill>
-		
+		<skill name="Emergency Rescue" id="70" level="49" required-level="79" sp="13600000" />
+
 		<skill name="Aggression" id="28" level="53" required-level="80" sp="13600000" />
 		<skill name="Aggression Aura" id="18" level="41" required-level="80" sp="13600000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="49" required-level="80" sp="13600000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="49" required-level="80" sp="13600000" />
 		<skill name="Heavy Armor Mastery" id="232" level="56" required-level="80" sp="13600000" />
 		<skill name="Shield Charge" id="1898" level="5" required-level="80" sp="13600000" />
+		<skill name="Eva's Protection" id="1623" level="1" required-level="80" sp="13600000">
+			<item id="90052" count="1" /> <!-- Scroll: Eva's Protection -->
+		</skill>
+		<skill name="Shackle" id="402" level="15" required-level="80" sp="13600000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
 		<skill name="Magic Resistance" id="147" level="55" required-level="80" sp="13600000" />
+		<skill name="Mass Shackling" id="404" level="10" required-level="80" sp="13600000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Evolution Power" id="45189" level="1" required-level="80">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Guard Stance" id="288" level="5" required-level="80" sp="13600000" />
+		<skill name="Entangle" id="102" level="20" required-level="80" sp="13600000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="55" required-level="80" sp="13600000" />
 		<skill name="Final Fortress" id="291" level="16" required-level="80" sp="13600000" />
 		<skill name="Summon Attractive Cubic" id="449" level="7" required-level="80" sp="13600000" />
 		<skill name="Summon Life Cubic" id="67" level="11" required-level="80" sp="13600000" />
 		<skill name="Summon Storm Cubic" id="10" level="11" required-level="80" sp="13600000" />
 		<skill name="Knighthood" id="429" level="3" required-level="80" sp="13600000" />
-		<skill name="Tribunal" id="400" level="18" required-level="80" sp="13600000" />
+		<skill name="Holy Aura" id="107" level="13" required-level="80" sp="13600000" />
+		<skill name="White Guardian Transformation" id="54102" level="1" required-level="80">
+			<item id="92401" count="1" /> <!-- Spellbook - White Guardian -->
+		</skill>
+		<skill name="Tribunal" id="400" level="20" required-level="80" sp="13600000" />
 		<skill name="Shield Bash" id="352" level="8" required-level="80" sp="13600000" />
 		<skill name="Critical Vulnerability Decrease" id="53004" level="3" required-level="80" sp="13600000" />
-		<skill name="Eva's Protection" id="1623" level="1" required-level="80" sp="13600000">
-			<item id="90049"/> <!-- Scroll: Eva's Protection -->
-		</skill>
-		
+		<skill name="Emergency Rescue" id="70" level="50" required-level="80" sp="13600000" />
+
 		<skill name="Aggression" id="28" level="54" required-level="81" sp="160000000" />
 		<skill name="Aggression Aura" id="18" level="42" required-level="81" sp="160000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="50" required-level="81" sp="160000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="50" required-level="81" sp="160000000" />
 		<skill name="Heavy Armor Mastery" id="232" level="57" required-level="81" sp="160000000" />
 		<skill name="Shield Charge" id="1898" level="6" required-level="81" sp="160000000" />
-		<skill name="Eva’s Protection" id="1623" level="2" required-level="81" sp="160000000" />
+		<skill name="Eva's Protection" id="1623" level="2" required-level="81" sp="160000000" />
+		<skill name="Shackle" id="402" level="16" required-level="81" sp="160000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
 		<skill name="Magic Resistance" id="147" level="56" required-level="81" sp="160000000" />
+		<skill name="Mass Shackling" id="404" level="11" required-level="81" sp="160000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
 		<skill name="Mass Chain Strike" id="53003" level="2" required-level="81" sp="160000000" />
+		<skill name="Entangle" id="102" level="21" required-level="81" sp="160000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="56" required-level="81" sp="160000000" />
 		<skill name="Final Fortress" id="291" level="17" required-level="81" sp="160000000" />
 		<skill name="Knighthood" id="429" level="4" required-level="81" sp="160000000" />
-		
+		<skill name="Tribunal" id="400" level="21" required-level="81" sp="160000000" />
+		<skill name="Emergency Rescue" id="70" level="51" required-level="81" sp="160000000" />
+
 		<skill name="Aggression" id="28" level="55" required-level="82" sp="170000000" />
 		<skill name="Aggression Aura" id="18" level="43" required-level="82" sp="170000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="51" required-level="82" sp="170000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="51" required-level="82" sp="170000000" />
 		<skill name="Heavy Armor Mastery" id="232" level="58" required-level="82" sp="170000000" />
 		<skill name="Shield Charge" id="1898" level="7" required-level="82" sp="170000000" />
-		<skill name="Eva’s Protection" id="1623" level="3" required-level="82" sp="170000000" />
+		<skill name="Eva's Protection" id="1623" level="3" required-level="82" sp="170000000" />
+		<skill name="Shackle" id="402" level="17" required-level="82" sp="170000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
 		<skill name="Magic Resistance" id="147" level="57" required-level="82" sp="170000000" />
+		<skill name="Mass Shackling" id="404" level="12" required-level="82" sp="170000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Entangle" id="102" level="22" required-level="82" sp="170000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="57" required-level="82" sp="170000000" />
 		<skill name="Final Fortress" id="291" level="18" required-level="82" sp="170000000" />
 		<skill name="Summon Attractive Cubic" id="449" level="8" required-level="82" sp="170000000" />
 		<skill name="Summon Life Cubic" id="67" level="12" required-level="82" sp="170000000" />
 		<skill name="Summon Storm Cubic" id="10" level="12" required-level="82" sp="170000000" />
 		<skill name="Knighthood" id="429" level="5" required-level="82" sp="170000000" />
-		<skill name="Tribunal" id="400" level="19" required-level="82" sp="170000000" />
+		<skill name="Holy Aura" id="107" level="14" required-level="82" sp="170000000" />
+		<skill name="Tribunal" id="400" level="22" required-level="82" sp="170000000" />
 		<skill name="Shield Bash" id="352" level="9" required-level="82" sp="170000000" />
 		<skill name="Critical Vulnerability Decrease" id="53004" level="4" required-level="82" sp="170000000" />
 		<skill name="Chain Strike" id="10015" level="2" required-level="82" sp="170000000" />
-		
+		<skill name="Emergency Rescue" id="70" level="52" required-level="82" sp="170000000" />
+
 		<skill name="Aggression" id="28" level="56" required-level="83" sp="240000000" />
 		<skill name="Aggression Aura" id="18" level="44" required-level="83" sp="240000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="52" required-level="83" sp="240000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="52" required-level="83" sp="240000000" />
 		<skill name="Heavy Armor Mastery" id="232" level="59" required-level="83" sp="240000000" />
 		<skill name="Shield Charge" id="1898" level="8" required-level="83" sp="240000000" />
-		<skill name="Eva’s Protection" id="1623" level="4" required-level="83" sp="240000000" />
+		<skill name="Eva's Protection" id="1623" level="4" required-level="83" sp="240000000" />
+		<skill name="Shackle" id="402" level="18" required-level="83" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
 		<skill name="Magic Resistance" id="147" level="58" required-level="83" sp="240000000" />
+		<skill name="Mass Shackling" id="404" level="13" required-level="83" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Entangle" id="102" level="23" required-level="83" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="58" required-level="83" sp="240000000" />
 		<skill name="Final Fortress" id="291" level="19" required-level="83" sp="240000000" />
 		<skill name="Knighthood" id="429" level="6" required-level="83" sp="240000000" />
-		
+		<skill name="Tribunal" id="400" level="23" required-level="83" sp="240000000" />
+		<skill name="Emergency Rescue" id="70" level="53" required-level="83" sp="240000000" />
+
 		<skill name="Aggression" id="28" level="57" required-level="84" sp="240000000" />
 		<skill name="Aggression Aura" id="18" level="45" required-level="84" sp="240000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="53" required-level="84" sp="240000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="53" required-level="84" sp="240000000" />
 		<skill name="Heavy Armor Mastery" id="232" level="60" required-level="84" sp="240000000" />
 		<skill name="Shield Charge" id="1898" level="9" required-level="84" sp="240000000" />
-		<skill name="Eva’s Protection" id="1623" level="5" required-level="84" sp="240000000" />
+		<skill name="Eva's Protection" id="1623" level="5" required-level="84" sp="240000000" />
+		<skill name="Shackle" id="402" level="19" required-level="84" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
 		<skill name="Magic Resistance" id="147" level="59" required-level="84" sp="240000000" />
+		<skill name="Mass Shackling" id="404" level="14" required-level="84" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
 		<skill name="Mass Chain Strike" id="53003" level="3" required-level="84" sp="240000000" />
+		<skill name="Entangle" id="102" level="24" required-level="84" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="59" required-level="84" sp="240000000" />
 		<skill name="Final Fortress" id="291" level="20" required-level="84" sp="240000000" />
 		<skill name="Summon Attractive Cubic" id="449" level="9" required-level="84" sp="240000000" />
 		<skill name="Summon Life Cubic" id="67" level="13" required-level="84" sp="240000000" />
 		<skill name="Summon Storm Cubic" id="10" level="13" required-level="84" sp="240000000" />
 		<skill name="Knighthood" id="429" level="7" required-level="84" sp="240000000" />
-		<skill name="Tribunal" id="400" level="20" required-level="84" sp="240000000" />
+		<skill name="Tribunal" id="400" level="24" required-level="84" sp="240000000" />
 		<skill name="Shield Bash" id="352" level="10" required-level="84" sp="240000000" />
 		<skill name="Critical Vulnerability Decrease" id="53004" level="5" required-level="84" sp="240000000" />
 		<skill name="Chain Strike" id="10015" level="3" required-level="84" sp="240000000" />
-		
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="54" required-level="85" sp="840000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="55" required-level="86" sp="924000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="56" required-level="87" sp="1016400000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="57" required-level="88" sp="1118040000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="58" required-level="89" sp="1229844000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="59" required-level="90" sp="1352828400" />
+		<skill name="Emergency Rescue" id="70" level="54" required-level="84" sp="240000000" />
+
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="54" required-level="85" sp="840000000" />
 		<skill name="Heavy Armor Mastery" id="232" level="61" required-level="85" sp="840000000" />
-		<skill name="Heavy Armor Mastery" id="232" level="62" required-level="86" sp="924000000" />
-		<skill name="Heavy Armor Mastery" id="232" level="63" required-level="87" sp="1016400000" />
-		<skill name="Heavy Armor Mastery" id="232" level="64" required-level="88" sp="1118040000" />
-		<skill name="Heavy Armor Mastery" id="232" level="65" required-level="89" sp="1229844000" />
-		<skill name="Heavy Armor Mastery" id="232" level="66" required-level="90" sp="1352828400" />
+		<skill name="Shackle" id="402" level="20" required-level="85" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
 		<skill name="Magic Resistance" id="147" level="60" required-level="85" sp="840000000" />
-		<skill name="Magic Resistance" id="147" level="61" required-level="86" sp="924000000" />
-		<skill name="Magic Resistance" id="147" level="62" required-level="87" sp="1016400000" />
-		<skill name="Magic Resistance" id="147" level="63" required-level="88" sp="1118040000" />
-		<skill name="Magic Resistance" id="147" level="64" required-level="89" sp="1229844000" />
-		<skill name="Magic Resistance" id="147" level="65" required-level="90" sp="1352828400" />
+		<skill name="Mass Shackling" id="404" level="15" required-level="85" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Entangle" id="102" level="25" required-level="85" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="60" required-level="85" sp="840000000" />
 		<skill name="Final Fortress" id="291" level="21" required-level="85" sp="840000000" />
-		<skill name="Final Fortress" id="291" level="22" required-level="86" sp="924000000" />
-		<skill name="Final Fortress" id="291" level="23" required-level="87" sp="1016400000" />
-		<skill name="Final Fortress" id="291" level="24" required-level="88" sp="1118040000" />
-		<skill name="Final Fortress" id="291" level="25" required-level="89" sp="1229844000" />
-		<skill name="Final Fortress" id="291" level="26" required-level="90" sp="1352828400" />
 		<skill name="Knighthood" id="429" level="8" required-level="85" sp="840000000" />
-		<skill name="Knighthood" id="429" level="9" required-level="86" sp="924000000" />
-		<skill name="Knighthood" id="429" level="10" required-level="87" sp="1016400000" />
-		<skill name="Knighthood" id="429" level="11" required-level="88" sp="1118040000" />
-		<skill name="Knighthood" id="429" level="12" required-level="89" sp="1229844000" />
-		<skill name="Knighthood" id="429" level="13" required-level="90" sp="1352828400" />
+		<skill name="Holy Aura" id="107" level="15" required-level="85" sp="840000000" />
+		<skill name="Tribunal" id="400" level="25" required-level="85" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="55" required-level="85" sp="840000000" />
+
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="55" required-level="86" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="232" level="62" required-level="86" sp="840000000" />
+		<skill name="Shackle" id="402" level="21" required-level="86" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Magic Resistance" id="147" level="61" required-level="86" sp="840000000" />
+		<skill name="Mass Shackling" id="404" level="16" required-level="86" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Entangle" id="102" level="26" required-level="86" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="61" required-level="86" sp="840000000" />
+		<skill name="Final Fortress" id="291" level="22" required-level="86" sp="840000000" />
+		<skill name="Knighthood" id="429" level="9" required-level="86" sp="840000000" />
+		<skill name="Tribunal" id="400" level="26" required-level="86" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="56" required-level="86" sp="840000000" />
+
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="56" required-level="87" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="232" level="63" required-level="87" sp="840000000" />
+		<skill name="Shackle" id="402" level="22" required-level="87" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Magic Resistance" id="147" level="62" required-level="87" sp="840000000" />
+		<skill name="Mass Shackling" id="404" level="17" required-level="87" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Entangle" id="102" level="27" required-level="87" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="62" required-level="87" sp="840000000" />
+		<skill name="Final Fortress" id="291" level="23" required-level="87" sp="840000000" />
+		<skill name="Knighthood" id="429" level="10" required-level="87" sp="840000000" />
+		<skill name="Tribunal" id="400" level="27" required-level="87" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="57" required-level="87" sp="840000000" />
+
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="57" required-level="88" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="232" level="64" required-level="88" sp="840000000" />
+		<skill name="Shackle" id="402" level="23" required-level="88" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Magic Resistance" id="147" level="63" required-level="88" sp="840000000" />
+		<skill name="Mass Shackling" id="404" level="18" required-level="88" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Entangle" id="102" level="28" required-level="88" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="63" required-level="88" sp="840000000" />
+		<skill name="Final Fortress" id="291" level="24" required-level="88" sp="840000000" />
+		<skill name="Knighthood" id="429" level="11" required-level="88" sp="840000000" />
+		<skill name="Tribunal" id="400" level="28" required-level="88" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="58" required-level="88" sp="840000000" />
+
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="58" required-level="89" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="232" level="65" required-level="89" sp="840000000" />
+		<skill name="Shackle" id="402" level="24" required-level="89" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Magic Resistance" id="147" level="64" required-level="89" sp="840000000" />
+		<skill name="Mass Shackling" id="404" level="19" required-level="89" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Entangle" id="102" level="29" required-level="89" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="64" required-level="89" sp="840000000" />
+		<skill name="Final Fortress" id="291" level="25" required-level="89" sp="840000000" />
+		<skill name="Knighthood" id="429" level="12" required-level="89" sp="840000000" />
+		<skill name="Tribunal" id="400" level="29" required-level="89" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="59" required-level="89" sp="840000000" />
+
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="59" required-level="90" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="232" level="66" required-level="90" sp="840000000" />
+		<skill name="Shackle" id="402" level="25" required-level="90" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Magic Resistance" id="147" level="65" required-level="90" sp="840000000" />
+		<skill name="Mass Shackling" id="404" level="20" required-level="90" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Entangle" id="102" level="30" required-level="90" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="65" required-level="90" sp="840000000" />
+		<skill name="Final Fortress" id="291" level="26" required-level="90" sp="840000000" />
+		<skill name="Knighthood" id="429" level="13" required-level="90" sp="840000000" />
+		<skill name="Tribunal" id="400" level="30" required-level="90" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="60" required-level="90" sp="840000000" />
+
 	</skillTree>
 </list>

--- a/data/skillTrees/3rdClass/FortuneSeeker.xml
+++ b/data/skillTrees/3rdClass/FortuneSeeker.xml
@@ -1,157 +1,263 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="117" parentClassId="55">
-		<skill name="White Guardian" id="54102" level="1" required-level="80" >
-			<item id="92401"/>
-		</skill>
-		<skill name="Spinning Slasher" id="36" level="38" required-level="76" sp="7200000" />
-		<skill name="Polearm Mastery" id="216" level="46" required-level="76" sp="7200000" />
-		<skill name="Light Armor Mastery" id="227" level="51" required-level="76" sp="7200000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="46" required-level="76" sp="7200000" />
-		<skill name="Heavy Armor Mastery" id="231" level="51" required-level="76" sp="7200000" />
-		<skill name="Earthquake" id="347" level="1" required-level="76" sp="7200000" />
-		<skill name="Spoil Festival" id="302" level="10" required-level="76" sp="7200000" />
-		<skill name="Spoil" id="254" level="13" required-level="76" sp="7200000" />
-		<skill name="Power Crush" id="260" level="38" required-level="76" sp="7200000" />
+
 		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="7200000">
-			<item id="8620"/> <!-- Ancient Book: Divine Inspiration (Manuscript) -->
+			<item id="8620" count="1" /> <!-- Buff Expansion Book Lv. 3 -->
 		</skill>
 		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="7200000">
-			<item id="8621"/> <!-- Ancient Book: Divine Inspiration (Original Version) -->
+			<item id="8621" count="1" /> <!-- Buff Expansion Book Lv. 4 -->
 		</skill>
-		<skill name="Collecting Mastery" id="45248" level="3" required-level="76" sp="7200000" />
-		<skill name="Collecting Mastery" id="45248" level="4" required-level="80" sp="7200000" />
+		<skill name="Spinning Slasher" id="36" level="41" required-level="76" sp="7200000" />
+		<skill name="Polearm Mastery" id="216" level="46" required-level="76" sp="7200000" />
+		<skill name="Light Armor Mastery" id="227" level="51" required-level="76" sp="7200000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="205" level="46" required-level="76" sp="7200000" />
+		<skill name="Weapon Mastery" id="141" level="5" required-level="76" sp="7200000" />
+		<skill name="Heavy Armor Mastery" id="231" level="51" required-level="76" sp="7200000" />
+		<skill name="Evolution Defense" id="45188" level="1" required-level="76">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Earthquake" id="347" level="1" required-level="76" sp="7200000" />
+		<skill name="Spoil Festival" id="302" level="10" required-level="76" sp="7200000" />
+		<skill name="Master of Combat" id="430" level="1" required-level="76" sp="7200000" />
+		<!-- Might Lv. 4 -->
+		<skill name="Maphr's Might" id="45119" level="4" required-level="76" sp="7200000">
+			<item id="94135" count="1" /> <!-- Master's Book: Might -->
+		</skill>
+		<!-- Shield Lv. 4-->
+		<skill name="Maphr's Shield" id="45120" level="4" required-level="76" sp="7200000">
+			<item id="94136" count="1" /> <!-- Master's Book: Shield -->
+		</skill>
+		<!-- Acumen Lv. 4 -->
+		<skill name="Maphr's Acumen" id="45130" level="4" required-level="76" sp="7200000">
+			<item id="94370" count="1" /> <!-- Master's Book: Acumen -->
+		</skill>
+		<!-- Empower Lv. 4 -->
+		<skill name="Maphr's Empower" id="45131" level="4" required-level="76" sp="7200000">
+			<item id="94361" count="1" /> <!-- Master's Book: Empower -->
+		</skill>
+		<!-- Wild Magic Lv. 3 -->
+		<skill name="Maphr's Wild Magic" id="45132" level="3" required-level="76" sp="7200000">
+			<item id="94368" count="1" /> <!-- Master's Book: Wild Magic -->
+		</skill>
+		<!-- Wind Walk Lv. 3 -->
+		<skill name="Maphr's Wind Walk" id="45117" level="3" required-level="76" sp="7200000">
+			<item id="94365" count="1" /> <!-- Master's Book: Wind Walk -->
+		</skill>
+		<!-- Magic Barrier Lv. 3 -->
+		<skill name="Maphr's Magic Barrier" id="45118" level="3" required-level="76" sp="7200000">
+			<item id="94362" count="1" /> <!-- Master's Book: Magic Barrier -->
+		</skill>
+		<!-- Focus Lv. 4 -->
+		<skill name="Maphr's Focus" id="45114" level="4" required-level="76" sp="7200000">
+			<item id="94363" count="1" /> <!-- Master's Book: Focus -->
+		</skill>
+		<!-- Death Whisper Lv. 4 -->
+		<skill name="Maphr's Death Whisper" id="45115" level="4" required-level="76" sp="7200000">
+			<item id="94364" count="1" /> <!-- Master's Book: Death Whisper -->
+		</skill>
+		<!-- Haste Lv. 3 -->
+		<skill name="Maphr's Haste" id="45116" level="3" required-level="76" sp="7200000">
+			<item id="94369" count="1" /> <!-- Master's Book: Haste -->
+		</skill>
+		<!-- Berserker Spirit Lv. 3 -->
+		<skill name="Maphr's Berserker Spirit" id="45133" level="3" required-level="76" sp="7200000">
+			<item id="94366" count="1" /> <!-- Master's Book: Berserker Spirit -->
+		</skill>
+		<!-- Clarity Lv. 4 -->
+		<skill name="Maphr's Clarity" id="45134" level="4" required-level="76" sp="7200000">
+			<item id="94367" count="1" /> <!-- Master's Book: Clarity -->
+		</skill>
+		<skill name="Detection" id="45190" level="1" required-level="76" sp="7200000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Final Secret" id="917" level="1" required-level="76" sp="7200000">
+			<item id="90080" count="1" /> <!-- Scroll: Final Secret -->
+		</skill>
 		<skill name="Mount Kukuru" id="1836" level="1" required-level="76">
-			<item id="90041" count="1" /> <!-- Spellbook: Mount Kukuru  -->
+			<item id="90041" count="1" /> <!-- Spellbook - Ride Kukura -->
 		</skill>
-		<skill name="Glory Ability" id="45361" level="1" required-level="86">
-			<item id="94046"/> <!-- Spellbook: Glory Ability Lv. 1 -->
+		<skill name="Spoil" id="254" level="13" required-level="76" sp="7200000" />
+		<skill name="Power Break" id="260" level="38" required-level="76" sp="7200000" />
+		<skill name="Spoil Crush" id="348" level="1" required-level="76" sp="7200000">
+			<item id="90079" count="1" /> <!-- Scroll: Spoil Crush -->
 		</skill>
-		<skill name="Mount White Wings" id="54200" level="1" required-level="87">
-			<item id="93059"/> <!-- Spellbook: Summon White Wings -->
-		</skill>	
-		<skill name="Mount Shining Lady" id="54202" level="1" required-level="89">
-			<item id="93061"/> <!-- Spellbook: Summon Silver Saint -->
-		</skill>
-		
-		<skill name="Spinning Slasher" id="36" level="39" required-level="77" sp="7200000" />
+		<skill name="Rush" id="994" level="3" required-level="76" sp="7200000" />
+		<skill name="Fatal Strike" id="190" level="41" required-level="76" sp="7200000" />
+		<skill name="Emergency Rescue" id="70" level="46" required-level="76" sp="7200000" />
+
+		<skill name="Spinning Slasher" id="36" level="42" required-level="77" sp="7200000" />
 		<skill name="Polearm Mastery" id="216" level="47" required-level="77" sp="7200000" />
 		<skill name="Light Armor Mastery" id="227" level="52" required-level="77" sp="7200000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="47" required-level="77" sp="7200000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="205" level="47" required-level="77" sp="7200000" />
+		<skill name="Collecting Mastery" id="45248" level="2" required-level="77" sp="7200000">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Heavy Armor Mastery" id="231" level="52" required-level="77" sp="7200000" />
 		<skill name="Earthquake" id="347" level="2" required-level="77" sp="7200000" />
-		<skill name="Power Crush" id="260" level="39" required-level="77" sp="7200000" />
-		<skill name="Spoil Crush" id="348" level="1" required-level="77" sp="7200000">
-			<item id="90079"/> <!-- Scroll: Spoil Crush -->
-		</skill>
 		<skill name="Armor Crush" id="362" level="1" required-level="77" sp="7200000">
-			<item id="90078"/> <!-- Scroll: Armor Crush -->
+			<item id="90078" count="1" /> <!-- Scroll: Armor Crush -->
 		</skill>
-		
-		<skill name="Spinning Slasher" id="36" level="40" required-level="78" sp="16700000" />
+		<skill name="Power Break" id="260" level="39" required-level="77" sp="7200000" />
+		<skill name="Spoil Crush" id="348" level="2" required-level="77" sp="7200000" />
+		<skill name="Buff Thief" id="45390" level="1" required-level="77" sp="7200000">
+			<item id="94141" count="1" /> <!-- Spellbook: Buff Thief -->
+		</skill>
+		<skill name="Fatal Strike" id="190" level="42" required-level="77" sp="7200000" />
+		<skill name="Emergency Rescue" id="70" level="47" required-level="77" sp="7200000" />
+
+		<skill name="Spinning Slasher" id="36" level="43" required-level="78" sp="16700000" />
 		<skill name="Polearm Mastery" id="216" level="48" required-level="78" sp="16700000" />
 		<skill name="Light Armor Mastery" id="227" level="53" required-level="78" sp="16700000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="48" required-level="78" sp="16700000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="205" level="48" required-level="78" sp="16700000" />
 		<skill name="Heavy Armor Mastery" id="231" level="53" required-level="78" sp="16700000" />
 		<skill name="Earthquake" id="347" level="3" required-level="78" sp="16700000" />
 		<skill name="Spoil Festival" id="302" level="11" required-level="78" sp="16700000" />
-		<skill name="Master of Combat" id="430" level="1" required-level="78" sp="16700000" />
 		<skill name="Spoil" id="254" level="14" required-level="78" sp="16700000" />
 		<skill name="Provoke" id="286" level="8" required-level="78" sp="16700000" />
 		<skill name="Armor Crush" id="362" level="2" required-level="78" sp="16700000" />
-		<skill name="Power Crush" id="260" level="40" required-level="78" sp="16700000" />
-		<skill name="Body Impale" id="1613" level="10" required-level="78" sp="16700000" />
-		<skill name="Spoil Crush" id="348" level="2" required-level="78" sp="16700000" />
-		<skill name="Rush" id="994" level="1" required-level="78" sp="16700000" />
+		<skill name="Power Break" id="260" level="40" required-level="78" sp="16700000" />
+		<skill name="Body Crush" id="1613" level="10" required-level="78" sp="16700000" />
+		<skill name="Spoil Crush" id="348" level="3" required-level="78" sp="16700000" />
+		<skill name="Fatal Strike" id="190" level="43" required-level="78" sp="16700000" />
 		<skill name="Braveheart" id="440" level="1" required-level="78" sp="16700000" />
-		
+		<skill name="Emergency Rescue" id="70" level="48" required-level="78" sp="16700000" />
+
+		<skill name="Spinning Slasher" id="36" level="44" required-level="79" sp="16700000" />
 		<skill name="Earthquake" id="347" level="4" required-level="79" sp="16700000" />
-		<skill name="Armor Crush" id="362" level="3" required-level="79" sp="16700000" />
-		<skill name="Spoil Crush" id="348" level="3" required-level="79" sp="16700000" />
-		<skill name="Final Secret" id="917" level="1" required-level="79" sp="16700000">
-			<item id="90080"/> <!-- Scroll: Final Secret -->
+		<skill name="Final Frenzy" id="290" level="15" required-level="79" sp="16700000">
+			<item id="57" count="500000" /> <!-- Adena -->
 		</skill>
-		
+		<skill name="Armor Crush" id="362" level="3" required-level="79" sp="16700000" />
+		<skill name="Spoil Crush" id="348" level="4" required-level="79" sp="16700000" />
+		<skill name="Fatal Strike" id="190" level="44" required-level="79" sp="16700000" />
+		<skill name="Emergency Rescue" id="70" level="49" required-level="79" sp="16700000" />
+
+		<skill name="Spinning Slasher" id="36" level="45" required-level="80" sp="16700000" />
 		<skill name="Polearm Mastery" id="216" level="49" required-level="80" sp="16700000" />
 		<skill name="Light Armor Mastery" id="227" level="54" required-level="80" sp="16700000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="49" required-level="80" sp="16700000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="205" level="49" required-level="80" sp="16700000" />
 		<skill name="Heavy Armor Mastery" id="231" level="54" required-level="80" sp="16700000" />
 		<skill name="Earthquake" id="347" level="5" required-level="80" sp="16700000" />
 		<skill name="Tenacity" id="1617" level="4" required-level="80" sp="16700000" />
 		<skill name="Spoil Festival" id="302" level="12" required-level="80" sp="16700000" />
+		<skill name="Master of Combat" id="430" level="2" required-level="80" sp="16700000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Evolution Power" id="45189" level="1" required-level="80">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Spoil" id="254" level="15" required-level="80" sp="16700000" />
 		<skill name="Provoke" id="286" level="9" required-level="80" sp="16700000" />
 		<skill name="Armor Crush" id="362" level="4" required-level="80" sp="16700000" />
-		<skill name="Power Crush" id="260" level="41" required-level="80" sp="16700000" />
-		<skill name="Spoil Crush" id="348" level="4" required-level="80" sp="16700000" />
-		
+		<skill name="Power Break" id="260" level="41" required-level="80" sp="16700000" />
+		<skill name="Spoil Crush" id="348" level="5" required-level="80" sp="16700000" />
+		<skill name="White Guardian Transformation" id="54102" level="1" required-level="80">
+			<item id="92401" count="1" /> <!-- Spellbook - White Guardian -->
+		</skill>
+		<skill name="Fatal Strike" id="190" level="45" required-level="80" sp="16700000" />
+		<skill name="Emergency Rescue" id="70" level="50" required-level="80" sp="16700000" />
+
 		<skill name="Polearm Mastery" id="216" level="50" required-level="81" sp="160000000" />
 		<skill name="Light Armor Mastery" id="227" level="55" required-level="81" sp="160000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="50" required-level="81" sp="160000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="205" level="50" required-level="81" sp="160000000" />
 		<skill name="Heavy Armor Mastery" id="231" level="55" required-level="81" sp="160000000" />
 		<skill name="Earthquake" id="347" level="6" required-level="81" sp="160000000" />
 		<skill name="Armor Crush" id="362" level="5" required-level="81" sp="160000000" />
-		<skill name="Power Crush" id="260" level="42" required-level="81" sp="160000000" />
-		<skill name="Spoil Crush" id="348" level="5" required-level="81" sp="160000000" />
-		
+		<skill name="Power Break" id="260" level="42" required-level="81" sp="160000000" />
+		<skill name="Spoil Crush" id="348" level="6" required-level="81" sp="160000000" />
+		<skill name="Fatal Strike" id="190" level="46" required-level="81" sp="160000000" />
+		<skill name="Emergency Rescue" id="70" level="51" required-level="81" sp="160000000" />
+
 		<skill name="Polearm Mastery" id="216" level="51" required-level="82" sp="170000000" />
 		<skill name="Light Armor Mastery" id="227" level="56" required-level="82" sp="170000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="51" required-level="82" sp="170000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="205" level="51" required-level="82" sp="170000000" />
 		<skill name="Heavy Armor Mastery" id="231" level="56" required-level="82" sp="170000000" />
 		<skill name="Earthquake" id="347" level="7" required-level="82" sp="170000000" />
 		<skill name="Spoil Festival" id="302" level="13" required-level="82" sp="170000000" />
 		<skill name="Spoil" id="254" level="16" required-level="82" sp="170000000" />
 		<skill name="Provoke" id="286" level="10" required-level="82" sp="170000000" />
 		<skill name="Armor Crush" id="362" level="6" required-level="82" sp="170000000" />
-		<skill name="Power Crush" id="260" level="43" required-level="82" sp="170000000" />
-		<skill name="Body Impale" id="1613" level="11" required-level="82" sp="170000000" />
-		<skill name="Spoil Crush" id="348" level="6" required-level="82" sp="170000000" />
+		<skill name="Power Break" id="260" level="43" required-level="82" sp="170000000" />
+		<skill name="Body Crush" id="1613" level="11" required-level="82" sp="170000000" />
+		<skill name="Spoil Crush" id="348" level="7" required-level="82" sp="170000000" />
 		<skill name="Weapon Reinforcement" id="1615" level="4" required-level="82" sp="170000000" />
-		
+		<skill name="Fatal Strike" id="190" level="47" required-level="82" sp="170000000" />
+		<skill name="Emergency Rescue" id="70" level="52" required-level="82" sp="170000000" />
+
 		<skill name="Polearm Mastery" id="216" level="52" required-level="83" sp="240000000" />
 		<skill name="Light Armor Mastery" id="227" level="57" required-level="83" sp="240000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="52" required-level="83" sp="240000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="205" level="52" required-level="83" sp="240000000" />
 		<skill name="Heavy Armor Mastery" id="231" level="57" required-level="83" sp="240000000" />
 		<skill name="Earthquake" id="347" level="8" required-level="83" sp="240000000" />
 		<skill name="Armor Crush" id="362" level="7" required-level="83" sp="240000000" />
-		<skill name="Power Crush" id="260" level="44" required-level="83" sp="240000000" />
-		<skill name="Spoil Crush" id="348" level="7" required-level="83" sp="240000000" />
-		
+		<skill name="Power Break" id="260" level="44" required-level="83" sp="240000000" />
+		<skill name="Spoil Crush" id="348" level="8" required-level="83" sp="240000000" />
+		<skill name="Fatal Strike" id="190" level="48" required-level="83" sp="240000000" />
+		<skill name="Emergency Rescue" id="70" level="53" required-level="83" sp="240000000" />
+
 		<skill name="Polearm Mastery" id="216" level="53" required-level="84" sp="240000000" />
 		<skill name="Light Armor Mastery" id="227" level="58" required-level="84" sp="240000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="53" required-level="84" sp="240000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="205" level="53" required-level="84" sp="240000000" />
 		<skill name="Heavy Armor Mastery" id="231" level="58" required-level="84" sp="240000000" />
 		<skill name="Earthquake" id="347" level="9" required-level="84" sp="240000000" />
 		<skill name="Spoil Festival" id="302" level="14" required-level="84" sp="240000000" />
 		<skill name="Spoil" id="254" level="17" required-level="84" sp="240000000" />
 		<skill name="Provoke" id="286" level="11" required-level="84" sp="240000000" />
 		<skill name="Armor Crush" id="362" level="8" required-level="84" sp="240000000" />
-		<skill name="Power Crush" id="260" level="45" required-level="84" sp="240000000" />
-		<skill name="Spoil Crush" id="348" level="8" required-level="84" sp="240000000" />
-		
+		<skill name="Power Break" id="260" level="45" required-level="84" sp="240000000" />
+		<skill name="Body Crush" id="1613" level="12" required-level="84" sp="240000000" />
+		<skill name="Spoil Crush" id="348" level="9" required-level="84" sp="240000000" />
+		<skill name="Fatal Strike" id="190" level="49" required-level="84" sp="240000000" />
+		<skill name="Emergency Rescue" id="70" level="54" required-level="84" sp="240000000" />
+
 		<skill name="Polearm Mastery" id="216" level="54" required-level="85" sp="840000000" />
-		<skill name="Polearm Mastery" id="216" level="55" required-level="86" sp="924000000" />
-		<skill name="Polearm Mastery" id="216" level="56" required-level="87" sp="1016400000" />
-		<skill name="Polearm Mastery" id="216" level="57" required-level="88" sp="1118040000" />
-		<skill name="Polearm Mastery" id="216" level="58" required-level="89" sp="1229844000" />
-		<skill name="Polearm Mastery" id="216" level="59" required-level="90" sp="1352828400" />
 		<skill name="Light Armor Mastery" id="227" level="59" required-level="85" sp="840000000" />
-		<skill name="Light Armor Mastery" id="227" level="60" required-level="86" sp="924000000" />
-		<skill name="Light Armor Mastery" id="227" level="61" required-level="87" sp="1016400000" />
-		<skill name="Light Armor Mastery" id="227" level="62" required-level="88" sp="1118040000" />
-		<skill name="Light Armor Mastery" id="227" level="63" required-level="89" sp="1229844000" />
-		<skill name="Light Armor Mastery" id="227" level="64" required-level="90" sp="1352828400" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="54" required-level="85" sp="840000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="55" required-level="86" sp="924000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="56" required-level="87" sp="1016400000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="57" required-level="88" sp="1118040000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="58" required-level="89" sp="1229844000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="59" required-level="90" sp="1352828400" />
+		<skill name="Sword / Blunt Weapon Mastery" id="205" level="54" required-level="85" sp="840000000" />
 		<skill name="Heavy Armor Mastery" id="231" level="59" required-level="85" sp="840000000" />
-		<skill name="Heavy Armor Mastery" id="231" level="60" required-level="86" sp="924000000" />
-		<skill name="Heavy Armor Mastery" id="231" level="61" required-level="87" sp="1016400000" />
-		<skill name="Heavy Armor Mastery" id="231" level="62" required-level="88" sp="1118040000" />
-		<skill name="Heavy Armor Mastery" id="231" level="63" required-level="89" sp="1229844000" />
-		<skill name="Heavy Armor Mastery" id="231" level="64" required-level="90" sp="1352828400" />
+		<skill name="Spoil Crush" id="348" level="10" required-level="85" sp="840000000" />
+		<skill name="Weapon Reinforcement" id="1615" level="5" required-level="85" sp="840000000" />
+		<skill name="Fatal Strike" id="190" level="50" required-level="85" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="55" required-level="85" sp="840000000" />
+
+		<skill name="Polearm Mastery" id="216" level="55" required-level="86" sp="840000000" />
+		<skill name="Light Armor Mastery" id="227" level="60" required-level="86" sp="840000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="205" level="55" required-level="86" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="231" level="60" required-level="86" sp="840000000" />
+		<skill name="Spoil Crush" id="348" level="11" required-level="86" sp="840000000" />
+		<skill name="Fatal Strike" id="190" level="51" required-level="86" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="56" required-level="86" sp="840000000" />
+
+		<skill name="Polearm Mastery" id="216" level="56" required-level="87" sp="840000000" />
+		<skill name="Light Armor Mastery" id="227" level="61" required-level="87" sp="840000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="205" level="56" required-level="87" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="231" level="61" required-level="87" sp="840000000" />
+		<skill name="Spoil Crush" id="348" level="12" required-level="87" sp="840000000" />
+		<skill name="Fatal Strike" id="190" level="52" required-level="87" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="57" required-level="87" sp="840000000" />
+
+		<skill name="Polearm Mastery" id="216" level="57" required-level="88" sp="840000000" />
+		<skill name="Light Armor Mastery" id="227" level="62" required-level="88" sp="840000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="205" level="57" required-level="88" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="231" level="62" required-level="88" sp="840000000" />
+		<skill name="Spoil Crush" id="348" level="13" required-level="88" sp="840000000" />
+		<skill name="Fatal Strike" id="190" level="53" required-level="88" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="58" required-level="88" sp="840000000" />
+
+		<skill name="Polearm Mastery" id="216" level="58" required-level="89" sp="840000000" />
+		<skill name="Light Armor Mastery" id="227" level="63" required-level="89" sp="840000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="205" level="58" required-level="89" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="231" level="63" required-level="89" sp="840000000" />
+		<skill name="Spoil Crush" id="348" level="14" required-level="89" sp="840000000" />
+		<skill name="Fatal Strike" id="190" level="54" required-level="89" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="59" required-level="89" sp="840000000" />
+
+		<skill name="Polearm Mastery" id="216" level="59" required-level="90" sp="840000000" />
+		<skill name="Light Armor Mastery" id="227" level="64" required-level="90" sp="840000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="205" level="59" required-level="90" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="231" level="64" required-level="90" sp="840000000" />
+		<skill name="Spoil Crush" id="348" level="15" required-level="90" sp="840000000" />
+		<skill name="Fatal Strike" id="190" level="55" required-level="90" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="60" required-level="90" sp="840000000" />
 	</skillTree>
 </list>

--- a/data/skillTrees/3rdClass/GhostHunter.xml
+++ b/data/skillTrees/3rdClass/GhostHunter.xml
@@ -1,134 +1,340 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="108" parentClassId="36">
-		<skill name="White Guardian" id="54102" level="1" required-level="80" >
-			<item id="92401"/>
+
+		<skill name="Bluff" id="358" level="1" required-level="76" sp="5700000">
+			<item id="91294" count="1" /> <!-- Scroll: Bluff -->
 		</skill>
-		<skill name="Bluff" id="358" level="1" required-level="76" sp="5700000" />
+		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="5700000">
+			<item id="8620" count="1" /> <!-- Buff Expansion Book Lv. 3 -->
+		</skill>
+		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="5700000">
+			<item id="8621" count="1" /> <!-- Buff Expansion Book Lv. 4 -->
+		</skill>
 		<skill name="Throwing Blood Dagger" id="1630" level="1" required-level="76" sp="5700000" />
 		<skill name="Dagger Mastery" id="209" level="46" required-level="76" sp="5700000" />
 		<skill name="Light Armor Mastery" id="233" level="48" required-level="76" sp="5700000" />
-		<skill name="Sting" id="223" level="50" required-level="76" sp="5700000" />
-		<skill name="Freezing Strike" id="105" level="25" required-level="76" sp="5700000" />
-		<skill name="Drain Energy" id="70" level="54" required-level="76" sp="5700000" />
-		<skill name="Bleed" id="96" level="7" required-level="76" sp="5700000" />
-		<skill name="Hex" id="122" level="16" required-level="76" sp="5700000" />
-		<skill name="Deadly Blow" id="263" level="38" required-level="76" sp="5700000" />
-		<skill name="Lethal Blow" id="344" level="1" required-level="76" sp="5700000" />
-		<skill name="Power Break" id="115" level="18" required-level="76" sp="5700000" />
-		<skill name="Backstab" id="30" level="38" required-level="76" sp="5700000" />
-		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="5700000">
-			<item id="8620"/> <!-- Ancient Book: Divine Inspiration (Manuscript) -->
+		<skill name="Weapon Mastery" id="141" level="5" required-level="76" sp="5700000" />
+		<skill name="Confusion" id="2" level="21" required-level="76" sp="5700000" />
+		<skill name="Freezing Weapon" id="105" level="28" required-level="76" sp="5700000" />
+		<skill name="Evolution Defense" id="45188" level="1" required-level="76">
+			<item id="57" count="5000000" /> <!-- Adena -->
 		</skill>
-		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="5700000">
-			<item id="8621"/> <!-- Ancient Book: Divine Inspiration (Original Version) -->
+		<skill name="Drain Energy" id="45250" level="26" required-level="76" sp="5700000" />
+		<skill name="Blood Attack" id="223" level="51" required-level="76" sp="5700000" />
+		<skill name="Bleed" id="96" level="7" required-level="76" sp="5700000" />
+		<!-- Might Lv. 4 -->
+		<skill name="Might" id="1068" level="4" required-level="76" sp="5700000">
+			<item id="94135" count="1" /> <!-- Master's Book: Might -->
+		</skill>
+		<!-- Shield Lv. 4-->
+		<skill name="Shield" id="1040" level="4" required-level="76" sp="5700000">
+			<item id="94136" count="1" /> <!-- Master's Book: Shield -->
+		</skill>
+		<!-- Acumen Lv. 4 -->
+		<skill name="Acumen" id="45104" level="4" required-level="76" sp="5700000">
+			<item id="94370" count="1" /> <!-- Master's Book: Acumen -->
+		</skill>
+		<!-- Empower Lv. 4 -->
+		<skill name="Empower" id="45105" level="4" required-level="76" sp="5700000">
+			<item id="94361" count="1" /> <!-- Master's Book: Empower -->
+		</skill>
+		<!-- Wild Magic Lv. 3 -->
+		<skill name="Wild Magic" id="45106" level="3" required-level="76" sp="5700000">
+			<item id="94368" count="1" /> <!-- Master's Book: Wild Magic -->
+		</skill>
+		<!-- Wind Walk Lv. 3 -->
+		<skill name="Wind Walk" id="45107" level="3" required-level="76" sp="5700000">
+			<item id="94365" count="1" /> <!-- Master's Book: Wind Walk -->
+		</skill>
+		<!-- Magic Barrier Lv. 3 -->
+		<skill name="Magic Barrier" id="45108" level="3" required-level="76" sp="5700000">
+			<item id="94362" count="1" /> <!-- Master's Book: Magic Barrier -->
+		</skill>
+		<!-- Focus Lv. 4 -->
+		<skill name="Focus" id="45109" level="4" required-level="76" sp="5700000">
+			<item id="94363" count="1" /> <!-- Master's Book: Focus -->
+		</skill>
+		<!-- Death Whisper Lv. 4 -->
+		<skill name="Death Whisper" id="45110" level="4" required-level="76" sp="5700000">
+			<item id="94364" count="1" /> <!-- Master's Book: Death Whisper -->
+		</skill>
+		<!-- Haste Lv. 3 -->
+		<skill name="Haste" id="45111" level="3" required-level="76" sp="5700000">
+			<item id="94369" count="1" /> <!-- Master's Book: Haste -->
+		</skill>
+		<!-- Berserker Spirit Lv. 3 -->
+		<skill name="Berserker Spirit" id="45112" level="3" required-level="76" sp="5700000">
+			<item id="94366" count="1" /> <!-- Master's Book: Berserker Spirit -->
+		</skill>
+		<!-- Clarity Lv. 4 -->
+		<skill name="Clarity" id="45113" level="4" required-level="76" sp="5700000">
+			<item id="94367" count="1" /> <!-- Master's Book: Clarity -->
+		</skill>
+		<skill name="Detection" id="45190" level="1" required-level="76" sp="5700000">
+			<item id="57" count="5000000" /> <!-- Adena -->
 		</skill>
 		<skill name="Mount Saber Tooth Cougar" id="1835" level="1" required-level="76">
-			<item id="90040"/> <!-- Spellbook: Mount Saber Tooth Cougar -->
+			<item id="90040" count="1" /> <!-- Spellbook: Ride Sabretooth Cougar -->
 		</skill>
-		<skill name="Glory Ability" id="45361" level="1" required-level="86">
-			<item id="94046"/> <!-- Spellbook: Glory Ability Lv. 1 -->
+		<skill name="Hex" id="122" level="16" required-level="76" sp="5700000" />
+		<skill name="Power Break" id="115" level="18" required-level="76" sp="5700000">
+			<item id="57" count="500000" /> <!-- Adena -->
 		</skill>
-		<skill name="Mount White Wings" id="54200" level="1" required-level="87">
-			<item id="93059"/> <!-- Spellbook: Summon White Wings -->
-		</skill>	
-		<skill name="Mount Shining Lady" id="54202" level="1" required-level="89">
-			<item id="93061"/> <!-- Spellbook: Summon Silver Saint -->
-		</skill>
-		
+		<skill name="Deadly Blow" id="263" level="41" required-level="76" sp="5700000" />
+		<skill name="Lethal Blow" id="344" level="1" required-level="76" sp="5700000" />
+		<skill name="Backstab" id="30" level="38" required-level="76" sp="5700000" />
+		<skill name="Emergency Rescue" id="70" level="46" required-level="76" sp="5700000" />
+
 		<skill name="Bluff" id="358" level="2" required-level="77" sp="5700000" />
 		<skill name="Dagger Mastery" id="209" level="47" required-level="77" sp="5700000" />
 		<skill name="Light Armor Mastery" id="233" level="49" required-level="77" sp="5700000" />
-		<skill name="Sting" id="223" level="51" required-level="77" sp="5700000" />
-		<skill name="Drain Energy" id="70" level="55" required-level="77" sp="5700000" />
-		<skill name="Bleed" id="96" level="8" required-level="77" sp="5700000" />
-		<skill name="Deadly Blow" id="263" level="39" required-level="77" sp="5700000" />
-		<skill name="Backstab" id="30" level="39" required-level="77" sp="5700000" />
+		<skill name="Confusion" id="2" level="22" required-level="77" sp="5700000" />
+		<skill name="Drain Energy" id="45250" level="27" required-level="77" sp="5700000" />
 		<skill name="Critical Wound" id="531" level="1" required-level="77" sp="5700000">
-			<item id="90055"/> <!-- Scroll: Critical Wound -->
+			<item id="90055" count="1" /> <!-- Scroll: Critical Wound -->
 		</skill>
+		<skill name="Blood Attack" id="223" level="52" required-level="77" sp="5700000" />
+		<skill name="Bleed" id="96" level="8" required-level="77" sp="5700000" />
 		<skill name="Clear Movements" id="1631" level="1" required-level="77" sp="5700000">
-			<item id="90054"/> <!-- Scroll: Clear Movements -->
+			<item id="90054" count="1" /> <!-- Scroll: Clear Movements -->
 		</skill>
-		
+		<skill name="Hex" id="122" level="17" required-level="77" sp="5700000" />
+		<skill name="Deadly Blow" id="263" level="42" required-level="77" sp="5700000" />
+		<skill name="Lethal Blow" id="344" level="2" required-level="77" sp="5700000" />
+		<skill name="Backstab" id="30" level="39" required-level="77" sp="5700000" />
+		<skill name="Emergency Rescue" id="70" level="47" required-level="77" sp="5700000" />
+
 		<skill name="Bluff" id="358" level="3" required-level="78" sp="13300000" />
 		<skill name="Dagger Mastery" id="209" level="48" required-level="78" sp="13300000" />
 		<skill name="Light Armor Mastery" id="233" level="50" required-level="78" sp="13300000" />
-		<skill name="Sting" id="223" level="52" required-level="78" sp="13300000" />
-		<skill name="Freezing Strike" id="105" level="26" required-level="78" sp="13300000" />
-		<skill name="Drain Energy" id="70" level="56" required-level="78" sp="13300000" />
+		<skill name="Confusion" id="2" level="23" required-level="78" sp="13300000" />
+		<skill name="Freezing Weapon" id="105" level="29" required-level="78" sp="13300000" />
+		<skill name="Drain Energy" id="45250" level="28" required-level="78" sp="13300000" />
+		<skill name="Blood Attack" id="223" level="53" required-level="78" sp="13300000" />
 		<skill name="Bleed" id="96" level="9" required-level="78" sp="13300000" />
 		<skill name="Sand Bomb" id="412" level="11" required-level="78" sp="13300000" />
-		<skill name="Hex" id="122" level="17" required-level="78" sp="13300000" />
-		<skill name="Deadly Blow" id="263" level="40" required-level="78" sp="13300000" />
+		<skill name="Hex" id="122" level="18" required-level="78" sp="13300000" />
 		<skill name="Power Break" id="115" level="19" required-level="78" sp="13300000" />
+		<skill name="Deadly Blow" id="263" level="43" required-level="78" sp="13300000" />
+		<skill name="Lethal Blow" id="344" level="3" required-level="78" sp="13300000" />
 		<skill name="Backstab" id="30" level="40" required-level="78" sp="13300000" />
-		<skill name="Shadow Step" id="821" level="8" required-level="78" sp="13300000" />
 		<skill name="Focus Power" id="357" level="1" required-level="78" sp="13300000">
-			<item id="90056"/> <!-- Scroll: Focus Power -->
+			<item id="90056" count="1" /> <!-- Scroll: Focus Power -->
 		</skill>
 		<skill name="Focus Death" id="355" level="1" required-level="78" sp="13300000">
-			<item id="90058"/> <!-- Scroll: Focus Death -->
+			<item id="90058" count="1" /> <!-- Scroll: Focus Death -->
 		</skill>
-		
+		<skill name="Shadow Step" id="821" level="8" required-level="78" sp="13300000" />
+		<skill name="Emergency Rescue" id="70" level="48" required-level="78" sp="13300000" />
+
 		<skill name="Bluff" id="358" level="4" required-level="79" sp="13300000" />
-		<skill name="Bleed" id="96" level="10" required-level="79" sp="13300000" />
+		<skill name="Confusion" id="2" level="24" required-level="79" sp="13300000" />
 		<skill name="Counterattack" id="447" level="1" required-level="79" sp="13300000">
-			<item id="90061"/> <!-- Scroll: Counterattack -->
+			<item id="90061" count="1" /> <!-- Scroll: Counterattack -->
 		</skill>
+		<skill name="Drain Energy" id="45250" level="29" required-level="79" sp="13300000" />
+		<skill name="Blood Attack" id="223" level="54" required-level="79" sp="13300000" />
+		<skill name="Bleed" id="96" level="10" required-level="79" sp="13300000" />
+		<skill name="Hex" id="122" level="19" required-level="79" sp="13300000" />
+		<skill name="Deadly Blow" id="263" level="44" required-level="79" sp="13300000" />
+		<skill name="Lethal Blow" id="344" level="4" required-level="79" sp="13300000" />
+		<skill name="Emergency Rescue" id="70" level="49" required-level="79" sp="13300000" />
 
 		<skill name="Bluff" id="358" level="5" required-level="80" sp="13300000" />
 		<skill name="Dagger Mastery" id="209" level="49" required-level="80" sp="13300000" />
 		<skill name="Light Armor Mastery" id="233" level="51" required-level="80" sp="13300000" />
+		<skill name="Confusion" id="2" level="25" required-level="80" sp="13300000" />
+		<skill name="Freezing Weapon" id="105" level="30" required-level="80" sp="13300000" />
+		<skill name="Drain Energy" id="45250" level="30" required-level="80" sp="13300000" />
+		<skill name="Blood Attack" id="223" level="55" required-level="80" sp="13300000" />
 		<skill name="Bleed" id="96" level="11" required-level="80" sp="13300000" />
-		<skill name="Deadly Blow" id="263" level="41" required-level="80" sp="13300000" />
-		<skill name="Backstab" id="30" level="41" required-level="80" sp="13300000" />
-		<skill name="Ghost Walking" id="770" level="1" required-level="80" sp="13300000">
-			<item id="90135"/> <!-- Scroll: Ghost Walking -->
+		<skill name="Evolution Power" id="45189" level="1" required-level="80">
+			<item id="57" count="10000000" /> <!-- Adena -->
 		</skill>
+		<skill name="Ghost Walking" id="770" level="1" required-level="80" sp="13300000">
+			<item id="90135" count="1" /> <!-- Scroll: Ghost Walking -->
+		</skill>
+		<skill name="Hex" id="122" level="20" required-level="80" sp="13300000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="20" required-level="80" sp="13300000" />
+		<skill name="Deadly Blow" id="263" level="45" required-level="80" sp="13300000" />
+		<skill name="Lethal Blow" id="344" level="5" required-level="80" sp="13300000" />
+		<skill name="White Guardian Transformation" id="54102" level="1" required-level="80">
+			<item id="92401" count="1" /> <!-- Spellbook - White Guardian -->
+		</skill>
+		<skill name="Backstab" id="30" level="41" required-level="80" sp="13300000" />
+		<skill name="Emergency Rescue" id="70" level="50" required-level="80" sp="13300000" />
 
 		<skill name="Bluff" id="358" level="6" required-level="81" sp="160000000" />
 		<skill name="Dagger Mastery" id="209" level="50" required-level="81" sp="160000000" />
 		<skill name="Light Armor Mastery" id="233" level="52" required-level="81" sp="160000000" />
+		<skill name="Confusion" id="2" level="26" required-level="81" sp="160000000" />
+		<skill name="Drain Energy" id="45250" level="31" required-level="81" sp="160000000" />
 		<skill name="Critical Wound" id="531" level="2" required-level="81" sp="160000000" />
+		<skill name="Blood Attack" id="223" level="56" required-level="81" sp="160000000" />
 		<skill name="Bleed" id="96" level="12" required-level="81" sp="160000000" />
 		<skill name="Clear Movements" id="1631" level="2" required-level="81" sp="160000000" />
-		<skill name="Deadly Blow" id="263" level="42" required-level="81" sp="160000000" />
+		<skill name="Hex" id="122" level="21" required-level="81" sp="160000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="21" required-level="81" sp="160000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Deadly Blow" id="263" level="46" required-level="81" sp="160000000" />
+		<skill name="Lethal Blow" id="344" level="6" required-level="81" sp="160000000" />
 		<skill name="Backstab" id="30" level="42" required-level="81" sp="160000000" />
+		<skill name="Emergency Rescue" id="70" level="51" required-level="81" sp="160000000" />
 
 		<skill name="Bluff" id="358" level="7" required-level="82" sp="170000000" />
 		<skill name="Dagger Mastery" id="209" level="51" required-level="82" sp="170000000" />
 		<skill name="Light Armor Mastery" id="233" level="53" required-level="82" sp="170000000" />
+		<skill name="Confusion" id="2" level="27" required-level="82" sp="170000000" />
+		<skill name="Freezing Weapon" id="105" level="31" required-level="82" sp="170000000" />
+		<skill name="Drain Energy" id="45250" level="32" required-level="82" sp="170000000" />
+		<skill name="Blood Attack" id="223" level="57" required-level="82" sp="170000000" />
 		<skill name="Bleed" id="96" level="13" required-level="82" sp="170000000" />
-		<skill name="Deadly Blow" id="263" level="43" required-level="82" sp="170000000" />
-		<skill name="Lethal Blow" id="344" level="2" required-level="82" sp="170000000" />
+		<skill name="Hex" id="122" level="22" required-level="82" sp="170000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="22" required-level="82" sp="170000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Deadly Blow" id="263" level="47" required-level="82" sp="170000000" />
+		<skill name="Lethal Blow" id="344" level="7" required-level="82" sp="170000000" />
 		<skill name="Backstab" id="30" level="43" required-level="82" sp="170000000" />
+		<skill name="Emergency Rescue" id="70" level="52" required-level="82" sp="170000000" />
 
 		<skill name="Bluff" id="358" level="8" required-level="83" sp="240000000" />
 		<skill name="Dagger Mastery" id="209" level="52" required-level="83" sp="240000000" />
 		<skill name="Light Armor Mastery" id="233" level="54" required-level="83" sp="240000000" />
+		<skill name="Confusion" id="2" level="28" required-level="83" sp="240000000" />
+		<skill name="Drain Energy" id="45250" level="33" required-level="83" sp="240000000" />
+		<skill name="Blood Attack" id="223" level="58" required-level="83" sp="240000000" />
 		<skill name="Bleed" id="96" level="14" required-level="83" sp="240000000" />
-		<skill name="Deadly Blow" id="263" level="44" required-level="83" sp="240000000" />
+		<skill name="Hex" id="122" level="23" required-level="83" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="23" required-level="83" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Deadly Blow" id="263" level="48" required-level="83" sp="240000000" />
+		<skill name="Lethal Blow" id="344" level="8" required-level="83" sp="240000000" />
 		<skill name="Backstab" id="30" level="44" required-level="83" sp="240000000" />
+		<skill name="Emergency Rescue" id="70" level="53" required-level="83" sp="240000000" />
 
 		<skill name="Bluff" id="358" level="9" required-level="84" sp="240000000" />
 		<skill name="Dagger Mastery" id="209" level="53" required-level="84" sp="240000000" />
 		<skill name="Light Armor Mastery" id="233" level="55" required-level="84" sp="240000000" />
+		<skill name="Confusion" id="2" level="29" required-level="84" sp="240000000" />
+		<skill name="Freezing Weapon" id="105" level="32" required-level="84" sp="240000000" />
+		<skill name="Drain Energy" id="45250" level="34" required-level="84" sp="240000000" />
+		<skill name="Blood Attack" id="223" level="59" required-level="84" sp="240000000" />
 		<skill name="Bleed" id="96" level="15" required-level="84" sp="240000000" />
-		<skill name="Deadly Blow" id="263" level="45" required-level="84" sp="240000000" />
+		<skill name="Hex" id="122" level="24" required-level="84" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="24" required-level="84" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Deadly Blow" id="263" level="49" required-level="84" sp="240000000" />
+		<skill name="Lethal Blow" id="344" level="9" required-level="84" sp="240000000" />
 		<skill name="Backstab" id="30" level="45" required-level="84" sp="240000000" />
-		
+		<skill name="Emergency Rescue" id="70" level="54" required-level="84" sp="240000000" />
+
 		<skill name="Dagger Mastery" id="209" level="54" required-level="85" sp="840000000" />
-		<skill name="Dagger Mastery" id="209" level="55" required-level="86" sp="924000000" />
-		<skill name="Dagger Mastery" id="209" level="56" required-level="87" sp="1016400000" />
-		<skill name="Dagger Mastery" id="209" level="57" required-level="88" sp="1118040000" />
-		<skill name="Dagger Mastery" id="209" level="58" required-level="89" sp="1229844000" />
-		<skill name="Dagger Mastery" id="209" level="59" required-level="90" sp="1352828400" />
 		<skill name="Light Armor Mastery" id="233" level="56" required-level="85" sp="840000000" />
-		<skill name="Light Armor Mastery" id="233" level="57" required-level="86" sp="924000000" />
-		<skill name="Light Armor Mastery" id="233" level="58" required-level="87" sp="1016400000" />
-		<skill name="Light Armor Mastery" id="233" level="59" required-level="88" sp="1118040000" />
-		<skill name="Light Armor Mastery" id="233" level="60" required-level="89" sp="1229844000" />
-		<skill name="Light Armor Mastery" id="233" level="61" required-level="90" sp="1352828400" />
+		<skill name="Confusion" id="2" level="30" required-level="85" sp="840000000" />
+		<skill name="Drain Energy" id="45250" level="35" required-level="85" sp="840000000" />
+		<skill name="Blood Attack" id="223" level="60" required-level="85" sp="840000000" />
+		<skill name="Hex" id="122" level="25" required-level="85" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="25" required-level="85" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Deadly Blow" id="263" level="50" required-level="85" sp="840000000" />
+		<skill name="Lethal Blow" id="344" level="10" required-level="85" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="55" required-level="85" sp="840000000" />
+
+		<skill name="Dagger Mastery" id="209" level="55" required-level="86" sp="840000000" />
+		<skill name="Light Armor Mastery" id="233" level="57" required-level="86" sp="840000000" />
+		<skill name="Confusion" id="2" level="31" required-level="86" sp="840000000" />
+		<skill name="Freezing Weapon" id="105" level="33" required-level="86" sp="840000000" />
+		<skill name="Drain Energy" id="45250" level="36" required-level="86" sp="840000000" />
+		<skill name="Blood Attack" id="223" level="61" required-level="86" sp="840000000" />
+		<skill name="Hex" id="122" level="26" required-level="86" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="26" required-level="86" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Deadly Blow" id="263" level="51" required-level="86" sp="840000000" />
+		<skill name="Lethal Blow" id="344" level="11" required-level="86" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="56" required-level="86" sp="840000000" />
+
+		<skill name="Dagger Mastery" id="209" level="56" required-level="87" sp="840000000" />
+		<skill name="Light Armor Mastery" id="233" level="58" required-level="87" sp="840000000" />
+		<skill name="Confusion" id="2" level="32" required-level="87" sp="840000000" />
+		<skill name="Drain Energy" id="45250" level="37" required-level="87" sp="840000000" />
+		<skill name="Blood Attack" id="223" level="62" required-level="87" sp="840000000" />
+		<skill name="Hex" id="122" level="27" required-level="87" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="27" required-level="87" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Deadly Blow" id="263" level="52" required-level="87" sp="840000000" />
+		<skill name="Lethal Blow" id="344" level="12" required-level="87" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="57" required-level="87" sp="840000000" />
+
+		<skill name="Dagger Mastery" id="209" level="57" required-level="88" sp="840000000" />
+		<skill name="Light Armor Mastery" id="233" level="59" required-level="88" sp="840000000" />
+		<skill name="Confusion" id="2" level="33" required-level="88" sp="840000000" />
+		<skill name="Freezing Weapon" id="105" level="34" required-level="88" sp="840000000" />
+		<skill name="Drain Energy" id="45250" level="38" required-level="88" sp="840000000" />
+		<skill name="Blood Attack" id="223" level="63" required-level="88" sp="840000000" />
+		<skill name="Hex" id="122" level="28" required-level="88" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="28" required-level="88" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Deadly Blow" id="263" level="53" required-level="88" sp="840000000" />
+		<skill name="Lethal Blow" id="344" level="13" required-level="88" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="58" required-level="88" sp="840000000" />
+
+		<skill name="Dagger Mastery" id="209" level="58" required-level="89" sp="840000000" />
+		<skill name="Light Armor Mastery" id="233" level="60" required-level="89" sp="840000000" />
+		<skill name="Confusion" id="2" level="34" required-level="89" sp="840000000" />
+		<skill name="Drain Energy" id="45250" level="39" required-level="89" sp="840000000" />
+		<skill name="Blood Attack" id="223" level="64" required-level="89" sp="840000000" />
+		<skill name="Hex" id="122" level="29" required-level="89" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="29" required-level="89" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Deadly Blow" id="263" level="54" required-level="89" sp="840000000" />
+		<skill name="Lethal Blow" id="344" level="14" required-level="89" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="59" required-level="89" sp="840000000" />
+
+		<skill name="Dagger Mastery" id="209" level="59" required-level="90" sp="840000000" />
+		<skill name="Light Armor Mastery" id="233" level="61" required-level="90" sp="840000000" />
+		<skill name="Confusion" id="2" level="35" required-level="90" sp="840000000" />
+		<skill name="Freezing Weapon" id="105" level="35" required-level="90" sp="840000000" />
+		<skill name="Drain Energy" id="45250" level="40" required-level="90" sp="840000000" />
+		<skill name="Blood Attack" id="223" level="65" required-level="90" sp="840000000" />
+		<skill name="Hex" id="122" level="30" required-level="90" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="30" required-level="90" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Deadly Blow" id="263" level="55" required-level="90" sp="840000000" />
+		<skill name="Lethal Blow" id="344" level="15" required-level="90" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="60" required-level="90" sp="840000000" />
+
 	</skillTree>
 </list>

--- a/data/skillTrees/3rdClass/GhostSentinel.xml
+++ b/data/skillTrees/3rdClass/GhostSentinel.xml
@@ -1,119 +1,323 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="109" parentClassId="37">
-		<skill name="White Guardian" id="54102" level="1" required-level="80" >
-			<item id="92401"/>
+
+		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="6300000">
+			<item id="8620" count="1" /> <!-- Buff Expansion Book Lv. 3 -->
+		</skill>
+		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="6300000">
+			<item id="8621" count="1" /> <!-- Buff Expansion Book Lv. 4 -->
 		</skill>
 		<skill name="Light Armor Mastery" id="233" level="48" required-level="76" sp="6300000" />
 		<skill name="Bow Mastery" id="208" level="53" required-level="76" sp="6300000" />
-		<skill name="Double Shot" id="19" level="38" required-level="76" sp="6300000" />
+		<skill name="Weapon Mastery" id="141" level="5" required-level="76" sp="6300000" />
+		<skill name="Double Shot" id="19" level="41" required-level="76" sp="6300000" />
 		<skill name="Spirit of Sagittarius" id="415" level="1" required-level="76" sp="6300000" />
-		<skill name="Sting" id="223" level="50" required-level="76" sp="6300000" />
-		<skill name="Freezing Strike" id="105" level="25" required-level="76" sp="6300000" />
-		<skill name="Drain Energy" id="70" level="54" required-level="76" sp="6300000" />
-		<skill name="Detect Darkness" id="53005" level="1" required-level="76" sp="6300000" />
+		<skill name="Confusion" id="2" level="21" required-level="76" sp="6300000" />
+		<skill name="Freezing Weapon" id="105" level="28" required-level="76" sp="6300000" />
+		<skill name="Evolution Defense" id="45188" level="1" required-level="76">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Drain Energy" id="45250" level="26" required-level="76" sp="6300000" />
+		<skill name="Blood Attack" id="223" level="51" required-level="76" sp="6300000" />
+		<!-- Might Lv. 4 -->
+		<skill name="Might" id="1068" level="4" required-level="76" sp="6300000">
+			<item id="94135" count="1" /> <!-- Master's Book: Might -->
+		</skill>
+		<!-- Shield Lv. 4 -->
+		<skill name="Shield" id="1040" level="4" required-level="76" sp="6300000">
+			<item id="94136" count="1" /> <!-- Master's Book: Shield -->
+		</skill>
+		<!-- Acumen Lv. 4 -->
+		<skill name="Acumen" id="45104" level="4" required-level="76" sp="6300000">
+			<item id="94370" count="1" /> <!-- Master's Book: Acumen -->
+		</skill>
+		<!-- Empower Lv. 4 -->
+		<skill name="Empower" id="45105" level="4" required-level="76" sp="6300000">
+			<item id="94361" count="1" /> <!-- Master's Book: Empower -->
+		</skill>
+		<!-- Wild Magic Lv. 3 -->
+		<skill name="Wild Magic" id="45106" level="3" required-level="76" sp="6300000">
+			<item id="94368" count="1" /> <!-- Master's Book: Wild Magic -->
+		</skill>
+		<!-- Wind Walk Lv. 3 -->
+		<skill name="Wind Walk" id="45107" level="3" required-level="76" sp="6300000">
+			<item id="94365" count="1" /> <!-- Master's Book: Wind Walk -->
+		</skill>
+		<!-- Magic Barrier Lv. 3 -->
+		<skill name="Magic Barrier" id="45108" level="3" required-level="76" sp="6300000">
+			<item id="94362" count="1" /> <!-- Master's Book: Magic Barrier -->
+		</skill>
+		<!-- Focus Lv. 4 -->
+		<skill name="Focus" id="45109" level="4" required-level="76" sp="6300000">
+			<item id="94363" count="1" /> <!-- Master's Book: Focus -->
+		</skill>
+		<!-- Death Whisper Lv. 4 -->
+		<skill name="Death Whisper" id="45110" level="4" required-level="76" sp="6300000">
+			<item id="94364" count="1" /> <!-- Master's Book: Death Whisper -->
+		</skill>
+		<!-- Haste Lv. 3 -->
+		<skill name="Haste" id="45111" level="3" required-level="76" sp="6300000">
+			<item id="94369" count="1" /> <!-- Master's Book: Haste -->
+		</skill>
+		<!-- Berserker Spirit Lv. 3 -->
+		<skill name="Berserker Spirit" id="45112" level="3" required-level="76" sp="6300000">
+			<item id="94366" count="1" /> <!-- Master's Book: Berserker Spirit -->
+		</skill>
+		<!-- Clarity Lv. 4 -->
+		<skill name="Clarity" id="45113" level="4" required-level="76" sp="6300000">
+			<item id="94367" count="1" /> <!-- Master's Book: Clarity -->
+		</skill>
+		<skill name="Detect Darkness" id="53005" level="1" required-level="76" sp="6300000">
+			<item id="91482" count="1" /> <!-- Scroll: Detect Darkness -->
+		</skill>
 		<skill name="Fatal Counter" id="314" level="17" required-level="76" sp="6300000" />
 		<skill name="Stun Shot" id="101" level="41" required-level="76" sp="6300000" />
-		<skill name="Hex" id="122" level="16" required-level="76" sp="6300000" />
-		<skill name="Lethal Shot" id="343" level="1" required-level="76" sp="6300000" />
-		<skill name="Power Break" id="115" level="18" required-level="76" sp="6300000" />
-		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="6300000">
-			<item id="8620"/> <!-- Ancient Book: Divine Inspiration (Manuscript) -->
-		</skill>
-		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="6300000">
-			<item id="8621"/> <!-- Ancient Book: Divine Inspiration (Original Version) -->
-		</skill>
 		<skill name="Mount Saber Tooth Cougar" id="1835" level="1" required-level="76">
-			<item id="90040"/> <!-- Spellbook: Mount Saber Tooth Cougar -->
+			<item id="90040" count="1" /> <!-- Spellbook: Ride Sabretooth Cougar -->
 		</skill>
-		<skill name="Glory Ability" id="45361" level="1" required-level="86">
-			<item id="94046"/> <!-- Spellbook: Glory Ability Lv. 1 -->
+		<skill name="Hex" id="122" level="16" required-level="76" sp="6300000" />
+		<skill name="Power Break" id="115" level="18" required-level="76" sp="6300000" />
+		<skill name="Lethal Shot" id="343" level="1" required-level="76" sp="6300000" />
+		<skill name="Dark Sense" id="45387" level="1" required-level="76" sp="6300000">
+			<item id="94140" count="1" /> <!-- Spellbook: Dark Sense -->
 		</skill>
-		<skill name="Mount White Wings" id="54200" level="1" required-level="87">
-			<item id="93059"/> <!-- Spellbook: Summon White Wings -->
-		</skill>	
-		<skill name="Mount Shining Lady" id="54202" level="1" required-level="89">
-			<item id="93061"/> <!-- Spellbook: Summon Silver Saint -->
-		</skill>
-		
+		<skill name="Emergency Rescue" id="70" level="46" required-level="76" sp="6300000" />
+
 		<skill name="Light Armor Mastery" id="233" level="49" required-level="77" sp="6300000" />
 		<skill name="Bow Mastery" id="208" level="54" required-level="77" sp="6300000" />
-		<skill name="Double Shot" id="19" level="39" required-level="77" sp="6300000" />
-		<skill name="Sting" id="223" level="51" required-level="77" sp="6300000" />
+		<skill name="Double Shot" id="19" level="42" required-level="77" sp="6300000" />
+		<skill name="Confusion" id="2" level="22" required-level="77" sp="6300000" />
 		<skill name="Hamstring Shot" id="354" level="1" required-level="77" sp="6300000" />
-		<skill name="Drain Energy" id="70" level="55" required-level="77" sp="6300000" />
+		<skill name="Drain Energy" id="45250" level="27" required-level="77" sp="6300000" />
+		<skill name="Blood Attack" id="223" level="52" required-level="77" sp="6300000" />
 		<skill name="Fatal Counter" id="314" level="18" required-level="77" sp="6300000" />
 		<skill name="Stun Shot" id="101" level="42" required-level="77" sp="6300000" />
+		<skill name="Hex" id="122" level="17" required-level="77" sp="6300000" />
 		<skill name="Lethal Shot" id="343" level="2" required-level="77" sp="6300000" />
-		
+		<skill name="Emergency Rescue" id="70" level="47" required-level="77" sp="6300000" />
+
 		<skill name="Light Armor Mastery" id="233" level="50" required-level="78" sp="14700000" />
 		<skill name="Bow Mastery" id="208" level="55" required-level="78" sp="14700000" />
-		<skill name="Double Shot" id="19" level="40" required-level="78" sp="14700000" />
-		<skill name="Sting" id="223" level="52" required-level="78" sp="14700000" />
-		<skill name="Freezing Strike" id="105" level="26" required-level="78" sp="14700000" />
-		<skill name="Drain Energy" id="70" level="56" required-level="78" sp="14700000" />
+		<skill name="Real Target" id="522" level="1" required-level="78" sp="14700000">
+			<item id="90062" count="1" /> <!-- Scroll: Real Target -->
+		</skill>
+		<skill name="Double Shot" id="19" level="43" required-level="78" sp="14700000" />
+		<skill name="Confusion" id="2" level="23" required-level="78" sp="14700000" />
+		<skill name="Freezing Weapon" id="105" level="29" required-level="78" sp="14700000" />
+		<skill name="Drain Energy" id="45250" level="28" required-level="78" sp="14700000" />
+		<skill name="Blood Attack" id="223" level="53" required-level="78" sp="14700000" />
 		<skill name="Fatal Counter" id="314" level="19" required-level="78" sp="14700000" />
 		<skill name="Stun Shot" id="101" level="43" required-level="78" sp="14700000" />
-		<skill name="Hex" id="122" level="17" required-level="78" sp="14700000" />
-		<skill name="Lethal Shot" id="343" level="3" required-level="78" sp="14700000" />
+		<skill name="Hex" id="122" level="18" required-level="78" sp="14700000" />
 		<skill name="Power Break" id="115" level="19" required-level="78" sp="14700000" />
-		<skill name="Real Target" id="522" level="1" required-level="78" sp="14700000">
-			<item id="90062"/> <!-- Scroll: Real Target -->
-		</skill>
-		
+		<skill name="Lethal Shot" id="343" level="3" required-level="78" sp="14700000" />
+		<skill name="Emergency Rescue" id="70" level="48" required-level="78" sp="14700000" />
+
+		<skill name="Double Shot" id="19" level="44" required-level="79" sp="14700000" />
+		<skill name="Confusion" id="2" level="24" required-level="79" sp="14700000" />
+		<skill name="Drain Energy" id="45250" level="29" required-level="79" sp="14700000" />
+		<skill name="Blood Attack" id="223" level="54" required-level="79" sp="14700000" />
+		<skill name="Hex" id="122" level="19" required-level="79" sp="14700000" />
 		<skill name="Lethal Shot" id="343" level="4" required-level="79" sp="14700000" />
 		<skill name="Death Sting" id="990" level="1" required-level="79" sp="14700000">
-			<item id="90063"/> <!-- Scroll: Death Sting -->
+			<item id="90063" count="1" /> <!-- Scroll: Death Sting -->
 		</skill>
-		
+		<skill name="Emergency Rescue" id="70" level="49" required-level="79" sp="14700000" />
+
 		<skill name="Light Armor Mastery" id="233" level="51" required-level="80" sp="14700000" />
 		<skill name="Bow Mastery" id="208" level="56" required-level="80" sp="14700000" />
 		<skill name="Real Target" id="522" level="2" required-level="80" sp="14700000" />
-		<skill name="Double Shot" id="19" level="41" required-level="80" sp="14700000" />
-		<skill name="Dead Eye" id="414" level="9" required-level="80" sp="14700000" />
-		<skill name="Stun Shot" id="101" level="44" required-level="80" sp="14700000" />
-		<skill name="Lethal Shot" id="343" level="5" required-level="80" sp="14700000" />
-		<skill name="Ghost Piercing" id="773" level="1" required-level="80" sp="14700000">
-			<item id="90066"/> <!-- Scroll: Ghost Piercing -->
+		<skill name="Double Shot" id="19" level="45" required-level="80" sp="14700000" />
+		<skill name="Confusion" id="2" level="25" required-level="80" sp="14700000" />
+		<skill name="Freezing Weapon" id="105" level="30" required-level="80" sp="14700000" />
+		<skill name="Drain Energy" id="45250" level="30" required-level="80" sp="14700000" />
+		<skill name="Blood Attack" id="223" level="55" required-level="80" sp="14700000" />
+		<skill name="Dead Eye" id="414" level="9" required-level="80" sp="14700000">
+				<item id="57" count="1000000" /> <!-- Adena -->
 		</skill>
+		<skill name="Evolution Power" id="45189" level="1" required-level="80">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Stun Shot" id="101" level="44" required-level="80" sp="14700000" />
+		<skill name="Ghost Piercing" id="773" level="1" required-level="80" sp="14700000">
+			<item id="90066" count="1" /> <!-- Scroll: Ghost Piercing -->
+		</skill>	
+		<skill name="Hex" id="122" level="20" required-level="80" sp="14700000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="20" required-level="80" sp="14700000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Lethal Shot" id="343" level="5" required-level="80" sp="14700000" />
+		<skill name="White Guardian Transformation" id="54102" level="1" required-level="80">
+			<item id="92401" count="1" /> <!-- Spellbook - White Guardian -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="50" required-level="80" sp="14700000" />
 
 		<skill name="Light Armor Mastery" id="233" level="52" required-level="81" sp="160000000" />
 		<skill name="Bow Mastery" id="208" level="57" required-level="81" sp="160000000" />
-		<skill name="Double Shot" id="19" level="42" required-level="81" sp="160000000" />
+		<skill name="Double Shot" id="19" level="46" required-level="81" sp="160000000" />
+		<skill name="Confusion" id="2" level="26" required-level="81" sp="160000000" />
+		<skill name="Drain Energy" id="45250" level="31" required-level="81" sp="160000000" />
+		<skill name="Blood Attack" id="223" level="56" required-level="81" sp="160000000" />
 		<skill name="Stun Shot" id="101" level="45" required-level="81" sp="160000000" />
+		<skill name="Hex" id="122" level="21" required-level="81" sp="160000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="21" required-level="81" sp="160000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
 		<skill name="Lethal Shot" id="343" level="6" required-level="81" sp="160000000" />
+		<skill name="Emergency Rescue" id="70" level="51" required-level="81" sp="160000000" />
 
 		<skill name="Light Armor Mastery" id="233" level="53" required-level="82" sp="170000000" />
 		<skill name="Bow Mastery" id="208" level="58" required-level="82" sp="170000000" />
 		<skill name="Real Target" id="522" level="3" required-level="82" sp="170000000" />
-		<skill name="Double Shot" id="19" level="43" required-level="82" sp="170000000" />
+		<skill name="Double Shot" id="19" level="47" required-level="82" sp="170000000" />
+		<skill name="Confusion" id="2" level="27" required-level="82" sp="170000000" />
+		<skill name="Freezing Weapon" id="105" level="31" required-level="82" sp="170000000" />
+		<skill name="Drain Energy" id="45250" level="32" required-level="82" sp="170000000" />
+		<skill name="Blood Attack" id="223" level="57" required-level="82" sp="170000000" />
 		<skill name="Stun Shot" id="101" level="46" required-level="82" sp="170000000" />
+		<skill name="Hex" id="122" level="22" required-level="82" sp="170000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="22" required-level="82" sp="170000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
 		<skill name="Lethal Shot" id="343" level="7" required-level="82" sp="170000000" />
+		<skill name="Emergency Rescue" id="70" level="52" required-level="82" sp="170000000" />
 
 		<skill name="Light Armor Mastery" id="233" level="54" required-level="83" sp="240000000" />
 		<skill name="Bow Mastery" id="208" level="59" required-level="83" sp="240000000" />
-		<skill name="Double Shot" id="19" level="44" required-level="83" sp="240000000" />
+		<skill name="Double Shot" id="19" level="48" required-level="83" sp="240000000" />
+		<skill name="Confusion" id="2" level="28" required-level="83" sp="240000000" />
+		<skill name="Drain Energy" id="45250" level="33" required-level="83" sp="240000000" />
+		<skill name="Blood Attack" id="223" level="58" required-level="83" sp="240000000" />
 		<skill name="Stun Shot" id="101" level="47" required-level="83" sp="240000000" />
+		<skill name="Hex" id="122" level="23" required-level="83" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="23" required-level="83" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
 		<skill name="Lethal Shot" id="343" level="8" required-level="83" sp="240000000" />
+		<skill name="Emergency Rescue" id="70" level="53" required-level="83" sp="240000000" />
 
 		<skill name="Light Armor Mastery" id="233" level="55" required-level="84" sp="240000000" />
 		<skill name="Bow Mastery" id="208" level="60" required-level="84" sp="240000000" />
 		<skill name="Real Target" id="522" level="4" required-level="84" sp="240000000" />
-		<skill name="Double Shot" id="19" level="45" required-level="84" sp="240000000" />
+		<skill name="Double Shot" id="19" level="49" required-level="84" sp="240000000" />
+		<skill name="Confusion" id="2" level="29" required-level="84" sp="240000000" />
+		<skill name="Freezing Weapon" id="105" level="32" required-level="84" sp="240000000" />
+		<skill name="Drain Energy" id="45250" level="34" required-level="84" sp="240000000" />
+		<skill name="Blood Attack" id="223" level="59" required-level="84" sp="240000000" />
 		<skill name="Stun Shot" id="101" level="48" required-level="84" sp="240000000" />
+		<skill name="Hex" id="122" level="24" required-level="84" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="24" required-level="84" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
 		<skill name="Lethal Shot" id="343" level="9" required-level="84" sp="240000000" />
-		
+		<skill name="Emergency Rescue" id="70" level="54" required-level="84" sp="240000000" />
+
 		<skill name="Light Armor Mastery" id="233" level="56" required-level="85" sp="840000000" />
-		<skill name="Light Armor Mastery" id="233" level="57" required-level="86" sp="924000000" />
-		<skill name="Light Armor Mastery" id="233" level="58" required-level="87" sp="1016400000" />
-		<skill name="Light Armor Mastery" id="233" level="59" required-level="88" sp="1118040000" />
-		<skill name="Light Armor Mastery" id="233" level="60" required-level="89" sp="1229844000" />
-		<skill name="Light Armor Mastery" id="233" level="61" required-level="90" sp="1352828400" />
 		<skill name="Bow Mastery" id="208" level="61" required-level="85" sp="840000000" />
-		<skill name="Bow Mastery" id="208" level="62" required-level="86" sp="924000000" />
-		<skill name="Bow Mastery" id="208" level="63" required-level="87" sp="1016400000" />
-		<skill name="Bow Mastery" id="208" level="64" required-level="88" sp="1118040000" />
-		<skill name="Bow Mastery" id="208" level="65" required-level="89" sp="1229844000" />
-		<skill name="Bow Mastery" id="208" level="66" required-level="90" sp="1352828400" />
+		<skill name="Double Shot" id="19" level="50" required-level="85" sp="840000000" />
+		<skill name="Confusion" id="2" level="30" required-level="85" sp="840000000" />
+		<skill name="Drain Energy" id="45250" level="35" required-level="85" sp="840000000" />
+		<skill name="Blood Attack" id="223" level="60" required-level="85" sp="840000000" />
+		<skill name="Dead Eye" id="414" level="10" required-level="85" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Hex" id="122" level="25" required-level="85" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="25" required-level="85" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Lethal Shot" id="343" level="10" required-level="85" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="55" required-level="85" sp="840000000" />
+
+		<skill name="Light Armor Mastery" id="233" level="57" required-level="86" sp="840000000" />
+		<skill name="Bow Mastery" id="208" level="62" required-level="86" sp="840000000" />
+		<skill name="Double Shot" id="19" level="51" required-level="86" sp="840000000" />
+		<skill name="Confusion" id="2" level="31" required-level="86" sp="840000000" />
+		<skill name="Freezing Weapon" id="105" level="33" required-level="86" sp="840000000" />
+		<skill name="Drain Energy" id="45250" level="36" required-level="86" sp="840000000" />
+		<skill name="Blood Attack" id="223" level="61" required-level="86" sp="840000000" />
+		<skill name="Hex" id="122" level="26" required-level="86" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="26" required-level="86" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Lethal Shot" id="343" level="11" required-level="86" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="56" required-level="86" sp="840000000" />
+
+		<skill name="Light Armor Mastery" id="233" level="58" required-level="87" sp="840000000" />
+		<skill name="Bow Mastery" id="208" level="63" required-level="87" sp="840000000" />
+		<skill name="Double Shot" id="19" level="52" required-level="87" sp="840000000" />
+		<skill name="Confusion" id="2" level="32" required-level="87" sp="840000000" />
+		<skill name="Drain Energy" id="45250" level="37" required-level="87" sp="840000000" />
+		<skill name="Blood Attack" id="223" level="62" required-level="87" sp="840000000" />
+		<skill name="Hex" id="122" level="27" required-level="87" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="27" required-level="87" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Lethal Shot" id="343" level="12" required-level="87" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="57" required-level="87" sp="840000000" />
+
+		<skill name="Light Armor Mastery" id="233" level="59" required-level="88" sp="840000000" />
+		<skill name="Bow Mastery" id="208" level="64" required-level="88" sp="840000000" />
+		<skill name="Double Shot" id="19" level="53" required-level="88" sp="840000000" />
+		<skill name="Confusion" id="2" level="33" required-level="88" sp="840000000" />
+		<skill name="Freezing Weapon" id="105" level="34" required-level="88" sp="840000000" />
+		<skill name="Drain Energy" id="45250" level="38" required-level="88" sp="840000000" />
+		<skill name="Blood Attack" id="223" level="63" required-level="88" sp="840000000" />
+		<skill name="Hex" id="122" level="28" required-level="88" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="28" required-level="88" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Lethal Shot" id="343" level="13" required-level="88" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="58" required-level="88" sp="840000000" />
+
+		<skill name="Light Armor Mastery" id="233" level="60" required-level="89" sp="840000000" />
+		<skill name="Bow Mastery" id="208" level="65" required-level="89" sp="840000000" />
+		<skill name="Double Shot" id="19" level="54" required-level="89" sp="840000000" />
+		<skill name="Confusion" id="2" level="34" required-level="89" sp="840000000" />
+		<skill name="Drain Energy" id="45250" level="39" required-level="89" sp="840000000" />
+		<skill name="Blood Attack" id="223" level="64" required-level="89" sp="840000000" />
+		<skill name="Hex" id="122" level="29" required-level="89" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="29" required-level="89" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Lethal Shot" id="343" level="14" required-level="89" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="59" required-level="89" sp="840000000" />
+
+		<skill name="Light Armor Mastery" id="233" level="61" required-level="90" sp="840000000" />
+		<skill name="Bow Mastery" id="208" level="66" required-level="90" sp="840000000" />
+		<skill name="Double Shot" id="19" level="55" required-level="90" sp="840000000" />
+		<skill name="Confusion" id="2" level="35" required-level="90" sp="840000000" />
+		<skill name="Freezing Weapon" id="105" level="35" required-level="90" sp="840000000" />
+		<skill name="Drain Energy" id="45250" level="40" required-level="90" sp="840000000" />
+		<skill name="Blood Attack" id="223" level="65" required-level="90" sp="840000000" />
+		<skill name="Hex" id="122" level="30" required-level="90" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="30" required-level="90" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Lethal Shot" id="343" level="15" required-level="90" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="60" required-level="90" sp="840000000" />
+
 	</skillTree>
 </list>

--- a/data/skillTrees/3rdClass/GrandKhavatari.xml
+++ b/data/skillTrees/3rdClass/GrandKhavatari.xml
@@ -1,131 +1,254 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="114" parentClassId="48">
-		<skill name="White Guardian" id="54102" level="1" required-level="80" >
-			<item id="92401"/>
+
+		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="6100000">
+			<item id="8620" count="1" /> <!-- Buff Expansion Book Lv. 3 -->
+		</skill>
+		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="6100000">
+			<item id="8621" count="1" /> <!-- Buff Expansion Book Lv. 4 -->
 		</skill>
 		<skill name="Force Burst" id="17" level="35" required-level="76" sp="6100000" />
 		<skill name="Fist Weapon Mastery" id="210" level="46" required-level="76" sp="6100000" />
 		<skill name="Light Armor Mastery" id="233" level="48" required-level="76" sp="6100000" />
-		<skill name="Burning Fist" id="280" level="38" required-level="76" sp="6100000" />
-		<skill name="Force Blaster" id="54" level="50" required-level="76" sp="6100000" />
-		<skill name="Soul Breaker" id="281" level="38" required-level="76" sp="6100000" />
-		<skill name="Raging Force" id="346" level="1" required-level="76" sp="6100000" />
-		<skill name="Force Storm" id="35" level="29" required-level="76" sp="6100000" />
-		<skill name="Hurricane Assault" id="284" level="41" required-level="76" sp="6100000" />
-		<skill name="Cripple" id="95" level="21" required-level="76" sp="6100000" />
-		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="6100000">
-			<item id="8620"/> <!-- Ancient Book: Divine Inspiration (Manuscript) -->
+		<skill name="Weapon Mastery" id="141" level="5" required-level="76" sp="6100000" />
+		<skill name="Burning Fist" id="280" level="41" required-level="76" sp="6100000" />
+		<skill name="Evolution Defense" id="45188" level="1" required-level="76">
+			<item id="57" count="5000000" /> <!-- Adena -->
 		</skill>
-		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="6100000">
-			<item id="8621"/> <!-- Ancient Book: Divine Inspiration (Original Version) -->
+		<skill name="Force Blaster" id="54" level="50" required-level="76" sp="6100000" />
+		<skill name="Crushing Fist" id="281" level="38" required-level="76" sp="6100000" />
+		<skill name="Master of Combat" id="430" level="1" required-level="76" sp="6100000" />
+		<skill name="Chant of Might" id="45126" level="4" required-level="76" sp="6100000" />
+		<skill name="Chant of Shield" id="45127" level="4" required-level="76" sp="6100000" />
+		<skill name="Hawk Nature" id="425" level="1" required-level="76" sp="6100000">
+			<item id="91295" count="1" /> <!-- Scroll: Hawk Spirit Totem -->
+		</skill>
+		<!-- Might Lv. 4 -->
+		<skill name="Chant of Might" id="45126" level="4" required-level="76" sp="6100000">
+			<item id="94135" count="1" /> <!-- Master's Book: Might -->
+		</skill>
+		<!-- Shield Lv. 4 -->
+		<skill name="Chant of Shield" id="45127" level="4" required-level="76" sp="6100000">
+			<item id="94136" count="1" /> <!-- Master's Book: Shield -->
+		</skill>
+		<!-- Acumen Lv. 4 -->
+		<skill name="Chant of Acumen" id="45135" level="4" required-level="76" sp="6100000">
+			<item id="94370" count="1" /> <!-- Master's Book: Acumen -->
+		</skill>
+		<!-- Empower Lv. 4 -->
+		<skill name="Chant of Empower" id="45136" level="4" required-level="76" sp="6100000">
+			<item id="94361" count="1" /> <!-- Master's Book: Empower -->
+		</skill>
+		<!-- Wild Magic Lv. 3 -->
+		<skill name="Chant of Wild Magic" id="45137" level="3" required-level="76" sp="6100000">
+			<item id="94368" count="1" /> <!-- Master's Book: Wild Magic -->
+		</skill>
+		<!-- Wind Walk Lv. 3 -->
+		<skill name="Chant of Wind Walk" id="45124" level="3" required-level="76" sp="6100000">
+			<item id="94365" count="1" /> <!-- Master's Book: Wind Walk -->
+		</skill>
+		<!-- Magic Barrier Lv. 3 -->
+		<skill name="Chant Of Magic Barrier" id="45125" level="3" required-level="76" sp="6100000">
+			<item id="94362" count="1" /> <!-- Master's Book: Magic Barrier -->
+		</skill>
+		<!-- Focus Lv. 4 -->
+		<skill name="Chant Of Focus" id="45121" level="4" required-level="76" sp="6100000">
+			<item id="94363" count="1" /> <!-- Master's Book: Focus -->
+		</skill>
+		<!-- Death Whisper Lv. 4 -->
+		<skill name="Chant Of Death Whisper" id="45122" level="4" required-level="76" sp="6100000">
+			<item id="94364" count="1" /> <!-- Master's Book: Death Whisper -->
+		</skill>
+		<!-- Haste Lv. 3 -->
+		<skill name="Chant of Haste" id="45123" level="3" required-level="76" sp="6100000">
+			<item id="94369" count="1" /> <!-- Master's Book: Haste -->
+		</skill>
+		<!-- Berserker Spirit Lv. 3 -->
+		<skill name="Chant Of Berserker Spirit" id="45128" level="3" required-level="76" sp="6100000">
+			<item id="94366" count="1" /> <!-- Master's Book: Berserker Spirit -->
+		</skill>
+		<!-- Clarity Lv. 4 -->
+		<skill name="Chant Of Clarity" id="45129" level="4" required-level="76" sp="6100000">
+			<item id="94367" count="1" /> <!-- Master's Book: Clarity -->
+		</skill>
+
+		<skill name="Detection" id="45190" level="1" required-level="76" sp="6100000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Final Secret" id="917" level="1" required-level="76" sp="6100000">
+			<item id="90080" count="1" /> <!-- Scroll: Final Secret -->
 		</skill>
 		<skill name="Mount Black Bear" id="1837" level="1" required-level="76">
-			<item id="90042"/> <!--  Spellbook: Mount Black Bear -->
+			<item id="90042" count="1" /> <!-- Spellbook - Mount Black Bear -->
 		</skill>
-		<skill name="Glory Ability" id="45361" level="1" required-level="86">
-			<item id="94046"/> <!-- Spellbook: Glory Ability Lv. 1 -->
-		</skill>
-		<skill name="Mount White Wings" id="54200" level="1" required-level="87">
-			<item id="93059"/> <!-- Spellbook: Summon White Wings -->
-		</skill>	
-		<skill name="Mount Shining Lady" id="54202" level="1" required-level="89">
-			<item id="93061"/> <!-- Spellbook: Summon Silver Saint -->
-		</skill>
-		
+		<skill name="Raging Force" id="346" level="1" required-level="76" sp="6100000" />
+		<skill name="Force Storm" id="35" level="29" required-level="76" sp="6100000" />
+		<skill name="Rush" id="994" level="3" required-level="76" sp="6100000" />
+		<skill name="Hurricane Assault" id="284" level="46" required-level="76" sp="6100000" />
+		<skill name="Cripple" id="95" level="28" required-level="76" sp="6100000" />
+		<skill name="Emergency Rescue" id="70" level="46" required-level="76" sp="6100000" />
+
 		<skill name="Force Burst" id="17" level="36" required-level="77" sp="6100000" />
 		<skill name="Fist Weapon Mastery" id="210" level="47" required-level="77" sp="6100000" />
 		<skill name="Light Armor Mastery" id="233" level="49" required-level="77" sp="6100000" />
-		<skill name="Burning Fist" id="280" level="39" required-level="77" sp="6100000" />
+		<skill name="Burning Fist" id="280" level="42" required-level="77" sp="6100000" />
 		<skill name="Force Blaster" id="54" level="51" required-level="77" sp="6100000" />
-		<skill name="Soul Breaker" id="281" level="39" required-level="77" sp="6100000" />
-		<skill name="Force Storm" id="35" level="30" required-level="77" sp="6100000" />
-		<skill name="Hurricane Assault" id="284" level="42" required-level="77" sp="6100000" />
+		<skill name="Crushing Fist" id="281" level="39" required-level="77" sp="6100000" />
 		<skill name="Force Barrier" id="443" level="1" required-level="77" sp="6100000">
-			<item id="90070"/> <!-- Scroll: Force Barrier -->
+			<item id="90070" count="1" /> <!-- Scroll: Force Barrier -->
 		</skill>
-		
+		<skill name="Force Storm" id="35" level="30" required-level="77" sp="6100000" />
+		<skill name="Hurricane Assault" id="284" level="47" required-level="77" sp="6100000" />
+		<skill name="Emergency Rescue" id="70" level="47" required-level="77" sp="6100000" />
+
 		<skill name="Force Burst" id="17" level="37" required-level="78" sp="14200000" />
 		<skill name="Fist Weapon Mastery" id="210" level="48" required-level="78" sp="14200000" />
 		<skill name="Light Armor Mastery" id="233" level="50" required-level="78" sp="14200000" />
-		<skill name="Burning Fist" id="280" level="40" required-level="78" sp="14200000" />
+		<skill name="Burning Fist" id="280" level="43" required-level="78" sp="14200000" />
 		<skill name="Force Blaster" id="54" level="52" required-level="78" sp="14200000" />
-		<skill name="Master of Combat" id="430" level="1" required-level="78" sp="14200000" />
-		<skill name="Soul Breaker" id="281" level="40" required-level="78" sp="14200000" />
+		<skill name="Crushing Fist" id="281" level="40" required-level="78" sp="14200000" />
 		<skill name="Raging Force" id="346" level="2" required-level="78" sp="14200000" />
 		<skill name="Force Storm" id="35" level="31" required-level="78" sp="14200000" />
-		<skill name="Hurricane Assault" id="284" level="43" required-level="78" sp="14200000" />
+		<skill name="Hurricane Assault" id="284" level="48" required-level="78" sp="14200000" />
 		<skill name="Braveheart" id="440" level="1" required-level="78" sp="14200000" />
-		<skill name="Cripple" id="95" level="22" required-level="78" sp="14200000" />
-		<skill name="Rush" id="994" level="1" required-level="78" sp="14200000">
-			<item id="90071"/> <!-- Scroll: Rush -->
-		</skill>
-		
+		<skill name="Cripple" id="95" level="29" required-level="78" sp="14200000" />
+		<skill name="Emergency Rescue" id="70" level="48" required-level="78" sp="14200000" />
+
 		<skill name="Force Mastery" id="993" level="8" required-level="79" sp="14200000" />
-		<skill name="Burning Fist" id="280" level="41" required-level="79" sp="14200000" />
-		<skill name="Hawk Spirit Totem" id="425" level="1" required-level="79" sp="14200000" />
-		<skill name="Cripple" id="95" level="23" required-level="79" sp="14200000" />
-		<skill name="Final Secret" id="917" level="1" required-level="79" sp="14200000">
-			<item id="90080"/> <!-- Scroll: Final Secret -->
-		</skill>
-		
+		<skill name="Burning Fist" id="280" level="44" required-level="79" sp="14200000" />
+		<skill name="Hurricane Assault" id="284" level="49" required-level="79" sp="14200000" />
+		<skill name="Emergency Rescue" id="70" level="49" required-level="79" sp="14200000" />
+
 		<skill name="Fist Weapon Mastery" id="210" level="49" required-level="80" sp="14200000" />
 		<skill name="Light Armor Mastery" id="233" level="51" required-level="80" sp="14200000" />
-		<skill name="Burning Fist" id="280" level="42" required-level="80" sp="14200000" />
+		<skill name="Burning Fist" id="280" level="45" required-level="80" sp="14200000" />
 		<skill name="Force Blaster" id="54" level="53" required-level="80" sp="14200000" />
-		<skill name="Soul Breaker" id="281" level="41" required-level="80" sp="14200000" />
-		<skill name="Raging Force" id="346" level="3" required-level="80" sp="14200000" />
-		<skill name="Hurricane Assault" id="284" level="44" required-level="80" sp="14200000" />
-		<skill name="Cripple" id="95" level="24" required-level="80" sp="14200000" />
-		<skill name="Maximum Force Focus" id="918" level="1" required-level="80" sp="14200000">
-			<item id="90072"/> <!-- Scroll: Maximum Force Focus -->
+		<skill name="Crushing Fist" id="281" level="41" required-level="80" sp="14200000" />
+		<skill name="Master of Combat" id="430" level="2" required-level="80" sp="14200000">
+			<item id="57" count="500000" /> <!-- Adena -->
 		</skill>
+		<skill name="Evolution Power" id="45189" level="1" required-level="80">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Maximum Force Focus" id="918" level="1" required-level="80" sp="14200000">
+			<item id="90072" count="1" /> <!-- Scroll: Maximum Force Focus -->
+		</skill>
+		<skill name="Raging Force" id="346" level="3" required-level="80" sp="14200000" />
+		<skill name="White Guardian Transformation" id="54102" level="1" required-level="80">
+			<item id="92401" count="1" /> <!-- Spellbook - White Guardian -->
+		</skill>
+		<skill name="Hurricane Assault" id="284" level="50" required-level="80" sp="14200000" />
+		<skill name="Cripple" id="95" level="30" required-level="80" sp="14200000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="50" required-level="80" sp="14200000" />
 
 		<skill name="Fist Weapon Mastery" id="210" level="50" required-level="81" sp="160000000" />
 		<skill name="Light Armor Mastery" id="233" level="52" required-level="81" sp="160000000" />
-		<skill name="Burning Fist" id="280" level="43" required-level="81" sp="160000000" />
+		<skill name="Burning Fist" id="280" level="46" required-level="81" sp="160000000" />
 		<skill name="Force Blaster" id="54" level="54" required-level="81" sp="160000000" />
-		<skill name="Soul Breaker" id="281" level="42" required-level="81" sp="160000000" />
-		<skill name="Hurricane Assault" id="284" level="45" required-level="81" sp="160000000" />
-		<skill name="Cripple" id="95" level="25" required-level="81" sp="160000000" />
+		<skill name="Crushing Fist" id="281" level="42" required-level="81" sp="160000000" />
+		<skill name="Full Knockdown" id="1896" level="1" required-level="81" sp="160000000">
+			<item id="91201" count="1" /> <!-- Scroll: Full Knockdown -->
+		</skill>
+		<skill name="Hurricane Assault" id="284" level="51" required-level="81" sp="160000000" />
+		<skill name="Cripple" id="95" level="31" required-level="81" sp="160000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="51" required-level="81" sp="160000000" />
 
 		<skill name="Fist Weapon Mastery" id="210" level="51" required-level="82" sp="170000000" />
 		<skill name="Light Armor Mastery" id="233" level="53" required-level="82" sp="170000000" />
-		<skill name="Burning Fist" id="280" level="44" required-level="82" sp="170000000" />
+		<skill name="Burning Fist" id="280" level="47" required-level="82" sp="170000000" />
 		<skill name="Force Blaster" id="54" level="55" required-level="82" sp="170000000" />
-		<skill name="Soul Breaker" id="281" level="43" required-level="82" sp="170000000" />
+		<skill name="Crushing Fist" id="281" level="43" required-level="82" sp="170000000" />
+		<skill name="Full Knockdown" id="1896" level="2" required-level="82" sp="170000000" />
 		<skill name="Raging Force" id="346" level="4" required-level="82" sp="170000000" />
-		<skill name="Hurricane Assault" id="284" level="46" required-level="82" sp="170000000" />
-		<skill name="Cripple" id="95" level="26" required-level="82" sp="170000000" />
+		<skill name="Hurricane Assault" id="284" level="52" required-level="82" sp="170000000" />
+		<skill name="Cripple" id="95" level="32" required-level="82" sp="170000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="52" required-level="82" sp="170000000" />
 
 		<skill name="Fist Weapon Mastery" id="210" level="52" required-level="83" sp="240000000" />
 		<skill name="Light Armor Mastery" id="233" level="54" required-level="83" sp="240000000" />
-		<skill name="Burning Fist" id="280" level="45" required-level="83" sp="240000000" />
+		<skill name="Burning Fist" id="280" level="48" required-level="83" sp="240000000" />
 		<skill name="Force Blaster" id="54" level="56" required-level="83" sp="240000000" />
-		<skill name="Soul Breaker" id="281" level="44" required-level="83" sp="240000000" />
-		<skill name="Hurricane Assault" id="284" level="47" required-level="83" sp="240000000" />
-		<skill name="Cripple" id="95" level="27" required-level="83" sp="240000000" />
+		<skill name="Crushing Fist" id="281" level="44" required-level="83" sp="240000000" />
+		<skill name="Full Knockdown" id="1896" level="3" required-level="83" sp="240000000" />
+		<skill name="Hurricane Assault" id="284" level="53" required-level="83" sp="240000000" />
+		<skill name="Cripple" id="95" level="33" required-level="83" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="53" required-level="83" sp="240000000" />
 
 		<skill name="Fist Weapon Mastery" id="210" level="53" required-level="84" sp="240000000" />
 		<skill name="Light Armor Mastery" id="233" level="55" required-level="84" sp="240000000" />
-		<skill name="Burning Fist" id="280" level="46" required-level="84" sp="240000000" />
+		<skill name="Burning Fist" id="280" level="49" required-level="84" sp="240000000" />
 		<skill name="Force Blaster" id="54" level="57" required-level="84" sp="240000000" />
-		<skill name="Soul Breaker" id="281" level="45" required-level="84" sp="240000000" />
+		<skill name="Crushing Fist" id="281" level="45" required-level="84" sp="240000000" />
+		<skill name="Full Knockdown" id="1896" level="4" required-level="84" sp="240000000" />
 		<skill name="Raging Force" id="346" level="5" required-level="84" sp="240000000" />
-		<skill name="Hurricane Assault" id="284" level="48" required-level="84" sp="240000000" />
-		<skill name="Cripple" id="95" level="28" required-level="84" sp="240000000" />
-		
+		<skill name="Hurricane Assault" id="284" level="54" required-level="84" sp="240000000" />
+		<skill name="Cripple" id="95" level="34" required-level="84" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="54" required-level="84" sp="240000000" />
+
 		<skill name="Fist Weapon Mastery" id="210" level="54" required-level="85" sp="840000000" />
-		<skill name="Fist Weapon Mastery" id="210" level="55" required-level="86" sp="924000000" />
-		<skill name="Fist Weapon Mastery" id="210" level="56" required-level="87" sp="1016400000" />
-		<skill name="Fist Weapon Mastery" id="210" level="57" required-level="88" sp="1118040000" />
-		<skill name="Fist Weapon Mastery" id="210" level="58" required-level="89" sp="1229844000" />
-		<skill name="Fist Weapon Mastery" id="210" level="59" required-level="90" sp="1352828400" />
 		<skill name="Light Armor Mastery" id="233" level="56" required-level="85" sp="840000000" />
+		<skill name="Burning Fist" id="280" level="50" required-level="85" sp="840000000" />
+		<skill name="Hurricane Assault" id="284" level="55" required-level="85" sp="840000000" />
+		<skill name="Cripple" id="95" level="35" required-level="85" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="55" required-level="85" sp="840000000" />
+
+		<skill name="Fist Weapon Mastery" id="210" level="55" required-level="86" sp="840000000" />
 		<skill name="Light Armor Mastery" id="233" level="57" required-level="86" sp="840000000" />
+		<skill name="Burning Fist" id="280" level="51" required-level="86" sp="840000000" />
+		<skill name="Hurricane Assault" id="284" level="56" required-level="86" sp="840000000" />
+		<skill name="Cripple" id="95" level="36" required-level="86" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="56" required-level="86" sp="840000000" />
+
+		<skill name="Fist Weapon Mastery" id="210" level="56" required-level="87" sp="840000000" />
 		<skill name="Light Armor Mastery" id="233" level="58" required-level="87" sp="840000000" />
+		<skill name="Burning Fist" id="280" level="52" required-level="87" sp="840000000" />
+		<skill name="Hurricane Assault" id="284" level="57" required-level="87" sp="840000000" />
+		<skill name="Cripple" id="95" level="37" required-level="87" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="57" required-level="87" sp="840000000" />
+
+		<skill name="Fist Weapon Mastery" id="210" level="57" required-level="88" sp="840000000" />
 		<skill name="Light Armor Mastery" id="233" level="59" required-level="88" sp="840000000" />
+		<skill name="Burning Fist" id="280" level="53" required-level="88" sp="840000000" />
+		<skill name="Hurricane Assault" id="284" level="58" required-level="88" sp="840000000" />
+		<skill name="Cripple" id="95" level="38" required-level="88" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="58" required-level="88" sp="840000000" />
+
+		<skill name="Fist Weapon Mastery" id="210" level="58" required-level="89" sp="840000000" />
 		<skill name="Light Armor Mastery" id="233" level="60" required-level="89" sp="840000000" />
+		<skill name="Burning Fist" id="280" level="54" required-level="89" sp="840000000" />
+		<skill name="Hurricane Assault" id="284" level="59" required-level="89" sp="840000000" />
+		<skill name="Cripple" id="95" level="39" required-level="89" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="59" required-level="89" sp="840000000" />
+
+		<skill name="Fist Weapon Mastery" id="210" level="59" required-level="90" sp="840000000" />
 		<skill name="Light Armor Mastery" id="233" level="61" required-level="90" sp="840000000" />
+		<skill name="Burning Fist" id="280" level="55" required-level="90" sp="840000000" />
+		<skill name="Hurricane Assault" id="284" level="60" required-level="90" sp="840000000" />
+		<skill name="Cripple" id="95" level="40" required-level="90" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="60" required-level="90" sp="840000000" />
+
 	</skillTree>
 </list>

--- a/data/skillTrees/3rdClass/HellKnight.xml
+++ b/data/skillTrees/3rdClass/HellKnight.xml
@@ -1,107 +1,172 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="91" parentClassId="6">
-		<skill name="White Guardian" id="54102" level="1" required-level="80" >
-			<item id="92401"/>
-		</skill>
+
 		<skill name="Aggression" id="28" level="50" required-level="76" sp="5400000" />
 		<skill name="Shield Strike" id="984" level="16" required-level="76" sp="5400000" />
 		<skill name="Aggression Aura" id="18" level="38" required-level="76" sp="5400000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="46" required-level="76" sp="5400000" />
+		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="5400000">
+			<item id="8620" count="1" /> <!-- Buff Expansion Book Lv. 3 -->
+		</skill>
+		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="5400000">
+			<item id="8621" count="1" /> <!-- Buff Expansion Book Lv. 4 -->
+		</skill>
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="46" required-level="76" sp="5400000" />
+		<skill name="Weapon Mastery" id="141" level="5" required-level="76" sp="5400000" />
 		<skill name="Heavy Armor Mastery" id="232" level="53" required-level="76" sp="5400000" />
-		<skill name="Drain Energy" id="70" level="54" required-level="76" sp="5400000" />
+		<skill name="Evolution Defense" id="45188" level="1" required-level="76">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Magic Resistance" id="147" level="52" required-level="76" sp="5400000" />
+		<!-- Might Lv. 4 -->
+		<skill name="Might" id="1068" level="4" required-level="76" sp="5400000">
+			<item id="94135" count="1" /> <!-- Master's Book: Might -->
+		</skill>
+		<!-- Shield Lv. 4 -->
+		<skill name="Shield" id="1040" level="4" required-level="76" sp="5400000">
+			<item id="94136" count="1" /> <!-- Master's Book: Shield -->
+		</skill>
+		<!-- Acumen Lv. 4 -->
+		<skill name="Acumen" id="45104" level="4" required-level="76" sp="5400000">
+			<item id="94370" count="1" /> <!-- Master's Book: Acumen -->
+		</skill>
+		<!-- Empower Lv. 4 -->
+		<skill name="Empower" id="45105" level="4" required-level="76" sp="5400000">
+			<item id="94361" count="1" /> <!-- Master's Book: Empower -->
+		</skill>
+		<!-- Wild Magic Lv. 3 -->
+		<skill name="Wild Magic" id="45106" level="3" required-level="76" sp="5400000">
+			<item id="94368" count="1" /> <!-- Master's Book: Wild Magic -->
+		</skill>
+		<!-- Wind Walk Lv. 3 -->
+		<skill name="Wind Walk" id="45107" level="3" required-level="76" sp="5400000">
+			<item id="94365" count="1" /> <!-- Master's Book: Wind Walk -->
+		</skill>
+		<!-- Magic Barrier Lv. 3 -->
+		<skill name="Magic Barrier" id="45108" level="3" required-level="76" sp="5400000">
+			<item id="94362" count="1" /> <!-- Master's Book: Magic Barrier -->
+		</skill>
+		<!-- Focus Lv. 4 -->
+		<skill name="Focus" id="45109" level="4" required-level="76" sp="5400000">
+			<item id="94363" count="1" /> <!-- Master's Book: Focus -->
+		</skill>
+		<!-- Death Whisper Lv. 4 -->
+		<skill name="Death Whisper" id="45110" level="4" required-level="76" sp="5400000">
+			<item id="94364" count="1" /> <!-- Master's Book: Death Whisper -->
+		</skill>
+		<!-- Haste Lv. 3 -->
+		<skill name="Haste" id="45111" level="3" required-level="76" sp="5400000">
+			<item id="94369" count="1" /> <!-- Master's Book: Haste -->
+		</skill>
+		<!-- Berserker Spirit Lv. 3 -->
+		<skill name="Berserker Spirit" id="45112" level="3" required-level="76" sp="5400000">
+			<item id="94366" count="1" /> <!-- Master's Book: Berserker Spirit -->
+		</skill>
+		<!-- Clarity Lv. 4 -->
+		<skill name="Clarity" id="45113" level="4" required-level="76" sp="5400000">
+			<item id="94367" count="1" /> <!-- Master's Book: Clarity -->
+		</skill>
+		<skill name="Detection" id="45190" level="1" required-level="76" sp="5400000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Shield Stun" id="92" level="53" required-level="76" sp="5400000" />
+		<skill name="Mount Golden Lion" id="1833" level="1" required-level="76">
+			<item id="90038" count="1" /> <!-- Spellbook - Ride Golden Lion -->
+		</skill>
 		<skill name="Life Scavenge" id="46" level="16" required-level="76" sp="5400000" />
+		<skill name="Help of Hatred" id="45370" level="1" required-level="76" sp="5400000">
+			<item id="93871" count="1" /> <!-- Spellbook: Knight's Help -->
+		</skill>
 		<skill name="Final Fortress" id="291" level="12" required-level="76" sp="5400000" />
 		<skill name="Fortitude" id="335" level="1" required-level="76" sp="5400000" />
 		<skill name="Hamstring" id="127" level="15" required-level="76" sp="5400000" />
+		<skill name="Dark Strike" id="45257" level="26" required-level="76" sp="5400000" />
 		<skill name="Horror" id="65" level="14" required-level="76" sp="5400000" />
-		<skill name="Critical Vulnerability Decrease" id="53004" level="1" required-level="76" sp="5400000" />
+		<skill name="Critical Vulnerability Decrease" id="53004" level="1" required-level="76" sp="5400000">
+			<item id="91485" count="1" /> <!-- Scroll: Critical Vulnerability Decrease -->
+		</skill>
 		<skill name="Chain Strike" id="10015" level="1" required-level="76" sp="5400000" />
-		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="5400000">
-			<item id="8620"/> <!-- Ancient Book: Divine Inspiration (Manuscript) -->
-		</skill>
-		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="5400000">
-			<item id="8621"/> <!-- Ancient Book: Divine Inspiration (Original Version) -->
-		</skill>
-		<skill name="Mount Gold Maned Lion" id="1833" level="1" required-level="76">
-			<item id="90038"/> <!-- Spellbook: Mount Golden Lion -->
-		</skill>
-		<skill name="Glory Ability" id="45361" level="1" required-level="86">
-			<item id="94046"/> <!-- Spellbook: Glory Ability Lv. 1 -->
-		</skill>
-		<skill name="Mount White Wings" id="54200" level="1" required-level="87">
-			<item id="93059"/> <!-- Spellbook: Summon White Wings -->
-		</skill>	
-		<skill name="Mount Shining Lady" id="54202" level="1" required-level="89">
-			<item id="93061"/> <!-- Spellbook: Summon Silver Saint -->
-		</skill>
-		
+		<skill name="Emergency Rescue" id="70" level="46" required-level="76" sp="5400000" />
+
 		<skill name="Aggression" id="28" level="51" required-level="77" sp="5400000" />
 		<skill name="Shield Strike" id="984" level="17" required-level="77" sp="5400000" />
 		<skill name="Aggression Aura" id="18" level="39" required-level="77" sp="5400000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="47" required-level="77" sp="5400000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="47" required-level="77" sp="5400000" />
 		<skill name="Heavy Armor Mastery" id="232" level="54" required-level="77" sp="5400000" />
-		<skill name="Drain Energy" id="70" level="55" required-level="77" sp="5400000" />
 		<skill name="Magic Resistance" id="147" level="53" required-level="77" sp="5400000" />
+		<skill name="Vengeance" id="368" level="1" required-level="77" sp="5400000">
+			<item id="90046" count="1" /> <!-- Scroll: Vengeance -->
+		</skill>
 		<skill name="Shield Stun" id="92" level="54" required-level="77" sp="5400000" />
 		<skill name="Deflect Magic" id="913" level="1" required-level="77" sp="5400000" />
 		<skill name="Final Fortress" id="291" level="13" required-level="77" sp="5400000" />
-		<skill name="Vengeance" id="368" level="1" required-level="77" sp="5400000">
-			<item id="90046"/> <!-- Scroll: Vengeance -->
-		</skill>
-		
+		<skill name="Dark Strike" id="45257" level="27" required-level="77" sp="5400000" />
+		<skill name="Emergency Rescue" id="70" level="47" required-level="77" sp="5400000" />
+
 		<skill name="Aggression" id="28" level="52" required-level="78" sp="12600000" />
 		<skill name="Shield Strike" id="984" level="18" required-level="78" sp="12600000" />
 		<skill name="Aggression Aura" id="18" level="40" required-level="78" sp="12600000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="48" required-level="78" sp="12600000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="48" required-level="78" sp="12600000" />
 		<skill name="Heavy Armor Mastery" id="232" level="55" required-level="78" sp="12600000" />
-		<skill name="Drain Energy" id="70" level="56" required-level="78" sp="12600000" />
 		<skill name="Magic Resistance" id="147" level="54" required-level="78" sp="12600000" />
-		<skill name="Mass Chain Strike" id="53003" level="1" required-level="78" sp="12600000" />
+		<skill name="Mass Chain Strike" id="53003" level="1" required-level="78" sp="12600000">
+			<item id="91484" count="1" /> <!-- Scroll: Mass Chain Strike -->
+		</skill>
 		<skill name="Shield Stun" id="92" level="55" required-level="78" sp="12600000" />
 		<skill name="Life Scavenge" id="46" level="17" required-level="78" sp="12600000" />
 		<skill name="Final Fortress" id="291" level="14" required-level="78" sp="12600000" />
 		<skill name="Summon Dark Panther" id="283" level="8" required-level="78" sp="12600000" />
+		<skill name="Touch of Death" id="342" level="1" required-level="78" sp="12600000">
+			<item id="90048" count="1" /> <!-- Scroll: Touch of Death -->
+		</skill>
 		<skill name="Knighthood" id="429" level="1" required-level="78" sp="12600000" />
 		<skill name="Corpse Plague" id="103" level="5" required-level="78" sp="12600000" />
 		<skill name="Hamstring" id="127" level="16" required-level="78" sp="12600000" />
+		<skill name="Dark Strike" id="45257" level="28" required-level="78" sp="12600000" />
 		<skill name="Horror" id="65" level="15" required-level="78" sp="12600000" />
 		<skill name="Critical Vulnerability Decrease" id="53004" level="2" required-level="78" sp="12600000" />
-		<skill name="Touch of Death" id="342" level="1" required-level="78" sp="12600000">
-			<item id="90048"/> <!-- Scroll: Touch of Death -->
-		</skill>
-		
+		<skill name="Emergency Rescue" id="70" level="48" required-level="78" sp="12600000" />
+
+		<skill name="Shield Strike" id="984" level="19" required-level="79" sp="12600000" />
 		<skill name="Life Scavenge" id="46" level="18" required-level="79" sp="12600000" />
 		<skill name="Final Fortress" id="291" level="15" required-level="79" sp="12600000" />
 		<skill name="Knighthood" id="429" level="2" required-level="79" sp="12600000" />
 		<skill name="Hamstring" id="127" level="17" required-level="79" sp="12600000" />
+		<skill name="Dark Strike" id="45257" level="29" required-level="79" sp="12600000" />
 		<skill name="Shield of Faith" id="528" level="1" required-level="79" sp="12600000">
-			<item id="90049"/> <!-- Scroll: Shield of Faith -->
+			<item id="90049" count="1" /> <!-- Scroll: Shield of Faith -->
 		</skill>
-		
+		<skill name="Emergency Rescue" id="70" level="49" required-level="79" sp="12600000" />
+
 		<skill name="Aggression" id="28" level="53" required-level="80" sp="12600000" />
-		<skill name="Shield Strike" id="984" level="19" required-level="80" sp="12600000" />
+		<skill name="Shield Strike" id="984" level="20" required-level="80" sp="12600000" />
 		<skill name="Aggression Aura" id="18" level="41" required-level="80" sp="12600000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="49" required-level="80" sp="12600000" />
+		<skill name="Insane Crusher" id="762" level="1" required-level="80" sp="12600000">
+			<item id="90051" count="1" /> <!-- Scroll: Insane Crusher -->
+		</skill>
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="49" required-level="80" sp="12600000" />
 		<skill name="Heavy Armor Mastery" id="232" level="56" required-level="80" sp="12600000" />
 		<skill name="Magic Resistance" id="147" level="55" required-level="80" sp="12600000" />
+		<skill name="Evolution Power" id="45189" level="1" required-level="80">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Shield Stun" id="92" level="56" required-level="80" sp="12600000" />
 		<skill name="Life Scavenge" id="46" level="19" required-level="80" sp="12600000" />
 		<skill name="Final Fortress" id="291" level="16" required-level="80" sp="12600000" />
 		<skill name="Knighthood" id="429" level="3" required-level="80" sp="12600000" />
+		<skill name="White Guardian Transformation" id="54102" level="1" required-level="80">
+			<item id="92401" count="1" /> <!-- Spellbook - White Guardian -->
+		</skill>
 		<skill name="Hamstring" id="127" level="18" required-level="80" sp="12600000" />
+		<skill name="Dark Strike" id="45257" level="30" required-level="80" sp="12600000" />
 		<skill name="Horror" id="65" level="16" required-level="80" sp="12600000" />
 		<skill name="Critical Vulnerability Decrease" id="53004" level="3" required-level="80" sp="12600000" />
-		<skill name="Insane Crusher" id="762" level="1" required-level="80" sp="12600000">
-			<item id="90051"/> <!-- Scroll: Insane Crusher -->
-		</skill>
+		<skill name="Emergency Rescue" id="70" level="50" required-level="80" sp="12600000" />
 
 		<skill name="Aggression" id="28" level="54" required-level="81" sp="160000000" />
-		<skill name="Shield Strike" id="984" level="20" required-level="81" sp="160000000" />
+		<skill name="Shield Strike" id="984" level="21" required-level="81" sp="160000000" />
 		<skill name="Aggression Aura" id="18" level="42" required-level="81" sp="160000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="50" required-level="81" sp="160000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="50" required-level="81" sp="160000000" />
 		<skill name="Heavy Armor Mastery" id="232" level="57" required-level="81" sp="160000000" />
 		<skill name="Magic Resistance" id="147" level="56" required-level="81" sp="160000000" />
 		<skill name="Mass Chain Strike" id="53003" level="2" required-level="81" sp="160000000" />
@@ -110,11 +175,12 @@
 		<skill name="Final Fortress" id="291" level="17" required-level="81" sp="160000000" />
 		<skill name="Knighthood" id="429" level="4" required-level="81" sp="160000000" />
 		<skill name="Hamstring" id="127" level="19" required-level="81" sp="160000000" />
-		
+		<skill name="Emergency Rescue" id="70" level="51" required-level="81" sp="160000000" />
+
 		<skill name="Aggression" id="28" level="55" required-level="82" sp="170000000" />
-		<skill name="Shield Strike" id="984" level="21" required-level="82" sp="170000000" />
+		<skill name="Shield Strike" id="984" level="22" required-level="82" sp="170000000" />
 		<skill name="Aggression Aura" id="18" level="43" required-level="82" sp="170000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="51" required-level="82" sp="170000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="51" required-level="82" sp="170000000" />
 		<skill name="Heavy Armor Mastery" id="232" level="58" required-level="82" sp="170000000" />
 		<skill name="Magic Resistance" id="147" level="57" required-level="82" sp="170000000" />
 		<skill name="Shield Stun" id="92" level="58" required-level="82" sp="170000000" />
@@ -126,11 +192,12 @@
 		<skill name="Horror" id="65" level="17" required-level="82" sp="170000000" />
 		<skill name="Critical Vulnerability Decrease" id="53004" level="4" required-level="82" sp="170000000" />
 		<skill name="Chain Strike" id="10015" level="2" required-level="82" sp="170000000" />
-		
+		<skill name="Emergency Rescue" id="70" level="52" required-level="82" sp="170000000" />
+
 		<skill name="Aggression" id="28" level="56" required-level="83" sp="240000000" />
-		<skill name="Shield Strike" id="984" level="22" required-level="83" sp="240000000" />
+		<skill name="Shield Strike" id="984" level="23" required-level="83" sp="240000000" />
 		<skill name="Aggression Aura" id="18" level="44" required-level="83" sp="240000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="52" required-level="83" sp="240000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="52" required-level="83" sp="240000000" />
 		<skill name="Heavy Armor Mastery" id="232" level="59" required-level="83" sp="240000000" />
 		<skill name="Magic Resistance" id="147" level="58" required-level="83" sp="240000000" />
 		<skill name="Shield Stun" id="92" level="59" required-level="83" sp="240000000" />
@@ -139,11 +206,12 @@
 		<skill name="Summon Dark Panther" id="283" level="10" required-level="83" sp="240000000" />
 		<skill name="Knighthood" id="429" level="6" required-level="83" sp="240000000" />
 		<skill name="Hamstring" id="127" level="21" required-level="83" sp="240000000" />
-		
+		<skill name="Emergency Rescue" id="70" level="53" required-level="83" sp="240000000" />
+
 		<skill name="Aggression" id="28" level="57" required-level="84" sp="240000000" />
-		<skill name="Shield Strike" id="984" level="23" required-level="84" sp="240000000" />
+		<skill name="Shield Strike" id="984" level="24" required-level="84" sp="240000000" />
 		<skill name="Aggression Aura" id="18" level="45" required-level="84" sp="240000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="53" required-level="84" sp="240000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="53" required-level="84" sp="240000000" />
 		<skill name="Heavy Armor Mastery" id="232" level="60" required-level="84" sp="240000000" />
 		<skill name="Magic Resistance" id="147" level="59" required-level="84" sp="240000000" />
 		<skill name="Mass Chain Strike" id="53003" level="3" required-level="84" sp="240000000" />
@@ -156,36 +224,54 @@
 		<skill name="Horror" id="65" level="18" required-level="84" sp="240000000" />
 		<skill name="Critical Vulnerability Decrease" id="53004" level="5" required-level="84" sp="240000000" />
 		<skill name="Chain Strike" id="10015" level="3" required-level="84" sp="240000000" />
-		
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="54" required-level="85" sp="840000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="55" required-level="86" sp="924000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="56" required-level="87" sp="1016400000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="57" required-level="88" sp="1118040000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="58" required-level="89" sp="1229844000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="59" required-level="90" sp="1352828400" />
+		<skill name="Emergency Rescue" id="70" level="54" required-level="84" sp="240000000" />
+
+		<skill name="Shield Strike" id="984" level="25" required-level="85" sp="840000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="54" required-level="85" sp="840000000" />
 		<skill name="Heavy Armor Mastery" id="232" level="61" required-level="85" sp="840000000" />
-		<skill name="Heavy Armor Mastery" id="232" level="62" required-level="86" sp="924000000" />
-		<skill name="Heavy Armor Mastery" id="232" level="63" required-level="87" sp="1016400000" />
-		<skill name="Heavy Armor Mastery" id="232" level="64" required-level="88" sp="1118040000" />
-		<skill name="Heavy Armor Mastery" id="232" level="65" required-level="89" sp="1229844000" />
-		<skill name="Heavy Armor Mastery" id="232" level="66" required-level="90" sp="1352828400" />
 		<skill name="Magic Resistance" id="147" level="60" required-level="85" sp="840000000" />
-		<skill name="Magic Resistance" id="147" level="61" required-level="86" sp="924000000" />
-		<skill name="Magic Resistance" id="147" level="62" required-level="87" sp="1016400000" />
-		<skill name="Magic Resistance" id="147" level="63" required-level="88" sp="1118040000" />
-		<skill name="Magic Resistance" id="147" level="64" required-level="89" sp="1229844000" />
-		<skill name="Magic Resistance" id="147" level="65" required-level="90" sp="1352828400" />
 		<skill name="Final Fortress" id="291" level="21" required-level="85" sp="840000000" />
-		<skill name="Final Fortress" id="291" level="22" required-level="86" sp="924000000" />
-		<skill name="Final Fortress" id="291" level="23" required-level="87" sp="1016400000" />
-		<skill name="Final Fortress" id="291" level="24" required-level="88" sp="1118040000" />
-		<skill name="Final Fortress" id="291" level="25" required-level="89" sp="1229844000" />
-		<skill name="Final Fortress" id="291" level="26" required-level="90" sp="1352828400" />
 		<skill name="Knighthood" id="429" level="8" required-level="85" sp="840000000" />
-		<skill name="Knighthood" id="429" level="9" required-level="86" sp="924000000" />
-		<skill name="Knighthood" id="429" level="10" required-level="87" sp="1016400000" />
-		<skill name="Knighthood" id="429" level="11" required-level="88" sp="1118040000" />
-		<skill name="Knighthood" id="429" level="12" required-level="89" sp="1229844000" />
-		<skill name="Knighthood" id="429" level="13" required-level="90" sp="1352828400" />
+		<skill name="Emergency Rescue" id="70" level="55" required-level="85" sp="840000000" />
+
+		<skill name="Shield Strike" id="984" level="26" required-level="86" sp="840000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="55" required-level="86" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="232" level="62" required-level="86" sp="840000000" />
+		<skill name="Magic Resistance" id="147" level="61" required-level="86" sp="840000000" />
+		<skill name="Final Fortress" id="291" level="22" required-level="86" sp="840000000" />
+		<skill name="Knighthood" id="429" level="9" required-level="86" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="56" required-level="86" sp="840000000" />
+
+		<skill name="Shield Strike" id="984" level="27" required-level="87" sp="840000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="56" required-level="87" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="232" level="63" required-level="87" sp="840000000" />
+		<skill name="Magic Resistance" id="147" level="62" required-level="87" sp="840000000" />
+		<skill name="Final Fortress" id="291" level="23" required-level="87" sp="840000000" />
+		<skill name="Knighthood" id="429" level="10" required-level="87" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="57" required-level="87" sp="840000000" />
+
+		<skill name="Shield Strike" id="984" level="28" required-level="88" sp="840000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="57" required-level="88" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="232" level="64" required-level="88" sp="840000000" />
+		<skill name="Magic Resistance" id="147" level="63" required-level="88" sp="840000000" />
+		<skill name="Final Fortress" id="291" level="24" required-level="88" sp="840000000" />
+		<skill name="Knighthood" id="429" level="11" required-level="88" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="58" required-level="88" sp="840000000" />
+
+		<skill name="Shield Strike" id="984" level="29" required-level="89" sp="840000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="58" required-level="89" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="232" level="65" required-level="89" sp="840000000" />
+		<skill name="Magic Resistance" id="147" level="64" required-level="89" sp="840000000" />
+		<skill name="Final Fortress" id="291" level="25" required-level="89" sp="840000000" />
+		<skill name="Knighthood" id="429" level="12" required-level="89" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="59" required-level="89" sp="840000000" />
+
+		<skill name="Shield Strike" id="984" level="30" required-level="90" sp="840000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="59" required-level="90" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="232" level="66" required-level="90" sp="840000000" />
+		<skill name="Magic Resistance" id="147" level="65" required-level="90" sp="840000000" />
+		<skill name="Final Fortress" id="291" level="26" required-level="90" sp="840000000" />
+		<skill name="Knighthood" id="429" level="13" required-level="90" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="60" required-level="90" sp="840000000" />
 	</skillTree>
 </list>

--- a/data/skillTrees/3rdClass/Hierophant.xml
+++ b/data/skillTrees/3rdClass/Hierophant.xml
@@ -1,92 +1,184 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="98" parentClassId="17">
-		<skill name="White Guardian" id="54102" level="1" required-level="80" >
-			<item id="92401"/>
-		</skill>
-		<skill name="Might" id="1068" level="4" required-level="76" sp="8000000">
-			<item id="99046" count="1" /> <!-- Master's Book: Might -->
-		</skill>
-		<skill name="Shield" id="1040" level="4" required-level="76" sp="8000000">
-			<item id="99047" count="1" /> <!-- Master's Book: Shield -->
-		</skill>
-		<skill name="Magic Barrier" id="1036" level="4" required-level="76" sp="8000000">
-			<item id="99049" count="1" /> <!-- Master's Book: Magic Barrier -->
-		</skill>
+
 		<skill name="Anti Magic" id="146" level="46" required-level="76" sp="8000000" />
+		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="8000000">
+			<item id="8620" count="1" /> <!-- Buff Expansion Book Lv. 3 -->
+		</skill>
+		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="8000000">
+			<item id="8621" count="1" /> <!-- Buff Expansion Book Lv. 4 -->
+		</skill>
+		<skill name="Root Mastery" id="45238" level="1" required-level="76" sp="8000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Light Armor Mastery" id="236" level="42" required-level="76" sp="8000000" />
 		<skill name="Robe Mastery" id="235" level="42" required-level="76" sp="8000000" />
 		<skill name="Weapon Mastery" id="249" level="43" required-level="76" sp="8000000" />
 		<skill name="Heavy Armor Mastery" id="259" level="34" required-level="76" sp="8000000" />
-		<skill name="Mana Burn" id="1398" level="1" required-level="76" sp="8000000" />
-		<skill name="Dryad Root" id="1201" level="34" required-level="76" sp="8000000" />
-		<skill name="Might of Heaven" id="1028" level="20" required-level="76" sp="8000000" />
-		<skill name="Word of Fear" id="1272" level="14" required-level="76" sp="8000000" />
-		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="8000000">
-			<item id="8620"/> <!-- Ancient Book: Divine Inspiration (Manuscript) -->
+		<skill name="Sleep Mastery" id="45239" level="1" required-level="76" sp="8000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
 		</skill>
-		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="8000000">
-			<item id="8621"/> <!-- Ancient Book: Divine Inspiration (Original Version) -->
+		<skill name="Mana Burn" id="1398" level="1" required-level="76" sp="8000000">
+			<item id="91293" count="1" /> <!-- Scroll: Mana Burn -->
 		</skill>
-		<skill name="Mount Gold Maned Lion" id="1833" level="1" required-level="76">
-			<item id="90038"/> <!-- Spellbook: Mount Golden Lion -->
+		<skill name="Evolution Defense" id="45188" level="1" required-level="76">
+			<item id="57" count="5000000" /> <!-- Adena -->
 		</skill>
-		<skill name="Glory Ability" id="45361" level="1" required-level="86">
-			<item id="94046"/> <!-- Spellbook: Glory Ability Lv. 1 -->
+		<skill name="Dryad Root" id="1201" level="33" required-level="76" sp="8000000" />
+
+		<!-- Might Lv. 4 -->
+		<skill name="Might" id="1068" level="4" required-level="76" sp="8000000">
+			<item id="94135" count="1" /> <!-- Master's Book: Might -->
 		</skill>
-		<skill name="Mount White Wings" id="54200" level="1" required-level="87">
-			<item id="93059"/> <!-- Spellbook: Summon White Wings -->
+
+		<!-- Shield Lv. 4 -->
+		<skill name="Shield" id="1040" level="4" required-level="76" sp="8000000">
+			<item id="94136" count="1" /> <!-- Master's Book: Shield -->
 		</skill>
-		<skill name="Mount Shining Lady" id="54202" level="1" required-level="89">
-			<item id="93061"/> <!-- Spellbook: Summon Silver Saint -->
+		<!-- Acumen Lv. 4 -->
+		<skill name="Acumen" id="45104" level="4" required-level="76" sp="8000000">
+			<item id="94370" count="1" /> <!-- Master's Book: Acumen -->
+		</skill>
+		<!-- Empower Lv. 4 -->
+		<skill name="Empower" id="45105" level="4" required-level="76" sp="8000000">
+			<item id="94361" count="1" /> <!-- Master's Book: Empower -->
+		</skill>
+		<!-- Wild Magic Lv. 3 -->
+		<skill name="Wild Magic" id="45106" level="3" required-level="76" sp="8000000">
+			<item id="94368" count="1" /> <!-- Master's Book: Wild Magic -->
+		</skill>
+		<!-- Wind Walk Lv. 3 -->
+		<skill name="Wind Walk" id="45107" level="3" required-level="76" sp="8000000">
+			<item id="94365" count="1" /> <!-- Master's Book: Wind Walk -->
+		</skill>
+		<!-- Magic Barrier Lv. 3 -->
+		<skill name="Magic Barrier" id="45108" level="3" required-level="76" sp="8000000">
+			<item id="94362" count="1" /> <!-- Master's Book: Magic Barrier -->
+		</skill>
+		<!-- Focus Lv. 4 -->
+		<skill name="Focus" id="45109" level="4" required-level="76" sp="8000000">
+			<item id="94363" count="1" /> <!-- Master's Book: Focus -->
+		</skill>
+		<!-- Death Whisper Lv. 4 -->
+		<skill name="Death Whisper" id="45110" level="4" required-level="76" sp="8000000">
+			<item id="94364" count="1" /> <!-- Master's Book: Death Whisper -->
+		</skill>
+		<!-- Haste Lv. 3 -->
+		<skill name="Haste" id="45111" level="3" required-level="76" sp="8000000">
+			<item id="94369" count="1" /> <!-- Master's Book: Haste -->
+		</skill>
+		<!-- Berserker Spirit Lv. 3 -->
+		<skill name="Berserker Spirit" id="45112" level="3" required-level="76" sp="8000000">
+			<item id="94366" count="1" /> <!-- Master's Book: Berserker Spirit -->
+		</skill>
+		<!-- Clarity Lv. 4 -->
+		<skill name="Clarity" id="45113" level="4" required-level="76" sp="8000000">
+			<item id="94367" count="1" /> <!-- Master's Book: Clarity -->
+		</skill>
+		<skill name="Detection" id="45190" level="1" required-level="76" sp="8000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Mount Golden Lion" id="1833" level="1" required-level="76">
+			<item id="90038" count="1" /> <!-- Spellbook - Ride Golden Lion -->
+		</skill>
+		<skill name="Counter Critical" id="1542" level="1" required-level="76" sp="8000000">
+			<item id="90102" count="1" /> <!-- Scroll: Counter Critical -->
+		</skill>
+		<skill name="Mana Gain" id="1460" level="1" required-level="76" sp="8000000">
+			<item id="90106" count="1" /> <!-- Scroll: Mana Gain -->
 		</skill>
 		<skill name="Prophecy of Fire" id="1356" level="1" required-level="76" sp="8000000">
-			<item id="90098"/> <!-- Scroll: Prophecy of Fire -->
+			<item id="90098" count="1" /> <!-- Scroll: Prophecy of Fire -->
 		</skill>
-		
+		<skill name="Divine Beam" id="45241" level="1" required-level="76" sp="8000000">
+			<item id="93103" count="1" /> <!-- Spellbook: Divine Beam -->
+		</skill>
+		<skill name="Might of Heaven" id="1028" level="21" required-level="76" sp="8000000" />
+		<skill name="Weakness" id="1164" level="20" required-level="76" sp="10000000" />
+		<skill name="Word of Fear" id="1272" level="14" required-level="76" sp="8000000" />
+		<skill name="Sleep" id="1069" level="46" required-level="76" sp="8000000" />
+		<skill name="Fatal Strike" id="190" level="38" required-level="76" sp="8000000" />
 		<skill name="Anti Magic" id="146" level="47" required-level="77" sp="8000000" />
+		<skill name="Block Defense" id="1358" level="1" required-level="77" sp="8000000">
+			<item id="90099" count="1" /> <!-- Scroll: Block Defense -->
+		</skill>
+		<skill name="Block Wind Walk" id="1359" level="1" required-level="77" sp="8000000">
+			<item id="90100" count="1" /> <!-- Scroll: Block Wind Walk -->
+		</skill>
 		<skill name="Light Armor Mastery" id="236" level="43" required-level="77" sp="8000000" />
 		<skill name="Robe Mastery" id="235" level="43" required-level="77" sp="8000000" />
 		<skill name="Weapon Mastery" id="249" level="44" required-level="77" sp="8000000" />
 		<skill name="Heavy Armor Mastery" id="259" level="35" required-level="77" sp="8000000" />
 		<skill name="Mana Burn" id="1398" level="2" required-level="77" sp="8000000" />
-		<skill name="Block Wind Walk" id="1359" level="1" required-level="77" sp="8000000">
-			<item id="90100"/> <!-- Scroll: Block Wind Walk -->
-		</skill>
-		<skill name="Block Shield" id="1358" level="1" required-level="77" sp="8000000">
-			<item id="90099"/> <!-- Scroll: Block Shield -->
-		</skill>
-		
+		<skill name="Mana Gain" id="1460" level="2" required-level="77" sp="8000000" />
+		<skill name="Divine Beam" id="45241" level="2" required-level="77" sp="8000000" />
+		<skill name="Might of Heaven" id="1028" level="22" required-level="77" sp="8000000" />
+		<skill name="Sleep" id="1069" level="47" required-level="77" sp="8000000" />
+		<skill name="Fatal Strike" id="190" level="39" required-level="77" sp="8000000" />
+
 		<skill name="Anti Magic" id="146" level="48" required-level="78" sp="17400000" />
 		<skill name="Light Armor Mastery" id="236" level="44" required-level="78" sp="17400000" />
 		<skill name="Robe Mastery" id="235" level="44" required-level="78" sp="17400000" />
 		<skill name="Weapon Mastery" id="249" level="45" required-level="78" sp="17400000" />
 		<skill name="Heavy Armor Mastery" id="259" level="36" required-level="78" sp="17400000" />
 		<skill name="Mana Burn" id="1398" level="3" required-level="78" sp="17400000" />
-		<skill name="Dryad Root" id="1201" level="35" required-level="78" sp="17400000" />
-		<skill name="Might of Heaven" id="1028" level="21" required-level="78" sp="17400000" />
-		<skill name="Word of Fear" id="1272" level="15" required-level="78" sp="17400000" />
+		<skill name="Dryad Root" id="1201" level="34" required-level="78" sp="17400000" />
+		<skill name="Mana Gain" id="1460" level="3" required-level="78" sp="17400000" />
 		<skill name="Enlightenment" id="1533" level="1" required-level="78" sp="17400000">
-			<item id="90111"/> <!-- Scroll: Enlightenment -->
+			<item id="90111" count="1" /> <!-- Scroll: Enlightenment -->
 		</skill>
-		
+		<skill name="Divine Beam" id="45241" level="3" required-level="78" sp="17400000" />
+		<skill name="Might of Heaven" id="1028" level="23" required-level="78" sp="17400000" />
+		<skill name="Weakness" id="1164" level="21" required-level="78" sp="10000000" />
+		<skill name="Word of Fear" id="1272" level="15" required-level="78" sp="17400000" />
+		<skill name="Sleep" id="1069" level="48" required-level="78" sp="17400000" />
+		<skill name="Fatal Strike" id="190" level="40" required-level="78" sp="17400000" />
+
+		<skill name="Root Mastery" id="45238" level="2" required-level="79" sp="17400000" />
+		<skill name="Sleep Mastery" id="45239" level="2" required-level="79" sp="17400000" />
 		<skill name="Mana Burn" id="1398" level="4" required-level="79" sp="17400000" />
-		<skill name="Dryad Root" id="1201" level="36" required-level="79" sp="17400000" />
 		<skill name="Turn to Stone" id="1540" level="1" required-level="79" sp="17400000">
-			<item id="90101"/> <!-- Scroll: Turn to Stone -->
+			<item id="90101" count="1" /> <!-- Scroll: Turn to Stone -->
 		</skill>
-		
+		<skill name="Mana Gain" id="1460" level="4" required-level="79" sp="17400000" />
+		<skill name="Divine Beam" id="45241" level="4" required-level="79" sp="17400000" />
+		<skill name="Might of Heaven" id="1028" level="24" required-level="79" sp="17400000" />
+		<skill name="Sleep" id="1069" level="49" required-level="79" sp="17400000" />
+
 		<skill name="Anti Magic" id="146" level="49" required-level="80" sp="17400000" />
+		<skill name="Swap Attack" id="45237" level="4" required-level="80" sp="10000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Light Armor Mastery" id="236" level="45" required-level="80" sp="17400000" />
 		<skill name="Robe Mastery" id="235" level="45" required-level="80" sp="17400000" />
 		<skill name="Weapon Mastery" id="249" level="46" required-level="80" sp="17400000" />
 		<skill name="Heavy Armor Mastery" id="259" level="37" required-level="80" sp="17400000" />
 		<skill name="Mana Burn" id="1398" level="5" required-level="80" sp="17400000" />
-		<skill name="Dryad Root" id="1201" level="37" required-level="80" sp="17400000" />
-		<skill name="Might of Heaven" id="1028" level="22" required-level="80" sp="17400000" />
-		<skill name="Counter Critical" id="1542" level="1" required-level="80" sp="17400000">
-			<item id="90102"/> <!-- Scroll: Counter Critical -->
+		<skill name="Swap Defense" id="1392" level="4" required-level="80" sp="10000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
 		</skill>
+		<skill name="Dryad Root" id="1201" level="35" required-level="80" sp="17400000" />
+		<skill name="Spell Master" id="1829" level="4" required-level="80" sp="2400000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Evolution Power" id="45189" level="1" required-level="80">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Poison" id="1168" level="8" required-level="80" sp="10000000" />
+		<skill name="Convert" id="1393" level="4" required-level="80" sp="10000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Mana Gain" id="1460" level="5" required-level="80" sp="17400000" />
+		<skill name="Enlightenment" id="1533" level="2" required-level="80" sp="17400000" />
+		<skill name="Divine Beam" id="45241" level="5" required-level="80" sp="17400000" />
+		<skill name="Might of Heaven" id="1028" level="25" required-level="80" sp="17400000" />
+		<skill name="Weakness" id="1164" level="22" required-level="80" sp="10000000" />
+		<skill name="White Guardian Transformation" id="54102" level="1" required-level="80">
+			<item id="92401" count="1" /> <!-- Spellbook - White Guardian -->
+		</skill>
+		<skill name="Sleep" id="1069" level="50" required-level="80" sp="17400000" />
+		<skill name="Fatal Strike" id="190" level="41" required-level="80" sp="17400000" />
 
 		<skill name="Anti Magic" id="146" level="50" required-level="81" sp="160000000" />
 		<skill name="Light Armor Mastery" id="236" level="46" required-level="81" sp="160000000" />
@@ -94,18 +186,35 @@
 		<skill name="Weapon Mastery" id="249" level="47" required-level="81" sp="160000000" />
 		<skill name="Heavy Armor Mastery" id="259" level="38" required-level="81" sp="160000000" />
 		<skill name="Mana Burn" id="1398" level="6" required-level="81" sp="160000000" />
-		<skill name="Dryad Root" id="1201" level="38" required-level="81" sp="160000000" />
-		<skill name="Might of Heaven" id="1028" level="23" required-level="81" sp="160000000" />
+		<skill name="Dryad Root" id="1201" level="36" required-level="81" sp="160000000" />
+		<skill name="Mana Gain" id="1460" level="6" required-level="81" sp="160000000" />
+		<skill name="Divine Beam" id="45241" level="6" required-level="81" sp="160000000" />
+		<skill name="Might of Heaven" id="1028" level="26" required-level="81" sp="160000000" />
+		<skill name="Weakness" id="1164" level="23" required-level="81" sp="10000000" />
+		<skill name="Sleep" id="1069" level="51" required-level="81" sp="160000000" />
+		<skill name="Fatal Strike" id="190" level="42" required-level="81" sp="160000000" />
 
 		<skill name="Anti Magic" id="146" level="51" required-level="82" sp="170000000" />
+		<skill name="Root Mastery" id="45238" level="3" required-level="82" sp="170000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Light Armor Mastery" id="236" level="47" required-level="82" sp="170000000" />
 		<skill name="Robe Mastery" id="235" level="47" required-level="82" sp="170000000" />
 		<skill name="Weapon Mastery" id="249" level="48" required-level="82" sp="170000000" />
 		<skill name="Heavy Armor Mastery" id="259" level="39" required-level="82" sp="170000000" />
+		<skill name="Sleep Mastery" id="45239" level="3" required-level="82" sp="170000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Mana Burn" id="1398" level="7" required-level="82" sp="170000000" />
-		<skill name="Dryad Root" id="1201" level="39" required-level="82" sp="170000000" />
+		<skill name="Dryad Root" id="1201" level="37" required-level="82" sp="170000000" />
+		<skill name="Counter Critical" id="1542" level="2" required-level="82" sp="170000000" />
+		<skill name="Mana Gain" id="1460" level="7" required-level="82" sp="170000000" />
 		<skill name="Prophecy of Fire" id="1356" level="2" required-level="82" sp="170000000" />
-		<skill name="Might of Heaven" id="1028" level="24" required-level="82" sp="170000000" />
+		<skill name="Divine Beam" id="45241" level="7" required-level="82" sp="170000000" />
+		<skill name="Might of Heaven" id="1028" level="27" required-level="82" sp="170000000" />
+		<skill name="Weakness" id="1164" level="24" required-level="82" sp="10000000" />
+		<skill name="Sleep" id="1069" level="52" required-level="82" sp="170000000" />
+		<skill name="Fatal Strike" id="190" level="43" required-level="82" sp="170000000" />
 
 		<skill name="Anti Magic" id="146" level="52" required-level="83" sp="240000000" />
 		<skill name="Light Armor Mastery" id="236" level="48" required-level="83" sp="240000000" />
@@ -113,8 +222,13 @@
 		<skill name="Weapon Mastery" id="249" level="49" required-level="83" sp="240000000" />
 		<skill name="Heavy Armor Mastery" id="259" level="40" required-level="83" sp="240000000" />
 		<skill name="Mana Burn" id="1398" level="8" required-level="83" sp="240000000" />
-		<skill name="Dryad Root" id="1201" level="40" required-level="83" sp="240000000" />
-		<skill name="Might of Heaven" id="1028" level="25" required-level="83" sp="240000000" />
+		<skill name="Dryad Root" id="1201" level="38" required-level="83" sp="240000000" />
+		<skill name="Mana Gain" id="1460" level="8" required-level="83" sp="240000000" />
+		<skill name="Divine Beam" id="45241" level="8" required-level="83" sp="240000000" />
+		<skill name="Might of Heaven" id="1028" level="28" required-level="83" sp="240000000" />
+		<skill name="Weakness" id="1164" level="25" required-level="83" sp="10000000" />
+		<skill name="Sleep" id="1069" level="53" required-level="83" sp="240000000" />
+		<skill name="Fatal Strike" id="190" level="44" required-level="83" sp="240000000" />
 
 		<skill name="Anti Magic" id="146" level="53" required-level="84" sp="240000000" />
 		<skill name="Light Armor Mastery" id="236" level="49" required-level="84" sp="240000000" />
@@ -122,39 +236,81 @@
 		<skill name="Weapon Mastery" id="249" level="50" required-level="84" sp="240000000" />
 		<skill name="Heavy Armor Mastery" id="259" level="41" required-level="84" sp="240000000" />
 		<skill name="Mana Burn" id="1398" level="9" required-level="84" sp="240000000" />
-		<skill name="Dryad Root" id="1201" level="41" required-level="84" sp="240000000" />
-		<skill name="Counter Critical" id="1542" level="2" required-level="84" sp="240000000" />
-		<skill name="Might of Heaven" id="1028" level="26" required-level="84" sp="240000000" />
-		
+		<skill name="Dryad Root" id="1201" level="39" required-level="84" sp="240000000" />
+		<skill name="Mana Gain" id="1460" level="9" required-level="84" sp="240000000" />
+		<skill name="Divine Beam" id="45241" level="9" required-level="84" sp="240000000" />
+		<skill name="Might of Heaven" id="1028" level="29" required-level="84" sp="240000000" />
+		<skill name="Weakness" id="1164" level="26" required-level="84" sp="10000000" />
+		<skill name="Sleep" id="1069" level="54" required-level="84" sp="240000000" />
+		<skill name="Fatal Strike" id="190" level="45" required-level="84" sp="240000000" />
+
 		<skill name="Anti Magic" id="146" level="54" required-level="85" sp="840000000" />
-		<skill name="Anti Magic" id="146" level="55" required-level="86" sp="924000000" />
-		<skill name="Anti Magic" id="146" level="56" required-level="87" sp="1016400000" />
-		<skill name="Anti Magic" id="146" level="57" required-level="88" sp="1118040000" />
-		<skill name="Anti Magic" id="146" level="58" required-level="89" sp="1229844000" />
-		<skill name="Anti Magic" id="146" level="59" required-level="90" sp="1352828400" />
+		<skill name="Root Mastery" id="45238" level="4" required-level="85" sp="840000000">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Light Armor Mastery" id="236" level="50" required-level="85" sp="840000000" />
-		<skill name="Light Armor Mastery" id="236" level="51" required-level="86" sp="924000000" />
-		<skill name="Light Armor Mastery" id="236" level="52" required-level="87" sp="1016400000" />
-		<skill name="Light Armor Mastery" id="236" level="53" required-level="88" sp="1118040000" />
-		<skill name="Light Armor Mastery" id="236" level="54" required-level="89" sp="1229844000" />
-		<skill name="Light Armor Mastery" id="236" level="55" required-level="90" sp="1352828400" />
 		<skill name="Robe Mastery" id="235" level="50" required-level="85" sp="840000000" />
-		<skill name="Robe Mastery" id="235" level="51" required-level="86" sp="924000000" />
-		<skill name="Robe Mastery" id="235" level="52" required-level="87" sp="1016400000" />
-		<skill name="Robe Mastery" id="235" level="53" required-level="88" sp="1118040000" />
-		<skill name="Robe Mastery" id="235" level="54" required-level="89" sp="1229844000" />
-		<skill name="Robe Mastery" id="235" level="55" required-level="90" sp="1352828400" />
 		<skill name="Weapon Mastery" id="249" level="51" required-level="85" sp="840000000" />
-		<skill name="Weapon Mastery" id="249" level="52" required-level="86" sp="924000000" />
-		<skill name="Weapon Mastery" id="249" level="53" required-level="87" sp="1016400000" />
-		<skill name="Weapon Mastery" id="249" level="54" required-level="88" sp="1118040000" />
-		<skill name="Weapon Mastery" id="249" level="55" required-level="89" sp="1229844000" />
-		<skill name="Weapon Mastery" id="249" level="56" required-level="90" sp="1352828400" />
 		<skill name="Heavy Armor Mastery" id="259" level="42" required-level="85" sp="840000000" />
-		<skill name="Heavy Armor Mastery" id="259" level="43" required-level="86" sp="924000000" />
-		<skill name="Heavy Armor Mastery" id="259" level="44" required-level="87" sp="1016400000" />
-		<skill name="Heavy Armor Mastery" id="259" level="45" required-level="88" sp="1118040000" />
-		<skill name="Heavy Armor Mastery" id="259" level="46" required-level="89" sp="1229844000" />
-		<skill name="Heavy Armor Mastery" id="259" level="47" required-level="90" sp="1352828400" />
+		<skill name="Sleep Mastery" id="45239" level="4" required-level="85" sp="840000000">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Dryad Root" id="1201" level="40" required-level="85" sp="840000000" />
+		<skill name="Poison" id="1168" level="9" required-level="85" sp="10000000" />
+		<skill name="Mana Gain" id="1460" level="10" required-level="85" sp="840000000" />
+		<skill name="Divine Beam" id="45241" level="10" required-level="85" sp="840000000" />
+		<skill name="Might of Heaven" id="1028" level="30" required-level="85" sp="840000000" />
+		<skill name="Sleep" id="1069" level="55" required-level="85" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="55" required-level="86" sp="840000000" />
+		<skill name="Light Armor Mastery" id="236" level="51" required-level="86" sp="840000000" />
+		<skill name="Robe Mastery" id="235" level="51" required-level="86" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="52" required-level="86" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="259" level="43" required-level="86" sp="840000000" />
+		<skill name="Dryad Root" id="1201" level="41" required-level="86" sp="840000000" />
+		<skill name="Divine Beam" id="45241" level="11" required-level="86" sp="840000000" />
+		<skill name="Might of Heaven" id="1028" level="31" required-level="86" sp="840000000" />
+		<skill name="Sleep" id="1069" level="56" required-level="86" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="56" required-level="87" sp="840000000" />
+		<skill name="Light Armor Mastery" id="236" level="52" required-level="87" sp="840000000" />
+		<skill name="Robe Mastery" id="235" level="52" required-level="87" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="53" required-level="87" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="259" level="44" required-level="87" sp="840000000" />
+		<skill name="Dryad Root" id="1201" level="42" required-level="87" sp="840000000" />
+		<skill name="Divine Beam" id="45241" level="12" required-level="87" sp="840000000" />
+		<skill name="Might of Heaven" id="1028" level="32" required-level="87" sp="840000000" />
+		<skill name="Sleep" id="1069" level="57" required-level="87" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="57" required-level="88" sp="840000000" />
+		<skill name="Light Armor Mastery" id="236" level="53" required-level="88" sp="840000000" />
+		<skill name="Robe Mastery" id="235" level="53" required-level="88" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="54" required-level="88" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="259" level="45" required-level="88" sp="840000000" />
+		<skill name="Dryad Root" id="1201" level="43" required-level="88" sp="840000000" />
+		<skill name="Divine Beam" id="45241" level="13" required-level="88" sp="840000000" />
+		<skill name="Might of Heaven" id="1028" level="33" required-level="88" sp="840000000" />
+		<skill name="Sleep" id="1069" level="58" required-level="88" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="58" required-level="89" sp="840000000" />
+		<skill name="Light Armor Mastery" id="236" level="54" required-level="89" sp="840000000" />
+		<skill name="Robe Mastery" id="235" level="54" required-level="89" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="55" required-level="89" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="259" level="46" required-level="89" sp="840000000" />
+		<skill name="Dryad Root" id="1201" level="44" required-level="89" sp="840000000" />
+		<skill name="Divine Beam" id="45241" level="14" required-level="89" sp="840000000" />
+		<skill name="Might of Heaven" id="1028" level="34" required-level="89" sp="840000000" />
+		<skill name="Sleep" id="1069" level="59" required-level="89" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="59" required-level="90" sp="840000000" />
+		<skill name="Light Armor Mastery" id="236" level="55" required-level="90" sp="840000000" />
+		<skill name="Robe Mastery" id="235" level="55" required-level="90" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="56" required-level="90" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="259" level="47" required-level="90" sp="840000000" />
+		<skill name="Dryad Root" id="1201" level="45" required-level="90" sp="840000000" />
+		<skill name="Poison" id="1168" level="10" required-level="90" sp="10000000" />
+		<skill name="Divine Beam" id="45241" level="15" required-level="90" sp="840000000" />
+		<skill name="Might of Heaven" id="1028" level="35" required-level="90" sp="840000000" />
+		<skill name="Sleep" id="1069" level="60" required-level="90" sp="840000000" />
 	</skillTree>
 </list>

--- a/data/skillTrees/3rdClass/HumanDeathKnight.xml
+++ b/data/skillTrees/3rdClass/HumanDeathKnight.xml
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
+	<skillTree type="classSkillTree" classId="199" parentClassId="198">
+
+		<skill name="Hellfire" id="45312" level="1" required-level="76" sp="8000000">
+			<item id="93631" count="1" /> <!-- Spellbook - Hellfire -->
+		</skill>
+		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="8000000">
+			<item id="8620" count="1" /> <!-- Buff Expansion Book Lv. 3 -->
+		</skill>
+		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="8000000">
+			<item id="8621" count="1" /> <!-- Buff Expansion Book Lv. 4 -->
+		</skill>
+		<skill name="Death Armor Mastery" id="45354" level="23" required-level="76" sp="8000000" />
+		<skill name="Death Sword Mastery" id="45353" level="23" required-level="76" sp="8000000" />
+		<skill name="Evolution Defense" id="45188" level="1" required-level="76">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Death Guard" id="45329" level="2" required-level="76" sp="8000000">
+			<item id="93388" count="1" /> <!-- Spellbook: Death Guard -->
+		</skill>
+		<skill name="Fist of Fury" id="45305" level="10" required-level="76" sp="8000000" />
+		<skill name="Might" id="1068" level="4" required-level="76" sp="8000000">
+			<item id="94135" count="1" /> <!-- Master's Book: Might -->
+		</skill>
+		<skill name="Ultimate Death Knight Transformation" id="54206" level="1" required-level="76" sp="8000000">
+			<item id="93387" count="1" /> <!-- Spellbook - Ultimate Death Knight Form -->
+		</skill>
+		<skill name="Detection" id="45190" level="1" required-level="76" sp="8000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Mount Night Mare" id="54207" level="1" required-level="76">
+			<item id="93383" count="1" /> <!-- Spellbook - Mount Nightmare Steed -->
+		</skill>
+		<skill name="Death Points" id="45352" level="3" required-level="76" auto-learn="true" />
+		<skill name="Devour" id="45389" level="1" required-level="76" sp="8000000">
+			<item id="94137" count="1" /> <!-- Spellbook: Devour -->
+		</skill>
+		<skill name="Deadly Ligament Rupture" id="45343" level="1" required-level="76" sp="8000000" />
+		<skill name="Death Blind" id="45342" level="11" required-level="76" sp="8000000" />
+		<skill name="Shield" id="1040" level="4" required-level="76" sp="8000000">
+			<item id="94136" count="1" /> <!-- Master's Book: Shield -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="46" required-level="76" sp="8000000" />
+
+		<skill name="Hellfire" id="45312" level="2" required-level="77" sp="10000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="2" required-level="77" sp="10000000" />
+		<skill name="Death Blind" id="45342" level="12" required-level="77" sp="10000000" />
+		<skill name="Emergency Rescue" id="70" level="47" required-level="77" sp="10000000" />
+
+		<skill name="Hellfire" id="45312" level="3" required-level="78" sp="12000000" />
+		<skill name="Death Armor Mastery" id="45354" level="24" required-level="78" sp="12000000" />
+		<skill name="Death Sword Mastery" id="45353" level="24" required-level="78" sp="12000000" />
+		<skill name="Punishment" id="45301" level="15" required-level="78" sp="12000000" />
+		<skill name="Fist of Fury" id="45305" level="11" required-level="78" sp="12000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="3" required-level="78" sp="12000000" />
+		<skill name="Death Blind" id="45342" level="13" required-level="78" sp="12000000" />
+		<skill name="Emergency Rescue" id="70" level="48" required-level="78" sp="12000000" />
+
+		<skill name="Hellfire" id="45312" level="4" required-level="79" sp="15000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="4" required-level="79" sp="15000000" />
+		<skill name="Death Blind" id="45342" level="14" required-level="79" sp="15000000" />
+		<skill name="Emergency Rescue" id="70" level="49" required-level="79" sp="15000000" />
+
+		<skill name="Hellfire" id="45312" level="5" required-level="80" sp="18000000" />
+		<skill name="Death Armor Mastery" id="45354" level="25" required-level="80" sp="18000000" />
+		<skill name="Death Sword Mastery" id="45353" level="25" required-level="80" sp="18000000" />
+		<skill name="Burning Field" id="45313" level="1" required-level="80" sp="18000000">
+			<item id="93384" count="1" /> <!-- Spellbook: Burning Field -->
+		</skill>
+		<skill name="Bone Cage" id="45338" level="5" required-level="80" sp="18000000" />
+		<skill name="Soul Steal" id="45335" level="4" required-level="80" sp="18000000" />
+		<skill name="Fist of Fury" id="45305" level="12" required-level="80" sp="18000000" />
+		<skill name="Evolution Power" id="45189" level="1" required-level="80">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Flaming Body" id="45332" level="3" required-level="80" sp="18000000" />
+		<skill name="Wipeout" id="45303" level="8" required-level="80" sp="18000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="5" required-level="80" sp="18000000" />
+		<skill name="Roar of Death" id="45328" level="4" required-level="80" sp="18000000" />
+		<skill name="Undying Body" id="45350" level="5" required-level="80" auto-learn="true" />
+		<skill name="Death Blind" id="45342" level="15" required-level="80" sp="18000000" />
+		<skill name="Deadly Pull" id="45311" level="8" required-level="80" sp="18000000" />
+		<skill name="Emergency Rescue" id="70" level="50" required-level="80" sp="18000000" />
+
+		<skill name="Hellfire" id="45312" level="6" required-level="81" sp="160000000" />
+		<skill name="Death Armor Mastery" id="45354" level="26" required-level="81" sp="160000000" />
+		<skill name="Death Sword Mastery" id="45353" level="26" required-level="81" sp="160000000" />
+		<skill name="Punishment" id="45301" level="16" required-level="81" sp="160000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="6" required-level="81" sp="160000000" />
+		<skill name="Death Blind" id="45342" level="16" required-level="81" sp="160000000" />
+		<skill name="Emergency Rescue" id="70" level="51" required-level="81" sp="160000000" />
+
+		<skill name="Hellfire" id="45312" level="7" required-level="82" sp="170000000" />
+		<skill name="Death Armor Mastery" id="45354" level="27" required-level="82" sp="170000000" />
+		<skill name="Death Sword Mastery" id="45353" level="27" required-level="82" sp="170000000" />
+		<skill name="Bone Cage" id="45338" level="6" required-level="82" sp="170000000" />
+		<skill name="Fist of Fury" id="45305" level="13" required-level="82" sp="170000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="7" required-level="82" sp="170000000" />
+		<skill name="Death Blind" id="45342" level="17" required-level="82" sp="170000000" />
+		<skill name="Emergency Rescue" id="70" level="52" required-level="82" sp="170000000" />
+
+		<skill name="Hellfire" id="45312" level="8" required-level="83" sp="240000000" />
+		<skill name="Death Armor Mastery" id="45354" level="28" required-level="83" sp="240000000" />
+		<skill name="Death Sword Mastery" id="45353" level="28" required-level="83" sp="240000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="8" required-level="83" sp="240000000" />
+		<skill name="Death Blind" id="45342" level="18" required-level="83" sp="240000000" />
+		<skill name="Emergency Rescue" id="70" level="53" required-level="83" sp="240000000" />
+
+		<skill name="Hellfire" id="45312" level="9" required-level="84" sp="240000000" />
+		<skill name="Death Armor Mastery" id="45354" level="29" required-level="84" sp="240000000" />
+		<skill name="Death Sword Mastery" id="45353" level="29" required-level="84" sp="240000000" />
+		<skill name="Bone Cage" id="45338" level="7" required-level="84" sp="240000000" />
+		<skill name="Fist of Fury" id="45305" level="14" required-level="84" sp="240000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="9" required-level="84" sp="240000000" />
+		<skill name="Death Blind" id="45342" level="19" required-level="84" sp="240000000" />
+		<skill name="Emergency Rescue" id="70" level="54" required-level="84" sp="240000000" />
+
+		<skill name="Hellfire" id="45312" level="10" required-level="85" sp="840000000" />
+		<skill name="Death Armor Mastery" id="45354" level="30" required-level="85" sp="840000000" />
+		<skill name="Death Sword Mastery" id="45353" level="30" required-level="85" sp="840000000" />
+		<skill name="Burning Field" id="45313" level="2" required-level="85" sp="840000000" />
+		<skill name="Punishment" id="45301" level="17" required-level="85" sp="840000000" />
+		<skill name="Fist of Fury" id="45305" level="15" required-level="85" sp="840000000" />
+		<skill name="Flaming Body" id="45332" level="4" required-level="85" sp="840000000" />
+		<skill name="Wipeout" id="45303" level="9" required-level="85" sp="840000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="10" required-level="85" sp="840000000" />
+		<skill name="Death Blind" id="45342" level="20" required-level="85" sp="840000000" />
+		<skill name="Deadly Pull" id="45311" level="9" required-level="85" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="55" required-level="85" sp="840000000" />
+
+		<skill name="Hellfire" id="45312" level="11" required-level="86" sp="840000000" />
+		<skill name="Death Armor Mastery" id="45354" level="31" required-level="86" sp="840000000" />
+		<skill name="Death Sword Mastery" id="45353" level="31" required-level="86" sp="840000000" />
+		<skill name="Bone Cage" id="45338" level="8" required-level="86" sp="840000000" />
+		<skill name="Fist of Fury" id="45305" level="16" required-level="86" sp="840000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="11" required-level="86" sp="840000000" />
+		<skill name="Death Blind" id="45342" level="21" required-level="86" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="56" required-level="86" sp="840000000" />
+
+		<skill name="Hellfire" id="45312" level="12" required-level="87" sp="840000000" />
+		<skill name="Death Armor Mastery" id="45354" level="32" required-level="87" sp="840000000" />
+		<skill name="Death Sword Mastery" id="45353" level="32" required-level="87" sp="840000000" />
+		<skill name="Punishment" id="45301" level="18" required-level="87" sp="840000000" />
+		<skill name="Fist of Fury" id="45305" level="17" required-level="87" sp="840000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="12" required-level="87" sp="840000000" />
+		<skill name="Death Blind" id="45342" level="22" required-level="87" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="57" required-level="87" sp="840000000" />
+
+		<skill name="Hellfire" id="45312" level="13" required-level="88" sp="840000000" />
+		<skill name="Death Armor Mastery" id="45354" level="33" required-level="88" sp="840000000" />
+		<skill name="Death Sword Mastery" id="45353" level="33" required-level="88" sp="840000000" />
+		<skill name="Bone Cage" id="45338" level="9" required-level="88" sp="840000000" />
+		<skill name="Fist of Fury" id="45305" level="18" required-level="88" sp="840000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="13" required-level="88" sp="840000000" />
+		<skill name="Death Blind" id="45342" level="23" required-level="88" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="58" required-level="88" sp="840000000" />
+
+		<skill name="Hellfire" id="45312" level="14" required-level="89" sp="840000000" />
+		<skill name="Death Armor Mastery" id="45354" level="34" required-level="89" sp="840000000" />
+		<skill name="Death Sword Mastery" id="45353" level="34" required-level="89" sp="840000000" />
+		<skill name="Punishment" id="45301" level="19" required-level="89" sp="840000000" />
+		<skill name="Fist of Fury" id="45305" level="19" required-level="89" sp="840000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="14" required-level="89" sp="840000000" />
+		<skill name="Death Blind" id="45342" level="24" required-level="89" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="59" required-level="89" sp="840000000" />
+
+		<skill name="Hellfire" id="45312" level="15" required-level="90" sp="840000000" />
+		<skill name="Death Armor Mastery" id="45354" level="35" required-level="90" sp="840000000" />
+		<skill name="Death Sword Mastery" id="45353" level="35" required-level="90" sp="840000000" />
+		<skill name="Burning Field" id="45313" level="3" required-level="90" sp="840000000" />
+		<skill name="Punishment" id="45301" level="20" required-level="90" sp="840000000" />
+		<skill name="Bone Cage" id="45338" level="10" required-level="90" sp="840000000" />
+		<skill name="Soul Steal" id="45335" level="5" required-level="90" sp="840000000" />
+		<skill name="Fist of Fury" id="45305" level="20" required-level="90" sp="840000000" />
+		<skill name="Flaming Body" id="45332" level="5" required-level="90" sp="840000000" />
+		<skill name="Wipeout" id="45303" level="10" required-level="90" sp="840000000" />
+		<skill name="Deadly Ligament Rupture" id="45343" level="15" required-level="90" sp="840000000" />
+		<skill name="Roar of Death" id="45328" level="5" required-level="90" sp="840000000" />
+		<skill name="Death Blind" id="45342" level="25" required-level="90" sp="840000000" />
+		<skill name="Deadly Pull" id="45311" level="10" required-level="90" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="60" required-level="90" sp="840000000" />
+	</skillTree>
+</list>

--- a/data/skillTrees/3rdClass/Maestro.xml
+++ b/data/skillTrees/3rdClass/Maestro.xml
@@ -1,144 +1,298 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="118" parentClassId="57">
-		<skill name="White Guardian" id="54102" level="1" required-level="80" >
-			<item id="92401"/>
+
+		<!-- Master Buffs 3rd Class -->
+		<!-- Might Lv. 4 -->
+		<skill name="Maphr's Might" id="45119" level="4" required-level="76" sp="7900000">
+			<item id="94135" count="1" /> <!-- Master's Book: Might -->
 		</skill>
-		<skill name="Spinning Slasher" id="36" level="38" required-level="76" sp="7900000" />
-		<skill name="Polearm Mastery" id="216" level="46" required-level="76" sp="7900000" />
-		<skill name="Light Armor Mastery" id="227" level="51" required-level="76" sp="7900000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="46" required-level="76" sp="7900000" />
-		<skill name="Heavy Armor Mastery" id="231" level="51" required-level="76" sp="7900000" />
+		<!-- Shield Lv. 4-->
+		<skill name="Maphr's Shield" id="45120" level="4" required-level="76" sp="7900000">
+			<item id="94136" count="1" /> <!-- Master's Book: Shield -->
+		</skill>
+		<!-- Acumen Lv. 4 -->
+		<skill name="Maphr's Acumen" id="45130" level="4" required-level="76" sp="7900000">
+			<item id="94370" count="1" /> <!-- Master's Book: Acumen -->
+		</skill>
+		<!-- Empower Lv. 4 -->
+		<skill name="Maphr's Empower" id="45131" level="4" required-level="76" sp="7900000">
+			<item id="94361" count="1" /> <!-- Master's Book: Empower -->
+		</skill>
+		<!-- Wild Magic Lv. 3 -->
+		<skill name="Maphr's Wild Magic" id="45132" level="3" required-level="76" sp="7900000">
+			<item id="94368" count="1" /> <!-- Master's Book: Wild Magic -->
+		</skill>
+		<!-- Wind Walk Lv. 3 -->
+		<skill name="Maphr's Wind Walk" id="45117" level="3" required-level="76" sp="7900000">
+			<item id="94365" count="1" /> <!-- Master's Book: Wind Walk -->
+		</skill>
+		<!-- Magic Barrier Lv. 3 -->
+		<skill name="Maphr's Magic Barrier" id="45118" level="3" required-level="76" sp="7900000">
+			<item id="94362" count="1" /> <!-- Master's Book: Magic Barrier -->
+		</skill>
+		<!-- Focus Lv. 4 -->
+		<skill name="Maphr's Focus" id="45114" level="4" required-level="76" sp="7900000">
+			<item id="94363" count="1" /> <!-- Master's Book: Focus -->
+		</skill>
+		<!-- Death Whisper Lv. 4 -->
+		<skill name="Maphr's Death Whisper" id="45115" level="4" required-level="76" sp="7900000">
+			<item id="94364" count="1" /> <!-- Master's Book: Death Whisper -->
+		</skill>
+		<!-- Haste Lv. 3 -->
+		<skill name="Maphr's Haste" id="45116" level="3" required-level="76" sp="7900000">
+			<item id="94369" count="1" /> <!-- Master's Book: Haste -->
+		</skill>
+		<!-- Berserker Spirit Lv. 3 -->
+		<skill name="Maphr's Berserker Spirit" id="45133" level="3" required-level="76" sp="7900000">
+			<item id="94366" count="1" /> <!-- Master's Book: Berserker Spirit -->
+		</skill>
+		<!-- Clarity Lv. 4 -->
+		<skill name="Maphr's Clarity" id="45134" level="4" required-level="76" sp="7900000">
+			<item id="94367" count="1" /> <!-- Master's Book: Clarity -->
+		</skill>
+
+		<!-- Lv. 76 Class Skills -->
+		<skill name="Summon Mechanic Golem" id="13" level="10" required-level="76" sp="7900000" />
+		<skill name="Spinning Slasher" id="36" level="41" required-level="76" sp="7900000" />
+		<skill name="Weapon Mastery" id="141" level="5" required-level="76" sp="7900000" />
+		<skill name="Fatal Strike" id="190" level="41" required-level="76" sp="7900000" />
+		<skill name="Power Break" id="260" level="38" required-level="76" sp="7900000" />
 		<skill name="Earthquake" id="347" level="1" required-level="76" sp="7900000" />
-		<skill name="Critical Creation" id="53001" level="1" required-level="76" sp="7900000" />
-		<skill name="Summon Mechanic Golem" id="25" level="10" required-level="76" sp="7900000" />
-		<skill name="Power Crush" id="260" level="38" required-level="76" sp="7900000" />
+		<skill name="Master of Combat" id="430" level="1" required-level="76" sp="7900000" />
+		<skill name="Final Secret" id="917" level="1" required-level="76" sp="7900000">
+			<item id="90080" count="1" /> <!-- Scroll: Final Secret -->
+		</skill>
+		<skill name="Rush" id="45252" level="3" required-level="40" sp="7900000" />
 		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="7900000">
-			<item id="8620"/> <!-- Ancient Book: Divine Inspiration (Manuscript) -->
+			<item id="8620" count="1" /> <!-- Buff Expansion Book Lv. 3 -->
 		</skill>
 		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="7900000">
-			<item id="8621"/> <!-- Ancient Book: Divine Inspiration (Original Version) -->
+			<item id="8621" count="1" /> <!-- Buff Expansion Book Lv. 4 -->
 		</skill>
 		<skill name="Mount Kukuru" id="1836" level="1" required-level="76">
-			<item id="90041"/> <!-- Spellbook: Mount Kukuru  -->
+			<item id="90041" count="1" /> <!-- Spellbook - Ride Kukura -->
 		</skill>
-		<skill name="Glory Ability" id="45361" level="1" required-level="86">
-			<item id="94046"/> <!-- Spellbook: Glory Ability Lv. 1 -->
+		<skill name="Evolution Defense" id="45188" level="1" required-level="76">
+			<item id="57" count="5000000" /> <!-- Adena -->
 		</skill>
-		<skill name="Mount White Wings" id="54200" level="1" required-level="87">
-			<item id="93059"/> <!-- Spellbook: Summon White Wings -->
-		</skill>	
-		<skill name="Mount Shining Lady" id="54202" level="1" required-level="89">
-			<item id="93061"/> <!-- Spellbook: Summon Silver Saint -->
+		<skill name="Detection" id="45190" level="1" required-level="76" sp="7900000">
+			<item id="57" count="5000000" /> <!-- Adena -->
 		</skill>
-		
-		<skill name="Spinning Slasher" id="36" level="39" required-level="77" sp="7900000" />
-		<skill name="Polearm Mastery" id="216" level="47" required-level="77" sp="7900000" />
-		<skill name="Light Armor Mastery" id="227" level="52" required-level="77" sp="7900000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="47" required-level="77" sp="7900000" />
-		<skill name="Heavy Armor Mastery" id="231" level="52" required-level="77" sp="7900000" />
+		<skill name="Earth Tremor" id="45249" level="1" required-level="76" sp="7900000">
+			<item id="93104" count="1" /> <!-- Scroll: Earth Tremor -->
+		</skill>
+		<skill name="Blessed by Sayha" id="45408" level="1" required-level="76">
+			<item id="57" count="10000000"/> <!-- Adena -->
+		</skill>
+		<skill name="Critical Creation" id="53001" level="1" required-level="76" sp="7900000">
+			<item id="91290" count="1" /> <!-- Scroll: Critical Creation -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="46" required-level="76" sp="7900000" />
+		<skill name="Dwarven Armor Mastery" id="47236" level="8" required-level="76" sp="7900000" />
+		<skill name="Dwarven Weapon Mastery" id="47235" level="8" required-level="76" sp="7900000" />
+		<skill name="Vital Gain" id="47210" level="1" required-level="76" sp="7900000">
+			<item id="95860" count="1" /> <!-- Scroll: Critical Creation -->
+		</skill>
+		<skill name="Mechanic Hero" id="47221" level="1" required-level="76" sp="7900000">
+			<item id="95861" count="1" /> <!-- Book: Mechanic Hero -->
+		</skill>
+
+
+		<!-- Lv. 77 Skills -->
+		<skill name="Spinning Slasher" id="36" level="42" required-level="77" sp="7900000" />
+		<skill name="Fatal Strike" id="190" level="42" required-level="77" sp="7900000" />
+		<skill name="Power Break" id="260" level="39" required-level="77" sp="7900000" />
 		<skill name="Earthquake" id="347" level="2" required-level="77" sp="7900000" />
-		<skill name="Power Crush" id="260" level="39" required-level="77" sp="7900000" />
 		<skill name="Armor Crush" id="362" level="1" required-level="77" sp="7900000">
-			<item id="90078"/> <!-- Scroll: Armor Crush -->
+			<item id="90078" count="1" /> <!-- Scroll: Armor Crush -->
 		</skill>
-		
-		<skill name="Spinning Slasher" id="36" level="40" required-level="78" sp="18400000" />
-		<skill name="Polearm Mastery" id="216" level="48" required-level="78" sp="18400000" />
-		<skill name="Light Armor Mastery" id="227" level="53" required-level="78" sp="18400000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="48" required-level="78" sp="18400000" />
-		<skill name="Heavy Armor Mastery" id="231" level="53" required-level="78" sp="18400000" />
-		<skill name="Earthquake" id="347" level="3" required-level="78" sp="18400000" />
-		<skill name="Creation Master" id="53002" level="1" required-level="78" sp="18400000" />
-		<skill name="Master of Combat" id="430" level="1" required-level="78" sp="18400000" />
+		<skill name="Weapon Reinforcement" id="1615" level="4" required-level="77" sp="7900000" />
+		<skill name="Earth Tremor" id="45249" level="2" required-level="77" sp="7900000" />
+		<skill name="Emergency Rescue" id="70" level="47" required-level="77" sp="7900000" />
+
+		<!-- Lv. 78 Skills -->
+		<skill name="Dwarven Restore Mastery" id="47237" level="5" required-level="77" sp="7900000" />
+		<skill name="Spinning Slasher" id="36" level="43" required-level="78" sp="18400000" />
+		<skill name="Fatal Strike" id="190" level="43" required-level="78" sp="18400000" />
+		<skill name="Power Break" id="260" level="40" required-level="78" sp="18400000" />
 		<skill name="Provoke" id="286" level="8" required-level="78" sp="18400000" />
-		<skill name="Armor Crush" id="362" level="2" required-level="78" sp="18400000" />
-		<skill name="Power Crush" id="260" level="40" required-level="78" sp="18400000" />
-		<skill name="Rush" id="994" level="1" required-level="78" sp="18400000" />
-		<skill name="Braveheart" id="440" level="1" required-level="78" sp="18400000" />
-		
-		<skill name="Earthquake" id="347" level="4" required-level="79" sp="18400000" />
-		<skill name="Critical Creation" id="53001" level="2" required-level="79" sp="18400000" />
-		<skill name="Armor Crush" id="362" level="3" required-level="79" sp="18400000" />
-		<skill name="Final Secret" id="917" level="1" required-level="79" sp="18400000">
-			<item id="90080"/> <!-- Scroll: Final Secret -->
+		<skill name="Final Frenzy" id="290" level="15" required-level="78" sp="18400000">
+			<item id="57" count="500000" /> <!-- Adena -->
 		</skill>
+		<skill name="Earthquake" id="347" level="3" required-level="78" sp="18400000" />
+		<skill name="Armor Crush" id="362" level="2" required-level="78" sp="18400000" />
+		<skill name="Braveheart" id="440" level="1" required-level="78" sp="18400000" />
+		<skill name="Body Crush" id="1613" level="10" required-level="78" sp="18400000" />
+		<skill name="Earth Tremor" id="45249" level="3" required-level="78" sp="18400000" />
+		<skill name="Forge Attack" id="47227" level="1" required-level="78" sp="18400000">
+			<item id="95863" count="1" /> <!-- Book: Forge Attack -->
+		</skill>
+		<skill name="Dwarven Armor Mastery" id="47236" level="9" required-level="77" sp="18400000" />
+		<skill name="Master of Creation" id="53002" level="1" required-level="78" sp="18400000">
+			<item id="91292" count="1" /> <!-- Scroll: Master of Creation -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="48" required-level="78" sp="18400000" />
 
-		<skill name="Polearm Mastery" id="216" level="49" required-level="80" sp="18400000" />
-		<skill name="Light Armor Mastery" id="227" level="54" required-level="80" sp="18400000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="49" required-level="80" sp="18400000" />
-		<skill name="Heavy Armor Mastery" id="231" level="54" required-level="80" sp="18400000" />
-		<skill name="Earthquake" id="347" level="5" required-level="80" sp="18400000" />
-		<skill name="Tenacity" id="1617" level="4" required-level="80" sp="18400000" />
+		<!-- Lv. 79 Skills -->
+		<skill name="Spinning Slasher" id="36" level="44" required-level="79" sp="18400000" />
+		<skill name="Fatal Strike" id="190" level="44" required-level="79" sp="18400000" />
+		<skill name="Armor Crush" id="362" level="3" required-level="79" sp="18400000" />
+		<skill name="Earth Tremor" id="45249" level="4" required-level="79" sp="18400000" />
+		<skill name="Dwarven Weapon Mastery" id="47235" level="9" required-level="79" sp="18400000" />
+		<skill name="Critical Creation" id="53001" level="2" required-level="79" sp="18400000">
+			<item id="91290" count="1" /> <!-- Scroll: Critical Creation -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="49" required-level="79" sp="18400000" />
+
+		<!-- Lv. 80 Skills -->
+		<skill name="Spinning Slasher" id="36" level="45" required-level="80" sp="18400000" />
+		<skill name="Fatal Strike" id="190" level="45" required-level="80" sp="18400000" />
+		<skill name="Power Break" id="260" level="41" required-level="80" sp="18400000" />
 		<skill name="Provoke" id="286" level="9" required-level="80" sp="18400000" />
+		<skill name="Earthquake" id="347" level="5" required-level="80" sp="18400000" />
 		<skill name="Armor Crush" id="362" level="4" required-level="80" sp="18400000" />
-		<skill name="Power Crush" id="260" level="41" required-level="80" sp="18400000" />
+		<skill name="Master of Combat" id="430" level="2" required-level="80" sp="18400000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Tenacity" id="1617" level="4" required-level="80" sp="18400000" />
+		<skill name="Evolution Power" id="45189" level="1" required-level="80">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Earth Tremor" id="45249" level="5" required-level="80" sp="18400000" />
+		<skill name="Blessed by Sayha" id="45408" level="2" required-level="80">
+			<item id="57" count="50000000"/> <!-- Adena -->
+		</skill>
+		<skill name="Forge Attack" id="47227" level="2" required-level="80" sp="18400000" />
+		<skill name="White Guardian Transformation" id="54102" level="1" required-level="80">
+			<item id="92401" count="1" /> <!-- Spellbook - White Guardian -->
+		</skill>
+		<skill name="Mechanic Masterpiece" id="47228" level="1" required-level="80">
+			<item id="95862" count="1" /> <!-- Spellbook - Mechanic Masterpiece -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="50" required-level="80" sp="18400000" />
 
-		<skill name="Polearm Mastery" id="216" level="50" required-level="81" sp="160000000" />
-		<skill name="Light Armor Mastery" id="227" level="55" required-level="81" sp="160000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="50" required-level="81" sp="160000000" />
-		<skill name="Heavy Armor Mastery" id="231" level="55" required-level="81" sp="160000000" />
+		<!-- Lv. 81 Skills -->
+		<skill name="Summon Mechanic Golem" id="13" level="11" required-level="81" sp="160000000" />
+		<skill name="Fatal Strike" id="190" level="46" required-level="81" sp="160000000" />
+		<skill name="Power Break" id="260" level="42" required-level="81" sp="160000000" />
 		<skill name="Earthquake" id="347" level="6" required-level="81" sp="160000000" />
-		<skill name="Summon Mechanic Golem" id="25" level="11" required-level="81" sp="160000000" />
 		<skill name="Armor Crush" id="362" level="5" required-level="81" sp="160000000" />
-		<skill name="Power Crush" id="260" level="42" required-level="81" sp="160000000" />
+		<skill name="Earth Tremor" id="45249" level="6" required-level="81" sp="160000000" />
+		<skill name="Dwarven Armor Mastery" id="47236" level="10" required-level="81" sp="160000000" />
+		<skill name="Emergency Rescue" id="70" level="51" required-level="81" sp="160000000" />
 
-		<skill name="Polearm Mastery" id="216" level="51" required-level="82" sp="170000000" />
-		<skill name="Light Armor Mastery" id="227" level="56" required-level="82" sp="170000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="51" required-level="82" sp="170000000" />
-		<skill name="Heavy Armor Mastery" id="231" level="56" required-level="82" sp="170000000" />
-		<skill name="Earthquake" id="347" level="7" required-level="82" sp="170000000" />
-		<skill name="Creation Master" id="53002" level="2" required-level="82" sp="170000000" />
-		<skill name="Summon Mechanic Golem" id="25" level="12" required-level="82" sp="170000000" />
+		<!-- Lv. 82 Skills -->
+		<skill name="Fatal Strike" id="190" level="47" required-level="82" sp="170000000" />
+		<skill name="Power Break" id="260" level="43" required-level="82" sp="170000000" />
 		<skill name="Provoke" id="286" level="10" required-level="82" sp="170000000" />
+		<skill name="Final Frenzy" id="290" level="16" required-level="82" sp="18400000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Earthquake" id="347" level="7" required-level="82" sp="170000000" />
 		<skill name="Armor Crush" id="362" level="6" required-level="82" sp="170000000" />
-		<skill name="Power Crush" id="260" level="43" required-level="82" sp="170000000" />
+		<skill name="Body Crush" id="1613" level="11" required-level="82" sp="170000000" />
 		<skill name="Weapon Reinforcement" id="1615" level="4" required-level="82" sp="170000000" />
+		<skill name="Earth Tremor" id="45249" level="7" required-level="82" sp="170000000" />
+		<skill name="Forge Attack" id="47227" level="3" required-level="82" sp="170000000" />
+		<skill name="Dwarven Weapon Mastery" id="47235" level="10" required-level="82" sp="170000000" />
+		<skill name="Dwarven Restore Mastery" id="47237" level="6" required-level="82" sp="170000000" />
+		<skill name="Master of Creation" id="53002" level="2" required-level="82" sp="170000000">
+			<item id="91292" count="1" /> <!-- Scroll: Master of Creation -->
+		</skill>
+		<skill name="Summon Mechanic Golem" id="13" level="12" required-level="82" sp="170000000" />
+		<skill name="Emergency Rescue" id="70" level="52" required-level="82" sp="170000000" />
 
-		<skill name="Polearm Mastery" id="216" level="52" required-level="83" sp="240000000" />
-		<skill name="Light Armor Mastery" id="227" level="57" required-level="83" sp="240000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="52" required-level="83" sp="240000000" />
-		<skill name="Heavy Armor Mastery" id="231" level="57" required-level="83" sp="240000000" />
+
+		<!-- Lv. 83 Skills -->
+		<skill name="Summon Mechanic Golem" id="13" level="13" required-level="83" sp="240000000" />
+		<skill name="Fatal Strike" id="190" level="48" required-level="83" sp="240000000" />
+		<skill name="Power Break" id="260" level="44" required-level="83" sp="240000000" />
 		<skill name="Earthquake" id="347" level="8" required-level="83" sp="240000000" />
-		<skill name="Summon Mechanic Golem" id="25" level="13" required-level="83" sp="240000000" />
 		<skill name="Armor Crush" id="362" level="7" required-level="83" sp="240000000" />
-		<skill name="Power Crush" id="260" level="44" required-level="83" sp="240000000" />
+		<skill name="Earth Tremor" id="45249" level="8" required-level="83" sp="240000000" />
+		<skill name="Dwarven Armor Mastery" id="47236" level="11" required-level="83" sp="240000000" />
+		<skill name="Emergency Rescue" id="70" level="53" required-level="83" sp="240000000" />
 
-		<skill name="Polearm Mastery" id="216" level="53" required-level="84" sp="240000000" />
-		<skill name="Light Armor Mastery" id="227" level="58" required-level="84" sp="240000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="53" required-level="84" sp="240000000" />
-		<skill name="Heavy Armor Mastery" id="231" level="58" required-level="84" sp="240000000" />
-		<skill name="Earthquake" id="347" level="9" required-level="84" sp="240000000" />
-		<skill name="Critical Creation" id="53001" level="3" required-level="84" sp="240000000" />
-		<skill name="Creation Master" id="53002" level="3" required-level="84" sp="240000000" />
-		<skill name="Summon Mechanic Golem" id="25" level="14" required-level="84" sp="240000000" />
+		<!-- Lv. 84 Skills -->
+		<skill name="Summon Mechanic Golem" id="13" level="14" required-level="84" sp="240000000" />
+		<skill name="Fatal Strike" id="190" level="49" required-level="84" sp="240000000" />
+		<skill name="Power Break" id="260" level="45" required-level="84" sp="240000000" />
 		<skill name="Provoke" id="286" level="11" required-level="84" sp="240000000" />
+		<skill name="Earthquake" id="347" level="9" required-level="84" sp="240000000" />
 		<skill name="Armor Crush" id="362" level="8" required-level="84" sp="240000000" />
-		<skill name="Power Crush" id="260" level="45" required-level="84" sp="240000000" />
-		
-		<skill name="Polearm Mastery" id="216" level="54" required-level="85" sp="840000000" />
-		<skill name="Polearm Mastery" id="216" level="55" required-level="86" sp="924000000" />
-		<skill name="Polearm Mastery" id="216" level="56" required-level="87" sp="1016400000" />
-		<skill name="Polearm Mastery" id="216" level="57" required-level="88" sp="1118040000" />
-		<skill name="Polearm Mastery" id="216" level="58" required-level="89" sp="1229844000" />
-		<skill name="Polearm Mastery" id="216" level="59" required-level="90" sp="1352828400" />
-		<skill name="Light Armor Mastery" id="227" level="59" required-level="85" sp="840000000" />
-		<skill name="Light Armor Mastery" id="227" level="60" required-level="86" sp="924000000" />
-		<skill name="Light Armor Mastery" id="227" level="61" required-level="87" sp="1016400000" />
-		<skill name="Light Armor Mastery" id="227" level="62" required-level="88" sp="1118040000" />
-		<skill name="Light Armor Mastery" id="227" level="63" required-level="89" sp="1229844000" />
-		<skill name="Light Armor Mastery" id="227" level="64" required-level="90" sp="1352828400" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="54" required-level="85" sp="840000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="55" required-level="86" sp="924000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="56" required-level="87" sp="1016400000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="57" required-level="88" sp="1118040000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="58" required-level="89" sp="1229844000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="205" level="59" required-level="90" sp="1352828400" />
-		<skill name="Heavy Armor Mastery" id="231" level="59" required-level="85" sp="840000000" />
-		<skill name="Heavy Armor Mastery" id="231" level="60" required-level="86" sp="924000000" />
-		<skill name="Heavy Armor Mastery" id="231" level="61" required-level="87" sp="1016400000" />
-		<skill name="Heavy Armor Mastery" id="231" level="62" required-level="88" sp="1118040000" />
-		<skill name="Heavy Armor Mastery" id="231" level="63" required-level="89" sp="1229844000" />
-		<skill name="Heavy Armor Mastery" id="231" level="64" required-level="90" sp="1352828400" />
+		<skill name="Body Crush" id="1613" level="12" required-level="84" sp="240000000" />
+		<skill name="Earth Tremor" id="45249" level="9" required-level="84" sp="240000000" />
+		<skill name="Forge Attack" id="47227" level="4" required-level="84" sp="170000000" />
+		<skill name="Dwarven Weapon Mastery" id="47235" level="11" required-level="84" sp="170000000" />
+		<skill name="Dwarven Restore Mastery" id="47237" level="7" required-level="84" sp="170000000" />
+		<skill name="Critical Creation" id="53001" level="3" required-level="84" sp="240000000">
+			<item id="91290" count="1" /> <!-- Scroll: Critical Creation -->
+		</skill>
+		<skill name="Master of Creation" id="53002" level="3" required-level="84" sp="240000000">
+			<item id="91292" count="1" /> <!-- Scroll: Master of Creation -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="54" required-level="84" sp="240000000" />
+
+		<!-- Lv. 85 Skills -->
+		<skill name="Fatal Strike" id="190" level="50" required-level="85" sp="840000000" />
+		<skill name="Earth Tremor" id="45249" level="10" required-level="85" sp="840000000" />
+		<skill name="Blessed by Sayha" id="45408" level="3" required-level="85">
+			<item id="57" count="100000000"/> <!-- Adena -->
+		</skill>
+		<skill name="Dwarven Armor Mastery" id="47236" level="12" required-level="84" sp="840000000" />
+		<skill name="Weapon Reinforcement" id="1615" level="5" required-level="85" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="55" required-level="85" sp="840000000" />
+
+		<!-- Lv. 86 Skills -->
+		<skill name="Fatal Strike" id="190" level="51" required-level="86" sp="840000000" />
+		<skill name="Final Frenzy" id="290" level="16" required-level="86" sp="840000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Fatal Strike" id="190" level="51" required-level="86" sp="840000000" />
+		<skill name="Armor Crush" id="362" level="9" required-level="86" sp="840000000" />
+		<skill name="Earth Tremor" id="45249" level="11" required-level="86" sp="840000000" />
+		<skill name="Forge Attack" id="47227" level="5" required-level="86" sp="840000000" />
+		<skill name="Dwarven Weapon Mastery" id="47235" level="12" required-level="86" sp="840000000" />
+		<skill name="Dwarven Restore Mastery" id="47237" level="8" required-level="86" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="56" required-level="86" sp="840000000" />
+
+		<!-- Lv. 87 Skills -->
+		<skill name="Fatal Strike" id="190" level="52" required-level="87" sp="840000000" />
+		<skill name="Earth Tremor" id="45249" level="12" required-level="87" sp="840000000" />
+		<skill name="Dwarven Armor Mastery" id="47236" level="13" required-level="87" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="57" required-level="87" sp="840000000" />
+
+		<!-- Lv. 88 Skills -->
+		<skill name="Fatal Strike" id="190" level="53" required-level="88" sp="840000000" />
+		<skill name="Armor Crush" id="362" level="10" required-level="88" sp="840000000" />
+		<skill name="Earth Tremor" id="45249" level="13" required-level="88" sp="840000000" />
+		<skill name="Forge Attack" id="47227" level="6" required-level="88" sp="840000000" />
+		<skill name="Dwarven Weapon Mastery" id="47235" level="13" required-level="88" sp="840000000" />
+		<skill name="Dwarven Restore Mastery" id="47237" level="9" required-level="88" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="58" required-level="88" sp="840000000" />
+
+		<!-- Lv. 89 Skills -->
+		<skill name="Fatal Strike" id="190" level="54" required-level="89" sp="840000000" />
+		<skill name="Earth Tremor" id="45249" level="14" required-level="89" sp="840000000" />
+		<skill name="Dwarven Armor Mastery" id="47236" level="14" required-level="89" sp="840000000" />
+		<skill name="Dwarven Weapon Mastery" id="47235" level="14" required-level="89" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="59" required-level="89" sp="840000000" />
+
+		<!-- Lv. 90 Skills -->
+		<skill name="Fatal Strike" id="190" level="55" required-level="90" sp="840000000" />
+		<skill name="Final Frenzy" id="290" level="16" required-level="90" sp="840000000">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Armor Crush" id="362" level="11" required-level="90" sp="840000000" />
+		<skill name="Earth Tremor" id="45249" level="15" required-level="90" sp="840000000" />
+		<skill name="Blessed by Sayha" id="45408" level="4" required-level="90">
+			<item id="57" count="200000000"/> <!-- Adena -->
+		</skill>
+		<skill name="Forge Attack" id="47227" level="7" required-level="90" sp="840000000" />
+		<skill name="Dwarven Armor Mastery" id="47236" level="15" required-level="90" sp="840000000" />
+		<skill name="Dwarven Weapon Mastery" id="47235" level="15" required-level="90" sp="840000000" />
+		<skill name="Dwarven Restore Mastery" id="47237" level="10" required-level="90" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="60" required-level="90" sp="840000000" />
 	</skillTree>
 </list>

--- a/data/skillTrees/3rdClass/MoonlightSentinel.xml
+++ b/data/skillTrees/3rdClass/MoonlightSentinel.xml
@@ -1,117 +1,249 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="102" parentClassId="24">
-		<skill name="White Guardian" id="54102" level="1" required-level="80" >
-			<item id="92401"/>
+
+		<skill name="Esprit" id="171" level="9" required-level="76" sp="7400000" />
+		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="7400000">
+			<item id="8620" count="1" /> <!-- Buff Expansion Book Lv. 3 -->
+		</skill>
+		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="7400000">
+			<item id="8621" count="1" /> <!-- Buff Expansion Book Lv. 4 -->
 		</skill>
 		<skill name="Burst Shot" id="24" level="32" required-level="76" sp="7400000" />
 		<skill name="Light Armor Mastery" id="233" level="48" required-level="76" sp="7400000" />
 		<skill name="Bow Mastery" id="208" level="53" required-level="76" sp="7400000" />
-		<skill name="Double Shot" id="19" level="38" required-level="76" sp="7400000" />
+		<skill name="Weapon Mastery" id="141" level="5" required-level="76" sp="7400000" />
+		<skill name="Double Shot" id="19" level="41" required-level="76" sp="7400000" />
 		<skill name="Spirit of Sagittarius" id="415" level="1" required-level="76" sp="7400000" />
-		<skill name="Detect Darkness" id="53005" level="1" required-level="76" sp="7400000" />
+		<skill name="Evolution Defense" id="45188" level="1" required-level="76">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<!-- Might Lv. 4 -->
+		<skill name="Might" id="1068" level="4" required-level="76" sp="7400000">
+			<item id="94135" count="1" /> <!-- Master's Book: Might -->
+		</skill>
+		<!-- Shield Lv. 4 -->
+		<skill name="Shield" id="1040" level="4" required-level="76" sp="7400000">
+			<item id="94136" count="1" /> <!-- Master's Book: Shield -->
+		</skill>
+		<!-- Acumen Lv. 4 -->
+		<skill name="Acumen" id="45104" level="4" required-level="76" sp="7400000">
+			<item id="94370" count="1" /> <!-- Master's Book: Acumen -->
+		</skill>
+		<!-- Empower Lv. 4 -->
+		<skill name="Empower" id="45105" level="4" required-level="76" sp="7400000">
+			<item id="94361" count="1" /> <!-- Master's Book: Empower -->
+		</skill>
+		<!-- Wild Magic Lv. 3 -->
+		<skill name="Wild Magic" id="45106" level="3" required-level="76" sp="7400000">
+			<item id="94368" count="1" /> <!-- Master's Book: Wild Magic -->
+		</skill>
+		<!-- Wind Walk Lv. 3 -->
+		<skill name="Wind Walk" id="45107" level="3" required-level="76" sp="7400000">
+			<item id="94365" count="1" /> <!-- Master's Book: Wind Walk -->
+		</skill>
+		<!-- Magic Barrier Lv. 3 -->
+		<skill name="Magic Barrier" id="45108" level="3" required-level="76" sp="7400000">
+			<item id="94362" count="1" /> <!-- Master's Book: Magic Barrier -->
+		</skill>
+		<!-- Focus Lv. 4 -->
+		<skill name="Focus" id="45109" level="4" required-level="76" sp="7400000">
+			<item id="94363" count="1" /> <!-- Master's Book: Focus -->
+		</skill>
+		<!-- Death Whisper Lv. 4 -->
+		<skill name="Death Whisper" id="45110" level="4" required-level="76" sp="7400000">
+			<item id="94364" count="1" /> <!-- Master's Book: Death Whisper -->
+		</skill>
+		<!-- Haste Lv. 3 -->
+		<skill name="Haste" id="45111" level="3" required-level="76" sp="7400000">
+			<item id="94369" count="1" /> <!-- Master's Book: Haste -->
+		</skill>
+		<!-- Berserker Spirit Lv. 3 -->
+		<skill name="Berserker Spirit" id="45112" level="3" required-level="76" sp="7400000">
+			<item id="94366" count="1" /> <!-- Master's Book: Berserker Spirit -->
+		</skill>
+		<!-- Clarity Lv. 4 -->
+		<skill name="Clarity" id="45113" level="4" required-level="76" sp="7400000">
+			<item id="94367" count="1" /> <!-- Master's Book: Clarity -->
+		</skill>
+		<skill name="Detect Darkness" id="53005" level="1" required-level="76" sp="7400000">
+			<item id="91482" count="1" /> <!-- Scroll: Detect Darkness -->
+		</skill>
 		<skill name="Stun Shot" id="101" level="41" required-level="76" sp="7400000" />
 		<skill name="Entangle" id="102" level="17" required-level="76" sp="7400000" />
-		<skill name="Charm" id="15" level="53" required-level="76" sp="7400000" />
-		<skill name="Lethal Shot" id="343" level="1" required-level="76" sp="7400000" />
-		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="7400000">
-			<item id="8620"/> <!-- Ancient Book: Divine Inspiration (Manuscript) -->
-		</skill>
-		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="7400000">
-			<item id="8621"/> <!-- Ancient Book: Divine Inspiration (Original Version) -->
-		</skill>
 		<skill name="Mount Pegasus" id="1834" level="1" required-level="76">
-			<item id="90039"/> <!-- Spellbook: Mount Pegasus -->
+			<item id="90039" count="1" /> <!-- Spellbook - Ride Pegasus -->
 		</skill>
-		<skill name="Glory Ability" id="45361" level="1" required-level="86">
-			<item id="94046"/> <!-- Spellbook: Glory Ability Lv. 1 -->
-		</skill>
-		<skill name="Mount White Wings" id="54200" level="1" required-level="87">
-			<item id="93059"/> <!-- Spellbook: Summon White Wings -->
-		</skill>	
-		<skill name="Mount Shining Lady" id="54202" level="1" required-level="89">
-			<item id="93061"/> <!-- Spellbook: Summon Silver Saint -->
-		</skill>
-		
+		<skill name="Slowdown" id="15" level="53" required-level="76" sp="7400000" />
+		<skill name="Lethal Shot" id="343" level="1" required-level="76" sp="7400000" />
+		<skill name="Emergency Rescue" id="70" level="46" required-level="76" sp="7400000" />
+
 		<skill name="Burst Shot" id="24" level="33" required-level="77" sp="7400000" />
 		<skill name="Light Armor Mastery" id="233" level="49" required-level="77" sp="7400000" />
 		<skill name="Bow Mastery" id="208" level="54" required-level="77" sp="7400000" />
-		<skill name="Double Shot" id="19" level="39" required-level="77" sp="7400000" />
+		<skill name="Double Shot" id="19" level="42" required-level="77" sp="7400000" />
 		<skill name="Hamstring Shot" id="354" level="1" required-level="77" sp="7400000" />
 		<skill name="Stun Shot" id="101" level="42" required-level="77" sp="7400000" />
 		<skill name="Lethal Shot" id="343" level="2" required-level="77" sp="7400000" />
-		
+		<skill name="Emergency Rescue" id="70" level="47" required-level="77" sp="7400000" />
+
 		<skill name="Burst Shot" id="24" level="34" required-level="78" sp="17400000" />
 		<skill name="Light Armor Mastery" id="233" level="50" required-level="78" sp="17400000" />
 		<skill name="Bow Mastery" id="208" level="55" required-level="78" sp="17400000" />
-		<skill name="Double Shot" id="19" level="40" required-level="78" sp="17400000" />
+		<skill name="Real Target" id="522" level="1" required-level="78" sp="17400000">
+			<item id="90062" count="1" /> <!-- Scroll: Real Target -->
+		</skill>
+		<skill name="Double Shot" id="19" level="43" required-level="78" sp="17400000" />
 		<skill name="Stun Shot" id="101" level="43" required-level="78" sp="17400000" />
 		<skill name="Entangle" id="102" level="18" required-level="78" sp="17400000" />
-		<skill name="Charm" id="15" level="54" required-level="78" sp="17400000" />
+		<skill name="Slowdown" id="15" level="54" required-level="78" sp="17400000" />
 		<skill name="Lethal Shot" id="343" level="3" required-level="78" sp="17400000" />
-		<skill name="Real Target" id="522" level="1" required-level="78" sp="17400000">
-			<item id="90062"/> <!-- Scroll: Real Target -->
-		</skill>
-		
+		<skill name="Emergency Rescue" id="70" level="48" required-level="78" sp="17400000" />
+
 		<skill name="Burst Shot" id="24" level="35" required-level="79" sp="17400000" />
+		<skill name="Double Shot" id="19" level="44" required-level="79" sp="17400000" />
+		<skill name="Entangle" id="102" level="19" required-level="79" sp="17400000" />
 		<skill name="Lethal Shot" id="343" level="4" required-level="79" sp="17400000" />
 		<skill name="Death Sting" id="990" level="1" required-level="79" sp="17400000">
-			<item id="90063"/> <!-- Scroll: Death Sting -->
+			<item id="90063" count="1" /> <!-- Scroll: Death Sting -->
 		</skill>
-		
-		<skill name="Rapid Fire" id="413" level="9" required-level="80" sp="17400000" />
+		<skill name="Emergency Rescue" id="70" level="49" required-level="79" sp="17400000" />
+
+		<skill name="Rapid Fire" id="413" level="9" required-level="80" sp="17400000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Burst Shot" id="24" level="36" required-level="80" sp="17400000" />
 		<skill name="Light Armor Mastery" id="233" level="51" required-level="80" sp="17400000" />
 		<skill name="Bow Mastery" id="208" level="56" required-level="80" sp="17400000" />
 		<skill name="Real Target" id="522" level="2" required-level="80" sp="17400000" />
-		<skill name="Double Shot" id="19" level="41" required-level="80" sp="17400000" />
-		<skill name="Stun Shot" id="101" level="44" required-level="80" sp="17400000" />
-		<skill name="Lethal Shot" id="343" level="5" required-level="80" sp="17400000" />
+		<skill name="Double Shot" id="19" level="45" required-level="80" sp="17400000" />
 		<skill name="Arrow Rain" id="772" level="1" required-level="80" sp="17400000">
-			<item id="90065"/> <!-- Scroll: Arrow Rain -->
+			<item id="90065" count="1" /> <!-- Scroll: Arrow Rain -->
 		</skill>
+		<skill name="Evolution Power" id="45189" level="1" required-level="80">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Stun Shot" id="101" level="44" required-level="80" sp="17400000" />
+		<skill name="Entangle" id="102" level="20" required-level="80" sp="17400000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="55" required-level="80" sp="17400000" />
+		<skill name="Lethal Shot" id="343" level="5" required-level="80" sp="17400000" />
+		<skill name="White Guardian Transformation" id="54102" level="1" required-level="80">
+			<item id="92401" count="1" /> <!-- Spellbook - White Guardian -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="50" required-level="80" sp="17400000" />
 
 		<skill name="Burst Shot" id="24" level="37" required-level="81" sp="160000000" />
 		<skill name="Light Armor Mastery" id="233" level="52" required-level="81" sp="160000000" />
 		<skill name="Bow Mastery" id="208" level="57" required-level="81" sp="160000000" />
-		<skill name="Double Shot" id="19" level="42" required-level="81" sp="160000000" />
+		<skill name="Double Shot" id="19" level="46" required-level="81" sp="160000000" />
 		<skill name="Stun Shot" id="101" level="45" required-level="81" sp="160000000" />
+		<skill name="Entangle" id="102" level="21" required-level="81" sp="160000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="56" required-level="81" sp="160000000" />
 		<skill name="Lethal Shot" id="343" level="6" required-level="81" sp="160000000" />
+		<skill name="Emergency Rescue" id="70" level="51" required-level="81" sp="160000000" />
 
 		<skill name="Burst Shot" id="24" level="38" required-level="82" sp="170000000" />
 		<skill name="Light Armor Mastery" id="233" level="53" required-level="82" sp="170000000" />
 		<skill name="Bow Mastery" id="208" level="58" required-level="82" sp="170000000" />
 		<skill name="Real Target" id="522" level="3" required-level="82" sp="170000000" />
-		<skill name="Double Shot" id="19" level="43" required-level="82" sp="170000000" />
+		<skill name="Double Shot" id="19" level="47" required-level="82" sp="170000000" />
 		<skill name="Stun Shot" id="101" level="46" required-level="82" sp="170000000" />
+		<skill name="Entangle" id="102" level="22" required-level="82" sp="170000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="57" required-level="82" sp="170000000" />
 		<skill name="Lethal Shot" id="343" level="7" required-level="82" sp="170000000" />
+		<skill name="Emergency Rescue" id="70" level="52" required-level="82" sp="170000000" />
 
 		<skill name="Burst Shot" id="24" level="39" required-level="83" sp="240000000" />
 		<skill name="Light Armor Mastery" id="233" level="54" required-level="83" sp="240000000" />
 		<skill name="Bow Mastery" id="208" level="59" required-level="83" sp="240000000" />
-		<skill name="Double Shot" id="19" level="44" required-level="83" sp="240000000" />
+		<skill name="Double Shot" id="19" level="48" required-level="83" sp="240000000" />
 		<skill name="Stun Shot" id="101" level="47" required-level="83" sp="240000000" />
+		<skill name="Entangle" id="102" level="23" required-level="83" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="58" required-level="83" sp="240000000" />
 		<skill name="Lethal Shot" id="343" level="8" required-level="83" sp="240000000" />
+		<skill name="Emergency Rescue" id="70" level="53" required-level="83" sp="240000000" />
 
 		<skill name="Burst Shot" id="24" level="40" required-level="84" sp="240000000" />
 		<skill name="Light Armor Mastery" id="233" level="55" required-level="84" sp="240000000" />
 		<skill name="Bow Mastery" id="208" level="60" required-level="84" sp="240000000" />
 		<skill name="Real Target" id="522" level="4" required-level="84" sp="240000000" />
-		<skill name="Double Shot" id="19" level="45" required-level="84" sp="240000000" />
+		<skill name="Double Shot" id="19" level="49" required-level="84" sp="240000000" />
 		<skill name="Stun Shot" id="101" level="48" required-level="84" sp="240000000" />
+		<skill name="Entangle" id="102" level="24" required-level="84" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="59" required-level="84" sp="240000000" />
 		<skill name="Lethal Shot" id="343" level="9" required-level="84" sp="240000000" />
-		
+		<skill name="Emergency Rescue" id="70" level="54" required-level="84" sp="240000000" />
+
+		<skill name="Rapid Fire" id="413" level="10" required-level="85" sp="840000000" />
 		<skill name="Light Armor Mastery" id="233" level="56" required-level="85" sp="840000000" />
-		<skill name="Light Armor Mastery" id="233" level="57" required-level="86" sp="924000000" />
-		<skill name="Light Armor Mastery" id="233" level="58" required-level="87" sp="1016400000" />
-		<skill name="Light Armor Mastery" id="233" level="59" required-level="88" sp="1118040000" />
-		<skill name="Light Armor Mastery" id="233" level="60" required-level="89" sp="1229844000" />
-		<skill name="Light Armor Mastery" id="233" level="61" required-level="90" sp="1352828400" />
 		<skill name="Bow Mastery" id="208" level="61" required-level="85" sp="840000000" />
-		<skill name="Bow Mastery" id="208" level="62" required-level="86" sp="924000000" />
-		<skill name="Bow Mastery" id="208" level="63" required-level="87" sp="1016400000" />
-		<skill name="Bow Mastery" id="208" level="64" required-level="88" sp="1118040000" />
-		<skill name="Bow Mastery" id="208" level="65" required-level="89" sp="1229844000" />
-		<skill name="Bow Mastery" id="208" level="66" required-level="90" sp="1352828400" />
+		<skill name="Double Shot" id="19" level="50" required-level="85" sp="840000000" />
+		<skill name="Entangle" id="102" level="25" required-level="85" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="60" required-level="85" sp="840000000" />
+		<skill name="Lethal Shot" id="343" level="10" required-level="85" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="55" required-level="85" sp="840000000" />
+
+		<skill name="Light Armor Mastery" id="233" level="57" required-level="86" sp="840000000" />
+		<skill name="Bow Mastery" id="208" level="62" required-level="86" sp="840000000" />
+		<skill name="Double Shot" id="19" level="51" required-level="86" sp="840000000" />
+		<skill name="Entangle" id="102" level="26" required-level="86" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="61" required-level="86" sp="840000000" />
+		<skill name="Lethal Shot" id="343" level="11" required-level="86" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="56" required-level="86" sp="840000000" />
+
+		<skill name="Light Armor Mastery" id="233" level="58" required-level="87" sp="840000000" />
+		<skill name="Bow Mastery" id="208" level="63" required-level="87" sp="840000000" />
+		<skill name="Double Shot" id="19" level="52" required-level="87" sp="840000000" />
+		<skill name="Entangle" id="102" level="27" required-level="87" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="62" required-level="87" sp="840000000" />
+		<skill name="Lethal Shot" id="343" level="12" required-level="87" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="57" required-level="87" sp="840000000" />
+
+		<skill name="Light Armor Mastery" id="233" level="59" required-level="88" sp="840000000" />
+		<skill name="Bow Mastery" id="208" level="64" required-level="88" sp="840000000" />
+		<skill name="Double Shot" id="19" level="53" required-level="88" sp="840000000" />
+		<skill name="Entangle" id="102" level="28" required-level="88" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="63" required-level="88" sp="840000000" />
+		<skill name="Lethal Shot" id="343" level="13" required-level="88" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="58" required-level="88" sp="840000000" />
+
+		<skill name="Light Armor Mastery" id="233" level="60" required-level="89" sp="840000000" />
+		<skill name="Bow Mastery" id="208" level="65" required-level="89" sp="840000000" />
+		<skill name="Double Shot" id="19" level="54" required-level="89" sp="840000000" />
+		<skill name="Entangle" id="102" level="29" required-level="89" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="64" required-level="89" sp="840000000" />
+		<skill name="Lethal Shot" id="343" level="14" required-level="89" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="59" required-level="89" sp="840000000" />
+
+		<skill name="Light Armor Mastery" id="233" level="61" required-level="90" sp="840000000" />
+		<skill name="Bow Mastery" id="208" level="66" required-level="90" sp="840000000" />
+		<skill name="Double Shot" id="19" level="55" required-level="90" sp="840000000" />
+		<skill name="Entangle" id="102" level="30" required-level="90" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="65" required-level="90" sp="840000000" />
+		<skill name="Lethal Shot" id="343" level="15" required-level="90" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="60" required-level="90" sp="840000000" />
+
 	</skillTree>
 </list>

--- a/data/skillTrees/3rdClass/MysticMuse.xml
+++ b/data/skillTrees/3rdClass/MysticMuse.xml
@@ -1,185 +1,296 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="103" parentClassId="27">
-		<skill name="White Guardian" id="54102" level="1" required-level="80" >
-			<item id="92401"/>
-		</skill>
+
 		<skill name="Anti Magic" id="146" level="46" required-level="76" sp="6100000" />
+		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="6100000">
+			<item id="8620" count="1" /> <!-- Buff Expansion Book Lv. 3 -->
+		</skill>
+		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="6100000">
+			<item id="8621" count="1" /> <!-- Buff Expansion Book Lv. 4 -->
+		</skill>
+		<skill name="Water Explosion" id="45379" level="1" required-level="76" sp="6100000">
+			<item id="93869" count="1" /> <!-- Spellbook: Elemental Burst -->
+		</skill>
 		<skill name="Robe Mastery" id="234" level="42" required-level="76" sp="6100000" />
 		<skill name="Weapon Mastery" id="249" level="43" required-level="76" sp="6100000" />
 		<skill name="Aqua Splash" id="1295" level="10" required-level="76" sp="6100000" />
-		<skill name="Hydro Blast" id="1235" level="29" required-level="76" sp="6100000" />
-		<skill name="Frost Bolt" id="1236" level="20" required-level="76" sp="6100000" />
+		<skill name="Hydro Blast" id="1235" level="31" required-level="76" sp="6100000" />
+		<skill name="Frost Bolt" id="1236" level="21" required-level="76" sp="6100000" />
+		<skill name="Evolution Defense" id="45188" level="1" required-level="76">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Ice Vortex" id="1340" level="1" required-level="76" sp="6100000" />
 		<skill name="Ice Dagger" id="1237" level="18" required-level="76" sp="6100000" />
-		<skill name="Bind" id="53006" level="1" required-level="76" sp="6100000" />
-		<skill name="Curse Weakness" id="1164" level="20" required-level="76" sp="6100000" />
+		<!-- Might Lv. 4 -->
+		<skill name="Might" id="1068" level="4" required-level="76" sp="6100000">
+			<item id="94135" count="1" /> <!-- Master's Book: Might -->
+		</skill>
+		<!-- Shield Lv. 4 -->
+		<skill name="Shield" id="1040" level="4" required-level="76" sp="6100000">
+			<item id="94136" count="1" /> <!-- Master's Book: Shield -->
+		</skill>
+		<!-- Acumen Lv. 4 -->
+		<skill name="Acumen" id="45104" level="4" required-level="76" sp="6100000">
+			<item id="94370" count="1" /> <!-- Master's Book: Acumen -->
+		</skill>
+		<!-- Empower Lv. 4 -->
+		<skill name="Empower" id="45105" level="4" required-level="76" sp="6100000">
+			<item id="94361" count="1" /> <!-- Master's Book: Empower -->
+		</skill>
+		<!-- Wild Magic Lv. 3 -->
+		<skill name="Wild Magic" id="45106" level="3" required-level="76" sp="6100000">
+			<item id="94368" count="1" /> <!-- Master's Book: Wild Magic -->
+		</skill>
+		<!-- Wind Walk Lv. 3 -->
+		<skill name="Wind Walk" id="45107" level="3" required-level="76" sp="6100000">
+			<item id="94365" count="1" /> <!-- Master's Book: Wind Walk -->
+		</skill>
+		<!-- Magic Barrier Lv. 3 -->
+		<skill name="Magic Barrier" id="45108" level="3" required-level="76" sp="6100000">
+			<item id="94362" count="1" /> <!-- Master's Book: Magic Barrier -->
+		</skill>
+		<!-- Focus Lv. 4 -->
+		<skill name="Focus" id="45109" level="4" required-level="76" sp="6100000">
+			<item id="94363" count="1" /> <!-- Master's Book: Focus -->
+		</skill>
+		<!-- Death Whisper Lv. 4 -->
+		<skill name="Death Whisper" id="45110" level="4" required-level="76" sp="6100000">
+			<item id="94364" count="1" /> <!-- Master's Book: Death Whisper -->
+		</skill>
+		<!-- Haste Lv. 3 -->
+		<skill name="Haste" id="45111" level="3" required-level="76" sp="6100000">
+			<item id="94369" count="1" /> <!-- Master's Book: Haste -->
+		</skill>
+		<!-- Berserker Spirit Lv. 3 -->
+		<skill name="Berserker Spirit" id="45112" level="3" required-level="76" sp="6100000">
+			<item id="94366" count="1" /> <!-- Master's Book: Berserker Spirit -->
+		</skill>
+		<!-- Clarity Lv. 4 -->
+		<skill name="Clarity" id="45113" level="4" required-level="76" sp="6100000">
+			<item id="94367" count="1" /> <!-- Master's Book: Clarity -->
+		</skill>
+
+		<skill name="Detection" id="45190" level="1" required-level="76" sp="6100000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Wind Shackle" id="1206" level="20" required-level="76" sp="6800000" />
+		<skill name="Mount Pegasus" id="1834" level="1" required-level="76">
+			<item id="90039" count="1" /> <!-- Spellbook - Ride Pegasus -->
+		</skill>
+		<skill name="Bind" id="53006" level="1" required-level="76" sp="6100000">
+			<item id="91483" count="1" /> <!-- Scroll: Bind -->
+		</skill>
 		<skill name="Aura Flare" id="1231" level="29" required-level="76" sp="6100000" />
+		<skill name="Weakness" id="1164" level="20" required-level="76" sp="6100000" />
 		<skill name="Blizzard" id="1290" level="2" required-level="76" sp="6100000" />
 		<skill name="Frost Wall" id="1174" level="23" required-level="76" sp="6100000" />
 		<skill name="Higher Mana Gain" id="285" level="28" required-level="76" sp="6100000" />
-		<skill name="Sleep" id="1069" level="43" required-level="76" sp="6100000" />
+		<skill name="Sleep" id="1069" level="46" required-level="76" sp="6100000" />
 		<skill name="Sleeping Cloud" id="1072" level="6" required-level="76" sp="6100000" />
-		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="6100000">
-			<item id="8620"/> <!-- Ancient Book: Divine Inspiration (Manuscript) -->
-		</skill>
-		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="6100000">
-			<item id="8621"/> <!-- Ancient Book: Divine Inspiration (Original Version) -->
-		</skill>
-		<skill name="Mount Pegasus" id="1834" level="1" required-level="76">
-			<item id="90039"/> <!-- Spellbook: Mount Pegasus -->
-		</skill>
-		<skill name="Glory Ability" id="45361" level="1" required-level="86">
-			<item id="94046"/> <!-- Spellbook: Glory Ability Lv. 1 -->
-		</skill>
-		<skill name="Mount White Wings" id="54200" level="1" required-level="87">
-			<item id="93059"/> <!-- Spellbook: Summon White Wings -->
-		</skill>	
-		<skill name="Mount Shining Lady" id="54202" level="1" required-level="89">
-			<item id="93061"/> <!-- Spellbook: Summon Silver Saint -->
-		</skill>
-		
 		<skill name="Anti Magic" id="146" level="47" required-level="77" sp="6100000" />
+		<skill name="Water Explosion" id="45379" level="2" required-level="77" sp="6100000" />
 		<skill name="Robe Mastery" id="234" level="43" required-level="77" sp="6100000" />
 		<skill name="Weapon Mastery" id="249" level="44" required-level="77" sp="6100000" />
-		<skill name="Hydro Blast" id="1235" level="30" required-level="77" sp="6100000" />
+		<skill name="Hydro Blast" id="1235" level="32" required-level="77" sp="6100000" />
+		<skill name="Frost Bolt" id="1236" level="22" required-level="77" sp="6100000" />
 		<skill name="Aura Flare" id="1231" level="30" required-level="77" sp="6100000" />
 		<skill name="Frost Wall" id="1174" level="24" required-level="77" sp="6100000" />
-		<skill name="Higher Mana Gain" id="285" level="29" required-level="77" sp="6100000" />
-		<skill name="Sleep" id="1069" level="44" required-level="77" sp="6100000" />
-		<skill name="Sleeping Cloud" id="1072" level="7" required-level="77" sp="6100000" />
 		<skill name="Arcane Power" id="337" level="1" required-level="77" sp="6100000">
-			<item id="90081"/> <!-- Scroll: Arcane Power -->
+			<item id="90081" count="1" /> <!-- Scroll: Arcane Power -->
 		</skill>
-		
+		<skill name="Higher Mana Gain" id="285" level="29" required-level="77" sp="6100000" />
+		<skill name="Sleep" id="1069" level="47" required-level="77" sp="6100000" />
+		<skill name="Sleeping Cloud" id="1072" level="7" required-level="77" sp="6100000" />
+
 		<skill name="Anti Magic" id="146" level="48" required-level="78" sp="13500000" />
+		<skill name="Water Explosion" id="45379" level="3" required-level="78" sp="13500000" />
 		<skill name="Robe Mastery" id="234" level="44" required-level="78" sp="13500000" />
 		<skill name="Weapon Mastery" id="249" level="45" required-level="78" sp="13500000" />
 		<skill name="Aqua Splash" id="1295" level="11" required-level="78" sp="13500000" />
-		<skill name="Hydro Blast" id="1235" level="31" required-level="78" sp="13500000" />
-		<skill name="Frost Bolt" id="1236" level="21" required-level="78" sp="13500000" />
+		<skill name="Hydro Blast" id="1235" level="33" required-level="78" sp="13500000" />
+		<skill name="Frost Bolt" id="1236" level="23" required-level="78" sp="13500000" />
 		<skill name="Ice Dagger" id="1237" level="19" required-level="78" sp="13500000" />
+		<skill name="Ice Vortex Crusher" id="1453" level="1" required-level="78" sp="13500000">
+			<item id="90083" count="1" /> <!-- Scroll: Ice Vortex Crusher -->
+		</skill>
+		<skill name="Wind Shackle" id="1206" level="21" required-level="78" sp="14900000" />
 		<skill name="Bind" id="53006" level="2" required-level="78" sp="13500000" />
-		<skill name="Curse Weakness" id="1164" level="21" required-level="78" sp="13500000" />
 		<skill name="Aura Flare" id="1231" level="31" required-level="78" sp="13500000" />
+		<skill name="Weakness" id="1164" level="21" required-level="78" sp="13500000" />
 		<skill name="Blizzard" id="1290" level="3" required-level="78" sp="13500000" />
 		<skill name="Frost Wall" id="1174" level="25" required-level="78" sp="13500000" />
 		<skill name="Arcane Power" id="337" level="2" required-level="78" sp="13500000" />
 		<skill name="Higher Mana Gain" id="285" level="30" required-level="78" sp="13500000" />
-		<skill name="Sleep" id="1069" level="45" required-level="78" sp="13500000" />
+		<skill name="Sleep" id="1069" level="48" required-level="78" sp="13500000" />
 		<skill name="Sleeping Cloud" id="1072" level="8" required-level="78" sp="13500000" />
-		<skill name="Ice Vortex Crusher" id="1453" level="1" required-level="78" sp="13500000">
-			<item id="90083"/> <!-- Scroll: Ice Vortex Crusher -->
-		</skill>
-		
+
+		<skill name="Water Explosion" id="45379" level="4" required-level="79" sp="13500000" />
 		<skill name="Aqua Splash" id="1295" level="12" required-level="79" sp="13500000" />
+		<skill name="Hydro Blast" id="1235" level="34" required-level="79" sp="13500000" />
+		<skill name="Frost Bolt" id="1236" level="24" required-level="79" sp="13500000" />
+		<skill name="Wind Shackle" id="1206" level="22" required-level="79" sp="14900000" />
 		<skill name="Frost Wall" id="1174" level="26" required-level="79" sp="13500000" />
 		<skill name="Arcane Power" id="337" level="3" required-level="79" sp="13500000" />
-		<skill name="Sleep" id="1069" level="46" required-level="79" sp="13500000" />
-		<skill name="Sleeping Cloud" id="1072" level="9" required-level="79" sp="13500000" />
 		<skill name="Arcane Chaos" id="1338" level="1" required-level="79" sp="13500000">
-			<item id="90085"/> <!-- Scroll: Arcane Chaos -->
+			<item id="90085" count="1" /> <!-- Scroll: Arcane Chaos -->
 		</skill>
-		
+		<skill name="Sleep" id="1069" level="49" required-level="79" sp="13500000" />
+		<skill name="Sleeping Cloud" id="1072" level="9" required-level="79" sp="13500000" />
+
 		<skill name="Anti Magic" id="146" level="49" required-level="80" sp="13500000" />
+		<skill name="Water Explosion" id="45379" level="5" required-level="80" sp="13500000" />
 		<skill name="Robe Mastery" id="234" level="45" required-level="80" sp="13500000" />
 		<skill name="Weapon Mastery" id="249" level="46" required-level="80" sp="13500000" />
 		<skill name="Aqua Splash" id="1295" level="13" required-level="80" sp="13500000" />
-		<skill name="Hydro Blast" id="1235" level="32" required-level="80" sp="13500000" />
+		<skill name="Hydro Blast" id="1235" level="35" required-level="80" sp="13500000" />
+		<skill name="Frost Bolt" id="1236" level="25" required-level="80" sp="13500000" />
+		<skill name="Spell Master" id="1830" level="4" required-level="80" sp="2400000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Arcane Shield" id="1556" level="1" required-level="80" sp="13500000">
+			<item id="90086" count="1" /> <!-- Scroll: Arcane Shield -->
+		</skill>
+		<skill name="Evolution Power" id="45189" level="1" required-level="80">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Wind Shackle" id="1206" level="23" required-level="80" sp="14900000" />
 		<skill name="Bind" id="53006" level="3" required-level="80" sp="13500000" />
-		<skill name="Curse Weakness" id="1164" level="22" required-level="80" sp="13500000" />
 		<skill name="Mana Regeneration" id="1047" level="5" required-level="80" sp="13500000" />
-		<skill name="Body To Mind" id="1157" level="6" required-level="80" sp="13500000" />
+		<skill name="Body to Mind" id="1157" level="6" required-level="80" sp="13500000" />
+		<skill name="Weakness" id="1164" level="22" required-level="80" sp="13500000" />
 		<skill name="Blizzard" id="1290" level="4" required-level="80" sp="13500000" />
 		<skill name="Frost Wall" id="1174" level="27" required-level="80" sp="13500000" />
 		<skill name="Arcane Power" id="337" level="4" required-level="80" sp="13500000" />
-		<skill name="Higher Mana Gain" id="285" level="31" required-level="80" sp="13500000" />
-		<skill name="Sleep" id="1069" level="47" required-level="80" sp="13500000" />
-		<skill name="Sleeping Cloud" id="1072" level="10" required-level="80" sp="13500000" />
-		<skill name="Arcane Shield" id="1556" level="1" required-level="80" sp="13500000">
-			<item id="90086"/> <!-- Scroll: Arcane Shield -->
+		<skill name="White Guardian Transformation" id="54102" level="1" required-level="80">
+			<item id="92401" count="1" /> <!-- Spellbook - White Guardian -->
 		</skill>
+		<skill name="Higher Mana Gain" id="285" level="31" required-level="80" sp="13500000" />
+		<skill name="Sleep" id="1069" level="50" required-level="80" sp="13500000" />
+		<skill name="Sleeping Cloud" id="1072" level="10" required-level="80" sp="13500000" />
 
 		<skill name="Anti Magic" id="146" level="50" required-level="81" sp="160000000" />
+		<skill name="Water Explosion" id="45379" level="6" required-level="81" sp="160000000" />
 		<skill name="Robe Mastery" id="234" level="46" required-level="81" sp="160000000" />
 		<skill name="Weapon Mastery" id="249" level="47" required-level="81" sp="160000000" />
 		<skill name="Aqua Splash" id="1295" level="14" required-level="81" sp="160000000" />
-		<skill name="Hydro Blast" id="1235" level="33" required-level="81" sp="160000000" />
+		<skill name="Hydro Blast" id="1235" level="36" required-level="81" sp="160000000" />
+		<skill name="Frost Bolt" id="1236" level="26" required-level="81" sp="160000000" />
 		<skill name="Arcane Shield" id="1556" level="2" required-level="81" sp="160000000" />
-		<skill name="Curse Weakness" id="1164" level="23" required-level="81" sp="160000000" />
-		<skill name="Body To Mind" id="1157" level="7" required-level="81" sp="160000000" />
+		<skill name="Wind Shackle" id="1206" level="24" required-level="81" sp="160000000" />
+		<skill name="Body to Mind" id="1157" level="7" required-level="81" sp="160000000" />
+		<skill name="Weakness" id="1164" level="23" required-level="81" sp="160000000" />
 		<skill name="Frost Wall" id="1174" level="28" required-level="81" sp="160000000" />
 		<skill name="Arcane Power" id="337" level="5" required-level="81" sp="160000000" />
 		<skill name="Higher Mana Gain" id="285" level="32" required-level="81" sp="160000000" />
-		<skill name="Sleep" id="1069" level="48" required-level="81" sp="160000000" />
+		<skill name="Sleep" id="1069" level="51" required-level="81" sp="160000000" />
 		<skill name="Sleeping Cloud" id="1072" level="11" required-level="81" sp="160000000" />
 
 		<skill name="Anti Magic" id="146" level="51" required-level="82" sp="170000000" />
+		<skill name="Water Explosion" id="45379" level="7" required-level="82" sp="170000000" />
 		<skill name="Robe Mastery" id="234" level="47" required-level="82" sp="170000000" />
 		<skill name="Weapon Mastery" id="249" level="48" required-level="82" sp="170000000" />
 		<skill name="Aqua Splash" id="1295" level="15" required-level="82" sp="170000000" />
-		<skill name="Hydro Blast" id="1235" level="34" required-level="82" sp="170000000" />
+		<skill name="Hydro Blast" id="1235" level="37" required-level="82" sp="170000000" />
+		<skill name="Frost Bolt" id="1236" level="27" required-level="82" sp="170000000" />
 		<skill name="Ice Vortex" id="1340" level="2" required-level="82" sp="170000000" />
 		<skill name="Arcane Shield" id="1556" level="3" required-level="82" sp="170000000" />
+		<skill name="Wind Shackle" id="1206" level="25" required-level="82" sp="170000000" />
 		<skill name="Bind" id="53006" level="4" required-level="82" sp="170000000" />
-		<skill name="Curse Weakness" id="1164" level="24" required-level="82" sp="170000000" />
-		<skill name="Body To Mind" id="1157" level="8" required-level="82" sp="170000000" />
+		<skill name="Body to Mind" id="1157" level="8" required-level="82" sp="170000000" />
+		<skill name="Weakness" id="1164" level="24" required-level="82" sp="170000000" />
 		<skill name="Blizzard" id="1290" level="5" required-level="82" sp="170000000" />
 		<skill name="Frost Wall" id="1174" level="29" required-level="82" sp="170000000" />
 		<skill name="Arcane Power" id="337" level="6" required-level="82" sp="170000000" />
 		<skill name="Higher Mana Gain" id="285" level="33" required-level="82" sp="170000000" />
-		<skill name="Sleep" id="1069" level="49" required-level="82" sp="170000000" />
+		<skill name="Sleep" id="1069" level="52" required-level="82" sp="170000000" />
 		<skill name="Sleeping Cloud" id="1072" level="12" required-level="82" sp="170000000" />
 
 		<skill name="Anti Magic" id="146" level="52" required-level="83" sp="240000000" />
+		<skill name="Water Explosion" id="45379" level="8" required-level="83" sp="240000000" />
 		<skill name="Robe Mastery" id="234" level="48" required-level="83" sp="240000000" />
 		<skill name="Weapon Mastery" id="249" level="49" required-level="83" sp="240000000" />
 		<skill name="Aqua Splash" id="1295" level="16" required-level="83" sp="240000000" />
-		<skill name="Hydro Blast" id="1235" level="35" required-level="83" sp="240000000" />
+		<skill name="Hydro Blast" id="1235" level="38" required-level="83" sp="240000000" />
+		<skill name="Frost Bolt" id="1236" level="28" required-level="83" sp="240000000" />
 		<skill name="Arcane Shield" id="1556" level="4" required-level="83" sp="240000000" />
-		<skill name="Curse Weakness" id="1164" level="25" required-level="83" sp="240000000" />
-		<skill name="Body To Mind" id="1157" level="9" required-level="83" sp="240000000" />
+		<skill name="Wind Shackle" id="1206" level="26" required-level="83" sp="240000000" />
+		<skill name="Body to Mind" id="1157" level="9" required-level="83" sp="240000000" />
+		<skill name="Weakness" id="1164" level="25" required-level="83" sp="240000000" />
 		<skill name="Frost Wall" id="1174" level="30" required-level="83" sp="240000000" />
 		<skill name="Arcane Power" id="337" level="7" required-level="83" sp="240000000" />
 		<skill name="Higher Mana Gain" id="285" level="34" required-level="83" sp="240000000" />
-		<skill name="Sleep" id="1069" level="50" required-level="83" sp="240000000" />
+		<skill name="Sleep" id="1069" level="53" required-level="83" sp="240000000" />
 		<skill name="Sleeping Cloud" id="1072" level="13" required-level="83" sp="240000000" />
 
 		<skill name="Anti Magic" id="146" level="53" required-level="84" sp="240000000" />
+		<skill name="Water Explosion" id="45379" level="9" required-level="84" sp="240000000" />
 		<skill name="Robe Mastery" id="234" level="49" required-level="84" sp="240000000" />
 		<skill name="Weapon Mastery" id="249" level="50" required-level="84" sp="240000000" />
 		<skill name="Aqua Splash" id="1295" level="17" required-level="84" sp="240000000" />
-		<skill name="Hydro Blast" id="1235" level="36" required-level="84" sp="240000000" />
+		<skill name="Hydro Blast" id="1235" level="39" required-level="84" sp="240000000" />
+		<skill name="Frost Bolt" id="1236" level="29" required-level="84" sp="240000000" />
 		<skill name="Ice Vortex" id="1340" level="3" required-level="84" sp="240000000" />
 		<skill name="Arcane Shield" id="1556" level="5" required-level="84" sp="240000000" />
 		<skill name="Ice Vortex Crusher" id="1453" level="2" required-level="84" sp="240000000" />
+		<skill name="Wind Shackle" id="1206" level="27" required-level="84" sp="240000000" />
 		<skill name="Bind" id="53006" level="5" required-level="84" sp="240000000" />
-		<skill name="Curse Weakness" id="1164" level="26" required-level="84" sp="240000000" />
-		<skill name="Body To Mind" id="1157" level="10" required-level="84" sp="240000000" />
+		<skill name="Body to Mind" id="1157" level="10" required-level="84" sp="240000000" />
+		<skill name="Weakness" id="1164" level="26" required-level="84" sp="240000000" />
 		<skill name="Blizzard" id="1290" level="6" required-level="84" sp="240000000" />
 		<skill name="Frost Wall" id="1174" level="31" required-level="84" sp="240000000" />
 		<skill name="Arcane Power" id="337" level="8" required-level="84" sp="240000000" />
 		<skill name="Higher Mana Gain" id="285" level="35" required-level="84" sp="240000000" />
-		<skill name="Sleep" id="1069" level="51" required-level="84" sp="240000000" />
+		<skill name="Sleep" id="1069" level="54" required-level="84" sp="240000000" />
 		<skill name="Sleeping Cloud" id="1072" level="14" required-level="84" sp="240000000" />
-		
+
 		<skill name="Anti Magic" id="146" level="54" required-level="85" sp="840000000" />
-		<skill name="Anti Magic" id="146" level="55" required-level="86" sp="924000000" />
-		<skill name="Anti Magic" id="146" level="56" required-level="87" sp="1016400000" />
-		<skill name="Anti Magic" id="146" level="57" required-level="88" sp="1118040000" />
-		<skill name="Anti Magic" id="146" level="58" required-level="89" sp="1229844000" />
-		<skill name="Anti Magic" id="146" level="59" required-level="90" sp="1352828400" />
+		<skill name="Water Explosion" id="45379" level="10" required-level="85" sp="840000000" />
 		<skill name="Robe Mastery" id="234" level="50" required-level="85" sp="840000000" />
-		<skill name="Robe Mastery" id="234" level="51" required-level="86" sp="924000000" />
-		<skill name="Robe Mastery" id="234" level="52" required-level="87" sp="1016400000" />
-		<skill name="Robe Mastery" id="234" level="53" required-level="88" sp="1118040000" />
-		<skill name="Robe Mastery" id="234" level="54" required-level="89" sp="1229844000" />
-		<skill name="Robe Mastery" id="234" level="55" required-level="90" sp="1352828400" />
 		<skill name="Weapon Mastery" id="249" level="51" required-level="85" sp="840000000" />
-		<skill name="Weapon Mastery" id="249" level="52" required-level="86" sp="924000000" />
-		<skill name="Weapon Mastery" id="249" level="53" required-level="87" sp="1016400000" />
-		<skill name="Weapon Mastery" id="249" level="54" required-level="88" sp="1118040000" />
-		<skill name="Weapon Mastery" id="249" level="55" required-level="89" sp="1229844000" />
-		<skill name="Weapon Mastery" id="249" level="56" required-level="90" sp="1352828400" />
+		<skill name="Hydro Blast" id="1235" level="40" required-level="85" sp="840000000" />
+		<skill name="Frost Bolt" id="1236" level="30" required-level="85" sp="840000000" />
+		<skill name="Higher Mana Gain" id="285" level="36" required-level="85" sp="840000000" />
+		<skill name="Sleep" id="1069" level="55" required-level="85" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="55" required-level="86" sp="840000000" />
+		<skill name="Water Explosion" id="45379" level="11" required-level="86" sp="840000000" />
+		<skill name="Robe Mastery" id="234" level="51" required-level="86" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="52" required-level="86" sp="840000000" />
+		<skill name="Hydro Blast" id="1235" level="41" required-level="86" sp="840000000" />
+		<skill name="Frost Bolt" id="1236" level="31" required-level="86" sp="840000000" />
+		<skill name="Sleep" id="1069" level="56" required-level="86" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="56" required-level="87" sp="840000000" />
+		<skill name="Water Explosion" id="45379" level="12" required-level="87" sp="840000000" />
+		<skill name="Robe Mastery" id="234" level="52" required-level="87" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="53" required-level="87" sp="840000000" />
+		<skill name="Hydro Blast" id="1235" level="42" required-level="87" sp="840000000" />
+		<skill name="Frost Bolt" id="1236" level="32" required-level="87" sp="840000000" />
+		<skill name="Sleep" id="1069" level="57" required-level="87" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="57" required-level="88" sp="840000000" />
+		<skill name="Water Explosion" id="45379" level="13" required-level="88" sp="840000000" />
+		<skill name="Robe Mastery" id="234" level="53" required-level="88" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="54" required-level="88" sp="840000000" />
+		<skill name="Hydro Blast" id="1235" level="43" required-level="88" sp="840000000" />
+		<skill name="Frost Bolt" id="1236" level="33" required-level="88" sp="840000000" />
+		<skill name="Sleep" id="1069" level="58" required-level="88" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="58" required-level="89" sp="840000000" />
+		<skill name="Water Explosion" id="45379" level="14" required-level="89" sp="840000000" />
+		<skill name="Robe Mastery" id="234" level="54" required-level="89" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="55" required-level="89" sp="840000000" />
+		<skill name="Hydro Blast" id="1235" level="44" required-level="89" sp="840000000" />
+		<skill name="Frost Bolt" id="1236" level="34" required-level="89" sp="840000000" />
+		<skill name="Sleep" id="1069" level="59" required-level="89" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="59" required-level="90" sp="840000000" />
+		<skill name="Water Explosion" id="45379" level="15" required-level="90" sp="840000000" />
+		<skill name="Robe Mastery" id="234" level="55" required-level="90" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="56" required-level="90" sp="840000000" />
+		<skill name="Hydro Blast" id="1235" level="45" required-level="90" sp="840000000" />
+		<skill name="Frost Bolt" id="1236" level="35" required-level="90" sp="840000000" />
+		<skill name="Sleep" id="1069" level="60" required-level="90" sp="840000000" />
 	</skillTree>
 </list>

--- a/data/skillTrees/3rdClass/PhoenixKnight.xml
+++ b/data/skillTrees/3rdClass/PhoenixKnight.xml
@@ -1,189 +1,382 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="90" parentClassId="5">
-		<skill name="White Guardian" id="54102" level="1" required-level="80" >
-			<item id="92401"/>
-		</skill>
+
 		<skill name="Aggression" id="28" level="50" required-level="76" sp="5400000" />
 		<skill name="Shield Strike" id="984" level="16" required-level="76" sp="5400000" />
 		<skill name="Aggression Aura" id="18" level="38" required-level="76" sp="5400000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="46" required-level="76" sp="5400000" />
+		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="5400000">
+			<item id="8620" count="1" /> <!-- Buff Expansion Book Lv. 3 -->
+		</skill>
+		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="5400000">
+			<item id="8621" count="1" /> <!-- Buff Expansion Book Lv. 4 -->
+		</skill>
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="46" required-level="76" sp="5400000" />
+		<skill name="Weapon Mastery" id="141" level="5" required-level="76" sp="5400000" />
 		<skill name="Heavy Armor Mastery" id="232" level="53" required-level="76" sp="5400000" />
 		<skill name="Sacrifice" id="69" level="26" required-level="76" sp="5400000" />
 		<skill name="Shield Charge" id="1898" level="1" required-level="76" sp="5400000" />
+		<skill name="Evolution Defense" id="45188" level="1" required-level="76">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Shackle" id="402" level="11" required-level="76" sp="5400000" />
 		<skill name="Magic Resistance" id="147" level="52" required-level="76" sp="5400000" />
 		<skill name="Mass Shackling" id="404" level="6" required-level="76" sp="5400000" />
+		<!-- Might Lv. 4 -->
+		<skill name="Might" id="1068" level="4" required-level="76" sp="5400000">
+			<item id="94135" count="1" /> <!-- Master's Book: Might -->
+		</skill>
+		<!-- Shield Lv. 4 -->
+		<skill name="Shield" id="1040" level="4" required-level="76" sp="5400000">
+			<item id="94136" count="1" /> <!-- Master's Book: Shield -->
+		</skill>
+		<!-- Acumen Lv. 4 -->
+		<skill name="Acumen" id="45104" level="4" required-level="76" sp="5400000">
+			<item id="94370" count="1" /> <!-- Master's Book: Acumen -->
+		</skill>
+		<!-- Empower Lv. 4 -->
+		<skill name="Empower" id="45105" level="4" required-level="76" sp="5400000">
+			<item id="94361" count="1" /> <!-- Master's Book: Empower -->
+		</skill>
+		<!-- Wild Magic Lv. 3 -->
+		<skill name="Wild Magic" id="45106" level="3" required-level="76" sp="5400000">
+			<item id="94368" count="1" /> <!-- Master's Book: Wild Magic -->
+		</skill>
+		<!-- Wind Walk Lv. 3 -->
+		<skill name="Wind Walk" id="45107" level="3" required-level="76" sp="5400000">
+			<item id="94365" count="1" /> <!-- Master's Book: Wind Walk -->
+		</skill>
+		<!-- Magic Barrier Lv. 3 -->
+		<skill name="Magic Barrier" id="45108" level="3" required-level="76" sp="5400000">
+			<item id="94362" count="1" /> <!-- Master's Book: Magic Barrier -->
+		</skill>
+		<!-- Focus Lv. 4 -->
+		<skill name="Focus" id="45109" level="4" required-level="76" sp="5400000">
+			<item id="94363" count="1" /> <!-- Master's Book: Focus -->
+		</skill>
+		<!-- Death Whisper Lv. 4 -->
+		<skill name="Death Whisper" id="45110" level="4" required-level="76" sp="5400000">
+			<item id="94364" count="1" /> <!-- Master's Book: Death Whisper -->
+		</skill>
+		<!-- Haste Lv. 3 -->
+		<skill name="Haste" id="45111" level="3" required-level="76" sp="5400000">
+			<item id="94369" count="1" /> <!-- Master's Book: Haste -->
+		</skill>
+		<!-- Berserker Spirit Lv. 3 -->
+		<skill name="Berserker Spirit" id="45112" level="3" required-level="76" sp="5400000">
+			<item id="94366" count="1" /> <!-- Master's Book: Berserker Spirit -->
+		</skill>
+		<!-- Clarity Lv. 4 -->
+		<skill name="Clarity" id="45113" level="4" required-level="76" sp="5400000">
+			<item id="94367" count="1" /> <!-- Master's Book: Clarity -->
+		</skill>
+		<skill name="Detection" id="45190" level="1" required-level="76" sp="5400000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Shield Stun" id="92" level="53" required-level="76" sp="5400000" />
+		<skill name="Mount Golden Lion" id="1833" level="1" required-level="76">
+			<item id="90038" count="1" /> <!-- Spellbook - Ride Golden Lion -->
+		</skill>
+		<skill name="Phoenix Help" id="45369" level="1" required-level="76" sp="5400000">
+			<item id="93871" count="1" /> <!-- Spellbook: Knight's Help -->
+		</skill>
 		<skill name="Final Fortress" id="291" level="12" required-level="76" sp="5400000" />
 		<skill name="Sanctuary" id="97" level="12" required-level="76" sp="5400000" />
+		<skill name="Holy Strike" id="49" level="26" required-level="76" sp="5400000" />
 		<skill name="Fortitude" id="335" level="1" required-level="76" sp="5400000" />
-		<skill name="Critical Vulnerability Decrease" id="53004" level="1" required-level="76" sp="5400000" />
+		<skill name="Critical Vulnerability Decrease" id="53004" level="1" required-level="76" sp="5400000">
+			<item id="91485" count="1" /> <!-- Scroll: Critical Vulnerability Decrease -->
+		</skill>
 		<skill name="Chain Strike" id="10015" level="1" required-level="76" sp="5400000" />
-		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="5400000">
-			<item id="8620"/> <!-- Ancient Book: Divine Inspiration (Manuscript) -->
-		</skill>
-		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="5400000">
-			<item id="8621"/> <!-- Ancient Book: Divine Inspiration (Original Version) -->
-		</skill>
-		<skill name="Mount Gold Maned Lion" id="1833" level="1" required-level="76">
-			<item id="90038"/> <!-- Spellbook: Mount Golden Lion -->
-		</skill>
-		<skill name="Glory Ability" id="45361" level="1" required-level="86">
-			<item id="94046"/> <!-- Spellbook: Glory Ability Lv. 1 -->
-		</skill>
-		<skill name="Mount White Wings" id="54200" level="1" required-level="87">
-			<item id="93059"/> <!-- Spellbook: Summon White Wings -->
-		</skill>	
-		<skill name="Mount Shining Lady" id="54202" level="1" required-level="89">
-			<item id="93061"/> <!-- Spellbook: Summon Silver Saint -->
-		</skill>
-		
+		<skill name="Emergency Rescue" id="70" level="46" required-level="76" sp="5400000" />
+
 		<skill name="Aggression" id="28" level="51" required-level="77" sp="5400000" />
 		<skill name="Shield Strike" id="984" level="17" required-level="77" sp="5400000" />
 		<skill name="Aggression Aura" id="18" level="39" required-level="77" sp="5400000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="47" required-level="77" sp="5400000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="47" required-level="77" sp="5400000" />
 		<skill name="Heavy Armor Mastery" id="232" level="54" required-level="77" sp="5400000" />
 		<skill name="Shield Charge" id="1898" level="2" required-level="77" sp="5400000" />
+		<skill name="Shackle" id="402" level="12" required-level="77" sp="5400000" />
 		<skill name="Magic Resistance" id="147" level="53" required-level="77" sp="5400000" />
+		<skill name="Mass Shackling" id="404" level="7" required-level="77" sp="5400000" />
+		<skill name="Vengeance" id="368" level="1" required-level="77" sp="5400000">
+			<item id="90046" count="1" /> <!-- Scroll: Vengeance -->
+		</skill>
 		<skill name="Shield Stun" id="92" level="54" required-level="77" sp="5400000" />
 		<skill name="Deflect Magic" id="913" level="1" required-level="77" sp="5400000" />
 		<skill name="Final Fortress" id="291" level="13" required-level="77" sp="5400000" />
-		<skill name="Vengeance" id="368" level="1" required-level="77" sp="5400000">
-			<item id="90046"/> <!-- Scroll: Vengeance -->
-		</skill>
-		
+		<skill name="Holy Strike" id="49" level="27" required-level="77" sp="5400000" />
+		<skill name="Emergency Rescue" id="70" level="47" required-level="77" sp="5400000" />
+
 		<skill name="Aggression" id="28" level="52" required-level="78" sp="12700000" />
 		<skill name="Shield Strike" id="984" level="18" required-level="78" sp="12700000" />
 		<skill name="Aggression Aura" id="18" level="40" required-level="78" sp="12700000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="48" required-level="78" sp="12700000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="48" required-level="78" sp="12700000" />
 		<skill name="Heavy Armor Mastery" id="232" level="55" required-level="78" sp="12700000" />
 		<skill name="Sacrifice" id="69" level="27" required-level="78" sp="12700000" />
 		<skill name="Shield Charge" id="1898" level="3" required-level="78" sp="12700000" />
+		<skill name="Shackle" id="402" level="13" required-level="78" sp="12700000" />
 		<skill name="Magic Resistance" id="147" level="54" required-level="78" sp="12700000" />
-		<skill name="Mass Shackling" id="404" level="7" required-level="78" sp="12700000" />
-		<skill name="Mass Chain Strike" id="53003" level="1" required-level="78" sp="12700000" />
+		<skill name="Mass Shackling" id="404" level="8" required-level="78" sp="12700000" />
+		<skill name="Mass Chain Strike" id="53003" level="1" required-level="78" sp="12700000">
+			<item id="91484" count="1" /> <!-- Scroll: Mass Chain Strike -->
+		</skill>
 		<skill name="Shield Stun" id="92" level="55" required-level="78" sp="12700000" />
 		<skill name="Final Fortress" id="291" level="14" required-level="78" sp="12700000" />
+		<skill name="Touch of Life" id="341" level="1" required-level="78" sp="12700000">
+			<item id="90047" count="1" /> <!-- Scroll: Touch of Life -->
+		</skill>
 		<skill name="Knighthood" id="429" level="1" required-level="78" sp="12700000" />
 		<skill name="Sanctuary" id="97" level="13" required-level="78" sp="12700000" />
+		<skill name="Holy Strike" id="49" level="28" required-level="78" sp="12700000" />
 		<skill name="Critical Vulnerability Decrease" id="53004" level="2" required-level="78" sp="12700000" />
-		<skill name="Touch of Life" id="341" level="1" required-level="78" sp="12700000">
-			<item id="90047"/> <!-- Scroll: Touch of Life -->
-		</skill>
-		
+		<skill name="Emergency Rescue" id="70" level="48" required-level="78" sp="12700000" />
+
+		<skill name="Shield Strike" id="984" level="19" required-level="79" sp="12700000" />
 		<skill name="Shield Charge" id="1898" level="4" required-level="79" sp="12700000" />
+		<skill name="Shackle" id="402" level="14" required-level="79" sp="12700000" />
+		<skill name="Mass Shackling" id="404" level="9" required-level="79" sp="12700000" />
 		<skill name="Final Fortress" id="291" level="15" required-level="79" sp="12700000" />
 		<skill name="Knighthood" id="429" level="2" required-level="79" sp="12700000" />
+		<skill name="Sanctuary" id="97" level="14" required-level="79" sp="12700000" />
+		<skill name="Holy Strike" id="49" level="29" required-level="79" sp="12700000" />
 		<skill name="Shield of Faith" id="528" level="1" required-level="79" sp="12700000">
-			<item id="90049"/> <!-- Scroll: Shield of Faith -->
+			<item id="90049" count="1" /> <!-- Scroll: Shield of Faith -->
 		</skill>
-		
+		<skill name="Emergency Rescue" id="70" level="49" required-level="79" sp="12700000" />
+
 		<skill name="Aggression" id="28" level="53" required-level="80" sp="12700000" />
-		<skill name="Shield Strike" id="984" level="19" required-level="80" sp="12700000" />
+		<skill name="Shield Strike" id="984" level="20" required-level="80" sp="12700000" />
 		<skill name="Aggression Aura" id="18" level="41" required-level="80" sp="12700000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="49" required-level="80" sp="12700000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="49" required-level="80" sp="12700000" />
 		<skill name="Heavy Armor Mastery" id="232" level="56" required-level="80" sp="12700000" />
 		<skill name="Sacrifice" id="69" level="28" required-level="80" sp="12700000" />
 		<skill name="Shield Charge" id="1898" level="5" required-level="80" sp="12700000" />
+		<skill name="Shackle" id="402" level="15" required-level="80" sp="12700000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
 		<skill name="Magic Resistance" id="147" level="55" required-level="80" sp="12700000" />
-		<skill name="Mass Shackling" id="404" level="8" required-level="80" sp="12700000" />
+		<skill name="Mass Shackling" id="404" level="10" required-level="80" sp="12700000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Evolution Power" id="45189" level="1" required-level="80">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Shield Stun" id="92" level="56" required-level="80" sp="12700000" />
 		<skill name="Final Fortress" id="291" level="16" required-level="80" sp="12700000" />
 		<skill name="Knighthood" id="429" level="3" required-level="80" sp="12700000" />
+		<skill name="Sanctuary" id="97" level="15" required-level="80" sp="12700000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Holy Strike" id="49" level="30" required-level="80" sp="12700000" />
+		<skill name="White Guardian Transformation" id="54102" level="1" required-level="80">
+			<item id="92401" count="1" /> <!-- Spellbook - White Guardian -->
+		</skill>
 		<skill name="Critical Vulnerability Decrease" id="53004" level="3" required-level="80" sp="12700000" />
 		<skill name="Shield of Sacrifice" id="1621" level="1" required-level="80" sp="12700000">
-			<item id="90050"/> <!-- Scroll: Shield of Sacrifice -->
+			<item id="90050" count="1" /> <!-- Scroll: Shield of Sacrifice -->
 		</skill>
+		<skill name="Emergency Rescue" id="70" level="50" required-level="80" sp="12700000" />
 
 		<skill name="Aggression" id="28" level="54" required-level="81" sp="160000000" />
-		<skill name="Shield Strike" id="984" level="20" required-level="81" sp="160000000" />
+		<skill name="Shield Strike" id="984" level="21" required-level="81" sp="160000000" />
 		<skill name="Aggression Aura" id="18" level="42" required-level="81" sp="160000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="50" required-level="81" sp="160000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="50" required-level="81" sp="160000000" />
 		<skill name="Heavy Armor Mastery" id="232" level="57" required-level="81" sp="160000000" />
 		<skill name="Sacrifice" id="69" level="29" required-level="81" sp="160000000" />
 		<skill name="Shield Charge" id="1898" level="6" required-level="81" sp="160000000" />
+		<skill name="Shackle" id="402" level="16" required-level="81" sp="160000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
 		<skill name="Magic Resistance" id="147" level="56" required-level="81" sp="160000000" />
+		<skill name="Mass Shackling" id="404" level="11" required-level="81" sp="160000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
 		<skill name="Mass Chain Strike" id="53003" level="2" required-level="81" sp="160000000" />
 		<skill name="Shield Stun" id="92" level="57" required-level="81" sp="160000000" />
 		<skill name="Final Fortress" id="291" level="17" required-level="81" sp="160000000" />
 		<skill name="Knighthood" id="429" level="4" required-level="81" sp="160000000" />
+		<skill name="Sanctuary" id="97" level="16" required-level="81" sp="160000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
 		<skill name="Shield of Sacrifice" id="1621" level="2" required-level="81" sp="160000000" />
+		<skill name="Emergency Rescue" id="70" level="51" required-level="81" sp="160000000" />
 
 		<skill name="Aggression" id="28" level="55" required-level="82" sp="170000000" />
-		<skill name="Shield Strike" id="984" level="21" required-level="82" sp="170000000" />
+		<skill name="Shield Strike" id="984" level="22" required-level="82" sp="170000000" />
 		<skill name="Aggression Aura" id="18" level="43" required-level="82" sp="170000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="51" required-level="82" sp="170000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="51" required-level="82" sp="170000000" />
 		<skill name="Heavy Armor Mastery" id="232" level="58" required-level="82" sp="170000000" />
 		<skill name="Sacrifice" id="69" level="30" required-level="82" sp="170000000" />
 		<skill name="Shield Charge" id="1898" level="7" required-level="82" sp="170000000" />
+		<skill name="Shackle" id="402" level="17" required-level="82" sp="170000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
 		<skill name="Magic Resistance" id="147" level="57" required-level="82" sp="170000000" />
-		<skill name="Mass Shackling" id="404" level="9" required-level="82" sp="170000000" />
+		<skill name="Mass Shackling" id="404" level="12" required-level="82" sp="170000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
 		<skill name="Shield Stun" id="92" level="58" required-level="82" sp="170000000" />
 		<skill name="Final Fortress" id="291" level="18" required-level="82" sp="170000000" />
 		<skill name="Knighthood" id="429" level="5" required-level="82" sp="170000000" />
+		<skill name="Sanctuary" id="97" level="17" required-level="82" sp="170000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
 		<skill name="Critical Vulnerability Decrease" id="53004" level="4" required-level="82" sp="170000000" />
 		<skill name="Chain Strike" id="10015" level="2" required-level="82" sp="170000000" />
 		<skill name="Shield of Sacrifice" id="1621" level="3" required-level="82" sp="170000000" />
+		<skill name="Emergency Rescue" id="70" level="52" required-level="82" sp="170000000" />
 
 		<skill name="Aggression" id="28" level="56" required-level="83" sp="240000000" />
-		<skill name="Shield Strike" id="984" level="22" required-level="83" sp="240000000" />
+		<skill name="Shield Strike" id="984" level="23" required-level="83" sp="240000000" />
 		<skill name="Aggression Aura" id="18" level="44" required-level="83" sp="240000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="52" required-level="83" sp="240000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="52" required-level="83" sp="240000000" />
 		<skill name="Heavy Armor Mastery" id="232" level="59" required-level="83" sp="240000000" />
 		<skill name="Sacrifice" id="69" level="31" required-level="83" sp="240000000" />
 		<skill name="Shield Charge" id="1898" level="8" required-level="83" sp="240000000" />
+		<skill name="Shackle" id="402" level="18" required-level="83" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
 		<skill name="Magic Resistance" id="147" level="58" required-level="83" sp="240000000" />
+		<skill name="Mass Shackling" id="404" level="13" required-level="83" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
 		<skill name="Shield Stun" id="92" level="59" required-level="83" sp="240000000" />
 		<skill name="Final Fortress" id="291" level="19" required-level="83" sp="240000000" />
 		<skill name="Knighthood" id="429" level="6" required-level="83" sp="240000000" />
+		<skill name="Sanctuary" id="97" level="18" required-level="83" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
 		<skill name="Shield of Sacrifice" id="1621" level="4" required-level="83" sp="240000000" />
+		<skill name="Emergency Rescue" id="70" level="53" required-level="83" sp="240000000" />
 
 		<skill name="Aggression" id="28" level="57" required-level="84" sp="240000000" />
-		<skill name="Shield Strike" id="984" level="23" required-level="84" sp="240000000" />
+		<skill name="Shield Strike" id="984" level="24" required-level="84" sp="240000000" />
 		<skill name="Aggression Aura" id="18" level="45" required-level="84" sp="240000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="53" required-level="84" sp="240000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="53" required-level="84" sp="240000000" />
 		<skill name="Heavy Armor Mastery" id="232" level="60" required-level="84" sp="240000000" />
 		<skill name="Sacrifice" id="69" level="32" required-level="84" sp="240000000" />
 		<skill name="Shield Charge" id="1898" level="9" required-level="84" sp="240000000" />
+		<skill name="Shackle" id="402" level="19" required-level="84" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
 		<skill name="Magic Resistance" id="147" level="59" required-level="84" sp="240000000" />
-		<skill name="Mass Shackling" id="404" level="10" required-level="84" sp="240000000" />
+		<skill name="Mass Shackling" id="404" level="14" required-level="84" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
 		<skill name="Mass Chain Strike" id="53003" level="3" required-level="84" sp="240000000" />
 		<skill name="Shield Stun" id="92" level="60" required-level="84" sp="240000000" />
 		<skill name="Final Fortress" id="291" level="20" required-level="84" sp="240000000" />
 		<skill name="Knighthood" id="429" level="7" required-level="84" sp="240000000" />
+		<skill name="Sanctuary" id="97" level="19" required-level="84" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
 		<skill name="Critical Vulnerability Decrease" id="53004" level="5" required-level="84" sp="240000000" />
 		<skill name="Chain Strike" id="10015" level="3" required-level="84" sp="240000000" />
 		<skill name="Shield of Sacrifice" id="1621" level="5" required-level="84" sp="240000000" />
-		
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="54" required-level="85" sp="840000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="55" required-level="86" sp="924000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="56" required-level="87" sp="1016400000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="57" required-level="88" sp="1118040000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="58" required-level="89" sp="1229844000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="59" required-level="90" sp="1352828400" />
+		<skill name="Emergency Rescue" id="70" level="54" required-level="84" sp="240000000" />
+
+		<skill name="Shield Strike" id="984" level="25" required-level="85" sp="840000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="54" required-level="85" sp="840000000" />
 		<skill name="Heavy Armor Mastery" id="232" level="61" required-level="85" sp="840000000" />
-		<skill name="Heavy Armor Mastery" id="232" level="62" required-level="86" sp="924000000" />
-		<skill name="Heavy Armor Mastery" id="232" level="63" required-level="87" sp="1016400000" />
-		<skill name="Heavy Armor Mastery" id="232" level="64" required-level="88" sp="1118040000" />
-		<skill name="Heavy Armor Mastery" id="232" level="65" required-level="89" sp="1229844000" />
-		<skill name="Heavy Armor Mastery" id="232" level="66" required-level="90" sp="1352828400" />
+		<skill name="Shackle" id="402" level="20" required-level="85" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
 		<skill name="Magic Resistance" id="147" level="60" required-level="85" sp="840000000" />
-		<skill name="Magic Resistance" id="147" level="61" required-level="86" sp="924000000" />
-		<skill name="Magic Resistance" id="147" level="62" required-level="87" sp="1016400000" />
-		<skill name="Magic Resistance" id="147" level="63" required-level="88" sp="1118040000" />
-		<skill name="Magic Resistance" id="147" level="64" required-level="89" sp="1229844000" />
-		<skill name="Magic Resistance" id="147" level="65" required-level="90" sp="1352828400" />
+		<skill name="Mass Shackling" id="404" level="15" required-level="85" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
 		<skill name="Final Fortress" id="291" level="21" required-level="85" sp="840000000" />
-		<skill name="Final Fortress" id="291" level="22" required-level="86" sp="924000000" />
-		<skill name="Final Fortress" id="291" level="23" required-level="87" sp="1016400000" />
-		<skill name="Final Fortress" id="291" level="24" required-level="88" sp="1118040000" />
-		<skill name="Final Fortress" id="291" level="25" required-level="89" sp="1229844000" />
-		<skill name="Final Fortress" id="291" level="26" required-level="90" sp="1352828400" />
 		<skill name="Knighthood" id="429" level="8" required-level="85" sp="840000000" />
-		<skill name="Knighthood" id="429" level="9" required-level="86" sp="924000000" />
-		<skill name="Knighthood" id="429" level="10" required-level="87" sp="1016400000" />
-		<skill name="Knighthood" id="429" level="11" required-level="88" sp="1118040000" />
-		<skill name="Knighthood" id="429" level="12" required-level="89" sp="1229844000" />
-		<skill name="Knighthood" id="429" level="13" required-level="90" sp="1352828400" />
+		<skill name="Sanctuary" id="97" level="20" required-level="85" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="55" required-level="85" sp="840000000" />
+
+		<skill name="Shield Strike" id="984" level="26" required-level="86" sp="840000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="55" required-level="86" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="232" level="62" required-level="86" sp="840000000" />
+		<skill name="Shackle" id="402" level="21" required-level="86" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Magic Resistance" id="147" level="61" required-level="86" sp="840000000" />
+		<skill name="Mass Shackling" id="404" level="16" required-level="86" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Final Fortress" id="291" level="22" required-level="86" sp="840000000" />
+		<skill name="Knighthood" id="429" level="9" required-level="86" sp="840000000" />
+		<skill name="Sanctuary" id="97" level="21" required-level="86" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="56" required-level="86" sp="840000000" />
+
+		<skill name="Shield Strike" id="984" level="27" required-level="87" sp="840000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="56" required-level="87" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="232" level="63" required-level="87" sp="840000000" />
+		<skill name="Shackle" id="402" level="22" required-level="87" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Magic Resistance" id="147" level="62" required-level="87" sp="840000000" />
+		<skill name="Mass Shackling" id="404" level="17" required-level="87" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Final Fortress" id="291" level="23" required-level="87" sp="840000000" />
+		<skill name="Knighthood" id="429" level="10" required-level="87" sp="840000000" />
+		<skill name="Sanctuary" id="97" level="22" required-level="87" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="57" required-level="87" sp="840000000" />
+
+		<skill name="Shield Strike" id="984" level="28" required-level="88" sp="840000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="57" required-level="88" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="232" level="64" required-level="88" sp="840000000" />
+		<skill name="Shackle" id="402" level="23" required-level="88" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Magic Resistance" id="147" level="63" required-level="88" sp="840000000" />
+		<skill name="Mass Shackling" id="404" level="18" required-level="88" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Final Fortress" id="291" level="24" required-level="88" sp="840000000" />
+		<skill name="Knighthood" id="429" level="11" required-level="88" sp="840000000" />
+		<skill name="Sanctuary" id="97" level="23" required-level="88" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="58" required-level="88" sp="840000000" />
+
+		<skill name="Shield Strike" id="984" level="29" required-level="89" sp="840000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="58" required-level="89" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="232" level="65" required-level="89" sp="840000000" />
+		<skill name="Shackle" id="402" level="24" required-level="89" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Magic Resistance" id="147" level="64" required-level="89" sp="840000000" />
+		<skill name="Mass Shackling" id="404" level="19" required-level="89" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Final Fortress" id="291" level="25" required-level="89" sp="840000000" />
+		<skill name="Knighthood" id="429" level="12" required-level="89" sp="840000000" />
+		<skill name="Sanctuary" id="97" level="24" required-level="89" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="59" required-level="89" sp="840000000" />
+
+		<skill name="Shield Strike" id="984" level="30" required-level="90" sp="840000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="59" required-level="90" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="232" level="66" required-level="90" sp="840000000" />
+		<skill name="Shackle" id="402" level="25" required-level="90" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Magic Resistance" id="147" level="65" required-level="90" sp="840000000" />
+		<skill name="Mass Shackling" id="404" level="20" required-level="90" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Final Fortress" id="291" level="26" required-level="90" sp="840000000" />
+		<skill name="Knighthood" id="429" level="13" required-level="90" sp="840000000" />
+		<skill name="Sanctuary" id="97" level="25" required-level="90" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="60" required-level="90" sp="840000000" />
+
 	</skillTree>
 </list>

--- a/data/skillTrees/3rdClass/Sagittarius.xml
+++ b/data/skillTrees/3rdClass/Sagittarius.xml
@@ -1,115 +1,205 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="92" parentClassId="9">
-		<skill name="White Guardian" id="54102" level="1" required-level="80" >
-			<item id="92401"/>
+
+		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="9800000">
+			<item id="8620" count="1" /> <!-- Buff Expansion Book Lv. 3 -->
+		</skill>
+		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="9800000">
+			<item id="8621" count="1" /> <!-- Buff Expansion Book Lv. 4 -->
 		</skill>
 		<skill name="Burst Shot" id="24" level="32" required-level="76" sp="9800000" />
 		<skill name="Light Armor Mastery" id="233" level="48" required-level="76" sp="9800000" />
 		<skill name="Bow Mastery" id="208" level="53" required-level="76" sp="9800000" />
-		<skill name="Double Shot" id="19" level="38" required-level="76" sp="9800000" />
+		<skill name="Weapon Mastery" id="141" level="5" required-level="76" sp="9800000" />
+		<skill name="Double Shot" id="19" level="41" required-level="76" sp="9800000" />
 		<skill name="Spirit of Sagittarius" id="415" level="1" required-level="76" sp="9800000" />
-		<skill name="Detect Darkness" id="53005" level="1" required-level="76" sp="9800000" />
+		<skill name="Evolution Defense" id="45188" level="1" required-level="76">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<!-- Might Lv. 4 -->
+		<skill name="Might" id="1068" level="4" required-level="76" sp="9800000">
+			<item id="94135" count="1" /> <!-- Master's Book: Might -->
+		</skill>
+		<!-- Shield Lv. 4 -->
+		<skill name="Shield" id="1040" level="4" required-level="76" sp="9800000">
+			<item id="94136" count="1" /> <!-- Master's Book: Shield -->
+		</skill>
+		<!-- Acumen Lv. 4 -->
+		<skill name="Acumen" id="45104" level="4" required-level="76" sp="9800000">
+			<item id="94370" count="1" /> <!-- Master's Book: Acumen -->
+		</skill>
+		<!-- Empower Lv. 4 -->
+		<skill name="Empower" id="45105" level="4" required-level="76" sp="9800000">
+			<item id="94361" count="1" /> <!-- Master's Book: Empower -->
+		</skill>
+		<!-- Wild Magic Lv. 3 -->
+		<skill name="Wild Magic" id="45106" level="3" required-level="76" sp="9800000">
+			<item id="94368" count="1" /> <!-- Master's Book: Wild Magic -->
+		</skill>
+		<!-- Wind Walk Lv. 3 -->
+		<skill name="Wind Walk" id="45107" level="3" required-level="76" sp="9800000">
+			<item id="94365" count="1" /> <!-- Master's Book: Wind Walk -->
+		</skill>
+		<!-- Magic Barrier Lv. 3 -->
+		<skill name="Magic Barrier" id="45108" level="3" required-level="76" sp="9800000">
+			<item id="94362" count="1" /> <!-- Master's Book: Magic Barrier -->
+		</skill>
+		<!-- Focus Lv. 4 -->
+		<skill name="Focus" id="45109" level="4" required-level="76" sp="9800000">
+			<item id="94363" count="1" /> <!-- Master's Book: Focus -->
+		</skill>
+		<!-- Death Whisper Lv. 4 -->
+		<skill name="Death Whisper" id="45110" level="4" required-level="76" sp="9800000">
+			<item id="94364" count="1" /> <!-- Master's Book: Death Whisper -->
+		</skill>
+		<!-- Haste Lv. 3 -->
+		<skill name="Haste" id="45111" level="3" required-level="76" sp="9800000">
+			<item id="94369" count="1" /> <!-- Master's Book: Haste -->
+		</skill>
+		<!-- Berserker Spirit Lv. 3 -->
+		<skill name="Berserker Spirit" id="45112" level="3" required-level="76" sp="9800000">
+			<item id="94366" count="1" /> <!-- Master's Book: Berserker Spirit -->
+		</skill>
+		<!-- Clarity Lv. 4 -->
+		<skill name="Clarity" id="45113" level="4" required-level="76" sp="9800000">
+			<item id="94367" count="1" /> <!-- Master's Book: Clarity -->
+		</skill>
+		<skill name="Detect Darkness" id="53005" level="1" required-level="76" sp="9800000">
+			<item id="91482" count="1" /> <!-- Scroll: Detect Darkness -->
+		</skill>
 		<skill name="Stun Shot" id="101" level="41" required-level="76" sp="9800000" />
+		<skill name="Mount Golden Lion" id="1833" level="1" required-level="76">
+			<item id="90038" count="1" /> <!-- Spellbook - Ride Golden Lion -->
+		</skill>
 		<skill name="Lethal Shot" id="343" level="1" required-level="76" sp="9800000" />
-		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="9800000">
-			<item id="8620"/> <!-- Ancient Book: Divine Inspiration (Manuscript) -->
-		</skill>
-		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="9800000">
-			<item id="8621"/> <!-- Ancient Book: Divine Inspiration (Original Version) -->
-		</skill>
-		<skill name="Mount Gold Maned Lion" id="1833" level="1" required-level="76">
-			<item id="90038"/> <!-- Spellbook: Mount Golden Lion -->
-		</skill>
-		<skill name="Glory Ability" id="45361" level="1" required-level="86">
-			<item id="94046"/> <!-- Spellbook: Glory Ability Lv. 1 -->
-		</skill>
-		<skill name="Mount White Wings" id="54200" level="1" required-level="87">
-			<item id="93059"/> <!-- Spellbook: Summon White Wings -->
-		</skill>	
-		<skill name="Mount Shining Lady" id="54202" level="1" required-level="89">
-			<item id="93061"/> <!-- Spellbook: Summon Silver Saint -->
-		</skill>
-		
+		<skill name="Emergency Rescue" id="70" level="46" required-level="76" sp="9800000" />
+
 		<skill name="Burst Shot" id="24" level="33" required-level="77" sp="9800000" />
 		<skill name="Light Armor Mastery" id="233" level="49" required-level="77" sp="9800000" />
 		<skill name="Bow Mastery" id="208" level="54" required-level="77" sp="9800000" />
-		<skill name="Double Shot" id="19" level="39" required-level="77" sp="9800000" />
+		<skill name="Double Shot" id="19" level="42" required-level="77" sp="9800000" />
 		<skill name="Hamstring Shot" id="354" level="1" required-level="77" sp="9800000" />
 		<skill name="Stun Shot" id="101" level="42" required-level="77" sp="9800000" />
 		<skill name="Lethal Shot" id="343" level="2" required-level="77" sp="9800000" />
-		
+		<skill name="Emergency Rescue" id="70" level="47" required-level="77" sp="9800000" />
+
 		<skill name="Pain of Sagittarius" id="417" level="6" required-level="78" sp="22900000" />
 		<skill name="Burst Shot" id="24" level="34" required-level="78" sp="22900000" />
 		<skill name="Light Armor Mastery" id="233" level="50" required-level="78" sp="22900000" />
 		<skill name="Bow Mastery" id="208" level="55" required-level="78" sp="22900000" />
-		<skill name="Double Shot" id="19" level="40" required-level="78" sp="22900000" />
+		<skill name="Real Target" id="522" level="1" required-level="78" sp="22900000">
+			<item id="90062" count="1" /> <!-- Scroll: Real Target -->
+		</skill>
+		<skill name="Double Shot" id="19" level="43" required-level="78" sp="22900000" />
 		<skill name="Stun Shot" id="101" level="43" required-level="78" sp="22900000" />
 		<skill name="Lethal Shot" id="343" level="3" required-level="78" sp="22900000" />
-		<skill name="Real Target" id="522" level="1" required-level="78" sp="22900000">
-			<item id="90062"/> <!-- Scroll: Real Target -->
-		</skill>
-		
+		<skill name="Emergency Rescue" id="70" level="48" required-level="78" sp="22900000" />
+
 		<skill name="Burst Shot" id="24" level="35" required-level="79" sp="22900000" />
+		<skill name="Double Shot" id="19" level="44" required-level="79" sp="22900000" />
 		<skill name="Lethal Shot" id="343" level="4" required-level="79" sp="22900000" />
 		<skill name="Death Sting" id="990" level="1" required-level="79" sp="22900000">
-			<item id="90063"/> <!-- Scroll: Death Sting -->
+			<item id="90063" count="1" /> <!-- Scroll: Death Sting -->
 		</skill>
-		
+		<skill name="Emergency Rescue" id="70" level="49" required-level="79" sp="22900000" />
+
 		<skill name="Burst Shot" id="24" level="36" required-level="80" sp="22900000" />
 		<skill name="Light Armor Mastery" id="233" level="51" required-level="80" sp="22900000" />
 		<skill name="Bow Mastery" id="208" level="56" required-level="80" sp="22900000" />
 		<skill name="Real Target" id="522" level="2" required-level="80" sp="22900000" />
-		<skill name="Double Shot" id="19" level="41" required-level="80" sp="22900000" />
-		<skill name="Stun Shot" id="101" level="44" required-level="80" sp="22900000" />
-		<skill name="Snipe" id="313" level="9" required-level="80" sp="22900000" />
-		<skill name="Lethal Shot" id="343" level="5" required-level="80" sp="22900000" />
-		<skill name="Flame Hawk" id="771" level="1" required-level="80" sp="22900000">
-			<item id="90064"/> <!-- Scroll: Flame Hawk -->
+		<skill name="Double Shot" id="19" level="45" required-level="80" sp="22900000" />
+		<skill name="Evolution Power" id="45189" level="1" required-level="80">
+			<item id="57" count="10000000" /> <!-- Adena -->
 		</skill>
+		<skill name="Stun Shot" id="101" level="44" required-level="80" sp="22900000" />
+		<skill name="Flame Hawk" id="771" level="1" required-level="80" sp="22900000">
+			<item id="90064" count="1" /> <!-- Scroll: Flame Hawk -->
+		</skill>
+		<skill name="Snipe" id="313" level="9" required-level="80" sp="22900000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Lethal Shot" id="343" level="5" required-level="80" sp="22900000" />
+		<skill name="White Guardian Transformation" id="54102" level="1" required-level="80">
+			<item id="92401" count="1" /> <!-- Spellbook - White Guardian -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="50" required-level="80" sp="22900000" />
 
 		<skill name="Burst Shot" id="24" level="37" required-level="81" sp="160000000" />
 		<skill name="Light Armor Mastery" id="233" level="52" required-level="81" sp="160000000" />
 		<skill name="Bow Mastery" id="208" level="57" required-level="81" sp="160000000" />
-		<skill name="Double Shot" id="19" level="42" required-level="81" sp="160000000" />
+		<skill name="Double Shot" id="19" level="46" required-level="81" sp="160000000" />
 		<skill name="Stun Shot" id="101" level="45" required-level="81" sp="160000000" />
 		<skill name="Lethal Shot" id="343" level="6" required-level="81" sp="160000000" />
+		<skill name="Emergency Rescue" id="70" level="51" required-level="81" sp="160000000" />
 
 		<skill name="Pain of Sagittarius" id="417" level="7" required-level="82" sp="170000000" />
 		<skill name="Burst Shot" id="24" level="38" required-level="82" sp="170000000" />
 		<skill name="Light Armor Mastery" id="233" level="53" required-level="82" sp="170000000" />
 		<skill name="Bow Mastery" id="208" level="58" required-level="82" sp="170000000" />
 		<skill name="Real Target" id="522" level="3" required-level="82" sp="170000000" />
-		<skill name="Double Shot" id="19" level="43" required-level="82" sp="170000000" />
+		<skill name="Double Shot" id="19" level="47" required-level="82" sp="170000000" />
 		<skill name="Stun Shot" id="101" level="46" required-level="82" sp="170000000" />
 		<skill name="Lethal Shot" id="343" level="7" required-level="82" sp="170000000" />
+		<skill name="Emergency Rescue" id="70" level="52" required-level="82" sp="170000000" />
 
 		<skill name="Burst Shot" id="24" level="39" required-level="83" sp="240000000" />
 		<skill name="Light Armor Mastery" id="233" level="54" required-level="83" sp="240000000" />
 		<skill name="Bow Mastery" id="208" level="59" required-level="83" sp="240000000" />
-		<skill name="Double Shot" id="19" level="44" required-level="83" sp="240000000" />
+		<skill name="Double Shot" id="19" level="48" required-level="83" sp="240000000" />
 		<skill name="Stun Shot" id="101" level="47" required-level="83" sp="240000000" />
 		<skill name="Lethal Shot" id="343" level="8" required-level="83" sp="240000000" />
+		<skill name="Emergency Rescue" id="70" level="53" required-level="83" sp="240000000" />
 
 		<skill name="Burst Shot" id="24" level="40" required-level="84" sp="240000000" />
 		<skill name="Light Armor Mastery" id="233" level="55" required-level="84" sp="240000000" />
 		<skill name="Bow Mastery" id="208" level="60" required-level="84" sp="240000000" />
 		<skill name="Real Target" id="522" level="4" required-level="84" sp="240000000" />
-		<skill name="Double Shot" id="19" level="45" required-level="84" sp="240000000" />
+		<skill name="Double Shot" id="19" level="49" required-level="84" sp="240000000" />
 		<skill name="Stun Shot" id="101" level="48" required-level="84" sp="240000000" />
 		<skill name="Lethal Shot" id="343" level="9" required-level="84" sp="240000000" />
-		
+		<skill name="Emergency Rescue" id="70" level="54" required-level="84" sp="240000000" />
+
+		<skill name="Pain of Sagittarius" id="417" level="8" required-level="85" sp="840000000">
+			<item id="94138" count="1" /> <!-- Spellbook: Pain of Sagittarius -->
+		</skill>
 		<skill name="Light Armor Mastery" id="233" level="56" required-level="85" sp="840000000" />
-		<skill name="Light Armor Mastery" id="233" level="57" required-level="86" sp="924000000" />
-		<skill name="Light Armor Mastery" id="233" level="58" required-level="87" sp="1016400000" />
-		<skill name="Light Armor Mastery" id="233" level="59" required-level="88" sp="1118040000" />
-		<skill name="Light Armor Mastery" id="233" level="60" required-level="89" sp="1229844000" />
-		<skill name="Light Armor Mastery" id="233" level="61" required-level="90" sp="1352828400" />
 		<skill name="Bow Mastery" id="208" level="61" required-level="85" sp="840000000" />
-		<skill name="Bow Mastery" id="208" level="62" required-level="86" sp="924000000" />
-		<skill name="Bow Mastery" id="208" level="63" required-level="87" sp="1016400000" />
-		<skill name="Bow Mastery" id="208" level="64" required-level="88" sp="1118040000" />
-		<skill name="Bow Mastery" id="208" level="65" required-level="89" sp="1229844000" />
-		<skill name="Bow Mastery" id="208" level="66" required-level="90" sp="1352828400" />
+		<skill name="Double Shot" id="19" level="50" required-level="85" sp="840000000" />
+		<skill name="Snipe" id="313" level="10" required-level="85" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Lethal Shot" id="343" level="10" required-level="85" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="55" required-level="85" sp="840000000" />
+
+		<skill name="Light Armor Mastery" id="233" level="57" required-level="86" sp="840000000" />
+		<skill name="Bow Mastery" id="208" level="62" required-level="86" sp="840000000" />
+		<skill name="Double Shot" id="19" level="51" required-level="86" sp="840000000" />
+		<skill name="Lethal Shot" id="343" level="11" required-level="86" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="56" required-level="86" sp="840000000" />
+
+		<skill name="Light Armor Mastery" id="233" level="58" required-level="87" sp="840000000" />
+		<skill name="Bow Mastery" id="208" level="63" required-level="87" sp="840000000" />
+		<skill name="Double Shot" id="19" level="52" required-level="87" sp="840000000" />
+		<skill name="Lethal Shot" id="343" level="12" required-level="87" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="57" required-level="87" sp="840000000" />
+
+		<skill name="Light Armor Mastery" id="233" level="59" required-level="88" sp="840000000" />
+		<skill name="Bow Mastery" id="208" level="64" required-level="88" sp="840000000" />
+		<skill name="Double Shot" id="19" level="53" required-level="88" sp="840000000" />
+		<skill name="Lethal Shot" id="343" level="13" required-level="88" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="58" required-level="88" sp="840000000" />
+
+		<skill name="Light Armor Mastery" id="233" level="60" required-level="89" sp="840000000" />
+		<skill name="Bow Mastery" id="208" level="65" required-level="89" sp="840000000" />
+		<skill name="Double Shot" id="19" level="54" required-level="89" sp="840000000" />
+		<skill name="Lethal Shot" id="343" level="14" required-level="89" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="59" required-level="89" sp="840000000" />
+
+		<skill name="Light Armor Mastery" id="233" level="61" required-level="90" sp="840000000" />
+		<skill name="Bow Mastery" id="208" level="66" required-level="90" sp="840000000" />
+		<skill name="Double Shot" id="19" level="55" required-level="90" sp="840000000" />
+		<skill name="Lethal Shot" id="343" level="15" required-level="90" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="60" required-level="90" sp="840000000" />
 	</skillTree>
 </list>

--- a/data/skillTrees/3rdClass/ShillienSaint.xml
+++ b/data/skillTrees/3rdClass/ShillienSaint.xml
@@ -1,170 +1,337 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="112" parentClassId="43">
-		<skill name="White Guardian" id="54102" level="1" required-level="80" >
-			<item id="92401"/>
-		</skill>
-		<skill name="Might" id="1068" level="4" required-level="76" sp="8000000">
-			<item id="99046" count="1" /> <!-- Master's Book: Might -->
-		</skill>
-		<skill name="Shield" id="1040" level="4" required-level="76" sp="8000000">
-			<item id="99047" count="1" /> <!-- Master's Book: Shield -->
-		</skill>
-		<skill name="Empower" id="1059" level="4" required-level="76" sp="8000000">
-			<item id="99048" count="1" /> <!-- Master's Book: Empower -->
-		</skill>
+
 		<skill name="Anti Magic" id="146" level="46" required-level="76" sp="7400000" />
+		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="7400000">
+			<item id="8620" count="1" /> <!-- Buff Expansion Book Lv. 3 -->
+		</skill>
+		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="7400000">
+			<item id="8621" count="1" /> <!-- Buff Expansion Book Lv. 4 -->
+		</skill>
+		<skill name="Rapid Recharge" id="1428" level="6" required-level="76" sp="7400000" />
+		<skill name="Root Mastery" id="45238" level="1" required-level="76" sp="6800000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Light Armor Mastery" id="236" level="42" required-level="76" sp="7400000" />
 		<skill name="Robe Mastery" id="235" level="42" required-level="76" sp="7400000" />
 		<skill name="Weapon Mastery" id="249" level="43" required-level="76" sp="7400000" />
-		<skill name="Dryad Root" id="1201" level="34" required-level="76" sp="7400000" />
-		<skill name="Mass Recharge" id="1428" level="6" required-level="76" sp="7400000" />
-		<skill name="Wind Shackle" id="1206" level="20" required-level="76" sp="7400000" />
-		<skill name="Recharge" id="1013" level="33" required-level="76" sp="7400000" />
-		<skill name="Might of Heaven" id="1028" level="20" required-level="76" sp="7400000" />
-		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="7400000">
-			<item id="8620"/> <!-- Ancient Book: Divine Inspiration (Manuscript) -->
+		<skill name="Sleep Mastery" id="45239" level="1" required-level="76" sp="6800000">
+			<item id="57" count="1000000" /> <!-- Adena -->
 		</skill>
-		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="7400000">
-			<item id="8621"/> <!-- Ancient Book: Divine Inspiration (Original Version) -->
+		<skill name="Evolution Defense" id="45188" level="1" required-level="76">
+			<item id="57" count="5000000" /> <!-- Adena -->
 		</skill>
+		<skill name="Dryad Root" id="1201" level="33" required-level="76" sp="6800000" />
+		<skill name="Mass Stigma of Shillien" id="1897" level="6" required-level="76" sp="6800000" />
+		<skill name="Mass Cure" id="1550" level="1" required-level="76" sp="7400000">
+			<item id="90104" count="1" /> <!-- Scroll: Mass Cure -->
+		</skill>
+		<skill name="Mass Purify" id="1551" level="1" required-level="76" sp="7400000">
+			<item id="90109" count="1" /> <!-- Scroll: Mass Purify -->
+		</skill>
+		<skill name="Mass Wind Shackles" id="45243" level="1" required-level="76" sp="6800000">
+			<item id="93107" count="1" /> <!-- Scroll: Mass Wind Shackles -->
+		</skill>
+		<skill name="Mass Dryad Root" id="45242" level="1" required-level="76" sp="6800000">
+			<item id="93106" count="1" /> <!-- Scroll: Mass Dryad Root -->
+		</skill>
+		<!-- Might Lv. 4 -->
+		<skill name="Might" id="1068" level="4" required-level="76" sp="7400000">
+			<item id="94135" count="1" /> <!-- Master's Book: Might -->
+		</skill>
+		<!-- Shield Lv. 4 -->
+		<skill name="Shield" id="1040" level="4" required-level="76" sp="7400000">
+			<item id="94136" count="1" /> <!-- Master's Book: Shield -->
+		</skill>
+		<!-- Acumen Lv. 4 -->
+		<skill name="Acumen" id="45104" level="4" required-level="76" sp="7400000">
+			<item id="94370" count="1" /> <!-- Master's Book: Acumen -->
+		</skill>
+		<!-- Empower Lv. 4 -->
+		<skill name="Empower" id="45105" level="4" required-level="76" sp="7400000">
+			<item id="94361" count="1" /> <!-- Master's Book: Empower -->
+		</skill>
+		<!-- Wild Magic Lv. 3 -->
+		<skill name="Wild Magic" id="45106" level="3" required-level="76" sp="7400000">
+			<item id="94368" count="1" /> <!-- Master's Book: Wild Magic -->
+		</skill>
+		<!-- Wind Walk Lv. 3 -->
+		<skill name="Wind Walk" id="45107" level="3" required-level="76" sp="7400000">
+			<item id="94365" count="1" /> <!-- Master's Book: Wind Walk -->
+		</skill>
+		<!-- Magic Barrier Lv. 3 -->
+		<skill name="Magic Barrier" id="45108" level="3" required-level="76" sp="7400000">
+			<item id="94362" count="1" /> <!-- Master's Book: Magic Barrier -->
+		</skill>
+		<!-- Focus Lv. 4 -->
+		<skill name="Focus" id="45109" level="4" required-level="76" sp="7400000">
+			<item id="94363" count="1" /> <!-- Master's Book: Focus -->
+		</skill>
+		<!-- Death Whisper Lv. 4 -->
+		<skill name="Death Whisper" id="45110" level="4" required-level="76" sp="7400000">
+			<item id="94364" count="1" /> <!-- Master's Book: Death Whisper -->
+		</skill>
+		<!-- Haste Lv. 3 -->
+		<skill name="Haste" id="45111" level="3" required-level="76" sp="7400000">
+			<item id="94369" count="1" /> <!-- Master's Book: Haste -->
+		</skill>
+		<!-- Berserker Spirit Lv. 3 -->
+		<skill name="Berserker Spirit" id="45112" level="3" required-level="76" sp="7400000">
+			<item id="94366" count="1" /> <!-- Master's Book: Berserker Spirit -->
+		</skill>
+		<!-- Clarity Lv. 4 -->
+		<skill name="Clarity" id="45113" level="4" required-level="76" sp="7400000">
+			<item id="94367" count="1" /> <!-- Master's Book: Clarity -->
+		</skill>
+		<skill name="Detection" id="45190" level="1" required-level="76" sp="7400000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Wind Shackle" id="1206" level="20" required-level="76" sp="6800000" />
 		<skill name="Mount Saber Tooth Cougar" id="1835" level="1" required-level="76">
-			<item id="90040"/> <!-- Spellbook: Mount Saber Tooth Cougar -->
+			<item id="90040" count="1" /> <!-- Spellbook: Ride Sabretooth Cougar -->
 		</skill>
-		<skill name="Glory Ability" id="45361" level="1" required-level="86">
-			<item id="94046"/> <!-- Spellbook: Glory Ability Lv. 1 -->
-		</skill>
-		<skill name="Mount White Wings" id="54200" level="1" required-level="87">
-			<item id="93059"/> <!-- Spellbook: Summon White Wings -->
-		</skill>	
-		<skill name="Mount Shining Lady" id="54202" level="1" required-level="89">
-			<item id="93061"/> <!-- Spellbook: Summon Silver Saint -->
+		<skill name="Mana Gain" id="1460" level="1" required-level="76" sp="7400000">
+			<item id="90106" count="1" /> <!-- Scroll: Mana Gain -->
 		</skill>
 		<skill name="Prophecy of Wind" id="1357" level="1" required-level="76" sp="7400000">
-			<item id="90108"/> <!-- Scroll: Prophecy of Wind -->
+			<item id="90108" count="1" /> <!-- Scroll: Prophecy of Wind -->
 		</skill>
-		
+		<skill name="Divine Beam" id="45241" level="1" required-level="76" sp="6800000">
+			<item id="93103" count="1" /> <!-- Spellbook: Divine Beam -->
+		</skill>
+		<skill name="Might of Heaven" id="1028" level="21" required-level="76" sp="6800000" />
+		<skill name="Stigma of Shillien" id="1539" level="6" required-level="76" sp="6800000" />
+		<skill name="Boost Mana" id="1013" level="33" required-level="76" sp="7400000" />
+		<skill name="Sleep" id="1069" level="46" required-level="76" sp="6800000" />
 		<skill name="Anti Magic" id="146" level="47" required-level="77" sp="7400000" />
 		<skill name="Light Armor Mastery" id="236" level="43" required-level="77" sp="7400000" />
 		<skill name="Robe Mastery" id="235" level="43" required-level="77" sp="7400000" />
 		<skill name="Weapon Mastery" id="249" level="44" required-level="77" sp="7400000" />
-		<skill name="Mass Purify" id="1551" level="1" required-level="77" sp="7400000">
-			<item id="90109"/> <!-- Scroll: Mass Purify -->
-		</skill>
-		<skill name="Mass Cure Poison" id="1550" level="1" required-level="77" sp="7400000">
-			<item id="90104"/> <!-- Scroll: Mass Cure Poison -->
-		</skill>
-		
+		<skill name="Mass Stigma of Shillien" id="1897" level="7" required-level="77" sp="6800000" />
+		<skill name="Mass Wind Shackles" id="45243" level="2" required-level="77" sp="6800000" />
+		<skill name="Mass Dryad Root" id="45242" level="2" required-level="77" sp="6800000" />
+		<skill name="Mana Gain" id="1460" level="2" required-level="77" sp="7400000" />
+		<skill name="Divine Beam" id="45241" level="2" required-level="77" sp="6800000" />
+		<skill name="Might of Heaven" id="1028" level="22" required-level="77" sp="6800000" />
+		<skill name="Stigma of Shillien" id="1539" level="7" required-level="77" sp="6800000" />
+		<skill name="Sleep" id="1069" level="47" required-level="77" sp="6800000" />
+
 		<skill name="Anti Magic" id="146" level="48" required-level="78" sp="16300000" />
+		<skill name="Rapid Recharge" id="1428" level="7" required-level="78" sp="16300000" />
 		<skill name="Light Armor Mastery" id="236" level="44" required-level="78" sp="16300000" />
 		<skill name="Robe Mastery" id="235" level="44" required-level="78" sp="16300000" />
 		<skill name="Weapon Mastery" id="249" level="45" required-level="78" sp="16300000" />
-		<skill name="Dryad Root" id="1201" level="35" required-level="78" sp="16300000" />
-		<skill name="Mass Recharge" id="1428" level="7" required-level="78" sp="16300000" />
-		<skill name="Wind Shackle" id="1206" level="21" required-level="78" sp="16300000" />
-		<skill name="Recharge" id="1013" level="34" required-level="78" sp="16300000" />
-		<skill name="Shilen's Cursed Field" id="1897" level="5" required-level="78" sp="16300000" />
-		<skill name="Might of Heaven" id="1028" level="21" required-level="78" sp="16300000" />
-		<skill name="Stigma of Shilen" id="1539" level="5" required-level="78" sp="16300000" />
+		<skill name="Dryad Root" id="1201" level="34" required-level="78" sp="14900000" />
+		<skill name="Mass Stigma of Shillien" id="1897" level="8" required-level="78" sp="14900000" />
+		<skill name="Mass Wind Shackles" id="45243" level="3" required-level="78" sp="14900000" />
+		<skill name="Mass Dryad Root" id="45242" level="3" required-level="78" sp="14900000" />
+		<skill name="Wind Shackle" id="1206" level="21" required-level="78" sp="14900000" />
+		<skill name="Mana Gain" id="1460" level="3" required-level="78" sp="16300000" />
 		<skill name="Enlightenment" id="1533" level="1" required-level="78" sp="16300000">
-			<item id="90111"/> <!-- Scroll: Enlightenment -->
+			<item id="90111" count="1" /> <!-- Scroll: Enlightenment -->
 		</skill>
-		
-		<skill name="Dryad Root" id="1201" level="36" required-level="79" sp="16300000" />
-		<skill name="Wind Shackle" id="1206" level="22" required-level="79" sp="16300000" />
-		<skill name="Shilen's Cursed Field" id="1897" level="6" required-level="79" sp="16300000" />
-		<skill name="Stigma of Shilen" id="1539" level="6" required-level="79" sp="16300000" />
-		<skill name="Mana Gain" id="1460" level="1" required-level="79" sp="16300000">
-			<item id="90106"/> <!-- Scroll: Mana Gain -->
+		<skill name="Divine Beam" id="45241" level="3" required-level="78" sp="14900000" />
+		<skill name="Might of Heaven" id="1028" level="23" required-level="78" sp="14900000" />
+		<skill name="Stigma of Shillien" id="1539" level="8" required-level="78" sp="14900000" />
+		<skill name="Boost Mana" id="1013" level="34" required-level="78" sp="16300000" />
+		<skill name="Sleep" id="1069" level="48" required-level="78" sp="14900000" />
+
+		<skill name="Root Mastery" id="45238" level="2" required-level="79" sp="14900000">
+			<item id="57" count="2000000" /> <!-- Adena -->
 		</skill>
-		
+		<skill name="Sleep Mastery" id="45239" level="2" required-level="79" sp="14900000">
+			<item id="57" count="2000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Mass Stigma of Shillien" id="1897" level="9" required-level="79" sp="14900000" />
+		<skill name="Mass Wind Shackles" id="45243" level="4" required-level="79" sp="14900000" />
+		<skill name="Mass Dryad Root" id="45242" level="4" required-level="79" sp="14900000" />
+		<skill name="Wind Shackle" id="1206" level="22" required-level="79" sp="14900000" />
+		<skill name="Mana Gain" id="1460" level="4" required-level="79" sp="16300000" />
+		<skill name="Divine Beam" id="45241" level="4" required-level="79" sp="14900000" />
+		<skill name="Might of Heaven" id="1028" level="24" required-level="79" sp="14900000" />
+		<skill name="Stigma of Shillien" id="1539" level="9" required-level="79" sp="14900000" />
+		<skill name="Sleep" id="1069" level="49" required-level="79" sp="14900000" />
+
 		<skill name="Anti Magic" id="146" level="49" required-level="80" sp="16300000" />
+		<skill name="Rapid Recharge" id="1428" level="8" required-level="80" sp="16300000" />
 		<skill name="Light Armor Mastery" id="236" level="45" required-level="80" sp="16300000" />
 		<skill name="Robe Mastery" id="235" level="45" required-level="80" sp="16300000" />
 		<skill name="Weapon Mastery" id="249" level="46" required-level="80" sp="16300000" />
-		<skill name="Dryad Root" id="1201" level="37" required-level="80" sp="16300000" />
-		<skill name="Mass Recharge" id="1428" level="8" required-level="80" sp="16300000" />
-		<skill name="Wind Shackle" id="1206" level="23" required-level="80" sp="16300000" />
-		<skill name="Recharge" id="1013" level="35" required-level="80" sp="16300000" />
-		<skill name="Mana Gain" id="1460" level="2" required-level="80" sp="16300000" />
-		<skill name="Shilen's Cursed Field" id="1897" level="7" required-level="80" sp="16300000" />
-		<skill name="Might of Heaven" id="1028" level="22" required-level="80" sp="16300000" />
-		<skill name="Stigma of Shilen" id="1539" level="7" required-level="80" sp="16300000" />
-		<skill name="Lord of Vampires" id="1507" level="1" required-level="80" sp="16300000">
-			<item id="90110"/> <!-- Scroll: Lord of Vampires -->
+		<skill name="Dryad Root" id="1201" level="35" required-level="80" sp="14900000" />
+		<skill name="Mass Stigma of Shillien" id="1897" level="10" required-level="80" sp="14900000" />
+		<skill name="Mass Wind Shackles" id="45243" level="5" required-level="80" sp="14900000" />
+		<skill name="Swap Defense" id="1392" level="4" required-level="80" sp="10000000" />
+		<skill name="Mass Dryad Root" id="45242" level="5" required-level="80" sp="14900000" />
+		<skill name="Spell Master" id="1831" level="4" required-level="80" sp="2400000">
+			<item id="57" count="500000" /> <!-- Adena -->
 		</skill>
+		<skill name="Evolution Power" id="45189" level="1" required-level="80">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Wind Shackle" id="1206" level="23" required-level="80" sp="14900000" />
+		<skill name="Poison" id="1168" level="8" required-level="80" sp="14900000" />
+		<skill name="Spirit of Shillien" id="1507" level="1" required-level="80" sp="16300000">
+			<item id="90110" count="1" /> <!-- Scroll: Spirit of Shillien -->
+		</skill>
+		<skill name="Mana Gain" id="1460" level="5" required-level="80" sp="16300000" />
+		<skill name="Divine Beam" id="45241" level="5" required-level="80" sp="14900000" />
+		<skill name="Might of Heaven" id="1028" level="25" required-level="80" sp="14900000" />
+		<skill name="Stigma of Shillien" id="1539" level="10" required-level="80" sp="14900000" />
+		<skill name="White Guardian Transformation" id="54102" level="1" required-level="80">
+			<item id="92401" count="1" /> <!-- Spellbook - White Guardian -->
+		</skill>
+		<skill name="Boost Mana" id="1013" level="35" required-level="80" sp="16300000" />
+		<skill name="Sleep" id="1069" level="50" required-level="80" sp="14900000" />
 
 		<skill name="Anti Magic" id="146" level="50" required-level="81" sp="160000000" />
 		<skill name="Light Armor Mastery" id="236" level="46" required-level="81" sp="160000000" />
 		<skill name="Robe Mastery" id="235" level="46" required-level="81" sp="160000000" />
 		<skill name="Weapon Mastery" id="249" level="47" required-level="81" sp="160000000" />
-		<skill name="Dryad Root" id="1201" level="38" required-level="81" sp="160000000" />
+		<skill name="Dryad Root" id="1201" level="36" required-level="81" sp="160000000" />
+		<skill name="Mass Stigma of Shillien" id="1897" level="11" required-level="81" sp="160000000" />
+		<skill name="Mass Wind Shackles" id="45243" level="6" required-level="81" sp="160000000" />
+		<skill name="Mass Dryad Root" id="45242" level="6" required-level="81" sp="160000000" />
 		<skill name="Wind Shackle" id="1206" level="24" required-level="81" sp="160000000" />
-		<skill name="Recharge" id="1013" level="36" required-level="81" sp="160000000" />
-		<skill name="Mana Gain" id="1460" level="3" required-level="81" sp="160000000" />
-		<skill name="Shilen's Cursed Field" id="1897" level="8" required-level="81" sp="160000000" />
-		<skill name="Might of Heaven" id="1028" level="23" required-level="81" sp="160000000" />
-		<skill name="Stigma of Shilen" id="1539" level="8" required-level="81" sp="160000000" />
+		<skill name="Mana Gain" id="1460" level="6" required-level="81" sp="160000000" />
+		<skill name="Divine Beam" id="45241" level="6" required-level="81" sp="160000000" />
+		<skill name="Might of Heaven" id="1028" level="26" required-level="81" sp="160000000" />
+		<skill name="Stigma of Shillien" id="1539" level="11" required-level="81" sp="160000000" />
+		<skill name="Boost Mana" id="1013" level="36" required-level="81" sp="160000000" />
+		<skill name="Sleep" id="1069" level="51" required-level="81" sp="160000000" />
 
 		<skill name="Anti Magic" id="146" level="51" required-level="82" sp="170000000" />
+		<skill name="Rapid Recharge" id="1428" level="9" required-level="82" sp="170000000" />
+		<skill name="Root Mastery" id="45238" level="3" required-level="82" sp="170000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Light Armor Mastery" id="236" level="47" required-level="82" sp="170000000" />
 		<skill name="Robe Mastery" id="235" level="47" required-level="82" sp="170000000" />
 		<skill name="Weapon Mastery" id="249" level="48" required-level="82" sp="170000000" />
-		<skill name="Dryad Root" id="1201" level="39" required-level="82" sp="170000000" />
-		<skill name="Mass Recharge" id="1428" level="9" required-level="82" sp="170000000" />
+		<skill name="Sleep Mastery" id="45239" level="3" required-level="82" sp="170000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Dryad Root" id="1201" level="37" required-level="82" sp="170000000" />
+		<skill name="Mass Stigma of Shillien" id="1897" level="12" required-level="82" sp="170000000" />
+		<skill name="Mass Wind Shackles" id="45243" level="7" required-level="82" sp="170000000" />
+		<skill name="Mass Dryad Root" id="45242" level="7" required-level="82" sp="170000000" />
 		<skill name="Wind Shackle" id="1206" level="25" required-level="82" sp="170000000" />
-		<skill name="Recharge" id="1013" level="37" required-level="82" sp="170000000" />
-		<skill name="Shilen's Cursed Field" id="1897" level="9" required-level="82" sp="170000000" />
+		<skill name="Mana Gain" id="1460" level="7" required-level="82" sp="170000000" />
 		<skill name="Prophecy of Wind" id="1357" level="2" required-level="82" sp="170000000" />
-		<skill name="Might of Heaven" id="1028" level="24" required-level="82" sp="170000000" />
-		<skill name="Stigma of Shilen" id="1539" level="9" required-level="82" sp="170000000" />
+		<skill name="Divine Beam" id="45241" level="7" required-level="82" sp="170000000" />
+		<skill name="Might of Heaven" id="1028" level="27" required-level="82" sp="170000000" />
+		<skill name="Stigma of Shillien" id="1539" level="12" required-level="82" sp="170000000" />
+		<skill name="Boost Mana" id="1013" level="37" required-level="82" sp="170000000" />
+		<skill name="Sleep" id="1069" level="52" required-level="82" sp="170000000" />
 
 		<skill name="Anti Magic" id="146" level="52" required-level="83" sp="240000000" />
 		<skill name="Light Armor Mastery" id="236" level="48" required-level="83" sp="240000000" />
 		<skill name="Robe Mastery" id="235" level="48" required-level="83" sp="240000000" />
 		<skill name="Weapon Mastery" id="249" level="49" required-level="83" sp="240000000" />
-		<skill name="Dryad Root" id="1201" level="40" required-level="83" sp="240000000" />
+		<skill name="Dryad Root" id="1201" level="38" required-level="83" sp="240000000" />
+		<skill name="Mass Stigma of Shillien" id="1897" level="13" required-level="83" sp="240000000" />
+		<skill name="Mass Wind Shackles" id="45243" level="8" required-level="83" sp="240000000" />
+		<skill name="Mass Dryad Root" id="45242" level="8" required-level="83" sp="240000000" />
 		<skill name="Wind Shackle" id="1206" level="26" required-level="83" sp="240000000" />
-		<skill name="Recharge" id="1013" level="38" required-level="83" sp="240000000" />
-		<skill name="Shilen's Cursed Field" id="1897" level="10" required-level="83" sp="240000000" />
-		<skill name="Might of Heaven" id="1028" level="25" required-level="83" sp="240000000" />
-		<skill name="Stigma of Shilen" id="1539" level="10" required-level="83" sp="240000000" />
+		<skill name="Mana Gain" id="1460" level="8" required-level="83" sp="240000000" />
+		<skill name="Divine Beam" id="45241" level="8" required-level="83" sp="240000000" />
+		<skill name="Might of Heaven" id="1028" level="28" required-level="83" sp="240000000" />
+		<skill name="Stigma of Shillien" id="1539" level="13" required-level="83" sp="240000000" />
+		<skill name="Boost Mana" id="1013" level="38" required-level="83" sp="240000000" />
+		<skill name="Sleep" id="1069" level="53" required-level="83" sp="240000000" />
 
 		<skill name="Anti Magic" id="146" level="53" required-level="84" sp="240000000" />
+		<skill name="Rapid Recharge" id="1428" level="10" required-level="84" sp="240000000" />
 		<skill name="Light Armor Mastery" id="236" level="49" required-level="84" sp="240000000" />
 		<skill name="Robe Mastery" id="235" level="49" required-level="84" sp="240000000" />
 		<skill name="Weapon Mastery" id="249" level="50" required-level="84" sp="240000000" />
-		<skill name="Dryad Root" id="1201" level="41" required-level="84" sp="240000000" />
-		<skill name="Mass Recharge" id="1428" level="10" required-level="84" sp="240000000" />
+		<skill name="Dryad Root" id="1201" level="39" required-level="84" sp="240000000" />
+		<skill name="Mass Stigma of Shillien" id="1897" level="14" required-level="84" sp="240000000" />
+		<skill name="Mass Wind Shackles" id="45243" level="9" required-level="84" sp="240000000" />
+		<skill name="Mass Dryad Root" id="45242" level="9" required-level="84" sp="240000000" />
 		<skill name="Wind Shackle" id="1206" level="27" required-level="84" sp="240000000" />
-		<skill name="Recharge" id="1013" level="39" required-level="84" sp="240000000" />
-		<skill name="Shilen's Cursed Field" id="1897" level="11" required-level="84" sp="240000000" />
-		<skill name="Might of Heaven" id="1028" level="26" required-level="84" sp="240000000" />
-		<skill name="Stigma of Shilen" id="1539" level="11" required-level="84" sp="240000000" />
-		
+		<skill name="Mana Gain" id="1460" level="9" required-level="84" sp="240000000" />
+		<skill name="Divine Beam" id="45241" level="9" required-level="84" sp="240000000" />
+		<skill name="Might of Heaven" id="1028" level="29" required-level="84" sp="240000000" />
+		<skill name="Stigma of Shillien" id="1539" level="14" required-level="84" sp="240000000" />
+		<skill name="Boost Mana" id="1013" level="39" required-level="84" sp="240000000" />
+		<skill name="Sleep" id="1069" level="54" required-level="84" sp="240000000" />
+
 		<skill name="Anti Magic" id="146" level="54" required-level="85" sp="840000000" />
-		<skill name="Anti Magic" id="146" level="55" required-level="86" sp="924000000" />
-		<skill name="Anti Magic" id="146" level="56" required-level="87" sp="1016400000" />
-		<skill name="Anti Magic" id="146" level="57" required-level="88" sp="1118040000" />
-		<skill name="Anti Magic" id="146" level="58" required-level="89" sp="1229844000" />
-		<skill name="Anti Magic" id="146" level="59" required-level="90" sp="1352828400" />
+		<skill name="Root Mastery" id="45238" level="4" required-level="85" sp="840000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Light Armor Mastery" id="236" level="50" required-level="85" sp="840000000" />
-		<skill name="Light Armor Mastery" id="236" level="51" required-level="86" sp="924000000" />
-		<skill name="Light Armor Mastery" id="236" level="52" required-level="87" sp="1016400000" />
-		<skill name="Light Armor Mastery" id="236" level="53" required-level="88" sp="1118040000" />
-		<skill name="Light Armor Mastery" id="236" level="54" required-level="89" sp="1229844000" />
-		<skill name="Light Armor Mastery" id="236" level="55" required-level="90" sp="1352828400" />
 		<skill name="Robe Mastery" id="235" level="50" required-level="85" sp="840000000" />
-		<skill name="Robe Mastery" id="235" level="51" required-level="86" sp="924000000" />
-		<skill name="Robe Mastery" id="235" level="52" required-level="87" sp="1016400000" />
-		<skill name="Robe Mastery" id="235" level="53" required-level="88" sp="1118040000" />
-		<skill name="Robe Mastery" id="235" level="54" required-level="89" sp="1229844000" />
-		<skill name="Robe Mastery" id="235" level="55" required-level="90" sp="1352828400" />
 		<skill name="Weapon Mastery" id="249" level="51" required-level="85" sp="840000000" />
-		<skill name="Weapon Mastery" id="249" level="52" required-level="86" sp="924000000" />
-		<skill name="Weapon Mastery" id="249" level="53" required-level="87" sp="1016400000" />
-		<skill name="Weapon Mastery" id="249" level="54" required-level="88" sp="1118040000" />
-		<skill name="Weapon Mastery" id="249" level="55" required-level="89" sp="1229844000" />
-		<skill name="Weapon Mastery" id="249" level="56" required-level="90" sp="1352828400" />
+		<skill name="Sleep Mastery" id="45239" level="4" required-level="85" sp="840000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Dryad Root" id="1201" level="40" required-level="85" sp="840000000" />
+		<skill name="Mass Stigma of Shillien" id="1897" level="15" required-level="85" sp="840000000" />
+		<skill name="Mass Wind Shackles" id="45243" level="10" required-level="85" sp="840000000" />
+		<skill name="Mass Dryad Root" id="45242" level="10" required-level="85" sp="840000000" />
+		<skill name="Poison" id="1168" level="9" required-level="85" sp="840000000" />
+		<skill name="Mana Gain" id="1460" level="10" required-level="85" sp="840000000" />
+		<skill name="Divine Beam" id="45241" level="10" required-level="85" sp="840000000" />
+		<skill name="Might of Heaven" id="1028" level="30" required-level="85" sp="840000000" />
+		<skill name="Stigma of Shillien" id="1539" level="15" required-level="85" sp="840000000" />
+		<skill name="Sleep" id="1069" level="55" required-level="85" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="55" required-level="86" sp="840000000" />
+		<skill name="Light Armor Mastery" id="236" level="51" required-level="86" sp="840000000" />
+		<skill name="Robe Mastery" id="235" level="51" required-level="86" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="52" required-level="86" sp="840000000" />
+		<skill name="Dryad Root" id="1201" level="41" required-level="86" sp="840000000" />
+		<skill name="Mass Wind Shackles" id="45243" level="11" required-level="86" sp="840000000" />
+		<skill name="Mass Dryad Root" id="45242" level="11" required-level="86" sp="840000000" />
+		<skill name="Divine Beam" id="45241" level="11" required-level="86" sp="840000000" />
+		<skill name="Might of Heaven" id="1028" level="31" required-level="86" sp="840000000" />
+		<skill name="Sleep" id="1069" level="56" required-level="86" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="56" required-level="87" sp="840000000" />
+		<skill name="Light Armor Mastery" id="236" level="52" required-level="87" sp="840000000" />
+		<skill name="Robe Mastery" id="235" level="52" required-level="87" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="53" required-level="87" sp="840000000" />
+		<skill name="Dryad Root" id="1201" level="42" required-level="87" sp="840000000" />
+		<skill name="Mass Wind Shackles" id="45243" level="12" required-level="87" sp="840000000" />
+		<skill name="Mass Dryad Root" id="45242" level="12" required-level="87" sp="840000000" />
+		<skill name="Divine Beam" id="45241" level="12" required-level="87" sp="840000000" />
+		<skill name="Might of Heaven" id="1028" level="32" required-level="87" sp="840000000" />
+		<skill name="Sleep" id="1069" level="57" required-level="87" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="57" required-level="88" sp="840000000" />
+		<skill name="Light Armor Mastery" id="236" level="53" required-level="88" sp="840000000" />
+		<skill name="Robe Mastery" id="235" level="53" required-level="88" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="54" required-level="88" sp="840000000" />
+		<skill name="Dryad Root" id="1201" level="43" required-level="88" sp="840000000" />
+		<skill name="Mass Wind Shackles" id="45243" level="13" required-level="88" sp="840000000" />
+		<skill name="Mass Dryad Root" id="45242" level="13" required-level="88" sp="840000000" />
+		<skill name="Divine Beam" id="45241" level="13" required-level="88" sp="840000000" />
+		<skill name="Might of Heaven" id="1028" level="33" required-level="88" sp="840000000" />
+		<skill name="Sleep" id="1069" level="58" required-level="88" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="58" required-level="89" sp="840000000" />
+		<skill name="Light Armor Mastery" id="236" level="54" required-level="89" sp="840000000" />
+		<skill name="Robe Mastery" id="235" level="54" required-level="89" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="55" required-level="89" sp="840000000" />
+		<skill name="Dryad Root" id="1201" level="44" required-level="89" sp="840000000" />
+		<skill name="Mass Wind Shackles" id="45243" level="14" required-level="89" sp="840000000" />
+		<skill name="Mass Dryad Root" id="45242" level="14" required-level="89" sp="840000000" />
+		<skill name="Divine Beam" id="45241" level="14" required-level="89" sp="840000000" />
+		<skill name="Might of Heaven" id="1028" level="34" required-level="89" sp="840000000" />
+		<skill name="Sleep" id="1069" level="59" required-level="89" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="59" required-level="90" sp="840000000" />
+		<skill name="Light Armor Mastery" id="236" level="55" required-level="90" sp="840000000" />
+		<skill name="Robe Mastery" id="235" level="55" required-level="90" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="56" required-level="90" sp="840000000" />
+		<skill name="Dryad Root" id="1201" level="45" required-level="90" sp="840000000" />
+		<skill name="Mass Wind Shackles" id="45243" level="15" required-level="90" sp="840000000" />
+		<skill name="Mass Dryad Root" id="45242" level="15" required-level="90" sp="840000000" />
+		<skill name="Poison" id="1168" level="10" required-level="90" sp="840000000" />
+		<skill name="Divine Beam" id="45241" level="15" required-level="90" sp="840000000" />
+		<skill name="Might of Heaven" id="1028" level="35" required-level="90" sp="840000000" />
+		<skill name="Sleep" id="1069" level="60" required-level="90" sp="840000000" />
 	</skillTree>
 </list>

--- a/data/skillTrees/3rdClass/ShillienTemplar.xml
+++ b/data/skillTrees/3rdClass/ShillienTemplar.xml
@@ -1,18 +1,84 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="106" parentClassId="33">
-		<skill name="White Guardian" id="54102" level="1" required-level="80" >
-			<item id="92401"/>
-		</skill>
+
 		<skill name="Aggression" id="28" level="50" required-level="76" sp="4900000" />
 		<skill name="Aggression Aura" id="18" level="38" required-level="76" sp="4900000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="46" required-level="76" sp="4900000" />
+		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="4900000">
+			<item id="8620" count="1" /> <!-- Buff Expansion Book Lv. 3 -->
+		</skill>
+		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="4900000">
+			<item id="8621" count="1" /> <!-- Buff Expansion Book Lv. 4 -->
+		</skill>
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="46" required-level="76" sp="4900000" />
+		<skill name="Weapon Mastery" id="141" level="5" required-level="76" sp="4900000" />
 		<skill name="Heavy Armor Mastery" id="232" level="53" required-level="76" sp="4900000" />
-		<skill name="Sting" id="223" level="50" required-level="76" sp="4900000" />
-		<skill name="Freezing Strike" id="105" level="25" required-level="76" sp="4900000" />
-		<skill name="Drain Energy" id="70" level="54" required-level="76" sp="4900000" />
+		<skill name="Confusion" id="2" level="21" required-level="76" sp="4900000" />
+		<skill name="Freezing Weapon" id="105" level="28" required-level="76" sp="4900000" />
+		<skill name="Evolution Defense" id="45188" level="1" required-level="76">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Drain Energy" id="45250" level="26" required-level="76" sp="4900000" />
+		<skill name="Blood Attack" id="223" level="51" required-level="76" sp="4900000" />
 		<skill name="Life Leech" id="289" level="16" required-level="76" sp="4900000" />
 		<skill name="Magic Resistance" id="147" level="52" required-level="76" sp="4900000" />
+		<!-- Might Lv. 4-->
+		<skill name="Might" id="1068" level="4" required-level="76" sp="4900000">
+			<item id="94135" count="1" /> <!-- Master's Book: Might -->
+		</skill>
+		<!-- Shield Lv. 4 -->
+		<skill name="Shield" id="1040" level="4" required-level="76" sp="4900000">
+			<item id="94136" count="1" /> <!-- Master's Book: Shield -->
+		</skill>
+		<!-- Acumen Lv. 4 -->
+		<skill name="Acumen" id="45104" level="4" required-level="76" sp="4900000">
+			<item id="94370" count="1" /> <!-- Master's Book: Acumen -->
+		</skill>
+		<!-- Empower Lv. 4 -->
+		<skill name="Empower" id="45105" level="4" required-level="76" sp="4900000">
+			<item id="94361" count="1" /> <!-- Master's Book: Empower -->
+		</skill>
+		<!-- Wild Magic Lv. 3 -->
+		<skill name="Wild Magic" id="45106" level="3" required-level="76" sp="4900000">
+			<item id="94368" count="1" /> <!-- Master's Book: Wild Magic -->
+		</skill>
+		<!-- Wind Walk Lv. 3 -->
+		<skill name="Wind Walk" id="45107" level="3" required-level="76" sp="4900000">
+			<item id="94365" count="1" /> <!-- Master's Book: Wind Walk -->
+		</skill>
+		<!-- Magic Barrier Lv. 3 -->
+		<skill name="Magic Barrier" id="45108" level="3" required-level="76" sp="4900000">
+			<item id="94362" count="1" /> <!-- Master's Book: Magic Barrier -->
+		</skill>
+		<!-- Focus Lv. 4 -->
+		<skill name="Focus" id="45109" level="4" required-level="76" sp="4900000">
+			<item id="94363" count="1" /> <!-- Master's Book: Focus -->
+		</skill>
+		<!-- Death Whisper Lv. 4 -->
+		<skill name="Death Whisper" id="45110" level="4" required-level="76" sp="4900000">
+			<item id="94364" count="1" /> <!-- Master's Book: Death Whisper -->
+		</skill>
+		<!-- Haste Lv. 3 -->
+		<skill name="Haste" id="45111" level="3" required-level="76" sp="4900000">
+			<item id="94369" count="1" /> <!-- Master's Book: Haste -->
+		</skill>
+		<!-- Berserker Spirit Lv. 3 -->
+		<skill name="Berserker Spirit" id="45112" level="3" required-level="76" sp="4900000">
+			<item id="94366" count="1" /> <!-- Master's Book: Berserker Spirit -->
+		</skill>
+		<!-- Clarity Lv. 4 -->
+		<skill name="Clarity" id="45113" level="4" required-level="76" sp="4900000">
+			<item id="94367" count="1" /> <!-- Master's Book: Clarity -->
+		</skill>
+		<skill name="Detection" id="45190" level="1" required-level="76" sp="4900000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Mount Saber Tooth Cougar" id="1835" level="1" required-level="76">
+			<item id="90040" count="1" /> <!-- Spellbook: Ride Sabretooth Cougar -->
+		</skill>
+		<skill name="Shillien's Help" id="45372" level="1" required-level="76" sp="4900000">
+			<item id="93871" count="1" /> <!-- Spellbook: Knight's Help -->
+		</skill>
 		<skill name="Final Fortress" id="291" level="12" required-level="76" sp="4900000" />
 		<skill name="Judgment" id="401" level="16" required-level="76" sp="4900000" />
 		<skill name="Summon Vampiric Cubic" id="22" level="9" required-level="76" sp="4900000" />
@@ -21,169 +87,304 @@
 		<skill name="Hex" id="122" level="16" required-level="76" sp="4900000" />
 		<skill name="Power Break" id="115" level="18" required-level="76" sp="4900000" />
 		<skill name="Fortitude" id="335" level="1" required-level="76" sp="4900000" />
-		<skill name="Critical Vulnerability Decrease" id="53004" level="1" required-level="76" sp="4900000" />
+		<skill name="Critical Vulnerability Decrease" id="53004" level="1" required-level="76" sp="4900000">
+			<item id="91485" count="1" /> <!-- Scroll: Critical Vulnerability Decrease -->
+		</skill>
 		<skill name="Chain Strike" id="10015" level="1" required-level="76" sp="4900000" />
-		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="4900000">
-			<item id="8620"/> <!-- Ancient Book: Divine Inspiration (Manuscript) -->
-		</skill>
-		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="4900000">
-			<item id="8621"/> <!-- Ancient Book: Divine Inspiration (Original Version) -->
-		</skill>
-		<skill name="Mount Saber Tooth Cougar" id="1835" level="1" required-level="76">
-			<item id="90040"/> <!-- Spellbook: Mount Saber Tooth Cougar -->
-		</skill>
-		<skill name="Glory Ability" id="45361" level="1" required-level="86">
-			<item id="94046"/> <!-- Spellbook: Glory Ability Lv. 1 -->
-		</skill>
-		<skill name="Mount White Wings" id="54200" level="1" required-level="87">
-			<item id="93059"/> <!-- Spellbook: Summon White Wings -->
-		</skill>	
-		<skill name="Mount Shining Lady" id="54202" level="1" required-level="89">
-			<item id="93061"/> <!-- Spellbook: Summon Silver Saint -->
-		</skill>
-		
+		<skill name="Emergency Rescue" id="70" level="46" required-level="76" sp="4900000" />
+
 		<skill name="Aggression" id="28" level="51" required-level="77" sp="4900000" />
 		<skill name="Aggression Aura" id="18" level="39" required-level="77" sp="4900000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="47" required-level="77" sp="4900000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="47" required-level="77" sp="4900000" />
 		<skill name="Heavy Armor Mastery" id="232" level="54" required-level="77" sp="4900000" />
-		<skill name="Sting" id="223" level="51" required-level="77" sp="4900000" />
-		<skill name="Drain Energy" id="70" level="55" required-level="77" sp="4900000" />
+		<skill name="Confusion" id="2" level="22" required-level="77" sp="4900000" />
+		<skill name="Drain Energy" id="45250" level="27" required-level="77" sp="4900000" />
+		<skill name="Blood Attack" id="223" level="52" required-level="77" sp="4900000" />
 		<skill name="Magic Resistance" id="147" level="53" required-level="77" sp="4900000" />
+		<skill name="Vengeance" id="368" level="1" required-level="77" sp="4900000">
+			<item id="90046" count="1" /> <!-- Scroll: Vengeance -->
+		</skill>
 		<skill name="Deflect Magic" id="913" level="1" required-level="77" sp="4900000" />
 		<skill name="Final Fortress" id="291" level="13" required-level="77" sp="4900000" />
-		<skill name="Vengeance" id="368" level="1" required-level="77" sp="4900000">
-			<item id="90046"/> <!-- Scroll: Vengeance -->
-		</skill>
-		
+		<skill name="Judgment" id="401" level="17" required-level="77" sp="4900000" />
+		<skill name="Hex" id="122" level="17" required-level="77" sp="4900000" />
+		<skill name="Emergency Rescue" id="70" level="47" required-level="77" sp="4900000" />
+
 		<skill name="Aggression" id="28" level="52" required-level="78" sp="11400000" />
 		<skill name="Aggression Aura" id="18" level="40" required-level="78" sp="11400000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="48" required-level="78" sp="11400000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="48" required-level="78" sp="11400000" />
 		<skill name="Heavy Armor Mastery" id="232" level="55" required-level="78" sp="11400000" />
-		<skill name="Sting" id="223" level="52" required-level="78" sp="11400000" />
-		<skill name="Freezing Strike" id="105" level="26" required-level="78" sp="11400000" />
-		<skill name="Drain Energy" id="70" level="56" required-level="78" sp="11400000" />
+		<skill name="Confusion" id="2" level="23" required-level="78" sp="11400000" />
+		<skill name="Freezing Weapon" id="105" level="29" required-level="78" sp="11400000" />
+		<skill name="Drain Energy" id="45250" level="28" required-level="78" sp="11400000" />
+		<skill name="Blood Attack" id="223" level="53" required-level="78" sp="11400000" />
 		<skill name="Life Leech" id="289" level="17" required-level="78" sp="11400000" />
 		<skill name="Magic Resistance" id="147" level="54" required-level="78" sp="11400000" />
-		<skill name="Mass Chain Strike" id="53003" level="1" required-level="78" sp="11400000" />
+		<skill name="Mass Chain Strike" id="53003" level="1" required-level="78" sp="11400000">
+			<item id="91484" count="1" /> <!-- Scroll: Mass Chain Strike -->
+		</skill>
 		<skill name="Final Fortress" id="291" level="14" required-level="78" sp="11400000" />
-		<skill name="Judgment" id="401" level="17" required-level="78" sp="11400000" />
+		<skill name="Judgment" id="401" level="18" required-level="78" sp="11400000" />
 		<skill name="Summon Vampiric Cubic" id="22" level="10" required-level="78" sp="11400000" />
 		<skill name="Summon Viper Cubic" id="278" level="9" required-level="78" sp="11400000" />
 		<skill name="Summon Phantom Cubic" id="33" level="10" required-level="78" sp="11400000" />
+		<skill name="Touch of Death" id="342" level="1" required-level="78" sp="11400000">
+			<item id="90048" count="1" /> <!-- Scroll: Touch of Death -->
+		</skill>
 		<skill name="Knighthood" id="429" level="1" required-level="78" sp="11400000" />
-		<skill name="Lightning Strike" id="279" level="6" required-level="78" sp="11400000" />
-		<skill name="Hex" id="122" level="17" required-level="78" sp="11400000" />
+		<skill name="Hex" id="122" level="18" required-level="78" sp="11400000" />
 		<skill name="Power Break" id="115" level="19" required-level="78" sp="11400000" />
 		<skill name="Corpse Plague" id="103" level="5" required-level="78" sp="11400000" />
+		<skill name="Lightning Strike" id="279" level="6" required-level="78" sp="11400000" />
 		<skill name="Critical Vulnerability Decrease" id="53004" level="2" required-level="78" sp="11400000" />
-		<skill name="Touch of Death" id="342" level="1" required-level="78" sp="11400000">
-			<item id="90048"/> <!-- Scroll: Touch of Death -->
-		</skill>
-		
+		<skill name="Emergency Rescue" id="70" level="48" required-level="78" sp="11400000" />
+
+		<skill name="Confusion" id="2" level="24" required-level="79" sp="11400000" />
+		<skill name="Drain Energy" id="45250" level="29" required-level="79" sp="11400000" />
+		<skill name="Blood Attack" id="223" level="54" required-level="79" sp="11400000" />
 		<skill name="Final Fortress" id="291" level="15" required-level="79" sp="11400000" />
+		<skill name="Judgment" id="401" level="19" required-level="79" sp="11400000" />
 		<skill name="Knighthood" id="429" level="2" required-level="79" sp="11400000" />
+		<skill name="Hex" id="122" level="19" required-level="79" sp="11400000" />
 		<skill name="Shield of Faith" id="528" level="1" required-level="79" sp="11400000">
-			<item id="90049"/> <!-- Scroll: Shield of Faith -->
+			<item id="90049" count="1" /> <!-- Scroll: Shield of Faith -->
 		</skill>
-		
+		<skill name="Emergency Rescue" id="70" level="49" required-level="79" sp="11400000" />
+
 		<skill name="Aggression" id="28" level="53" required-level="80" sp="11400000" />
 		<skill name="Aggression Aura" id="18" level="41" required-level="80" sp="11400000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="49" required-level="80" sp="11400000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="49" required-level="80" sp="11400000" />
 		<skill name="Heavy Armor Mastery" id="232" level="56" required-level="80" sp="11400000" />
+		<skill name="Confusion" id="2" level="25" required-level="80" sp="11400000" />
+		<skill name="Freezing Weapon" id="105" level="30" required-level="80" sp="11400000" />
+		<skill name="Drain Energy" id="45250" level="30" required-level="80" sp="11400000" />
+		<skill name="Blood Attack" id="223" level="55" required-level="80" sp="11400000" />
 		<skill name="Magic Resistance" id="147" level="55" required-level="80" sp="11400000" />
+		<skill name="Mass Lightning Strike" id="10094" level="1" required-level="80" sp="11400000">
+			<item id="90053" count="1" /> <!-- Scroll: Mass Lightning Strike -->
+		</skill>
+		<skill name="Evolution Power" id="45189" level="1" required-level="80">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Final Fortress" id="291" level="16" required-level="80" sp="11400000" />
-		<skill name="Judgment" id="401" level="18" required-level="80" sp="11400000" />
+		<skill name="Judgment" id="401" level="20" required-level="80" sp="11400000" />
 		<skill name="Summon Vampiric Cubic" id="22" level="11" required-level="80" sp="11400000" />
 		<skill name="Summon Viper Cubic" id="278" level="10" required-level="80" sp="11400000" />
 		<skill name="Summon Phantom Cubic" id="33" level="11" required-level="80" sp="11400000" />
 		<skill name="Knighthood" id="429" level="3" required-level="80" sp="11400000" />
-		<skill name="Critical Vulnerability Decrease" id="53004" level="3" required-level="80" sp="11400000" />
-		<skill name="Mass Lightning Strike" id="10094" level="1" required-level="80" sp="11400000">
-			<item id="90053"/> <!-- Scroll: Mass Lightning Strike -->
+		<skill name="Hex" id="122" level="20" required-level="80" sp="11400000">
+				<item id="57" count="500000" /> <!-- Adena -->
 		</skill>
-		
+		<skill name="Power Break" id="115" level="20" required-level="80" sp="11400000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="White Guardian Transformation" id="54102" level="1" required-level="80">
+			<item id="92401" count="1" /> <!-- Spellbook - White Guardian -->
+		</skill>
+		<skill name="Critical Vulnerability Decrease" id="53004" level="3" required-level="80" sp="11400000" />
+		<skill name="Emergency Rescue" id="70" level="50" required-level="80" sp="11400000" />
+
 		<skill name="Aggression" id="28" level="54" required-level="81" sp="160000000" />
 		<skill name="Aggression Aura" id="18" level="42" required-level="81" sp="160000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="50" required-level="81" sp="160000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="50" required-level="81" sp="160000000" />
 		<skill name="Heavy Armor Mastery" id="232" level="57" required-level="81" sp="160000000" />
+		<skill name="Confusion" id="2" level="26" required-level="81" sp="160000000" />
+		<skill name="Drain Energy" id="45250" level="31" required-level="81" sp="160000000" />
+		<skill name="Blood Attack" id="223" level="56" required-level="81" sp="160000000" />
 		<skill name="Magic Resistance" id="147" level="56" required-level="81" sp="160000000" />
 		<skill name="Mass Lightning Strike" id="10094" level="2" required-level="81" sp="160000000" />
 		<skill name="Mass Chain Strike" id="53003" level="2" required-level="81" sp="160000000" />
 		<skill name="Final Fortress" id="291" level="17" required-level="81" sp="160000000" />
+		<skill name="Judgment" id="401" level="21" required-level="81" sp="160000000" />
 		<skill name="Knighthood" id="429" level="4" required-level="81" sp="160000000" />
-		
+		<skill name="Hex" id="122" level="21" required-level="81" sp="160000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="21" required-level="81" sp="160000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="51" required-level="81" sp="160000000" />
+
 		<skill name="Aggression" id="28" level="55" required-level="82" sp="170000000" />
 		<skill name="Aggression Aura" id="18" level="43" required-level="82" sp="170000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="51" required-level="82" sp="170000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="51" required-level="82" sp="170000000" />
 		<skill name="Heavy Armor Mastery" id="232" level="58" required-level="82" sp="170000000" />
+		<skill name="Confusion" id="2" level="27" required-level="82" sp="170000000" />
+		<skill name="Freezing Weapon" id="105" level="31" required-level="82" sp="170000000" />
+		<skill name="Drain Energy" id="45250" level="32" required-level="82" sp="170000000" />
+		<skill name="Blood Attack" id="223" level="57" required-level="82" sp="170000000" />
 		<skill name="Magic Resistance" id="147" level="57" required-level="82" sp="170000000" />
 		<skill name="Mass Lightning Strike" id="10094" level="3" required-level="82" sp="170000000" />
 		<skill name="Final Fortress" id="291" level="18" required-level="82" sp="170000000" />
-		<skill name="Judgment" id="401" level="19" required-level="82" sp="170000000" />
+		<skill name="Judgment" id="401" level="22" required-level="82" sp="170000000" />
 		<skill name="Summon Vampiric Cubic" id="22" level="12" required-level="82" sp="170000000" />
 		<skill name="Summon Viper Cubic" id="278" level="11" required-level="82" sp="170000000" />
 		<skill name="Summon Phantom Cubic" id="33" level="12" required-level="82" sp="170000000" />
 		<skill name="Knighthood" id="429" level="5" required-level="82" sp="170000000" />
+		<skill name="Hex" id="122" level="22" required-level="82" sp="170000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="22" required-level="82" sp="170000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
 		<skill name="Lightning Strike" id="279" level="7" required-level="82" sp="170000000" />
 		<skill name="Critical Vulnerability Decrease" id="53004" level="4" required-level="82" sp="170000000" />
 		<skill name="Chain Strike" id="10015" level="2" required-level="82" sp="170000000" />
-		
+		<skill name="Emergency Rescue" id="70" level="52" required-level="82" sp="170000000" />
+
 		<skill name="Aggression" id="28" level="56" required-level="83" sp="240000000" />
 		<skill name="Aggression Aura" id="18" level="44" required-level="83" sp="240000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="52" required-level="83" sp="240000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="52" required-level="83" sp="240000000" />
 		<skill name="Heavy Armor Mastery" id="232" level="59" required-level="83" sp="240000000" />
+		<skill name="Confusion" id="2" level="28" required-level="83" sp="240000000" />
+		<skill name="Drain Energy" id="45250" level="33" required-level="83" sp="240000000" />
+		<skill name="Blood Attack" id="223" level="58" required-level="83" sp="240000000" />
 		<skill name="Magic Resistance" id="147" level="58" required-level="83" sp="240000000" />
 		<skill name="Mass Lightning Strike" id="10094" level="4" required-level="83" sp="240000000" />
 		<skill name="Final Fortress" id="291" level="19" required-level="83" sp="240000000" />
+		<skill name="Judgment" id="401" level="23" required-level="83" sp="240000000" />
 		<skill name="Knighthood" id="429" level="6" required-level="83" sp="240000000" />
+		<skill name="Hex" id="122" level="23" required-level="83" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="23" required-level="83" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
 		<skill name="Lightning Strike" id="279" level="8" required-level="83" sp="240000000" />
-		
+		<skill name="Emergency Rescue" id="70" level="53" required-level="83" sp="240000000" />
+
 		<skill name="Aggression" id="28" level="57" required-level="84" sp="240000000" />
 		<skill name="Aggression Aura" id="18" level="45" required-level="84" sp="240000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="53" required-level="84" sp="240000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="53" required-level="84" sp="240000000" />
 		<skill name="Heavy Armor Mastery" id="232" level="60" required-level="84" sp="240000000" />
+		<skill name="Confusion" id="2" level="29" required-level="84" sp="240000000" />
+		<skill name="Freezing Weapon" id="105" level="32" required-level="84" sp="240000000" />
+		<skill name="Drain Energy" id="45250" level="34" required-level="84" sp="240000000" />
+		<skill name="Blood Attack" id="223" level="59" required-level="84" sp="240000000" />
 		<skill name="Magic Resistance" id="147" level="59" required-level="84" sp="240000000" />
 		<skill name="Mass Lightning Strike" id="10094" level="5" required-level="84" sp="240000000" />
 		<skill name="Mass Chain Strike" id="53003" level="3" required-level="84" sp="240000000" />
 		<skill name="Final Fortress" id="291" level="20" required-level="84" sp="240000000" />
-		<skill name="Judgment" id="401" level="20" required-level="84" sp="240000000" />
+		<skill name="Judgment" id="401" level="24" required-level="84" sp="240000000" />
 		<skill name="Summon Vampiric Cubic" id="22" level="13" required-level="84" sp="240000000" />
 		<skill name="Summon Viper Cubic" id="278" level="12" required-level="84" sp="240000000" />
 		<skill name="Summon Phantom Cubic" id="33" level="13" required-level="84" sp="240000000" />
 		<skill name="Knighthood" id="429" level="7" required-level="84" sp="240000000" />
+		<skill name="Hex" id="122" level="24" required-level="84" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="24" required-level="84" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
 		<skill name="Lightning Strike" id="279" level="9" required-level="84" sp="240000000" />
 		<skill name="Critical Vulnerability Decrease" id="53004" level="5" required-level="84" sp="240000000" />
 		<skill name="Chain Strike" id="10015" level="3" required-level="84" sp="240000000" />
-		
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="54" required-level="85" sp="840000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="55" required-level="86" sp="924000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="56" required-level="87" sp="1016400000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="57" required-level="88" sp="1118040000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="58" required-level="89" sp="1229844000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="59" required-level="90" sp="1352828400" />
+		<skill name="Emergency Rescue" id="70" level="54" required-level="84" sp="240000000" />
+
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="54" required-level="85" sp="840000000" />
 		<skill name="Heavy Armor Mastery" id="232" level="61" required-level="85" sp="840000000" />
-		<skill name="Heavy Armor Mastery" id="232" level="62" required-level="86" sp="924000000" />
-		<skill name="Heavy Armor Mastery" id="232" level="63" required-level="87" sp="1016400000" />
-		<skill name="Heavy Armor Mastery" id="232" level="64" required-level="88" sp="1118040000" />
-		<skill name="Heavy Armor Mastery" id="232" level="65" required-level="89" sp="1229844000" />
-		<skill name="Heavy Armor Mastery" id="232" level="66" required-level="90" sp="1352828400" />
+		<skill name="Confusion" id="2" level="30" required-level="85" sp="840000000" />
+		<skill name="Drain Energy" id="45250" level="35" required-level="85" sp="840000000" />
+		<skill name="Blood Attack" id="223" level="60" required-level="85" sp="840000000" />
 		<skill name="Magic Resistance" id="147" level="60" required-level="85" sp="840000000" />
-		<skill name="Magic Resistance" id="147" level="61" required-level="86" sp="924000000" />
-		<skill name="Magic Resistance" id="147" level="62" required-level="87" sp="1016400000" />
-		<skill name="Magic Resistance" id="147" level="63" required-level="88" sp="1118040000" />
-		<skill name="Magic Resistance" id="147" level="64" required-level="89" sp="1229844000" />
-		<skill name="Magic Resistance" id="147" level="65" required-level="90" sp="1352828400" />
 		<skill name="Final Fortress" id="291" level="21" required-level="85" sp="840000000" />
-		<skill name="Final Fortress" id="291" level="22" required-level="86" sp="924000000" />
-		<skill name="Final Fortress" id="291" level="23" required-level="87" sp="1016400000" />
-		<skill name="Final Fortress" id="291" level="24" required-level="88" sp="1118040000" />
-		<skill name="Final Fortress" id="291" level="25" required-level="89" sp="1229844000" />
-		<skill name="Final Fortress" id="291" level="26" required-level="90" sp="1352828400" />
+		<skill name="Judgment" id="401" level="25" required-level="85" sp="840000000" />
 		<skill name="Knighthood" id="429" level="8" required-level="85" sp="840000000" />
-		<skill name="Knighthood" id="429" level="9" required-level="86" sp="924000000" />
-		<skill name="Knighthood" id="429" level="10" required-level="87" sp="1016400000" />
-		<skill name="Knighthood" id="429" level="11" required-level="88" sp="1118040000" />
-		<skill name="Knighthood" id="429" level="12" required-level="89" sp="1229844000" />
-		<skill name="Knighthood" id="429" level="13" required-level="90" sp="1352828400" />
+		<skill name="Hex" id="122" level="25" required-level="85" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="25" required-level="85" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="55" required-level="85" sp="840000000" />
+
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="55" required-level="86" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="232" level="62" required-level="86" sp="840000000" />
+		<skill name="Confusion" id="2" level="31" required-level="86" sp="840000000" />
+		<skill name="Freezing Weapon" id="105" level="33" required-level="86" sp="840000000" />
+		<skill name="Drain Energy" id="45250" level="36" required-level="86" sp="840000000" />
+		<skill name="Blood Attack" id="223" level="61" required-level="86" sp="840000000" />
+		<skill name="Magic Resistance" id="147" level="61" required-level="86" sp="840000000" />
+		<skill name="Final Fortress" id="291" level="22" required-level="86" sp="840000000" />
+		<skill name="Judgment" id="401" level="26" required-level="86" sp="840000000" />
+		<skill name="Knighthood" id="429" level="9" required-level="86" sp="840000000" />
+		<skill name="Hex" id="122" level="26" required-level="86" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="26" required-level="86" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="56" required-level="86" sp="840000000" />
+
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="56" required-level="87" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="232" level="63" required-level="87" sp="840000000" />
+		<skill name="Confusion" id="2" level="32" required-level="87" sp="840000000" />
+		<skill name="Drain Energy" id="45250" level="37" required-level="87" sp="840000000" />
+		<skill name="Blood Attack" id="223" level="62" required-level="87" sp="840000000" />
+		<skill name="Magic Resistance" id="147" level="62" required-level="87" sp="840000000" />
+		<skill name="Final Fortress" id="291" level="23" required-level="87" sp="840000000" />
+		<skill name="Judgment" id="401" level="27" required-level="87" sp="840000000" />
+		<skill name="Knighthood" id="429" level="10" required-level="87" sp="840000000" />
+		<skill name="Hex" id="122" level="27" required-level="87" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="27" required-level="87" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="57" required-level="87" sp="840000000" />
+
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="57" required-level="88" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="232" level="64" required-level="88" sp="840000000" />
+		<skill name="Confusion" id="2" level="33" required-level="88" sp="840000000" />
+		<skill name="Freezing Weapon" id="105" level="34" required-level="88" sp="840000000" />
+		<skill name="Drain Energy" id="45250" level="38" required-level="88" sp="840000000" />
+		<skill name="Blood Attack" id="223" level="63" required-level="88" sp="840000000" />
+		<skill name="Magic Resistance" id="147" level="63" required-level="88" sp="840000000" />
+		<skill name="Final Fortress" id="291" level="24" required-level="88" sp="840000000" />
+		<skill name="Judgment" id="401" level="28" required-level="88" sp="840000000" />
+		<skill name="Knighthood" id="429" level="11" required-level="88" sp="840000000" />
+		<skill name="Hex" id="122" level="28" required-level="88" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="28" required-level="88" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="58" required-level="88" sp="840000000" />
+
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="58" required-level="89" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="232" level="65" required-level="89" sp="840000000" />
+		<skill name="Confusion" id="2" level="34" required-level="89" sp="840000000" />
+		<skill name="Drain Energy" id="45250" level="39" required-level="89" sp="840000000" />
+		<skill name="Blood Attack" id="223" level="64" required-level="89" sp="840000000" />
+		<skill name="Magic Resistance" id="147" level="64" required-level="89" sp="840000000" />
+		<skill name="Final Fortress" id="291" level="25" required-level="89" sp="840000000" />
+		<skill name="Judgment" id="401" level="29" required-level="89" sp="840000000" />
+		<skill name="Knighthood" id="429" level="12" required-level="89" sp="840000000" />
+		<skill name="Hex" id="122" level="29" required-level="89" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="29" required-level="89" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="59" required-level="89" sp="840000000" />
+
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="59" required-level="90" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="232" level="66" required-level="90" sp="840000000" />
+		<skill name="Confusion" id="2" level="35" required-level="90" sp="840000000" />
+		<skill name="Freezing Weapon" id="105" level="35" required-level="90" sp="840000000" />
+		<skill name="Drain Energy" id="45250" level="40" required-level="90" sp="840000000" />
+		<skill name="Blood Attack" id="223" level="65" required-level="90" sp="840000000" />
+		<skill name="Magic Resistance" id="147" level="65" required-level="90" sp="840000000" />
+		<skill name="Final Fortress" id="291" level="26" required-level="90" sp="840000000" />
+		<skill name="Judgment" id="401" level="30" required-level="90" sp="840000000" />
+		<skill name="Knighthood" id="429" level="13" required-level="90" sp="840000000" />
+		<skill name="Hex" id="122" level="30" required-level="90" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="30" required-level="90" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="60" required-level="90" sp="840000000" />
+
 	</skillTree>
 </list>

--- a/data/skillTrees/3rdClass/SoulHound.xml
+++ b/data/skillTrees/3rdClass/SoulHound.xml
@@ -1,155 +1,230 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
-    <skillTree type="classSkillTree" classId="195" parentClassId="194">
+	<skillTree type="classSkillTree" classId="195" parentClassId="194">
 
-        <skill name="Lightning Barrier" id="1515" level="1" required-level="76" sp="8000000">
-            <item id="91922"/> <!-- Scroll: Lightning Barrier -->
-        </skill>
-        <skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="8000000">
-            <item id="8620"/> <!-- Ancient Book: Divine Inspiration (Manuscript) -->
-        </skill>
-        <skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="8000000">
-            <item id="8621"/> <!-- Ancient Book: Divine Inspiration (Original Version) -->
-        </skill>
-        <skill name="Armor Mastery" id="464" level="4" required-level="76" sp="8000000">
-            <item id="57" count="1000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Weapon Mastery" id="463" level="4" required-level="76" sp="8000000">
-            <item id="57" count="1000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Mount Griffin" id="62002" level="1" required-level="76">
-            <item id="91946"/> <!-- Spellbook: Mount Griffin -->
-        </skill>
-		<skill name="Glory Ability" id="45361" level="1" required-level="86">
-			<item id="94046"/> <!-- Spellbook: Glory Ability Lv. 1 -->
+		<skill name="Lightning Barrier" id="1515" level="1" required-level="76" sp="8000000">
+			<item id="91922" count="1" /> <!-- Scroll: Lightning Barrier -->
 		</skill>
-		<skill name="Mount White Wings" id="54200" level="1" required-level="87">
-			<item id="93059"/> <!-- Spellbook: Summon White Wings -->
-		</skill>	
-		<skill name="Mount Shining Lady" id="54202" level="1" required-level="89">
-			<item id="93061"/> <!-- Spellbook: Summon Silver Saint -->
+		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="8000000">
+			<item id="8620" count="1" /> <!-- Buff Expansion Book Lv. 3 -->
 		</skill>
-        <skill name="Voice Bind" id="1447" level="1" required-level="76" sp="8000000"/>
-        <skill name="Shadow Bind" id="1446" level="1" required-level="76" sp="8000000"/>
-        <skill name="Lightning Shock" id="791" level="1" required-level="76" sp="8000000">
-            <item id="91923"/> <!-- Scroll: Lightning -->
-        </skill>
-        <skill name="Collect Light Souls" id="45151" level="2" required-level="76" sp="8000000">
-            <item id="91942"/> <!-- Crystal of Light -->
-        </skill>
-        <skill name="Collect Shadow Souls" id="45152" level="2" required-level="76" sp="8000000">
-            <item id="91943"/> <!-- Crystal of Shadows -->
-        </skill>
+		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="8000000">
+			<item id="8621" count="1" /> <!-- Buff Expansion Book Lv. 4 -->
+		</skill>
+		<skill name="Armor Mastery" id="464" level="4" required-level="76" sp="8000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Weapon Mastery" id="463" level="4" required-level="76" sp="8000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Evolution Defense" id="45188" level="1" required-level="76">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Master of Combat" id="430" level="1" required-level="76" sp="8000000" />
+		<skill name="Soul Might" id="45144" level="4" required-level="76" sp="8000000">
+			<item id="94135" count="1" /> <!-- Master's Book: Might -->
+		</skill>
+		<!-- Shield Lv. 4 -->
+		<skill name="Soul Shield" id="45145" level="4" required-level="76" sp="8000000">
+			<item id="94136" count="1" /> <!-- Master's Book: Shield -->
+		</skill>
+		<!-- Acumen Lv. 4 -->
+		<skill name="Soul Acumen" id="45146" level="4" required-level="76" sp="8000000">
+			<item id="94370" count="1" /> <!-- Master's Book: Acumen -->
+		</skill>
+		<!-- Empower Lv. 4 -->
+		<skill name="Soul Empower" id="45147" level="4" required-level="76" sp="8000000">
+			<item id="94361" count="1" /> <!-- Master's Book: Empower -->
+		</skill>
+		<!-- Wild Magic Lv. 3 -->
+		<skill name="Soul Wild Magic" id="45148" level="3" required-level="76" sp="8000000">
+			<item id="94368" count="1" /> <!-- Master's Book: Wild Magic -->
+		</skill>
+		<!-- Wind Walk Lv. 3 -->
+		<skill name="Soul Wind Walk" id="45142" level="3" required-level="76" sp="8000000">
+			<item id="94365" count="1" /> <!-- Master's Book: Wind Walk -->
+		</skill>
+		<!-- Magic Barrier Lv. 3 -->
+		<skill name="Soul Magic Barrier" id="45143" level="3" required-level="76" sp="8000000">
+			<item id="94362" count="1" /> <!-- Master's Book: Magic Barrier -->
+		</skill>
+		<!-- Focus Lv. 4 -->
+		<skill name="Soul Focus" id="45139" level="4" required-level="76" sp="8000000">
+			<item id="94363" count="1" /> <!-- Master's Book: Focus -->
+		</skill>
+		<!-- Death Whisper Lv. 4 -->
+		<skill name="Soul Death Whisper" id="45140" level="4" required-level="76" sp="8000000">
+			<item id="94364" count="1" /> <!-- Master's Book: Death Whisper -->
+		</skill>
+		<!-- Haste Lv. 3 -->
+		<skill name="Soul Haste" id="45141" level="3" required-level="76" sp="8000000">
+			<item id="94369" count="1" /> <!-- Master's Book: Haste -->
+		</skill>
+		<!-- Berserker Spirit Lv. 3 -->
+		<skill name="Soul Berserker Spirit" id="45149" level="3" required-level="76" sp="8000000">
+			<item id="94366" count="1" /> <!-- Master's Book: Berserker Spirit -->
+		</skill>
+		<!-- Clarity Lv. 4 -->
+		<skill name="Soul Clarity" id="45150" level="4" required-level="76" sp="8000000">
+			<item id="94367" count="1" /> <!-- Master's Book: Clarity -->
+		</skill>
+		<skill name="Detection" id="45190" level="1" required-level="76" sp="8000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Mount Griffin" id="62002" level="1" required-level="76">
+			<item id="91946" count="1" /> <!-- Spellbook - Mount Griffin -->
+		</skill>
+		<skill name="Voice Bind" id="1447" level="1" required-level="76" sp="8000000" />
+		<skill name="Shadow Bind" id="1446" level="1" required-level="76" sp="8000000" />
+		<skill name="Lightning" id="791" level="1" required-level="76" sp="8000000">
+			<item id="91923" count="1" /> <!-- Scroll: Lightning -->
+		</skill>
+		<skill name="Collect Light Souls" id="45151" level="2" required-level="76" sp="8000000">
+			<item id="4347" count="1" /> <!-- Crystal of Light -->
+		</skill>
+		<skill name="Collect Shadow Souls" id="45152" level="2" required-level="76" sp="8000000">
+			<item id="91943" count="1" /> <!-- Crystal of Shadows -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="46" required-level="76" sp="8000000" />
 
-        <skill name="Lightning Barrier" id="1515" level="2" required-level="78" sp="12000000"/>
-        <skill name="Critical Sense" id="626" level="4" required-level="78" sp="12000000" />
-        <skill name="Death Mark" id="1435" level="4" required-level="78" sp="12000000">
-            <item id="57" count="1000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Voice Bind" id="1447" level="2" required-level="78" sp="12000000"/>
-        <skill name="Shadow Bind" id="1446" level="2" required-level="78" sp="12000000"/>
-        <skill name="Lightning Shock" id="791" level="2" required-level="78" sp="12000000"/>
+		<skill name="Emergency Rescue" id="70" level="47" required-level="77" sp="10000000" />
 
-        <skill name="Lightning Barrier" id="1515" level="3" required-level="80" sp="18000000"/>
-        <skill name="Light Armor Mastery" id="465" level="8" required-level="80" sp="18000000">
-            <item id="57" count="1000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Rapier Mastery" id="474" level="8" required-level="80" sp="18000000">
-            <item id="57" count="1000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Soul Spark" id="45163" level="6" required-level="80" sp="18000000">
-            <item id="57" count="1000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Steal Divinity" id="1440" level="3" required-level="80" sp="18000000" />
-        <skill name="Blink" id="1448" level="1" required-level="80" sp="18000000" />
-        <skill name="Arcane Shield" id="1556" level="1" required-level="80" sp="18000000">
-            <item id="90086"/> <!-- Scroll: Arcane Shield -->
-        </skill>
-        <skill name="Abyssal Power" id="1474" level="3" required-level="80" sp="18000000">
-            <item id="57" count="1000000"/>
-        </skill>
-        <skill name="Voice Bind" id="1447" level="3" required-level="80" sp="18000000"/>
-        <skill name="Shadow Bind" id="1446" level="3" required-level="80" sp="18000000"/>
-        <skill name="Lightning Shock" id="791" level="3" required-level="80" sp="18000000"/>
-        <skill name="Soul Slash" id="45160" level="8" required-level="80" sp="18000000">
-            <item id="57" count="1000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Soul Link" id="1378" level="5" required-level="80" sp="18000000">
-            <item id="57" count="1000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Soul Strike" id="1516" level="8" required-level="80" sp="18000000">
-            <item id="57" count="1000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Soul Thrust" id="45161" level="6" required-level="80" sp="18000000">
-            <item id="57" count="1000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Soul Sense" id="1379" level="5" required-level="80" sp="18000000" />
+		<skill name="Lightning Barrier" id="1515" level="2" required-level="78" sp="12000000" />
+		<skill name="Critical Sense" id="626" level="4" required-level="78" sp="12000000" />
+		<skill name="Death Mark" id="1435" level="4" required-level="78" sp="12000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Voice Bind" id="1447" level="2" required-level="78" sp="12000000" />
+		<skill name="Shadow Bind" id="1446" level="2" required-level="78" sp="12000000" />
+		<skill name="Lightning" id="791" level="2" required-level="78" sp="12000000" />
+		<skill name="Emergency Rescue" id="70" level="48" required-level="78" sp="12000000" />
 
-        <skill name="Arcane Shield" id="1556" level="2" required-level="81" sp="160000000"/>
+		<skill name="Emergency Rescue" id="70" level="49" required-level="79" sp="15000000" />
 
-        <skill name="Lightning Barrier" id="1515" level="4" required-level="82" sp="170000000"/>
-        <skill name="Expert Casting" id="1527" level="3" required-level="82" sp="170000000">
-            <item id="57" count="1000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Arcane Shield" id="1556" level="3" required-level="82" sp="170000000"/>
-        <skill name="Voice Bind" id="1447" level="4" required-level="82" sp="170000000"/>
-        <skill name="Shadow Bind" id="1446" level="4" required-level="82" sp="170000000"/>
-        <skill name="Lightning Shock" id="791" level="4" required-level="82" sp="170000000"/>
+		<skill name="Lightning Barrier" id="1515" level="3" required-level="80" sp="18000000" />
+		<skill name="Light Armor Mastery" id="465" level="8" required-level="80" sp="18000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Rapier Mastery" id="474" level="8" required-level="80" sp="18000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Soul Spark" id="45163" level="6" required-level="80" sp="18000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Steal Divinity" id="1440" level="3" required-level="80" sp="18000000" />
+		<skill name="Master of Combat" id="430" level="2" required-level="80" sp="18000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Blink" id="1448" level="1" required-level="80" sp="18000000" />
+		<skill name="Arcane Shield" id="1556" level="1" required-level="80" sp="18000000">
+			<item id="90086" count="1" /> <!-- Scroll: Arcane Shield -->
+		</skill>
+		<skill name="Abyssal Power" id="1474" level="3" required-level="80" sp="18000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Evolution Power" id="45189" level="1" required-level="80">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Voice Bind" id="1447" level="3" required-level="80" sp="18000000" />
+		<skill name="Shadow Bind" id="1446" level="3" required-level="80" sp="18000000" />
+		<skill name="Lightning" id="791" level="3" required-level="80" sp="18000000" />
+		<skill name="Soul Slash" id="45160" level="8" required-level="80" sp="18000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Soul Link" id="1378" level="5" required-level="80" sp="18000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Soul Strike" id="1516" level="8" required-level="80" sp="18000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Soul Thrust" id="45161" level="6" required-level="80" sp="18000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Soul Sense" id="1379" level="5" required-level="80" sp="18000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="50" required-level="80" sp="18000000" />
 
-        <skill name="Arcane Shield" id="1556" level="4" required-level="83" sp="240000000"/>
+		<skill name="Arcane Shield" id="1556" level="2" required-level="81" sp="160000000" />
+		<skill name="Emergency Rescue" id="70" level="51" required-level="81" sp="160000000" />
 
-        <skill name="Lightning Barrier" id="1515" level="5" required-level="84" sp="240000000"/>
-        <skill name="Arcane Shield" id="1556" level="5" required-level="84" sp="240000000"/>
-        <skill name="Voice Bind" id="1447" level="5" required-level="84" sp="240000000"/>
-        <skill name="Shadow Bind" id="1446" level="5" required-level="84" sp="240000000"/>
-        <skill name="Lightning Shock" id="791" level="5" required-level="84" sp="240000000"/>
+		<skill name="Lightning Barrier" id="1515" level="4" required-level="82" sp="170000000" />
+		<skill name="Expert Casting" id="1527" level="3" required-level="82" sp="170000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Arcane Shield" id="1556" level="3" required-level="82" sp="170000000" />
+		<skill name="Voice Bind" id="1447" level="4" required-level="82" sp="170000000" />
+		<skill name="Shadow Bind" id="1446" level="4" required-level="82" sp="170000000" />
+		<skill name="Lightning" id="791" level="4" required-level="82" sp="170000000" />
+		<skill name="Emergency Rescue" id="70" level="52" required-level="82" sp="170000000" />
 
+		<skill name="Arcane Shield" id="1556" level="4" required-level="83" sp="240000000" />
+		<skill name="Emergency Rescue" id="70" level="53" required-level="83" sp="240000000" />
 
-        <skill name="Armor Mastery" id="464" level="5" required-level="85" sp="840000000">
-            <item id="57" count="2000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Light Armor Mastery" id="465" level="9" required-level="85" sp="840000000">
-            <item id="57" count="5000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Light Armor Mastery" id="465" level="10" required-level="90" sp="1680000000">
-            <item id="57" count="10000000"/> <!-- Adena -->
-        </skill>	
-        <skill name="Weapon Mastery" id="463" level="5" required-level="85" sp="840000000">
-            <item id="57" count="2000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Rapier Mastery" id="474" level="9" required-level="85" sp="840000000">
-            <item id="57" count="5000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Rapier Mastery" id="474" level="10" required-level="90" sp="1680000000">
-            <item id="57" count="10000000"/> <!-- Adena -->
-        </skill>		
-        <skill name="Soul Spark" id="45163" level="7" required-level="85" sp="840000000">
-            <item id="57" count="5000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Soul Spark" id="45163" level="8" required-level="90" sp="1680000000">
-            <item id="57" count="10000000"/> <!-- Adena -->
-        </skill>	
-        <skill name="Critical Sense" id="626" level="5" required-level="85" sp="840000000" />
-        <skill name="Death Mark" id="1435" level="5" required-level="85" sp="840000000">
-            <item id="57" count="2000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Soul Slash" id="45160" level="9" required-level="85" sp="840000000">
-            <item id="57" count="5000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Soul Slash" id="45160" level="10" required-level="90" sp="1680000000">
-            <item id="57" count="10000000"/> <!-- Adena -->
-        </skill>	
-        <skill name="Soul Strike" id="1516" level="9" required-level="85" sp="840000000">
-            <item id="57" count="5000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Soul Strike" id="1516" level="10" required-level="90" sp="1680000000">
-            <item id="57" count="10000000"/> <!-- Adena -->
-        </skill>	
-        <skill name="Soul Thrust" id="45161" level="7" required-level="85" sp="840000000">
-            <item id="57" count="5000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Soul Thrust" id="45161" level="8" required-level="90" sp="1680000000">
-            <item id="57" count="10000000"/> <!-- Adena -->
-        </skill>	
-    </skillTree>
+		<skill name="Lightning Barrier" id="1515" level="5" required-level="84" sp="240000000" />
+		<skill name="Arcane Shield" id="1556" level="5" required-level="84" sp="240000000" />
+		<skill name="Voice Bind" id="1447" level="5" required-level="84" sp="240000000" />
+		<skill name="Shadow Bind" id="1446" level="5" required-level="84" sp="240000000" />
+		<skill name="Lightning" id="791" level="5" required-level="84" sp="240000000" />
+		<skill name="Emergency Rescue" id="70" level="54" required-level="84" sp="240000000" />
+
+		<skill name="Armor Mastery" id="464" level="5" required-level="85" sp="840000000">
+			<item id="57" count="2000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Light Armor Mastery" id="465" level="9" required-level="85" sp="840000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Weapon Mastery" id="463" level="5" required-level="85" sp="840000000">
+			<item id="57" count="2000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Rapier Mastery" id="474" level="9" required-level="85" sp="840000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Soul Spark" id="45163" level="7" required-level="85" sp="840000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Critical Sense" id="626" level="5" required-level="85" sp="840000000" />
+		<skill name="Death Mark" id="1435" level="5" required-level="85" sp="840000000">
+			<item id="57" count="2000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Soul Slash" id="45160" level="9" required-level="85" sp="840000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Soul Strike" id="1516" level="9" required-level="85" sp="840000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Soul Thrust" id="45161" level="7" required-level="85" sp="840000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="55" required-level="85" sp="840000000" />
+
+		<skill name="Emergency Rescue" id="70" level="56" required-level="86" sp="840000000" />
+
+		<skill name="Emergency Rescue" id="70" level="57" required-level="87" sp="840000000" />
+
+		<skill name="Emergency Rescue" id="70" level="58" required-level="88" sp="840000000" />
+
+		<skill name="Emergency Rescue" id="70" level="59" required-level="89" sp="840000000" />
+
+		<skill name="Light Armor Mastery" id="465" level="10" required-level="90" sp="840000000">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Rapier Mastery" id="474" level="10" required-level="90" sp="840000000">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Soul Spark" id="45163" level="8" required-level="90" sp="840000000">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Soul Slash" id="45160" level="10" required-level="90" sp="840000000">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Soul Strike" id="1516" level="10" required-level="90" sp="840000000">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Soul Thrust" id="45161" level="8" required-level="90" sp="840000000">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="60" required-level="90" sp="840000000" />
+
+	</skillTree>
 </list>

--- a/data/skillTrees/3rdClass/Soultaker.xml
+++ b/data/skillTrees/3rdClass/Soultaker.xml
@@ -1,196 +1,297 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="95" parentClassId="13">
-		<skill name="White Guardian" id="54102" level="1" required-level="80" >
-			<item id="92401"/>
-		</skill>
+
 		<skill name="Anti Magic" id="146" level="46" required-level="76" sp="4500000" />
 		<skill name="Silence" id="1064" level="15" required-level="76" sp="4500000" />
+		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="4500000">
+			<item id="8620" count="1" /> <!-- Buff Expansion Book Lv. 3 -->
+		</skill>
+		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="4500000">
+			<item id="8621" count="1" /> <!-- Buff Expansion Book Lv. 4 -->
+		</skill>
+		<skill name="Void Explosion" id="45381" level="1" required-level="76" sp="4500000">
+			<item id="93869" count="1" /> <!-- Spellbook: Elemental Burst -->
+		</skill>
 		<skill name="Corpse Burst" id="1155" level="16" required-level="76" sp="4500000" />
 		<skill name="Dark Vortex" id="1343" level="1" required-level="76" sp="4500000" />
 		<skill name="Robe Mastery" id="234" level="42" required-level="76" sp="4500000" />
 		<skill name="Weapon Mastery" id="249" level="43" required-level="76" sp="4500000" />
-		<skill name="Vampiric Claw" id="1234" level="29" required-level="76" sp="4500000" />
+		<skill name="Evolution Defense" id="45188" level="1" required-level="76">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Vampiric Claw" id="1234" level="31" required-level="76" sp="4500000" />
 		<skill name="Mass Slow" id="1298" level="15" required-level="76" sp="4500000" />
-		<skill name="Bind" id="53006" level="1" required-level="76" sp="4500000" />
+		<!-- Might Lv. 4 -->
+		<skill name="Might" id="1068" level="4" required-level="76" sp="8000000">
+			<item id="94135" count="1" /> <!-- Master's Book: Might -->
+		</skill>
+		<!-- Shield Lv. 4 -->
+		<skill name="Shield" id="1040" level="4" required-level="76" sp="8000000">
+			<item id="94136" count="1" /> <!-- Master's Book: Shield -->
+		</skill>
+		<!-- Acumen Lv. 4 -->
+		<skill name="Acumen" id="45104" level="4" required-level="76" sp="8000000">
+			<item id="94370" count="1" /> <!-- Master's Book: Acumen -->
+		</skill>
+		<!-- Empower Lv. 4 -->
+		<skill name="Empower" id="45105" level="4" required-level="76" sp="8000000">
+			<item id="94361" count="1" /> <!-- Master's Book: Empower -->
+		</skill>
+		<!-- Wild Magic Lv. 3 -->
+		<skill name="Wild Magic" id="45106" level="3" required-level="76" sp="8000000">
+			<item id="94368" count="1" /> <!-- Master's Book: Wild Magic -->
+		</skill>
+		<!-- Wind Walk Lv. 3 -->
+		<skill name="Wind Walk" id="45107" level="3" required-level="76" sp="8000000">
+			<item id="94365" count="1" /> <!-- Master's Book: Wind Walk -->
+		</skill>
+		<!-- Magic Barrier Lv. 3 -->
+		<skill name="Magic Barrier" id="45108" level="3" required-level="76" sp="8000000">
+			<item id="94362" count="1" /> <!-- Master's Book: Magic Barrier -->
+		</skill>
+		<!-- Focus Lv. 4 -->
+		<skill name="Focus" id="45109" level="4" required-level="76" sp="8000000">
+			<item id="94363" count="1" /> <!-- Master's Book: Focus -->
+		</skill>
+		<!-- Death Whisper Lv. 4 -->
+		<skill name="Death Whisper" id="45110" level="4" required-level="76" sp="8000000">
+			<item id="94364" count="1" /> <!-- Master's Book: Death Whisper -->
+		</skill>
+		<!-- Haste Lv. 3 -->
+		<skill name="Haste" id="45111" level="3" required-level="76" sp="8000000">
+			<item id="94369" count="1" /> <!-- Master's Book: Haste -->
+		</skill>
+		<!-- Berserker Spirit Lv. 3 -->
+		<skill name="Berserker Spirit" id="45112" level="3" required-level="76" sp="8000000">
+			<item id="94366" count="1" /> <!-- Master's Book: Berserker Spirit -->
+		</skill>
+		<!-- Clarity Lv. 4 -->
+		<skill name="Clarity" id="45113" level="4" required-level="76" sp="8000000">
+			<item id="94367" count="1" /> <!-- Master's Book: Clarity -->
+		</skill>
+		<skill name="Detection" id="45190" level="1" required-level="76" sp="4500000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Mount Golden Lion" id="1833" level="1" required-level="76">
+			<item id="90038" count="1" /> <!-- Spellbook - Ride Golden Lion -->
+		</skill>
+		<skill name="Bind" id="53006" level="1" required-level="76" sp="4500000">
+			<item id="91483" count="1" /> <!-- Scroll: Bind -->
+		</skill>
 		<skill name="Corpse Life Drain" id="1151" level="17" required-level="76" sp="4500000" />
 		<skill name="Curse Disease" id="1269" level="10" required-level="76" sp="4500000" />
 		<skill name="Curse Gloom" id="1263" level="14" required-level="76" sp="4500000" />
-		<skill name="Curse Weakness" id="1164" level="20" required-level="76" sp="4500000" />
 		<skill name="Curse Death Link" id="1159" level="23" required-level="76" sp="4500000" />
 		<skill name="Curse Fear" id="1169" level="15" required-level="76" sp="4500000" />
 		<skill name="Curse Chaos" id="1222" level="16" required-level="76" sp="4500000" />
+		<skill name="Weakness" id="1164" level="20" required-level="76" sp="4500000" />
 		<skill name="Higher Mana Gain" id="285" level="28" required-level="76" sp="4500000" />
-		<skill name="Sleep" id="1069" level="43" required-level="76" sp="4500000" />
-		<skill name="Death Spike" id="1148" level="14" required-level="76" sp="4500000" />
+		<skill name="Sleep" id="1069" level="46" required-level="76" sp="4500000" />
+		<skill name="Death Spike" id="1148" level="16" required-level="76" sp="4500000" />
 		<skill name="Anchor" id="1170" level="14" required-level="76" sp="4500000" />
-		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="4500000">
-			<item id="8620"/> <!-- Ancient Book: Divine Inspiration (Manuscript) -->
-		</skill>
-		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="4500000">
-			<item id="8621"/> <!-- Ancient Book: Divine Inspiration (Original Version) -->
-		</skill>
-		<skill name="Mount Gold Maned Lion" id="1833" level="1" required-level="76">
-			<item id="90038"/> <!-- Spellbook: Mount Golden Lion -->
-		</skill>
-		<skill name="Glory Ability" id="45361" level="1" required-level="86">
-			<item id="94046"/> <!-- Spellbook: Glory Ability Lv. 1 -->
-		</skill>
-		<skill name="Mount White Wings" id="54200" level="1" required-level="87">
-			<item id="93059"/> <!-- Spellbook: Summon White Wings -->
-		</skill>	
-		<skill name="Mount Shining Lady" id="54202" level="1" required-level="89">
-			<item id="93061"/> <!-- Spellbook: Summon Silver Saint -->
-		</skill>
-		
+
 		<skill name="Anti Magic" id="146" level="47" required-level="77" sp="4500000" />
+		<skill name="Void Explosion" id="45381" level="2" required-level="77" sp="4500000" />
 		<skill name="Robe Mastery" id="234" level="43" required-level="77" sp="4500000" />
 		<skill name="Weapon Mastery" id="249" level="44" required-level="77" sp="4500000" />
-		<skill name="Vampiric Claw" id="1234" level="30" required-level="77" sp="4500000" />
+		<skill name="Vampiric Claw" id="1234" level="32" required-level="77" sp="4500000" />
 		<skill name="Mass Slow" id="1298" level="16" required-level="77" sp="4500000" />
 		<skill name="Curse Death Link" id="1159" level="24" required-level="77" sp="4500000" />
-		<skill name="Higher Mana Gain" id="285" level="29" required-level="77" sp="4500000" />
-		<skill name="Sleep" id="1069" level="44" required-level="77" sp="4500000" />
 		<skill name="Curse of Doom" id="1336" level="1" required-level="77" sp="4500000">
-			<item id="90087"/> <!-- Scroll: Curse of Doom -->
+			<item id="90087" count="1" /> <!-- Scroll: Curse of Doom -->
 		</skill>
-		
+		<skill name="Higher Mana Gain" id="285" level="29" required-level="77" sp="4500000" />
+		<skill name="Sleep" id="1069" level="47" required-level="77" sp="4500000" />
+		<skill name="Death Spike" id="1148" level="17" required-level="77" sp="4500000" />
+
 		<skill name="Anti Magic" id="146" level="48" required-level="78" sp="9800000" />
 		<skill name="Silence" id="1064" level="16" required-level="78" sp="9800000" />
+		<skill name="Void Explosion" id="45381" level="3" required-level="78" sp="9800000" />
 		<skill name="Corpse Burst" id="1155" level="17" required-level="78" sp="9800000" />
 		<skill name="Robe Mastery" id="234" level="44" required-level="78" sp="9800000" />
 		<skill name="Weapon Mastery" id="249" level="45" required-level="78" sp="9800000" />
-		<skill name="Vampiric Claw" id="1234" level="31" required-level="78" sp="9800000" />
+		<skill name="Vampiric Claw" id="1234" level="33" required-level="78" sp="9800000" />
 		<skill name="Mass Slow" id="1298" level="17" required-level="78" sp="9800000" />
 		<skill name="Mass Curse Gloom" id="1382" level="6" required-level="78" sp="9800000" />
 		<skill name="Bind" id="53006" level="2" required-level="78" sp="9800000" />
 		<skill name="Corpse Life Drain" id="1151" level="18" required-level="78" sp="9800000" />
+		<skill name="Curse of Abyss" id="1337" level="1" required-level="78" sp="9800000">
+			<item id="90088" count="1" /> <!-- Scroll: Curse of Abyss -->
+		</skill>
 		<skill name="Curse Disease" id="1269" level="11" required-level="78" sp="9800000" />
 		<skill name="Curse Gloom" id="1263" level="15" required-level="78" sp="9800000" />
-		<skill name="Curse Weakness" id="1164" level="21" required-level="78" sp="9800000" />
 		<skill name="Curse Death Link" id="1159" level="25" required-level="78" sp="9800000" />
 		<skill name="Curse Fear" id="1169" level="16" required-level="78" sp="9800000" />
 		<skill name="Curse Chaos" id="1222" level="17" required-level="78" sp="9800000" />
+		<skill name="Weakness" id="1164" level="21" required-level="78" sp="9800000" />
 		<skill name="Higher Mana Gain" id="285" level="30" required-level="78" sp="9800000" />
-		<skill name="Sleep" id="1069" level="45" required-level="78" sp="9800000" />
-		<skill name="Death Spike" id="1148" level="15" required-level="78" sp="9800000" />
+		<skill name="Sleep" id="1069" level="48" required-level="78" sp="9800000" />
+		<skill name="Death Spike" id="1148" level="18" required-level="78" sp="9800000" />
 		<skill name="Poisonous Cloud" id="1167" level="7" required-level="78" sp="9800000" />
 		<skill name="Anchor" id="1170" level="15" required-level="78" sp="9800000" />
-		<skill name="Curse of Abyss" id="1337" level="1" required-level="78" sp="9800000">
-			<item id="90088"/> <!-- Scroll: Curse of Abyss -->
-		</skill>
-		
+
+		<skill name="Void Explosion" id="45381" level="4" required-level="79" sp="9800000" />
 		<skill name="Corpse Burst" id="1155" level="18" required-level="79" sp="9800000" />
+		<skill name="Vampiric Claw" id="1234" level="34" required-level="79" sp="9800000" />
 		<skill name="Summon Cursed Man" id="1334" level="1" required-level="79" sp="9800000" />
-		<skill name="Sleep" id="1069" level="46" required-level="79" sp="9800000" />
-		
+		<skill name="Sleep" id="1069" level="49" required-level="79" sp="9800000" />
+		<skill name="Death Spike" id="1148" level="19" required-level="79" sp="9800000" />
+
 		<skill name="Anti Magic" id="146" level="49" required-level="80" sp="9800000" />
+		<skill name="Void Explosion" id="45381" level="5" required-level="80" sp="9800000" />
 		<skill name="Corpse Burst" id="1155" level="19" required-level="80" sp="9800000" />
 		<skill name="Robe Mastery" id="234" level="45" required-level="80" sp="9800000" />
 		<skill name="Weapon Mastery" id="249" level="46" required-level="80" sp="9800000" />
-		<skill name="Vampiric Claw" id="1234" level="32" required-level="80" sp="9800000" />
+		<skill name="Vampiric Claw" id="1234" level="35" required-level="80" sp="9800000" />
 		<skill name="Mass Curse Gloom" id="1382" level="7" required-level="80" sp="9800000" />
+		<skill name="Spell Master" id="1829" level="4" required-level="80" sp="2400000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Evolution Power" id="45189" level="1" required-level="80">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Poison" id="1168" level="8" required-level="80" sp="9800000" />
 		<skill name="Bind" id="53006" level="3" required-level="80" sp="9800000" />
 		<skill name="Curse Disease" id="1269" level="12" required-level="80" sp="9800000" />
 		<skill name="Curse Gloom" id="1263" level="16" required-level="80" sp="9800000" />
-		<skill name="Curse Weakness" id="1164" level="22" required-level="80" sp="9800000" />
 		<skill name="Curse Death Link" id="1159" level="26" required-level="80" sp="9800000" />
 		<skill name="Mana Regeneration" id="1047" level="5" required-level="80" sp="9800000" />
-		<skill name="Body To Mind" id="1157" level="6" required-level="80" sp="9800000" />
-		<skill name="Higher Mana Gain" id="285" level="31" required-level="80" sp="9800000" />
-		<skill name="Sleep" id="1069" level="47" required-level="80" sp="9800000" />
-		<skill name="Death Spike" id="1148" level="16" required-level="80" sp="9800000" />
-		<skill name="Anchor" id="1170" level="16" required-level="80" sp="9800000" />
-		<skill name="Vampiric Mist" id="1495" level="1" required-level="80" sp="9800000">
-			<item id="90089"/> <!-- Scroll: Vampiric Mist -->
+		<skill name="Body to Mind" id="1157" level="6" required-level="80" sp="9800000" />
+		<skill name="Weakness" id="1164" level="22" required-level="80" sp="9800000" />
+		<skill name="White Guardian Transformation" id="54102" level="1" required-level="80">
+			<item id="92401" count="1" /> <!-- Spellbook - White Guardian -->
 		</skill>
+		<skill name="Vampiric Mist" id="1495" level="1" required-level="80" sp="9800000">
+			<item id="90089" count="1" /> <!-- Scroll: Vampiric Mist -->
+		</skill>
+		<skill name="Higher Mana Gain" id="285" level="31" required-level="80" sp="9800000" />
+		<skill name="Sleep" id="1069" level="50" required-level="80" sp="9800000" />
+		<skill name="Death Spike" id="1148" level="20" required-level="80" sp="9800000" />
+		<skill name="Anchor" id="1170" level="16" required-level="80" sp="9800000" />
 
 		<skill name="Anti Magic" id="146" level="50" required-level="81" sp="160000000" />
+		<skill name="Void Explosion" id="45381" level="6" required-level="81" sp="160000000" />
 		<skill name="Corpse Burst" id="1155" level="20" required-level="81" sp="160000000" />
 		<skill name="Robe Mastery" id="234" level="46" required-level="81" sp="160000000" />
 		<skill name="Weapon Mastery" id="249" level="47" required-level="81" sp="160000000" />
-		<skill name="Vampiric Claw" id="1234" level="33" required-level="81" sp="160000000" />
+		<skill name="Vampiric Claw" id="1234" level="36" required-level="81" sp="160000000" />
 		<skill name="Mass Curse Gloom" id="1382" level="8" required-level="81" sp="160000000" />
 		<skill name="Curse Disease" id="1269" level="13" required-level="81" sp="160000000" />
 		<skill name="Curse Gloom" id="1263" level="17" required-level="81" sp="160000000" />
-		<skill name="Curse Weakness" id="1164" level="23" required-level="81" sp="160000000" />
 		<skill name="Curse Death Link" id="1159" level="27" required-level="81" sp="160000000" />
-		<skill name="Body To Mind" id="1157" level="7" required-level="81" sp="160000000" />
+		<skill name="Body to Mind" id="1157" level="7" required-level="81" sp="160000000" />
+		<skill name="Weakness" id="1164" level="23" required-level="81" sp="160000000" />
 		<skill name="Higher Mana Gain" id="285" level="32" required-level="81" sp="160000000" />
-		<skill name="Sleep" id="1069" level="48" required-level="81" sp="160000000" />
-		<skill name="Death Spike" id="1148" level="17" required-level="81" sp="160000000" />
+		<skill name="Sleep" id="1069" level="51" required-level="81" sp="160000000" />
+		<skill name="Death Spike" id="1148" level="21" required-level="81" sp="160000000" />
 		<skill name="Anchor" id="1170" level="17" required-level="81" sp="160000000" />
 
 		<skill name="Anti Magic" id="146" level="51" required-level="82" sp="170000000" />
+		<skill name="Void Explosion" id="45381" level="7" required-level="82" sp="170000000" />
 		<skill name="Corpse Burst" id="1155" level="21" required-level="82" sp="170000000" />
 		<skill name="Dark Vortex" id="1343" level="2" required-level="82" sp="170000000" />
 		<skill name="Robe Mastery" id="234" level="47" required-level="82" sp="170000000" />
 		<skill name="Weapon Mastery" id="249" level="48" required-level="82" sp="170000000" />
-		<skill name="Vampiric Claw" id="1234" level="34" required-level="82" sp="170000000" />
+		<skill name="Vampiric Claw" id="1234" level="37" required-level="82" sp="170000000" />
 		<skill name="Mass Curse Gloom" id="1382" level="9" required-level="82" sp="170000000" />
 		<skill name="Bind" id="53006" level="4" required-level="82" sp="170000000" />
 		<skill name="Curse Disease" id="1269" level="14" required-level="82" sp="170000000" />
 		<skill name="Curse Gloom" id="1263" level="18" required-level="82" sp="170000000" />
-		<skill name="Curse Weakness" id="1164" level="24" required-level="82" sp="170000000" />
 		<skill name="Curse Death Link" id="1159" level="28" required-level="82" sp="170000000" />
-		<skill name="Body To Mind" id="1157" level="8" required-level="82" sp="170000000" />
+		<skill name="Body to Mind" id="1157" level="8" required-level="82" sp="170000000" />
+		<skill name="Weakness" id="1164" level="24" required-level="82" sp="170000000" />
 		<skill name="Higher Mana Gain" id="285" level="33" required-level="82" sp="170000000" />
-		<skill name="Sleep" id="1069" level="49" required-level="82" sp="170000000" />
-		<skill name="Death Spike" id="1148" level="18" required-level="82" sp="170000000" />
+		<skill name="Sleep" id="1069" level="52" required-level="82" sp="170000000" />
+		<skill name="Death Spike" id="1148" level="22" required-level="82" sp="170000000" />
 		<skill name="Anchor" id="1170" level="18" required-level="82" sp="170000000" />
 
 		<skill name="Anti Magic" id="146" level="52" required-level="83" sp="240000000" />
+		<skill name="Void Explosion" id="45381" level="8" required-level="83" sp="240000000" />
 		<skill name="Corpse Burst" id="1155" level="22" required-level="83" sp="240000000" />
 		<skill name="Robe Mastery" id="234" level="48" required-level="83" sp="240000000" />
 		<skill name="Weapon Mastery" id="249" level="49" required-level="83" sp="240000000" />
-		<skill name="Vampiric Claw" id="1234" level="35" required-level="83" sp="240000000" />
+		<skill name="Vampiric Claw" id="1234" level="38" required-level="83" sp="240000000" />
 		<skill name="Mass Curse Gloom" id="1382" level="10" required-level="83" sp="240000000" />
 		<skill name="Summon Cursed Man" id="1334" level="2" required-level="83" sp="240000000" />
 		<skill name="Curse Disease" id="1269" level="15" required-level="83" sp="240000000" />
 		<skill name="Curse Gloom" id="1263" level="19" required-level="83" sp="240000000" />
-		<skill name="Curse Weakness" id="1164" level="25" required-level="83" sp="240000000" />
 		<skill name="Curse Death Link" id="1159" level="29" required-level="83" sp="240000000" />
-		<skill name="Body To Mind" id="1157" level="9" required-level="83" sp="240000000" />
+		<skill name="Body to Mind" id="1157" level="9" required-level="83" sp="240000000" />
+		<skill name="Weakness" id="1164" level="25" required-level="83" sp="240000000" />
 		<skill name="Higher Mana Gain" id="285" level="34" required-level="83" sp="240000000" />
-		<skill name="Sleep" id="1069" level="50" required-level="83" sp="240000000" />
-		<skill name="Death Spike" id="1148" level="19" required-level="83" sp="240000000" />
+		<skill name="Sleep" id="1069" level="53" required-level="83" sp="240000000" />
+		<skill name="Death Spike" id="1148" level="23" required-level="83" sp="240000000" />
 		<skill name="Anchor" id="1170" level="19" required-level="83" sp="240000000" />
 
 		<skill name="Anti Magic" id="146" level="53" required-level="84" sp="240000000" />
+		<skill name="Void Explosion" id="45381" level="9" required-level="84" sp="240000000" />
 		<skill name="Corpse Burst" id="1155" level="23" required-level="84" sp="240000000" />
 		<skill name="Dark Vortex" id="1343" level="3" required-level="84" sp="240000000" />
 		<skill name="Robe Mastery" id="234" level="49" required-level="84" sp="240000000" />
 		<skill name="Weapon Mastery" id="249" level="50" required-level="84" sp="240000000" />
-		<skill name="Vampiric Claw" id="1234" level="36" required-level="84" sp="240000000" />
+		<skill name="Vampiric Claw" id="1234" level="39" required-level="84" sp="240000000" />
 		<skill name="Mass Curse Gloom" id="1382" level="11" required-level="84" sp="240000000" />
 		<skill name="Bind" id="53006" level="5" required-level="84" sp="240000000" />
 		<skill name="Curse Disease" id="1269" level="16" required-level="84" sp="240000000" />
 		<skill name="Curse Gloom" id="1263" level="20" required-level="84" sp="240000000" />
-		<skill name="Curse Weakness" id="1164" level="26" required-level="84" sp="240000000" />
 		<skill name="Curse Death Link" id="1159" level="30" required-level="84" sp="240000000" />
-		<skill name="Body To Mind" id="1157" level="10" required-level="84" sp="240000000" />
+		<skill name="Body to Mind" id="1157" level="10" required-level="84" sp="240000000" />
+		<skill name="Weakness" id="1164" level="26" required-level="84" sp="240000000" />
 		<skill name="Higher Mana Gain" id="285" level="35" required-level="84" sp="240000000" />
-		<skill name="Sleep" id="1069" level="51" required-level="84" sp="240000000" />
-		<skill name="Death Spike" id="1148" level="20" required-level="84" sp="240000000" />
+		<skill name="Sleep" id="1069" level="54" required-level="84" sp="240000000" />
+		<skill name="Death Spike" id="1148" level="24" required-level="84" sp="240000000" />
 		<skill name="Anchor" id="1170" level="20" required-level="84" sp="240000000" />
-		
+
 		<skill name="Anti Magic" id="146" level="54" required-level="85" sp="840000000" />
-		<skill name="Anti Magic" id="146" level="55" required-level="86" sp="924000000" />
-		<skill name="Anti Magic" id="146" level="56" required-level="87" sp="1016400000" />
-		<skill name="Anti Magic" id="146" level="57" required-level="88" sp="1118040000" />
-		<skill name="Anti Magic" id="146" level="58" required-level="89" sp="1229844000" />
-		<skill name="Anti Magic" id="146" level="59" required-level="90" sp="1352828400" />
+		<skill name="Void Explosion" id="45381" level="10" required-level="85" sp="840000000" />
 		<skill name="Robe Mastery" id="234" level="50" required-level="85" sp="840000000" />
-		<skill name="Robe Mastery" id="234" level="51" required-level="86" sp="924000000" />
-		<skill name="Robe Mastery" id="234" level="52" required-level="87" sp="1016400000" />
-		<skill name="Robe Mastery" id="234" level="53" required-level="88" sp="1118040000" />
-		<skill name="Robe Mastery" id="234" level="54" required-level="89" sp="1229844000" />
-		<skill name="Robe Mastery" id="234" level="55" required-level="90" sp="1352828400" />
 		<skill name="Weapon Mastery" id="249" level="51" required-level="85" sp="840000000" />
-		<skill name="Weapon Mastery" id="249" level="52" required-level="86" sp="924000000" />
-		<skill name="Weapon Mastery" id="249" level="53" required-level="87" sp="1016400000" />
-		<skill name="Weapon Mastery" id="249" level="54" required-level="88" sp="1118040000" />
-		<skill name="Weapon Mastery" id="249" level="55" required-level="89" sp="1229844000" />
-		<skill name="Weapon Mastery" id="249" level="56" required-level="90" sp="1352828400" />
+		<skill name="Vampiric Claw" id="1234" level="40" required-level="85" sp="840000000" />
+		<skill name="Poison" id="1168" level="9" required-level="85" sp="840000000" />
+		<skill name="Higher Mana Gain" id="285" level="36" required-level="85" sp="840000000" />
+		<skill name="Sleep" id="1069" level="55" required-level="85" sp="840000000" />
+		<skill name="Death Spike" id="1148" level="25" required-level="85" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="55" required-level="86" sp="840000000" />
+		<skill name="Void Explosion" id="45381" level="11" required-level="86" sp="840000000" />
+		<skill name="Robe Mastery" id="234" level="51" required-level="86" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="52" required-level="86" sp="840000000" />
+		<skill name="Vampiric Claw" id="1234" level="41" required-level="86" sp="840000000" />
+		<skill name="Sleep" id="1069" level="56" required-level="86" sp="840000000" />
+		<skill name="Death Spike" id="1148" level="26" required-level="86" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="56" required-level="87" sp="840000000" />
+		<skill name="Void Explosion" id="45381" level="12" required-level="87" sp="840000000" />
+		<skill name="Robe Mastery" id="234" level="52" required-level="87" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="53" required-level="87" sp="840000000" />
+		<skill name="Vampiric Claw" id="1234" level="42" required-level="87" sp="840000000" />
+		<skill name="Sleep" id="1069" level="57" required-level="87" sp="840000000" />
+		<skill name="Death Spike" id="1148" level="27" required-level="87" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="57" required-level="88" sp="840000000" />
+		<skill name="Void Explosion" id="45381" level="13" required-level="88" sp="840000000" />
+		<skill name="Robe Mastery" id="234" level="53" required-level="88" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="54" required-level="88" sp="840000000" />
+		<skill name="Vampiric Claw" id="1234" level="43" required-level="88" sp="840000000" />
+		<skill name="Sleep" id="1069" level="58" required-level="88" sp="840000000" />
+		<skill name="Death Spike" id="1148" level="28" required-level="88" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="58" required-level="89" sp="840000000" />
+		<skill name="Void Explosion" id="45381" level="14" required-level="89" sp="840000000" />
+		<skill name="Robe Mastery" id="234" level="54" required-level="89" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="55" required-level="89" sp="840000000" />
+		<skill name="Vampiric Claw" id="1234" level="44" required-level="89" sp="840000000" />
+		<skill name="Sleep" id="1069" level="59" required-level="89" sp="840000000" />
+		<skill name="Death Spike" id="1148" level="29" required-level="89" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="59" required-level="90" sp="840000000" />
+		<skill name="Void Explosion" id="45381" level="15" required-level="90" sp="840000000" />
+		<skill name="Robe Mastery" id="234" level="55" required-level="90" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="56" required-level="90" sp="840000000" />
+		<skill name="Vampiric Claw" id="1234" level="45" required-level="90" sp="840000000" />
+		<skill name="Poison" id="1168" level="10" required-level="90" sp="840000000" />
+		<skill name="Sleep" id="1069" level="60" required-level="90" sp="840000000" />
+		<skill name="Death Spike" id="1148" level="30" required-level="90" sp="840000000" />
 	</skillTree>
 </list>

--- a/data/skillTrees/3rdClass/SpectralDancer.xml
+++ b/data/skillTrees/3rdClass/SpectralDancer.xml
@@ -1,120 +1,323 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="107" parentClassId="34">
-		<skill name="White Guardian" id="54102" level="1" required-level="80" >
-			<item id="92401"/>
-		</skill>
-		<skill name="Arrest" id="402" level="11" required-level="76" sp="7600000" />
-		<skill name="Dual Weapon Mastery" id="144" level="38" required-level="76" sp="7600000" />
-		<skill name="Heavy Armor Mastery" id="232" level="53" required-level="76" sp="7600000" />
-		<skill name="Sting" id="223" level="50" required-level="76" sp="7600000" />
-		<skill name="Freezing Strike" id="105" level="25" required-level="76" sp="7600000" />
-		<skill name="Drain Energy" id="70" level="54" required-level="76" sp="7600000" />
-		<skill name="Magic Resistance" id="147" level="52" required-level="76" sp="7600000" />
-		<skill name="Hex" id="122" level="16" required-level="76" sp="7600000" />
-		<skill name="Deadly Strike" id="1632" level="1" required-level="76" sp="7600000" />
-		<skill name="Power Break" id="115" level="18" required-level="76" sp="7600000" />
+
 		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="7600000">
-			<item id="8620"/> <!-- Ancient Book: Divine Inspiration (Manuscript) -->
+			<item id="8620" count="1" /> <!-- Buff Expansion Book Lv. 3 -->
 		</skill>
 		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="7600000">
-			<item id="8621"/> <!-- Ancient Book: Divine Inspiration (Original Version) -->
+			<item id="8621" count="1" /> <!-- Buff Expansion Book Lv. 4 -->
+		</skill>
+		<skill name="Weapon Mastery" id="141" level="5" required-level="76" sp="7600000" />
+		<skill name="Dual Sword Mastery" id="144" level="38" required-level="76" sp="7600000" />
+		<skill name="Heavy Armor Mastery" id="232" level="53" required-level="76" sp="7600000" />
+		<skill name="Confusion" id="2" level="21" required-level="76" sp="7600000" />
+		<skill name="Freezing Weapon" id="105" level="28" required-level="76" sp="7600000" />
+		<skill name="Evolution Defense" id="45188" level="1" required-level="76">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Shackle" id="402" level="11" required-level="76" sp="7600000" />
+		<skill name="Drain Energy" id="45250" level="26" required-level="76" sp="7600000" />
+		<skill name="Blood Attack" id="223" level="51" required-level="76" sp="7600000" />
+		<skill name="Magic Resistance" id="147" level="52" required-level="76" sp="7600000" />
+		<!-- Might Lv. 4 -->
+		<skill name="Might" id="1068" level="4" required-level="76" sp="7600000">
+			<item id="94135" count="1" /> <!-- Master's Book: Might -->
+		</skill>
+		<!-- Shield Lv. 4 -->
+		<skill name="Shield" id="1040" level="4" required-level="76" sp="7600000">
+			<item id="94136" count="1" /> <!-- Master's Book: Shield -->
+		</skill>
+		<!-- Acumen Lv. 4 -->
+		<skill name="Acumen" id="45104" level="4" required-level="76" sp="7600000">
+			<item id="94370" count="1" /> <!-- Master's Book: Acumen -->
+		</skill>
+		<!-- Empower Lv. 4 -->
+		<skill name="Empower" id="45105" level="4" required-level="76" sp="7600000">
+			<item id="94361" count="1" /> <!-- Master's Book: Empower -->
+		</skill>
+		<!-- Wild Magic Lv. 3 -->
+		<skill name="Wild Magic" id="45106" level="3" required-level="76" sp="7600000">
+			<item id="94368" count="1" /> <!-- Master's Book: Wild Magic -->
+		</skill>
+		<!-- Wind Walk Lv. 3 -->
+		<skill name="Wind Walk" id="45107" level="3" required-level="76" sp="7600000">
+			<item id="94365" count="1" /> <!-- Master's Book: Wind Walk -->
+		</skill>
+		<!-- Magic Barrier Lv. 3 -->
+		<skill name="Magic Barrier" id="45108" level="3" required-level="76" sp="7600000">
+			<item id="94362" count="1" /> <!-- Master's Book: Magic Barrier -->
+		</skill>
+		<!-- Focus Lv. 4 -->
+		<skill name="Focus" id="45109" level="4" required-level="76" sp="7600000">
+			<item id="94363" count="1" /> <!-- Master's Book: Focus -->
+		</skill>
+		<!-- Death Whisper Lv. 4 -->
+		<skill name="Death Whisper" id="45110" level="4" required-level="76" sp="7600000">
+			<item id="94364" count="1" /> <!-- Master's Book: Death Whisper -->
+		</skill>
+		<!-- Haste Lv. 3 -->
+		<skill name="Haste" id="45111" level="3" required-level="76" sp="7600000">
+			<item id="94369" count="1" /> <!-- Master's Book: Haste -->
+		</skill>
+		<!-- Berserker Spirit Lv. 3 -->
+		<skill name="Berserker Spirit" id="45112" level="3" required-level="76" sp="7600000">
+			<item id="94366" count="1" /> <!-- Master's Book: Berserker Spirit -->
+		</skill>
+		<!-- Clarity Lv. 4 -->
+		<skill name="Clarity" id="45113" level="4" required-level="76" sp="7600000">
+			<item id="94367" count="1" /> <!-- Master's Book: Clarity -->
+		</skill>
+		<skill name="Detection" id="45190" level="1" required-level="76" sp="7600000">
+			<item id="57" count="5000000" /> <!-- Adena -->
 		</skill>
 		<skill name="Mount Saber Tooth Cougar" id="1835" level="1" required-level="76">
-			<item id="90040"/> <!-- Spellbook: Mount Saber Tooth Cougar -->
+			<item id="90040" count="1" /> <!-- Spellbook: Ride Sabretooth Cougar -->
 		</skill>
-		<skill name="Glory Ability" id="45361" level="1" required-level="86">
-			<item id="94046"/> <!-- Spellbook: Glory Ability Lv. 1 -->
-		</skill>
-		<skill name="Mount White Wings" id="54200" level="1" required-level="87">
-			<item id="93059"/> <!-- Spellbook: Summon White Wings -->
-		</skill>	
-		<skill name="Mount Shining Lady" id="54202" level="1" required-level="89">
-			<item id="93061"/> <!-- Spellbook: Summon Silver Saint -->
-		</skill>
-		
-		<skill name="Dual Weapon Mastery" id="144" level="39" required-level="77" sp="7600000" />
-		<skill name="Heavy Armor Mastery" id="232" level="54" required-level="77" sp="7600000" />
-		<skill name="Sting" id="223" level="51" required-level="77" sp="7600000" />
-		<skill name="Drain Energy" id="70" level="55" required-level="77" sp="7600000" />
-		<skill name="Magic Resistance" id="147" level="53" required-level="77" sp="7600000" />
-		<skill name="Deadly Strike" id="1632" level="2" required-level="77" sp="7600000" />
-		<skill name="Dance of Shadows" id="366" level="1" required-level="77" sp="7600000">
-			<item id="90094"/> <!-- Scroll: Dance of Shadows -->
-		</skill>
-		
-		<skill name="Arrest" id="402" level="12" required-level="78" sp="17800000" />
-		<skill name="Dual Weapon Mastery" id="144" level="40" required-level="78" sp="17800000" />
-		<skill name="Heavy Armor Mastery" id="232" level="55" required-level="78" sp="17800000" />
-		<skill name="Sting" id="223" level="52" required-level="78" sp="17800000" />
-		<skill name="Freezing Strike" id="105" level="26" required-level="78" sp="17800000" />
-		<skill name="Drain Energy" id="70" level="56" required-level="78" sp="17800000" />
-		<skill name="Magic Resistance" id="147" level="54" required-level="78" sp="17800000" />
-		<skill name="Hex" id="122" level="17" required-level="78" sp="17800000" />
-		<skill name="Deadly Strike" id="1632" level="3" required-level="78" sp="17800000" />
-		<skill name="Power Break" id="115" level="19" required-level="78" sp="17800000" />
-		<skill name="Poison Blade Dance" id="84" level="4" required-level="78" sp="17800000" />
-		<skill name="Dance of Siren" id="365" level="1" required-level="78" sp="17800000">
-			<item id="90095"/> <!-- Scroll: Dance of Siren -->
-		</skill>
+		<skill name="Hex" id="122" level="16" required-level="76" sp="7600000" />
+		<skill name="Power Break" id="115" level="18" required-level="76" sp="7600000" />
+		<skill name="Deadly Strike" id="1632" level="1" required-level="76" sp="7600000" />
+		<skill name="Emergency Rescue" id="70" level="46" required-level="76" sp="7600000" />
 
-		<skill name="Dance of Medusa" id="367" level="1" required-level="79" sp="17800000">
-			<item id="90096"/> <!-- Scroll: Dance of Medusa -->
-		</skill>
-		
-		<skill name="Dual Weapon Mastery" id="144" level="41" required-level="80" sp="17800000" />
+		<skill name="Dual Sword Mastery" id="144" level="39" required-level="77" sp="7600000" />
+		<skill name="Heavy Armor Mastery" id="232" level="54" required-level="77" sp="7600000" />
+		<skill name="Confusion" id="2" level="22" required-level="77" sp="7600000" />
+		<skill name="Shackle" id="402" level="12" required-level="77" sp="7600000" />
+		<skill name="Drain Energy" id="45250" level="27" required-level="77" sp="7600000" />
+		<skill name="Blood Attack" id="223" level="52" required-level="77" sp="7600000" />
+		<skill name="Magic Resistance" id="147" level="53" required-level="77" sp="7600000" />
+		<skill name="Hex" id="122" level="17" required-level="77" sp="7600000" />
+		<skill name="Deadly Strike" id="1632" level="2" required-level="77" sp="7600000" />
+		<skill name="Emergency Rescue" id="70" level="47" required-level="77" sp="7600000" />
+
+		<skill name="Dual Sword Mastery" id="144" level="40" required-level="78" sp="17800000" />
+		<skill name="Heavy Armor Mastery" id="232" level="55" required-level="78" sp="17800000" />
+		<skill name="Confusion" id="2" level="23" required-level="78" sp="17800000" />
+		<skill name="Freezing Weapon" id="105" level="29" required-level="78" sp="17800000" />
+		<skill name="Shackle" id="402" level="13" required-level="78" sp="17800000" />
+		<skill name="Drain Energy" id="45250" level="28" required-level="78" sp="17800000" />
+		<skill name="Blood Attack" id="223" level="53" required-level="78" sp="17800000" />
+		<skill name="Magic Resistance" id="147" level="54" required-level="78" sp="17800000" />
+		<skill name="Hex" id="122" level="18" required-level="78" sp="17800000" />
+		<skill name="Power Break" id="115" level="19" required-level="78" sp="17800000" />
+		<skill name="Deadly Strike" id="1632" level="3" required-level="78" sp="17800000" />
+		<skill name="Poison Blade Dance" id="84" level="4" required-level="78" sp="17800000" />
+		<skill name="Emergency Rescue" id="70" level="48" required-level="78" sp="17800000" />
+
+		<skill name="Confusion" id="2" level="24" required-level="79" sp="17800000" />
+		<skill name="Shackle" id="402" level="14" required-level="79" sp="17800000" />
+		<skill name="Drain Energy" id="45250" level="29" required-level="79" sp="17800000" />
+		<skill name="Blood Attack" id="223" level="54" required-level="79" sp="17800000" />
+		<skill name="Hex" id="122" level="19" required-level="79" sp="17800000" />
+		<skill name="Dance of Medusa" id="367" level="1" required-level="79" sp="17800000" />
+		<skill name="Emergency Rescue" id="70" level="49" required-level="79" sp="17800000" />
+
+		<skill name="Dual Sword Mastery" id="144" level="41" required-level="80" sp="17800000" />
 		<skill name="Heavy Armor Mastery" id="232" level="56" required-level="80" sp="17800000" />
-		<skill name="Magic Resistance" id="147" level="55" required-level="80" sp="17800000" />
-		<skill name="Deadly Strike" id="1632" level="4" required-level="80" sp="17800000" />
-		<skill name="Dance of Berserker" id="915" level="1" required-level="80" sp="17800000">
-			<item id="90097"/> <!-- Scroll: Dance of Berserker -->
+		<skill name="Confusion" id="2" level="25" required-level="80" sp="17800000" />
+		<skill name="Freezing Weapon" id="105" level="30" required-level="80" sp="17800000" />
+		<skill name="Shackle" id="402" level="15" required-level="80" sp="17800000">
+			<item id="57" count="500000" /> <!-- Adena -->
 		</skill>
-		
-		<skill name="Dual Weapon Mastery" id="144" level="42" required-level="81" sp="160000000" />
+		<skill name="Drain Energy" id="45250" level="30" required-level="80" sp="17800000" />
+		<skill name="Blood Attack" id="223" level="55" required-level="80" sp="17800000" />
+		<skill name="Magic Resistance" id="147" level="55" required-level="80" sp="17800000" />
+		<skill name="Evolution Power" id="45189" level="1" required-level="80">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Hex" id="122" level="20" required-level="80" sp="17800000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="20" required-level="80" sp="17800000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Deadly Strike" id="1632" level="4" required-level="80" sp="17800000" />
+		<skill name="White Guardian Transformation" id="54102" level="1" required-level="80">
+			<item id="92401" count="1" /> <!-- Spellbook - White Guardian -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="50" required-level="80" sp="17800000" />
+
+		<skill name="Dual Sword Mastery" id="144" level="42" required-level="81" sp="160000000" />
 		<skill name="Heavy Armor Mastery" id="232" level="57" required-level="81" sp="160000000" />
+		<skill name="Confusion" id="2" level="26" required-level="81" sp="160000000" />
+		<skill name="Shackle" id="402" level="16" required-level="81" sp="160000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Drain Energy" id="45250" level="31" required-level="81" sp="160000000" />
+		<skill name="Blood Attack" id="223" level="56" required-level="81" sp="160000000" />
 		<skill name="Magic Resistance" id="147" level="56" required-level="81" sp="160000000" />
+		<skill name="Hex" id="122" level="21" required-level="81" sp="160000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="21" required-level="81" sp="160000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
 		<skill name="Deadly Strike" id="1632" level="5" required-level="81" sp="160000000" />
 		<skill name="Dance of Medusa" id="367" level="2" required-level="81" sp="160000000" />
-		<skill name="Dance of Shadows" id="366" level="2" required-level="81" sp="160000000" />
-		<skill name="Dance of Fury" id="275" level="2" required-level="81" sp="160000000" />
+		<skill name="Emergency Rescue" id="70" level="51" required-level="81" sp="160000000" />
 
-		<skill name="Dual Weapon Mastery" id="144" level="43" required-level="82" sp="170000000" />
+		<skill name="Dual Sword Mastery" id="144" level="43" required-level="82" sp="170000000" />
 		<skill name="Heavy Armor Mastery" id="232" level="58" required-level="82" sp="170000000" />
+		<skill name="Confusion" id="2" level="27" required-level="82" sp="170000000" />
+		<skill name="Freezing Weapon" id="105" level="31" required-level="82" sp="170000000" />
+		<skill name="Shackle" id="402" level="17" required-level="82" sp="170000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Drain Energy" id="45250" level="32" required-level="82" sp="170000000" />
+		<skill name="Blood Attack" id="223" level="57" required-level="82" sp="170000000" />
 		<skill name="Magic Resistance" id="147" level="57" required-level="82" sp="170000000" />
+		<skill name="Hex" id="122" level="22" required-level="82" sp="170000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="22" required-level="82" sp="170000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
 		<skill name="Deadly Strike" id="1632" level="6" required-level="82" sp="170000000" />
-		<skill name="Dance of Concentration" id="276" level="2" required-level="82" sp="170000000" />
+		<skill name="Emergency Rescue" id="70" level="52" required-level="82" sp="170000000" />
 
-		<skill name="Dual Weapon Mastery" id="144" level="44" required-level="83" sp="240000000" />
+		<skill name="Dual Sword Mastery" id="144" level="44" required-level="83" sp="240000000" />
 		<skill name="Heavy Armor Mastery" id="232" level="59" required-level="83" sp="240000000" />
+		<skill name="Confusion" id="2" level="28" required-level="83" sp="240000000" />
+		<skill name="Shackle" id="402" level="18" required-level="83" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Drain Energy" id="45250" level="33" required-level="83" sp="240000000" />
+		<skill name="Blood Attack" id="223" level="58" required-level="83" sp="240000000" />
 		<skill name="Magic Resistance" id="147" level="58" required-level="83" sp="240000000" />
+		<skill name="Hex" id="122" level="23" required-level="83" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="23" required-level="83" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
 		<skill name="Deadly Strike" id="1632" level="7" required-level="83" sp="240000000" />
 		<skill name="Dance of Medusa" id="367" level="3" required-level="83" sp="240000000" />
-		<skill name="Dance of Siren" id="365" level="2" required-level="83" sp="240000000" />
+		<skill name="Emergency Rescue" id="70" level="53" required-level="83" sp="240000000" />
 
-		<skill name="Dual Weapon Mastery" id="144" level="45" required-level="84" sp="240000000" />
+		<skill name="Dual Sword Mastery" id="144" level="45" required-level="84" sp="240000000" />
 		<skill name="Heavy Armor Mastery" id="232" level="60" required-level="84" sp="240000000" />
+		<skill name="Confusion" id="2" level="29" required-level="84" sp="240000000" />
+		<skill name="Freezing Weapon" id="105" level="32" required-level="84" sp="240000000" />
+		<skill name="Shackle" id="402" level="19" required-level="84" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Drain Energy" id="45250" level="34" required-level="84" sp="240000000" />
+		<skill name="Blood Attack" id="223" level="59" required-level="84" sp="240000000" />
 		<skill name="Magic Resistance" id="147" level="59" required-level="84" sp="240000000" />
+		<skill name="Hex" id="122" level="24" required-level="84" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="24" required-level="84" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
 		<skill name="Deadly Strike" id="1632" level="8" required-level="84" sp="240000000" />
-		<skill name="Dance of Shadows" id="366" level="3" required-level="84" sp="240000000" />
 		<skill name="Poison Blade Dance" id="84" level="5" required-level="84" sp="240000000" />
-		
-		<skill name="Dual Weapon Mastery" id="144" level="46" required-level="85" sp="840000000" />
-		<skill name="Dual Weapon Mastery" id="144" level="47" required-level="86" sp="924000000" />
-		<skill name="Dual Weapon Mastery" id="144" level="48" required-level="87" sp="1016400000" />
-		<skill name="Dual Weapon Mastery" id="144" level="49" required-level="88" sp="1118040000" />
-		<skill name="Dual Weapon Mastery" id="144" level="50" required-level="89" sp="1229844000" />
-		<skill name="Dual Weapon Mastery" id="144" level="51" required-level="90" sp="1352828400" />
+		<skill name="Emergency Rescue" id="70" level="54" required-level="84" sp="240000000" />
+
+		<skill name="Dual Sword Mastery" id="144" level="46" required-level="85" sp="840000000" />
 		<skill name="Heavy Armor Mastery" id="232" level="61" required-level="85" sp="840000000" />
-		<skill name="Heavy Armor Mastery" id="232" level="62" required-level="86" sp="924000000" />
-		<skill name="Heavy Armor Mastery" id="232" level="63" required-level="87" sp="1016400000" />
-		<skill name="Heavy Armor Mastery" id="232" level="64" required-level="88" sp="1118040000" />
-		<skill name="Heavy Armor Mastery" id="232" level="65" required-level="89" sp="1229844000" />
-		<skill name="Heavy Armor Mastery" id="232" level="66" required-level="90" sp="1352828400" />
+		<skill name="Confusion" id="2" level="30" required-level="85" sp="840000000" />
+		<skill name="Shackle" id="402" level="20" required-level="85" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Drain Energy" id="45250" level="35" required-level="85" sp="840000000" />
+		<skill name="Blood Attack" id="223" level="60" required-level="85" sp="840000000" />
 		<skill name="Magic Resistance" id="147" level="60" required-level="85" sp="840000000" />
+		<skill name="Hex" id="122" level="25" required-level="85" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="25" required-level="85" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="55" required-level="85" sp="840000000" />
+
+		<skill name="Dual Sword Mastery" id="144" level="47" required-level="86" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="232" level="62" required-level="86" sp="840000000" />
+		<skill name="Confusion" id="2" level="31" required-level="86" sp="840000000" />
+		<skill name="Freezing Weapon" id="105" level="33" required-level="86" sp="840000000" />
+		<skill name="Shackle" id="402" level="21" required-level="86" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Drain Energy" id="45250" level="36" required-level="86" sp="840000000" />
+		<skill name="Blood Attack" id="223" level="61" required-level="86" sp="840000000" />
 		<skill name="Magic Resistance" id="147" level="61" required-level="86" sp="840000000" />
+		<skill name="Hex" id="122" level="26" required-level="86" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="26" required-level="86" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="56" required-level="86" sp="840000000" />
+
+		<skill name="Dual Sword Mastery" id="144" level="48" required-level="87" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="232" level="63" required-level="87" sp="840000000" />
+		<skill name="Confusion" id="2" level="32" required-level="87" sp="840000000" />
+		<skill name="Shackle" id="402" level="22" required-level="87" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Drain Energy" id="45250" level="37" required-level="87" sp="840000000" />
+		<skill name="Blood Attack" id="223" level="62" required-level="87" sp="840000000" />
 		<skill name="Magic Resistance" id="147" level="62" required-level="87" sp="840000000" />
+		<skill name="Hex" id="122" level="27" required-level="87" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="27" required-level="87" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="57" required-level="87" sp="840000000" />
+
+		<skill name="Dual Sword Mastery" id="144" level="49" required-level="88" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="232" level="64" required-level="88" sp="840000000" />
+		<skill name="Confusion" id="2" level="33" required-level="88" sp="840000000" />
+		<skill name="Freezing Weapon" id="105" level="34" required-level="88" sp="840000000" />
+		<skill name="Shackle" id="402" level="23" required-level="88" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Drain Energy" id="45250" level="38" required-level="88" sp="840000000" />
+		<skill name="Blood Attack" id="223" level="63" required-level="88" sp="840000000" />
 		<skill name="Magic Resistance" id="147" level="63" required-level="88" sp="840000000" />
+		<skill name="Hex" id="122" level="28" required-level="88" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="28" required-level="88" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="58" required-level="88" sp="840000000" />
+
+		<skill name="Dual Sword Mastery" id="144" level="50" required-level="89" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="232" level="65" required-level="89" sp="840000000" />
+		<skill name="Confusion" id="2" level="34" required-level="89" sp="840000000" />
+		<skill name="Shackle" id="402" level="24" required-level="89" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Drain Energy" id="45250" level="39" required-level="89" sp="840000000" />
+		<skill name="Blood Attack" id="223" level="64" required-level="89" sp="840000000" />
 		<skill name="Magic Resistance" id="147" level="64" required-level="89" sp="840000000" />
+		<skill name="Hex" id="122" level="29" required-level="89" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="29" required-level="89" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="59" required-level="89" sp="840000000" />
+
+		<skill name="Dual Sword Mastery" id="144" level="51" required-level="90" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="232" level="66" required-level="90" sp="840000000" />
+		<skill name="Confusion" id="2" level="35" required-level="90" sp="840000000" />
+		<skill name="Freezing Weapon" id="105" level="35" required-level="90" sp="840000000" />
+		<skill name="Shackle" id="402" level="25" required-level="90" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Drain Energy" id="45250" level="40" required-level="90" sp="840000000" />
+		<skill name="Blood Attack" id="223" level="65" required-level="90" sp="840000000" />
 		<skill name="Magic Resistance" id="147" level="65" required-level="90" sp="840000000" />
+		<skill name="Hex" id="122" level="30" required-level="90" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Power Break" id="115" level="30" required-level="90" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="60" required-level="90" sp="840000000" />
+
 	</skillTree>
 </list>

--- a/data/skillTrees/3rdClass/SpectralMaster.xml
+++ b/data/skillTrees/3rdClass/SpectralMaster.xml
@@ -1,53 +1,103 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="111" parentClassId="41">
-		<skill name="White Guardian" id="54102" level="1" required-level="80" >
-			<item id="92401"/>
-		</skill>
+
 		<skill name="Anti Magic" id="146" level="46" required-level="76" sp="8300000" />
 		<skill name="Warrior Bane" id="1350" level="1" required-level="76" sp="8300000" />
 		<skill name="Mage Bane" id="1351" level="1" required-level="76" sp="8300000" />
+		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="8300000">
+			<item id="8620" count="1" /> <!-- Buff Expansion Book Lv. 3 -->
+		</skill>
+		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="8300000">
+			<item id="8621" count="1" /> <!-- Buff Expansion Book Lv. 4 -->
+		</skill>
 		<skill name="Light Armor Mastery" id="258" level="34" required-level="76" sp="8300000" />
 		<skill name="Robe Mastery" id="234" level="42" required-level="76" sp="8300000" />
 		<skill name="Weapon Mastery" id="249" level="43" required-level="76" sp="8300000" />
+		<skill name="Evolution Defense" id="45188" level="1" required-level="76">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Servitor Heal" id="1127" level="46" required-level="76" sp="8300000" />
+		<!-- Might Lv. 4 -->
+		<skill name="Might" id="1068" level="4" required-level="76" sp="8300000">
+			<item id="94135" count="1" /> <!-- Master's Book: Might -->
+		</skill>
+		<!--Shield Lv. 4 -->
+		<skill name="Shield" id="1040" level="4" required-level="76" sp="8300000">
+			<item id="94136" count="1" /> <!-- Master's Book: Shield -->
+		</skill>
+		<!-- Acumen Lv. 4 -->
+		<skill name="Acumen" id="45104" level="4" required-level="76" sp="8300000">
+			<item id="94370" count="1" /> <!-- Master's Book: Acumen -->
+		</skill>
+		<!-- Empower Lv. 4 -->
+		<skill name="Empower" id="45105" level="4" required-level="76" sp="8300000">
+			<item id="94361" count="1" /> <!-- Master's Book: Empower -->
+		</skill>
+		<!-- Wild Magic Lv. 3 -->
+		<skill name="Wild Magic" id="45106" level="3" required-level="76" sp="8300000">
+			<item id="94368" count="1" /> <!-- Master's Book: Wild Magic -->
+		</skill>
+		<!-- Wind Walk Lv. 3 -->
+		<skill name="Wind Walk" id="45107" level="3" required-level="76" sp="8300000">
+			<item id="94365" count="1" /> <!-- Master's Book: Wind Walk -->
+		</skill>
+		<!-- Magic Barrier Lv. 3 -->
+		<skill name="Magic Barrier" id="45108" level="3" required-level="76" sp="8300000">
+			<item id="94362" count="1" /> <!-- Master's Book: Magic Barrier -->
+		</skill>
+		<!-- Focus Lv. 4 -->
+		<skill name="Focus" id="45109" level="4" required-level="76" sp="8300000">
+			<item id="94363" count="1" /> <!-- Master's Book: Focus -->
+		</skill>
+		<!-- Death Whisper Lv. 4 -->
+		<skill name="Death Whisper" id="45110" level="4" required-level="76" sp="8300000">
+			<item id="94364" count="1" /> <!-- Master's Book: Death Whisper -->
+		</skill>
+		<!-- Haste Lv. 3 -->
+		<skill name="Haste" id="45111" level="3" required-level="76" sp="8300000">
+			<item id="94369" count="1" /> <!-- Master's Book: Haste -->
+		</skill>
+		<!-- Berserker Spirit Lv. 3 -->
+		<skill name="Berserker Spirit" id="45112" level="3" required-level="76" sp="8300000">
+			<item id="94366" count="1" /> <!-- Master's Book: Berserker Spirit -->
+		</skill>
+		<!-- Clarity Lv. 4 -->
+		<skill name="Clarity" id="45113" level="4" required-level="76" sp="8300000">
+			<item id="94367" count="1" /> <!-- Master's Book: Clarity -->
+		</skill>
+		<skill name="Detection" id="45190" level="1" required-level="76" sp="8300000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Wind Shackle" id="1206" level="20" required-level="76" sp="8300000" />
+		<skill name="Mount Saber Tooth Cougar" id="1835" level="1" required-level="76">
+			<item id="90040" count="1" /> <!-- Spellbook: Ride Sabretooth Cougar -->
+		</skill>
 		<skill name="Servitor Recharge" id="1126" level="35" required-level="76" sp="8300000" />
 		<skill name="Summon Spark Cubic" id="1281" level="11" required-level="76" sp="8300000" />
 		<skill name="Summon Phantom Cubic" id="33" level="9" required-level="76" sp="8300000" />
 		<skill name="Servitor Share" id="1557" level="1" required-level="76" sp="8300000">
-			<item id="90131"/> <!-- Scroll: Servitor Share -->
+			<item id="90131" count="1" /> <!-- Scroll: Servitor Share -->
 		</skill>
 		<skill name="Twister" id="1178" level="27" required-level="76" sp="8300000" />
-		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="8300000">
-			<item id="8620"/> <!-- Ancient Book: Divine Inspiration (Manuscript) -->
+		<skill name="Swift Servitor Heal" id="45362" level="46" required-level="76" sp="8300000" />
+		<skill name="Ethereal Strike" id="45377" level="1" required-level="76" sp="8300000">
+			<item id="93870" count="1" /> <!-- Spellbook: Ethereal Strike -->
 		</skill>
-		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="8300000">
-			<item id="8621"/> <!-- Ancient Book: Divine Inspiration (Original Version) -->
-		</skill>
-		<skill name="Mount Saber Tooth Cougar" id="1835" level="1" required-level="76">
-			<item id="90040"/> <!-- Spellbook: Mount Saber Tooth Cougar -->
-		</skill>
-		<skill name="Glory Ability" id="45361" level="1" required-level="86">
-			<item id="94046"/> <!-- Spellbook: Glory Ability Lv. 1 -->
-		</skill>
-		<skill name="Mount White Wings" id="54200" level="1" required-level="87">
-			<item id="93059"/> <!-- Spellbook: Summon White Wings -->
-		</skill>	
-		<skill name="Mount Shining Lady" id="54202" level="1" required-level="89">
-			<item id="93061"/> <!-- Spellbook: Summon Silver Saint -->
-		</skill>
-		
+
 		<skill name="Anti Magic" id="146" level="47" required-level="77" sp="8300000" />
 		<skill name="Light Armor Mastery" id="258" level="35" required-level="77" sp="8300000" />
 		<skill name="Robe Mastery" id="234" level="43" required-level="77" sp="8300000" />
 		<skill name="Weapon Mastery" id="249" level="44" required-level="77" sp="8300000" />
 		<skill name="Servitor Heal" id="1127" level="47" required-level="77" sp="8300000" />
 		<skill name="Servitor Recharge" id="1126" level="36" required-level="77" sp="8300000" />
-		<skill name="Summon Spectral Lord" id="1408" level="1" required-level="77" sp="8300000" />
 		<skill name="Summon Nightshade" id="1333" level="1" required-level="77" sp="8300000">
-			<item id="91205"/> <!-- Scroll: Summon Nightshade -->
+			<item id="91205" count="1" /> <!-- Scroll: Summon Nightshade -->
 		</skill>
-		
+		<skill name="Summon Spectral Lord" id="1408" level="1" required-level="77" sp="8300000" />
+		<skill name="Swift Servitor Heal" id="45362" level="47" required-level="77" sp="8300000" />
+		<skill name="Ethereal Strike" id="45377" level="2" required-level="77" sp="8300000" />
+
 		<skill name="Anti Magic" id="146" level="48" required-level="78" sp="18300000" />
 		<skill name="Warrior Bane" id="1350" level="2" required-level="78" sp="18300000" />
 		<skill name="Mage Bane" id="1351" level="2" required-level="78" sp="18300000" />
@@ -55,21 +105,27 @@
 		<skill name="Robe Mastery" id="234" level="44" required-level="78" sp="18300000" />
 		<skill name="Weapon Mastery" id="249" level="45" required-level="78" sp="18300000" />
 		<skill name="Servitor Heal" id="1127" level="48" required-level="78" sp="18300000" />
+		<skill name="Wind Shackle" id="1206" level="21" required-level="78" sp="18300000" />
 		<skill name="Servitor Recharge" id="1126" level="37" required-level="78" sp="18300000" />
 		<skill name="Summon Spark Cubic" id="1281" level="12" required-level="78" sp="18300000" />
 		<skill name="Summon Phantom Cubic" id="33" level="10" required-level="78" sp="18300000" />
 		<skill name="Spirit Sharing" id="1547" level="4" required-level="78" sp="18300000" />
 		<skill name="Servitor Share" id="1557" level="2" required-level="78" sp="18300000" />
-		<skill name="Twister" id="1178" level="28" required-level="78" sp="18300000" />
 		<skill name="Assassin Servitor" id="1348" level="1" required-level="78" sp="18300000">
-			<item id="90129"/> <!-- Scroll: Assassin Servitor -->
+			<item id="90129" count="1" /> <!-- Scroll: Assassin Servitor -->
 		</skill>
-		
+		<skill name="Twister" id="1178" level="28" required-level="78" sp="18300000" />
+		<skill name="Swift Servitor Heal" id="45362" level="48" required-level="78" sp="18300000" />
+		<skill name="Ethereal Strike" id="45377" level="3" required-level="78" sp="18300000" />
+
+		<skill name="Wind Shackle" id="1206" level="22" required-level="79" sp="18300000" />
 		<skill name="Summon Nightshade" id="1333" level="2" required-level="79" sp="18300000" />
 		<skill name="Final Servitor" id="1349" level="1" required-level="79" sp="18300000">
-			<item id="90130"/> <!-- Scroll: Final Servitor -->
+			<item id="90130" count="1" /> <!-- Scroll: Final Servitor -->
 		</skill>
-		
+		<skill name="Twister" id="1178" level="29" required-level="79" sp="18300000" />
+		<skill name="Ethereal Strike" id="45377" level="4" required-level="79" sp="18300000" />
+
 		<skill name="Anti Magic" id="146" level="49" required-level="80" sp="18300000" />
 		<skill name="Warrior Bane" id="1350" level="3" required-level="80" sp="18300000" />
 		<skill name="Mage Bane" id="1351" level="3" required-level="80" sp="18300000" />
@@ -77,21 +133,38 @@
 		<skill name="Robe Mastery" id="234" level="45" required-level="80" sp="18300000" />
 		<skill name="Weapon Mastery" id="249" level="46" required-level="80" sp="18300000" />
 		<skill name="Servitor Heal" id="1127" level="49" required-level="80" sp="18300000" />
+		<skill name="Spell Master" id="1831" level="4" required-level="80" sp="2400000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Evolution Power" id="45189" level="1" required-level="80">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Wind Shackle" id="1206" level="23" required-level="80" sp="18300000" />
+		<skill name="Poison" id="1168" level="8" required-level="80" sp="18300000" />
 		<skill name="Servitor Recharge" id="1126" level="38" required-level="80" sp="18300000" />
 		<skill name="Power Supremacy" id="1611" level="5" required-level="80" sp="18300000" />
 		<skill name="Summon Spark Cubic" id="1281" level="13" required-level="80" sp="18300000" />
 		<skill name="Summon Phantom Cubic" id="33" level="11" required-level="80" sp="18300000" />
-		<skill name="Twister" id="1178" level="29" required-level="80" sp="18300000" />
+		<skill name="Servitor Share" id="1557" level="3" required-level="80" sp="18300000" />
+		<skill name="Twister" id="1178" level="30" required-level="80" sp="18300000" />
+		<skill name="White Guardian Transformation" id="54102" level="1" required-level="80">
+			<item id="92401" count="1" /> <!-- Spellbook - White Guardian -->
+		</skill>
+		<skill name="Swift Servitor Heal" id="45362" level="49" required-level="80" sp="18300000" />
+		<skill name="Ethereal Strike" id="45377" level="5" required-level="80" sp="18300000" />
 
 		<skill name="Anti Magic" id="146" level="50" required-level="81" sp="160000000" />
 		<skill name="Light Armor Mastery" id="258" level="38" required-level="81" sp="160000000" />
 		<skill name="Robe Mastery" id="234" level="46" required-level="81" sp="160000000" />
 		<skill name="Weapon Mastery" id="249" level="47" required-level="81" sp="160000000" />
 		<skill name="Servitor Heal" id="1127" level="50" required-level="81" sp="160000000" />
+		<skill name="Wind Shackle" id="1206" level="24" required-level="81" sp="160000000" />
 		<skill name="Servitor Recharge" id="1126" level="39" required-level="81" sp="160000000" />
 		<skill name="Summon Nightshade" id="1333" level="3" required-level="81" sp="160000000" />
 		<skill name="Summon Spectral Lord" id="1408" level="2" required-level="81" sp="160000000" />
-		<skill name="Twister" id="1178" level="30" required-level="81" sp="160000000" />
+		<skill name="Twister" id="1178" level="31" required-level="81" sp="160000000" />
+		<skill name="Swift Servitor Heal" id="45362" level="50" required-level="81" sp="160000000" />
+		<skill name="Ethereal Strike" id="45377" level="6" required-level="81" sp="160000000" />
 
 		<skill name="Anti Magic" id="146" level="51" required-level="82" sp="170000000" />
 		<skill name="Warrior Bane" id="1350" level="4" required-level="82" sp="170000000" />
@@ -100,23 +173,29 @@
 		<skill name="Robe Mastery" id="234" level="47" required-level="82" sp="170000000" />
 		<skill name="Weapon Mastery" id="249" level="48" required-level="82" sp="170000000" />
 		<skill name="Servitor Heal" id="1127" level="51" required-level="82" sp="170000000" />
+		<skill name="Wind Shackle" id="1206" level="25" required-level="82" sp="170000000" />
 		<skill name="Servitor Recharge" id="1126" level="40" required-level="82" sp="170000000" />
 		<skill name="Summon Spark Cubic" id="1281" level="14" required-level="82" sp="170000000" />
 		<skill name="Summon Spectral Lord" id="1408" level="3" required-level="82" sp="170000000" />
 		<skill name="Summon Phantom Cubic" id="33" level="12" required-level="82" sp="170000000" />
 		<skill name="Spirit Sharing" id="1547" level="5" required-level="82" sp="170000000" />
-		<skill name="Servitor Share" id="1557" level="3" required-level="82" sp="170000000" />
-		<skill name="Twister" id="1178" level="31" required-level="82" sp="170000000" />
+		<skill name="Servitor Share" id="1557" level="4" required-level="82" sp="170000000" />
+		<skill name="Twister" id="1178" level="32" required-level="82" sp="170000000" />
+		<skill name="Swift Servitor Heal" id="45362" level="51" required-level="82" sp="170000000" />
+		<skill name="Ethereal Strike" id="45377" level="7" required-level="82" sp="170000000" />
 
 		<skill name="Anti Magic" id="146" level="52" required-level="83" sp="240000000" />
 		<skill name="Light Armor Mastery" id="258" level="40" required-level="83" sp="240000000" />
 		<skill name="Robe Mastery" id="234" level="48" required-level="83" sp="240000000" />
 		<skill name="Weapon Mastery" id="249" level="49" required-level="83" sp="240000000" />
 		<skill name="Servitor Heal" id="1127" level="52" required-level="83" sp="240000000" />
+		<skill name="Wind Shackle" id="1206" level="26" required-level="83" sp="240000000" />
 		<skill name="Servitor Recharge" id="1126" level="41" required-level="83" sp="240000000" />
 		<skill name="Summon Nightshade" id="1333" level="4" required-level="83" sp="240000000" />
 		<skill name="Summon Spectral Lord" id="1408" level="4" required-level="83" sp="240000000" />
-		<skill name="Twister" id="1178" level="32" required-level="83" sp="240000000" />
+		<skill name="Twister" id="1178" level="33" required-level="83" sp="240000000" />
+		<skill name="Swift Servitor Heal" id="45362" level="52" required-level="83" sp="240000000" />
+		<skill name="Ethereal Strike" id="45377" level="8" required-level="83" sp="240000000" />
 
 		<skill name="Anti Magic" id="146" level="53" required-level="84" sp="240000000" />
 		<skill name="Warrior Bane" id="1350" level="5" required-level="84" sp="240000000" />
@@ -125,39 +204,62 @@
 		<skill name="Robe Mastery" id="234" level="49" required-level="84" sp="240000000" />
 		<skill name="Weapon Mastery" id="249" level="50" required-level="84" sp="240000000" />
 		<skill name="Servitor Heal" id="1127" level="53" required-level="84" sp="240000000" />
+		<skill name="Wind Shackle" id="1206" level="27" required-level="84" sp="240000000" />
 		<skill name="Servitor Recharge" id="1126" level="42" required-level="84" sp="240000000" />
 		<skill name="Power Supremacy" id="1611" level="6" required-level="84" sp="240000000" />
 		<skill name="Summon Spark Cubic" id="1281" level="15" required-level="84" sp="240000000" />
 		<skill name="Summon Nightshade" id="1333" level="5" required-level="84" sp="240000000" />
 		<skill name="Summon Spectral Lord" id="1408" level="5" required-level="84" sp="240000000" />
 		<skill name="Summon Phantom Cubic" id="33" level="13" required-level="84" sp="240000000" />
-		<skill name="Twister" id="1178" level="33" required-level="84" sp="240000000" />
-		
+		<skill name="Servitor Share" id="1557" level="5" required-level="84" sp="240000000" />
+		<skill name="Twister" id="1178" level="34" required-level="84" sp="240000000" />
+		<skill name="Swift Servitor Heal" id="45362" level="53" required-level="84" sp="240000000" />
+		<skill name="Ethereal Strike" id="45377" level="9" required-level="84" sp="240000000" />
+
 		<skill name="Anti Magic" id="146" level="54" required-level="85" sp="840000000" />
-		<skill name="Anti Magic" id="146" level="55" required-level="86" sp="924000000" />
-		<skill name="Anti Magic" id="146" level="56" required-level="87" sp="1016400000" />
-		<skill name="Anti Magic" id="146" level="57" required-level="88" sp="1118040000" />
-		<skill name="Anti Magic" id="146" level="58" required-level="89" sp="1229844000" />
-		<skill name="Anti Magic" id="146" level="59" required-level="90" sp="1352828400" />
 		<skill name="Light Armor Mastery" id="258" level="42" required-level="85" sp="840000000" />
-		<skill name="Light Armor Mastery" id="258" level="43" required-level="86" sp="924000000" />
-		<skill name="Light Armor Mastery" id="258" level="44" required-level="87" sp="1016400000" />
-		<skill name="Light Armor Mastery" id="258" level="45" required-level="88" sp="1118040000" />
-		<skill name="Light Armor Mastery" id="258" level="46" required-level="89" sp="1229844000" />
-		<skill name="Light Armor Mastery" id="258" level="47" required-level="90" sp="1352828400" />
 		<skill name="Robe Mastery" id="234" level="50" required-level="85" sp="840000000" />
-		<skill name="Robe Mastery" id="234" level="51" required-level="86" sp="924000000" />
-		<skill name="Robe Mastery" id="234" level="52" required-level="87" sp="1016400000" />
-		<skill name="Robe Mastery" id="234" level="53" required-level="88" sp="1118040000" />
-		<skill name="Robe Mastery" id="234" level="54" required-level="89" sp="1229844000" />
-		<skill name="Robe Mastery" id="234" level="55" required-level="90" sp="1352828400" />
 		<skill name="Weapon Mastery" id="249" level="51" required-level="85" sp="840000000" />
-		<skill name="Weapon Mastery" id="249" level="52" required-level="86" sp="924000000" />
-		<skill name="Weapon Mastery" id="249" level="53" required-level="87" sp="1016400000" />
-		<skill name="Weapon Mastery" id="249" level="54" required-level="88" sp="1118040000" />
-		<skill name="Weapon Mastery" id="249" level="55" required-level="89" sp="1229844000" />
-		<skill name="Weapon Mastery" id="249" level="56" required-level="90" sp="1352828400" />
+		<skill name="Poison" id="1168" level="9" required-level="85" sp="840000000" />
 		<skill name="Summon Nightshade" id="1333" level="6" required-level="85" sp="840000000" />
 		<skill name="Summon Spectral Lord" id="1408" level="6" required-level="85" sp="840000000" />
+		<skill name="Twister" id="1178" level="35" required-level="85" sp="840000000" />
+		<skill name="Ethereal Strike" id="45377" level="10" required-level="85" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="55" required-level="86" sp="840000000" />
+		<skill name="Light Armor Mastery" id="258" level="43" required-level="86" sp="840000000" />
+		<skill name="Robe Mastery" id="234" level="51" required-level="86" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="52" required-level="86" sp="840000000" />
+		<skill name="Twister" id="1178" level="36" required-level="86" sp="840000000" />
+		<skill name="Ethereal Strike" id="45377" level="11" required-level="86" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="56" required-level="87" sp="840000000" />
+		<skill name="Light Armor Mastery" id="258" level="44" required-level="87" sp="840000000" />
+		<skill name="Robe Mastery" id="234" level="52" required-level="87" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="53" required-level="87" sp="840000000" />
+		<skill name="Twister" id="1178" level="37" required-level="87" sp="840000000" />
+		<skill name="Ethereal Strike" id="45377" level="12" required-level="87" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="57" required-level="88" sp="840000000" />
+		<skill name="Light Armor Mastery" id="258" level="45" required-level="88" sp="840000000" />
+		<skill name="Robe Mastery" id="234" level="53" required-level="88" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="54" required-level="88" sp="840000000" />
+		<skill name="Twister" id="1178" level="38" required-level="88" sp="840000000" />
+		<skill name="Ethereal Strike" id="45377" level="13" required-level="88" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="58" required-level="89" sp="840000000" />
+		<skill name="Light Armor Mastery" id="258" level="46" required-level="89" sp="840000000" />
+		<skill name="Robe Mastery" id="234" level="54" required-level="89" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="55" required-level="89" sp="840000000" />
+		<skill name="Twister" id="1178" level="39" required-level="89" sp="840000000" />
+		<skill name="Ethereal Strike" id="45377" level="14" required-level="89" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="59" required-level="90" sp="840000000" />
+		<skill name="Light Armor Mastery" id="258" level="47" required-level="90" sp="840000000" />
+		<skill name="Robe Mastery" id="234" level="55" required-level="90" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="56" required-level="90" sp="840000000" />
+		<skill name="Poison" id="1168" level="10" required-level="90" sp="840000000" />
+		<skill name="Twister" id="1178" level="40" required-level="90" sp="840000000" />
+		<skill name="Ethereal Strike" id="45377" level="15" required-level="90" sp="840000000" />
 	</skillTree>
 </list>

--- a/data/skillTrees/3rdClass/StormBlaster.xml
+++ b/data/skillTrees/3rdClass/StormBlaster.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
+	<skillTree type="classSkillTree" classId="211" parentClassId="210">
+	
+		<!-- Skills Lv76 -->		
+		<skill name="Weapon Mastery" id="141" level="5" required-level="76" sp="8000000"/>
+		<skill name="Armor Mastery" id="142" level="5" required-level="76" sp="8000000"/>
+		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="8000000" />
+		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="8000000" />
+		<skill name="Evolution Defense" id="45188" level="1" required-level="76" sp="0" />
+		<skill name="Detection" id="45190" level="1" required-level="76" sp="8000000" />
+		<skill name="Blessed by Sayha" id="45408" level="1" required-level="76" sp="0" />
+		<skill name="Goring Charge" id="47001" level="1" required-level="76" sp="8000000" />
+		<skill name="Dual Blow" id="47002" level="21" required-level="76" sp="8000000" />
+		<skill name="Wild Dance" id="47019" level="1" required-level="76" sp="8000000" />
+		<skill name="Elemental Focus" id="47021" level="4" required-level="76" sp="8000000" />
+		<skill name="Elemental Death Whisper" id="47022" level="4" required-level="76" sp="8000000" />
+		<skill name="Elemental Haste" id="47023" level="3" required-level="76" sp="8000000" />
+		<skill name="Elemental Wind Walk" id="47024" level="3" required-level="76" sp="8000000" />
+		<skill name="Elemental Magic Barrier" id="47025" level="3" required-level="76" sp="8000000" />
+		<skill name="Elemental Might" id="47026" level="4" required-level="76" sp="8000000" />
+		<skill name="Elemental Shield" id="47027" level="4" required-level="76" sp="8000000" />
+		<skill name="Elemental Acumen" id="47028" level="4" required-level="76" sp="8000000" />
+		<skill name="Elemental Empower" id="47029" level="4" required-level="76" sp="8000000" />
+		<skill name="Elemental Changing" id="47045" level="1" required-level="76" sp="8000000" />
+		<skill name="Elemental Care" id="47054" level="2" required-level="76" sp="8000000" />
+		<skill name="Elemental Wind" id="47061" level="2" required-level="76" sp="8000000" />
+		<skill name="Time Burst" id="47062" level="2" required-level="76" sp="8000000" />
+		<skill name="Firearms Mastery" id="47081" level="8" required-level="76" sp="8000000" />
+		<skill name="Light Armor Mastery" id="47082" level="8" required-level="76" sp="8000000" />
+		<skill name="Extra Hit" id="47085" level="1" required-level="76" sp="8000000" />
+		<skill name="Elemental Spirit" id="47101" level="3" required-level="76" sp="8000000" />
+		<skill name="Elemental Connection" id="47104" level="4" required-level="76" sp="8000000" />
+		<skill name="Mount Elemental Lyn Draco" id="54225" level="1" required-level="76" sp="8000000" />
+
+		<!-- Skills Lv77 -->		
+		<skill name="Dual Blow" id="47002" level="22" required-level="77" sp="10000000" />
+		<skill name="Quick Recharge" id="47083" level="4" required-level="77" sp="10000000" />
+		<skill name="Elemental Recovery" id="47105" level="5" required-level="77" sp="10000000" />
+
+		<!-- Skills Lv78 -->		
+		<skill name="Dual Blow" id="47002" level="23" required-level="78" sp="12000000" />
+		<skill name="Freezing Wound" id="47011" level="5" required-level="78" sp="12000000" />
+		<skill name="Light Armor Mastery" id="47082" level="9" required-level="78" sp="12000000" />
+
+		<!-- Skills Lv79 -->		
+		<skill name="Dual Blow" id="47002" level="24" required-level="79" sp="15000000" />
+		<skill name="Firearms Mastery" id="47081" level="9" required-level="79" sp="15000000" />
+		
+		<!-- Skills Lv80 -->		
+		<skill name="Evolution Power" id="45189" level="1" required-level="80" sp="0" />
+		<skill name="Blessed by Sayha" id="45408" level="2" required-level="80" sp="0" />
+		<skill name="Dual Blow" id="47002" level="25" required-level="80" sp="18000000" />
+		<skill name="Stealthy Swiftness" id="47008" level="1" required-level="80" sp="18000000" />
+		<skill name="Freezing Wound" id="47011" level="6" required-level="80" sp="18000000" />
+		<skill name="Dragon Strike" id="47041" level="1" required-level="80" sp="18000000" />
+		<skill name="Elemental Spirit" id="47101" level="4" required-level="80" sp="18000000" />
+		<skill name="White Guardian Transformation" id="54102" level="1" required-level="80" sp="0" />
+
+		<!-- Skills Lv81 -->		
+		<skill name="Dual Blow" id="47002" level="26" required-level="81" sp="160000000" />
+		<skill name="Light Armor Mastery" id="47082" level="10" required-level="81" sp="160000000" />
+
+		<!-- Skills Lv82 -->		
+		<skill name="Dual Blow" id="47002" level="27" required-level="82" sp="200000000" />
+		<skill name="Freezing Wound" id="47011" level="7" required-level="82" sp="200000000" />
+		<skill name="Firearms Mastery" id="47081" level="10" required-level="82" sp="200000000" />
+		<skill name="Quick Recharge" id="47083" level="5" required-level="82" sp="200000000" />
+		<skill name="Elemental Recovery" id="47105" level="6" required-level="82" sp="200000000" />
+
+		<!-- Skills Lv83 -->		
+		<skill name="Dual Blow" id="47002" level="28" required-level="83" sp="240000000" />
+		<skill name="Light Armor Mastery" id="47082" level="11" required-level="83" sp="240000000" />
+
+		<!-- Skills Lv84 -->		
+		<skill name="Dual Blow" id="47002" level="29" required-level="84" sp="350000000" />
+		<skill name="Elemental Recovery" id="47105" level="7" required-level="84" sp="350000000" />
+		<skill name="Firearms Mastery" id="47081" level="11" required-level="84" sp="350000000" />
+
+		<!-- Skills Lv85 -->		
+		<skill name="Blessed by Sayha" id="45408" level="3" required-level="85" sp="0" />
+		<skill name="Dual Blow" id="47002" level="29" required-level="85" sp="840000000" />
+		<skill name="Freezing Wound" id="47011" level="8" required-level="85" sp="840000000" />
+		<skill name="Light Armor Mastery" id="47082" level="12" required-level="85" sp="840000000" />
+		<skill name="Elemental Connection" id="47104" level="5" required-level="85" sp="840000000" />
+
+		<!-- Skills Lv86 -->		
+		<skill name="Dual Blow" id="47002" level="31" required-level="86" sp="840000000" />
+		<skill name="Firearms Mastery" id="47081" level="12" required-level="86" sp="840000000" />
+		<skill name="Elemental Recovery" id="47105" level="8" required-level="86" sp="840000000" />
+
+		<!-- Skills Lv87 -->		
+		<skill name="Dual Blow" id="47002" level="32" required-level="87" sp="840000000" />
+		<skill name="Light Armor Mastery" id="47082" level="13" required-level="87" sp="840000000" />
+
+		<!-- Skills Lv88 -->		
+		<skill name="Dual Blow" id="47002" level="33" required-level="88" sp="840000000" />
+		<skill name="Freezing Wound" id="47011" level="9" required-level="88" sp="840000000" />
+		<skill name="Firearms Mastery" id="47081" level="13" required-level="88" sp="840000000" />
+		<skill name="Elemental Recovery" id="47105" level="9" required-level="88" sp="840000000" />
+
+		<!-- Skills Lv89 -->		
+		<skill name="Dual Blow" id="47002" level="34" required-level="89" sp="840000000" />
+		<skill name="Firearms Mastery" id="47081" level="14" required-level="89" sp="840000000" />
+		<skill name="Light Armor Mastery" id="47082" level="14" required-level="89" sp="840000000" />
+
+		<!-- Skills Lv90 -->		
+		<skill name="Blessed by Sayha" id="45408" level="4" required-level="90" sp="0" />
+		<skill name="Dual Blow" id="47002" level="35" required-level="90" sp="840000000" />
+		<skill name="Freezing Wound" id="47011" level="10" required-level="90" sp="840000000" />
+		<skill name="Firearms Mastery" id="47081" level="15" required-level="90" sp="840000000" />
+		<skill name="Light Armor Mastery" id="47082" level="15" required-level="90" sp="840000000" />
+		<skill name="Elemental Recovery" id="47105" level="10" required-level="90" sp="840000000" />
+	</skillTree>
+</list>

--- a/data/skillTrees/3rdClass/StormScreamer.xml
+++ b/data/skillTrees/3rdClass/StormScreamer.xml
@@ -1,173 +1,285 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="110" parentClassId="40">
-		<skill name="White Guardian" id="54102" level="1" required-level="80" >
-			<item id="92401"/>
-		</skill>
+
 		<skill name="Anti Magic" id="146" level="46" required-level="76" sp="5700000" />
 		<skill name="Silence" id="1064" level="15" required-level="76" sp="5700000" />
+		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="5700000">
+			<item id="8620" count="1" /> <!-- Buff Expansion Book Lv. 3 -->
+		</skill>
+		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="5700000">
+			<item id="8621" count="1" /> <!-- Buff Expansion Book Lv. 4 -->
+		</skill>
 		<skill name="Tempest" id="1176" level="16" required-level="76" sp="5700000" />
+		<skill name="Thunder Explosion" id="45380" level="1" required-level="76" sp="5700000">
+			<item id="93869" count="1" /> <!-- Spellbook: Elemental Burst -->
+		</skill>
 		<skill name="Robe Mastery" id="234" level="42" required-level="76" sp="5700000" />
 		<skill name="Weapon Mastery" id="249" level="43" required-level="76" sp="5700000" />
 		<skill name="Wind Vortex" id="1341" level="1" required-level="76" sp="5700000" />
 		<skill name="Demon Wind" id="1291" level="2" required-level="76" sp="5700000" />
 		<skill name="Slow" id="1160" level="16" required-level="76" sp="5700000" />
-		<skill name="Vampiric Claw" id="1234" level="29" required-level="76" sp="5700000" />
-		<skill name="Bind" id="53006" level="1" required-level="76" sp="5700000" />
+		<skill name="Evolution Defense" id="45188" level="1" required-level="76">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Vampiric Claw" id="1234" level="31" required-level="76" sp="5700000" />
+		<!-- Might Lv. 4 -->
+		<skill name="Might" id="1068" level="4" required-level="76" sp="5700000">
+			<item id="94135" count="1" /> <!-- Master's Book: Might -->
+		</skill>
+		<!-- Shield Lv. 4 -->
+		<skill name="Shield" id="1040" level="4" required-level="76" sp="5700000">
+			<item id="94136" count="1" /> <!-- Master's Book: Shield -->
+		</skill>
+		<!-- Acumen Lv. 4 -->
+		<skill name="Acumen" id="45104" level="4" required-level="76" sp="5700000">
+			<item id="94370" count="1" /> <!-- Master's Book: Acumen -->
+		</skill>
+		<!-- Empower Lv. 4 -->
+		<skill name="Empower" id="45105" level="4" required-level="76" sp="5700000">
+			<item id="94361" count="1" /> <!-- Master's Book: Empower -->
+		</skill>
+		<!-- Wild Magic Lv. 3 -->
+		<skill name="Wild Magic" id="45106" level="3" required-level="76" sp="5700000">
+			<item id="94368" count="1" /> <!-- Master's Book: Wild Magic -->
+		</skill>
+		<!-- Wind Walk Lv. 3 -->
+		<skill name="Wind Walk" id="45107" level="3" required-level="76" sp="5700000">
+			<item id="94365" count="1" /> <!-- Master's Book: Wind Walk -->
+		</skill>
+		<!-- Magic Barrier Lv. 3 -->
+		<skill name="Magic Barrier" id="45108" level="3" required-level="76" sp="5700000">
+			<item id="94362" count="1" /> <!-- Master's Book: Magic Barrier -->
+		</skill>
+		<!-- Focus Lv. 4 -->
+		<skill name="Focus" id="45109" level="4" required-level="76" sp="5700000">
+			<item id="94363" count="1" /> <!-- Master's Book: Focus -->
+		</skill>
+		<!-- Death Whisper Lv. 4 -->
+		<skill name="Death Whisper" id="45110" level="4" required-level="76" sp="5700000">
+			<item id="94364" count="1" /> <!-- Master's Book: Death Whisper -->
+		</skill>
+		<!-- Haste Lv. 3 -->
+		<skill name="Haste" id="45111" level="3" required-level="76" sp="5700000">
+			<item id="94369" count="1" /> <!-- Master's Book: Haste -->
+		</skill>
+		<!-- Berserker Spirit Lv. 3 -->
+		<skill name="Berserker Spirit" id="45112" level="3" required-level="76" sp="5700000">
+			<item id="94366" count="1" /> <!-- Master's Book: Berserker Spirit -->
+		</skill>
+		<!-- Clarity Lv. 4 -->
+		<skill name="Clarity" id="45113" level="4" required-level="76" sp="5700000">
+			<item id="94367" count="1" /> <!-- Master's Book: Clarity -->
+		</skill>
+		<skill name="Detection" id="45190" level="1" required-level="76" sp="5700000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Wind Shackle" id="1206" level="20" required-level="76" sp="5700000" />
+		<skill name="Mount Saber Tooth Cougar" id="1835" level="1" required-level="76">
+			<item id="90040" count="1" /> <!-- Spellbook: Ride Sabretooth Cougar -->
+		</skill>
+		<skill name="Bind" id="53006" level="1" required-level="76" sp="5700000">
+			<item id="91483" count="1" /> <!-- Scroll: Bind -->
+		</skill>
 		<skill name="Corpse Life Drain" id="1151" level="17" required-level="76" sp="5700000" />
 		<skill name="Curse Death Link" id="1159" level="23" required-level="76" sp="5700000" />
 		<skill name="Curse Chaos" id="1222" level="16" required-level="76" sp="5700000" />
-		<skill name="Hurricane" id="1239" level="29" required-level="76" sp="5700000" />
+		<skill name="Hurricane" id="1239" level="31" required-level="76" sp="5700000" />
 		<skill name="Higher Mana Gain" id="285" level="28" required-level="76" sp="5700000" />
-		<skill name="Sleep" id="1069" level="43" required-level="76" sp="5700000" />
-		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="5700000">
-			<item id="8620"/> <!-- Ancient Book: Divine Inspiration (Manuscript) -->
-		</skill>
-		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="5700000">
-			<item id="8621"/> <!-- Ancient Book: Divine Inspiration (Original Version) -->
-		</skill>
-		<skill name="Mount Saber Tooth Cougar" id="1835" level="1" required-level="76">
-			<item id="90040"/> <!-- Spellbook: Mount Saber Tooth Cougar -->
-		</skill>
-		<skill name="Glory Ability" id="45361" level="1" required-level="86">
-			<item id="94046"/> <!-- Spellbook: Glory Ability Lv. 1 -->
-		</skill>
-		<skill name="Mount White Wings" id="54200" level="1" required-level="87">
-			<item id="93059"/> <!-- Spellbook: Summon White Wings -->
-		</skill>	
-		<skill name="Mount Shining Lady" id="54202" level="1" required-level="89">
-			<item id="93061"/> <!-- Spellbook: Summon Silver Saint -->
-		</skill>
-		
+		<skill name="Sleep" id="1069" level="46" required-level="76" sp="5700000" />
 		<skill name="Anti Magic" id="146" level="47" required-level="77" sp="5700000" />
+		<skill name="Thunder Explosion" id="45380" level="2" required-level="77" sp="5700000" />
 		<skill name="Robe Mastery" id="234" level="43" required-level="77" sp="5700000" />
 		<skill name="Weapon Mastery" id="249" level="44" required-level="77" sp="5700000" />
-		<skill name="Vampiric Claw" id="1234" level="30" required-level="77" sp="5700000" />
+		<skill name="Vampiric Claw" id="1234" level="32" required-level="77" sp="5700000" />
 		<skill name="Curse Death Link" id="1159" level="24" required-level="77" sp="5700000" />
-		<skill name="Hurricane" id="1239" level="30" required-level="77" sp="5700000" />
-		<skill name="Higher Mana Gain" id="285" level="29" required-level="77" sp="5700000" />
-		<skill name="Sleep" id="1069" level="44" required-level="77" sp="5700000" />
 		<skill name="Arcane Power" id="337" level="1" required-level="77" sp="5700000">
-			<item id="90081"/> <!-- Scroll: Arcane Power -->
+			<item id="90081" count="1" /> <!-- Scroll: Arcane Power -->
 		</skill>
-		
+		<skill name="Hurricane" id="1239" level="32" required-level="77" sp="5700000" />
+		<skill name="Higher Mana Gain" id="285" level="29" required-level="77" sp="5700000" />
+		<skill name="Sleep" id="1069" level="47" required-level="77" sp="5700000" />
+
 		<skill name="Anti Magic" id="146" level="48" required-level="78" sp="12400000" />
 		<skill name="Silence" id="1064" level="16" required-level="78" sp="12400000" />
 		<skill name="Tempest" id="1176" level="17" required-level="78" sp="12400000" />
+		<skill name="Thunder Explosion" id="45380" level="3" required-level="78" sp="12400000" />
 		<skill name="Robe Mastery" id="234" level="44" required-level="78" sp="12400000" />
 		<skill name="Weapon Mastery" id="249" level="45" required-level="78" sp="12400000" />
 		<skill name="Demon Wind" id="1291" level="3" required-level="78" sp="12400000" />
 		<skill name="Slow" id="1160" level="17" required-level="78" sp="12400000" />
-		<skill name="Vampiric Claw" id="1234" level="31" required-level="78" sp="12400000" />
+		<skill name="Vampiric Claw" id="1234" level="33" required-level="78" sp="12400000" />
+		<skill name="Wind Shackle" id="1206" level="21" required-level="78" sp="12400000" />
 		<skill name="Bind" id="53006" level="2" required-level="78" sp="12400000" />
 		<skill name="Corpse Life Drain" id="1151" level="18" required-level="78" sp="12400000" />
+		<skill name="Wind Vortex Slug" id="1456" level="1" required-level="78" sp="12400000">
+			<item id="90084" count="1" /> <!-- Scroll: Wind Vortex Slug -->
+		</skill>
 		<skill name="Curse Death Link" id="1159" level="25" required-level="78" sp="12400000" />
 		<skill name="Curse Chaos" id="1222" level="17" required-level="78" sp="12400000" />
 		<skill name="Arcane Power" id="337" level="2" required-level="78" sp="12400000" />
-		<skill name="Hurricane" id="1239" level="31" required-level="78" sp="12400000" />
+		<skill name="Hurricane" id="1239" level="33" required-level="78" sp="12400000" />
 		<skill name="Higher Mana Gain" id="285" level="30" required-level="78" sp="12400000" />
-		<skill name="Sleep" id="1069" level="45" required-level="78" sp="12400000" />
+		<skill name="Sleep" id="1069" level="48" required-level="78" sp="12400000" />
 		<skill name="Poisonous Cloud" id="1167" level="7" required-level="78" sp="12400000" />
-		<skill name="Wind Vortex Slug" id="1456" level="1" required-level="78" sp="12400000">
-			<item id="90084"/> <!-- Scroll: Wind Vortex Slug -->
-		</skill>
-		
+
 		<skill name="Tempest" id="1176" level="18" required-level="79" sp="12400000" />
+		<skill name="Thunder Explosion" id="45380" level="4" required-level="79" sp="12400000" />
+		<skill name="Vampiric Claw" id="1234" level="34" required-level="79" sp="12400000" />
+		<skill name="Wind Shackle" id="1206" level="22" required-level="79" sp="12400000" />
 		<skill name="Arcane Power" id="337" level="3" required-level="79" sp="12400000" />
-		<skill name="Sleep" id="1069" level="46" required-level="79" sp="12400000" />
 		<skill name="Arcane Chaos" id="1338" level="1" required-level="79" sp="12400000">
-			<item id="90085"/> <!-- Scroll: Arcane Chaos -->
+			<item id="90085" count="1" /> <!-- Scroll: Arcane Chaos -->
 		</skill>
-		
+		<skill name="Hurricane" id="1239" level="34" required-level="79" sp="12400000" />
+		<skill name="Sleep" id="1069" level="49" required-level="79" sp="12400000" />
+
 		<skill name="Anti Magic" id="146" level="49" required-level="80" sp="12400000" />
 		<skill name="Tempest" id="1176" level="19" required-level="80" sp="12400000" />
+		<skill name="Thunder Explosion" id="45380" level="5" required-level="80" sp="12400000" />
 		<skill name="Robe Mastery" id="234" level="45" required-level="80" sp="12400000" />
 		<skill name="Weapon Mastery" id="249" level="46" required-level="80" sp="12400000" />
 		<skill name="Demon Wind" id="1291" level="4" required-level="80" sp="12400000" />
+		<skill name="Vampiric Claw" id="1234" level="35" required-level="80" sp="12400000" />
+		<skill name="Spell Master" id="1831" level="4" required-level="80" sp="2400000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Arcane Shield" id="1556" level="1" required-level="80" sp="12400000">
+			<item id="90086" count="1" /> <!-- Scroll: Arcane Shield -->
+		</skill>
+		<skill name="Evolution Power" id="45189" level="1" required-level="80">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Wind Shackle" id="1206" level="23" required-level="80" sp="12400000" />
+		<skill name="Poison" id="1168" level="8" required-level="80" sp="12400000" />
 		<skill name="Bind" id="53006" level="3" required-level="80" sp="12400000" />
 		<skill name="Curse Death Link" id="1159" level="26" required-level="80" sp="12400000" />
 		<skill name="Mana Regeneration" id="1047" level="5" required-level="80" sp="12400000" />
-		<skill name="Body To Mind" id="1157" level="6" required-level="80" sp="12400000" />
+		<skill name="Body to Mind" id="1157" level="6" required-level="80" sp="12400000" />
 		<skill name="Arcane Power" id="337" level="4" required-level="80" sp="12400000" />
-		<skill name="Hurricane" id="1239" level="32" required-level="80" sp="12400000" />
-		<skill name="Higher Mana Gain" id="285" level="31" required-level="80" sp="12400000" />
-		<skill name="Sleep" id="1069" level="47" required-level="80" sp="12400000" />
-		<skill name="Arcane Shield" id="1556" level="1" required-level="80" sp="12400000">
-			<item id="90086"/> <!-- Scroll: Arcane Shield -->
+		<skill name="White Guardian Transformation" id="54102" level="1" required-level="80">
+			<item id="92401" count="1" /> <!-- Spellbook - White Guardian -->
 		</skill>
+		<skill name="Hurricane" id="1239" level="35" required-level="80" sp="12400000" />
+		<skill name="Higher Mana Gain" id="285" level="31" required-level="80" sp="12400000" />
+		<skill name="Sleep" id="1069" level="50" required-level="80" sp="12400000" />
 
 		<skill name="Anti Magic" id="146" level="50" required-level="81" sp="160000000" />
 		<skill name="Tempest" id="1176" level="20" required-level="81" sp="160000000" />
+		<skill name="Thunder Explosion" id="45380" level="6" required-level="81" sp="160000000" />
 		<skill name="Robe Mastery" id="234" level="46" required-level="81" sp="160000000" />
 		<skill name="Weapon Mastery" id="249" level="47" required-level="81" sp="160000000" />
+		<skill name="Vampiric Claw" id="1234" level="36" required-level="81" sp="160000000" />
 		<skill name="Arcane Shield" id="1556" level="2" required-level="81" sp="160000000" />
+		<skill name="Wind Shackle" id="1206" level="24" required-level="81" sp="160000000" />
 		<skill name="Curse Death Link" id="1159" level="27" required-level="81" sp="160000000" />
-		<skill name="Body To Mind" id="1157" level="7" required-level="81" sp="160000000" />
+		<skill name="Body to Mind" id="1157" level="7" required-level="81" sp="160000000" />
 		<skill name="Arcane Power" id="337" level="5" required-level="81" sp="160000000" />
-		<skill name="Hurricane" id="1239" level="33" required-level="81" sp="160000000" />
+		<skill name="Hurricane" id="1239" level="36" required-level="81" sp="160000000" />
 		<skill name="Higher Mana Gain" id="285" level="32" required-level="81" sp="160000000" />
-		<skill name="Sleep" id="1069" level="48" required-level="81" sp="160000000" />
+		<skill name="Sleep" id="1069" level="51" required-level="81" sp="160000000" />
 
 		<skill name="Anti Magic" id="146" level="51" required-level="82" sp="170000000" />
 		<skill name="Tempest" id="1176" level="21" required-level="82" sp="170000000" />
+		<skill name="Thunder Explosion" id="45380" level="7" required-level="82" sp="170000000" />
 		<skill name="Robe Mastery" id="234" level="47" required-level="82" sp="170000000" />
 		<skill name="Weapon Mastery" id="249" level="48" required-level="82" sp="170000000" />
 		<skill name="Wind Vortex" id="1341" level="2" required-level="82" sp="170000000" />
 		<skill name="Demon Wind" id="1291" level="5" required-level="82" sp="170000000" />
+		<skill name="Vampiric Claw" id="1234" level="37" required-level="82" sp="170000000" />
 		<skill name="Arcane Shield" id="1556" level="3" required-level="82" sp="170000000" />
+		<skill name="Wind Shackle" id="1206" level="25" required-level="82" sp="170000000" />
 		<skill name="Bind" id="53006" level="4" required-level="82" sp="170000000" />
 		<skill name="Curse Death Link" id="1159" level="28" required-level="82" sp="170000000" />
-		<skill name="Body To Mind" id="1157" level="8" required-level="82" sp="170000000" />
+		<skill name="Body to Mind" id="1157" level="8" required-level="82" sp="170000000" />
 		<skill name="Arcane Power" id="337" level="6" required-level="82" sp="170000000" />
-		<skill name="Hurricane" id="1239" level="34" required-level="82" sp="170000000" />
+		<skill name="Hurricane" id="1239" level="37" required-level="82" sp="170000000" />
 		<skill name="Higher Mana Gain" id="285" level="33" required-level="82" sp="170000000" />
-		<skill name="Sleep" id="1069" level="49" required-level="82" sp="170000000" />
+		<skill name="Sleep" id="1069" level="52" required-level="82" sp="170000000" />
 
 		<skill name="Anti Magic" id="146" level="52" required-level="83" sp="240000000" />
 		<skill name="Tempest" id="1176" level="22" required-level="83" sp="240000000" />
+		<skill name="Thunder Explosion" id="45380" level="8" required-level="83" sp="240000000" />
 		<skill name="Robe Mastery" id="234" level="48" required-level="83" sp="240000000" />
 		<skill name="Weapon Mastery" id="249" level="49" required-level="83" sp="240000000" />
+		<skill name="Vampiric Claw" id="1234" level="38" required-level="83" sp="240000000" />
 		<skill name="Arcane Shield" id="1556" level="4" required-level="83" sp="240000000" />
+		<skill name="Wind Shackle" id="1206" level="26" required-level="83" sp="240000000" />
 		<skill name="Curse Death Link" id="1159" level="29" required-level="83" sp="240000000" />
-		<skill name="Body To Mind" id="1157" level="9" required-level="83" sp="240000000" />
+		<skill name="Body to Mind" id="1157" level="9" required-level="83" sp="240000000" />
 		<skill name="Arcane Power" id="337" level="7" required-level="83" sp="240000000" />
-		<skill name="Hurricane" id="1239" level="35" required-level="83" sp="240000000" />
+		<skill name="Hurricane" id="1239" level="38" required-level="83" sp="240000000" />
 		<skill name="Higher Mana Gain" id="285" level="34" required-level="83" sp="240000000" />
-		<skill name="Sleep" id="1069" level="50" required-level="83" sp="240000000" />
+		<skill name="Sleep" id="1069" level="53" required-level="83" sp="240000000" />
 
 		<skill name="Anti Magic" id="146" level="53" required-level="84" sp="240000000" />
 		<skill name="Tempest" id="1176" level="23" required-level="84" sp="240000000" />
+		<skill name="Thunder Explosion" id="45380" level="9" required-level="84" sp="240000000" />
 		<skill name="Robe Mastery" id="234" level="49" required-level="84" sp="240000000" />
 		<skill name="Weapon Mastery" id="249" level="50" required-level="84" sp="240000000" />
 		<skill name="Wind Vortex" id="1341" level="3" required-level="84" sp="240000000" />
 		<skill name="Demon Wind" id="1291" level="6" required-level="84" sp="240000000" />
+		<skill name="Vampiric Claw" id="1234" level="39" required-level="84" sp="240000000" />
 		<skill name="Arcane Shield" id="1556" level="5" required-level="84" sp="240000000" />
+		<skill name="Wind Shackle" id="1206" level="27" required-level="84" sp="240000000" />
 		<skill name="Bind" id="53006" level="5" required-level="84" sp="240000000" />
 		<skill name="Wind Vortex Slug" id="1456" level="2" required-level="84" sp="240000000" />
 		<skill name="Curse Death Link" id="1159" level="30" required-level="84" sp="240000000" />
-		<skill name="Body To Mind" id="1157" level="10" required-level="84" sp="240000000" />
+		<skill name="Body to Mind" id="1157" level="10" required-level="84" sp="240000000" />
 		<skill name="Arcane Power" id="337" level="8" required-level="84" sp="240000000" />
-		<skill name="Hurricane" id="1239" level="36" required-level="84" sp="240000000" />
+		<skill name="Hurricane" id="1239" level="39" required-level="84" sp="240000000" />
 		<skill name="Higher Mana Gain" id="285" level="35" required-level="84" sp="240000000" />
-		<skill name="Sleep" id="1069" level="51" required-level="84" sp="240000000" />
-		
+		<skill name="Sleep" id="1069" level="54" required-level="84" sp="240000000" />
+
 		<skill name="Anti Magic" id="146" level="54" required-level="85" sp="840000000" />
-		<skill name="Anti Magic" id="146" level="55" required-level="86" sp="924000000" />
-		<skill name="Anti Magic" id="146" level="56" required-level="87" sp="1016400000" />
-		<skill name="Anti Magic" id="146" level="57" required-level="88" sp="1118040000" />
-		<skill name="Anti Magic" id="146" level="58" required-level="89" sp="1229844000" />
-		<skill name="Anti Magic" id="146" level="59" required-level="90" sp="1352828400" />
+		<skill name="Thunder Explosion" id="45380" level="10" required-level="85" sp="840000000" />
 		<skill name="Robe Mastery" id="234" level="50" required-level="85" sp="840000000" />
-		<skill name="Robe Mastery" id="234" level="51" required-level="86" sp="924000000" />
-		<skill name="Robe Mastery" id="234" level="52" required-level="87" sp="1016400000" />
-		<skill name="Robe Mastery" id="234" level="53" required-level="88" sp="1118040000" />
-		<skill name="Robe Mastery" id="234" level="54" required-level="89" sp="1229844000" />
-		<skill name="Robe Mastery" id="234" level="55" required-level="90" sp="1352828400" />
 		<skill name="Weapon Mastery" id="249" level="51" required-level="85" sp="840000000" />
-		<skill name="Weapon Mastery" id="249" level="52" required-level="86" sp="924000000" />
-		<skill name="Weapon Mastery" id="249" level="53" required-level="87" sp="1016400000" />
-		<skill name="Weapon Mastery" id="249" level="54" required-level="88" sp="1118040000" />
-		<skill name="Weapon Mastery" id="249" level="55" required-level="89" sp="1229844000" />
-		<skill name="Weapon Mastery" id="249" level="56" required-level="90" sp="1352828400" />
+		<skill name="Vampiric Claw" id="1234" level="40" required-level="85" sp="840000000" />
+		<skill name="Poison" id="1168" level="9" required-level="85" sp="840000000" />
+		<skill name="Hurricane" id="1239" level="40" required-level="85" sp="840000000" />
+		<skill name="Higher Mana Gain" id="285" level="36" required-level="85" sp="840000000" />
+		<skill name="Sleep" id="1069" level="55" required-level="85" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="55" required-level="86" sp="840000000" />
+		<skill name="Thunder Explosion" id="45380" level="11" required-level="86" sp="840000000" />
+		<skill name="Robe Mastery" id="234" level="51" required-level="86" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="52" required-level="86" sp="840000000" />
+		<skill name="Vampiric Claw" id="1234" level="41" required-level="86" sp="840000000" />
+		<skill name="Hurricane" id="1239" level="41" required-level="86" sp="840000000" />
+		<skill name="Sleep" id="1069" level="56" required-level="86" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="56" required-level="87" sp="840000000" />
+		<skill name="Thunder Explosion" id="45380" level="12" required-level="87" sp="840000000" />
+		<skill name="Robe Mastery" id="234" level="52" required-level="87" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="53" required-level="87" sp="840000000" />
+		<skill name="Vampiric Claw" id="1234" level="42" required-level="87" sp="840000000" />
+		<skill name="Hurricane" id="1239" level="42" required-level="87" sp="840000000" />
+		<skill name="Sleep" id="1069" level="57" required-level="87" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="57" required-level="88" sp="840000000" />
+		<skill name="Thunder Explosion" id="45380" level="13" required-level="88" sp="840000000" />
+		<skill name="Robe Mastery" id="234" level="53" required-level="88" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="54" required-level="88" sp="840000000" />
+		<skill name="Vampiric Claw" id="1234" level="43" required-level="88" sp="840000000" />
+		<skill name="Hurricane" id="1239" level="43" required-level="88" sp="840000000" />
+		<skill name="Sleep" id="1069" level="58" required-level="88" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="58" required-level="89" sp="840000000" />
+		<skill name="Thunder Explosion" id="45380" level="14" required-level="89" sp="840000000" />
+		<skill name="Robe Mastery" id="234" level="54" required-level="89" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="55" required-level="89" sp="840000000" />
+		<skill name="Vampiric Claw" id="1234" level="44" required-level="89" sp="840000000" />
+		<skill name="Hurricane" id="1239" level="44" required-level="89" sp="840000000" />
+		<skill name="Sleep" id="1069" level="59" required-level="89" sp="840000000" />
+
+		<skill name="Anti Magic" id="146" level="59" required-level="90" sp="840000000" />
+		<skill name="Thunder Explosion" id="45380" level="15" required-level="90" sp="840000000" />
+		<skill name="Robe Mastery" id="234" level="55" required-level="90" sp="840000000" />
+		<skill name="Weapon Mastery" id="249" level="56" required-level="90" sp="840000000" />
+		<skill name="Vampiric Claw" id="1234" level="45" required-level="90" sp="840000000" />
+		<skill name="Poison" id="1168" level="10" required-level="90" sp="840000000" />
+		<skill name="Hurricane" id="1239" level="45" required-level="90" sp="840000000" />
+		<skill name="Sleep" id="1069" level="60" required-level="90" sp="840000000" />
 	</skillTree>
 </list>

--- a/data/skillTrees/3rdClass/Swordmuse.xml
+++ b/data/skillTrees/3rdClass/Swordmuse.xml
@@ -1,112 +1,248 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="100" parentClassId="21">
-		<skill name="White Guardian" id="54102" level="1" required-level="80" >
-			<item id="92401"/>
-		</skill>
-		<skill name="Arrest" id="402" level="11" required-level="76" sp="10200000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="46" required-level="76" sp="10200000" />
-		<skill name="Heavy Armor Mastery" id="232" level="53" required-level="76" sp="10200000" />
-		<skill name="Magic Resistance" id="147" level="52" required-level="76" sp="10200000" />
-		<skill name="Entangle" id="102" level="17" required-level="76" sp="10200000" />
-		<skill name="Charm" id="15" level="53" required-level="76" sp="10200000" />
-		<skill name="Sword Symphony" id="98" level="6" required-level="76" sp="10200000" />
-		<skill name="Deadly Strike" id="1632" level="1" required-level="76" sp="10200000" />
+
 		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="10200000">
-			<item id="8620"/> <!-- Ancient Book: Divine Inspiration (Manuscript) -->
+			<item id="8620" count="1" /> <!-- Buff Expansion Book Lv. 3 -->
 		</skill>
 		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="10200000">
-			<item id="8621"/> <!-- Ancient Book: Divine Inspiration (Original Version) -->
+			<item id="8621" count="1" /> <!-- Buff Expansion Book Lv. 4 -->
 		</skill>
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="46" required-level="76" sp="10200000" />
+		<skill name="Weapon Mastery" id="141" level="5" required-level="76" sp="10200000" />
+		<skill name="Heavy Armor Mastery" id="232" level="53" required-level="76" sp="10200000" />
+		<skill name="Evolution Defense" id="45188" level="1" required-level="76">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Shackle" id="402" level="11" required-level="76" sp="10200000" />
+		<skill name="Magic Resistance" id="147" level="52" required-level="76" sp="10200000" />
+		<!-- Might Lv. 4 -->
+		<skill name="Might" id="1068" level="4" required-level="76" sp="10200000">
+			<item id="94135" count="1" /> <!-- Master's Book: Might -->
+		</skill>
+		<!-- Shield Lv. 4 -->
+		<skill name="Shield" id="1040" level="4" required-level="76" sp="10200000">
+			<item id="94136" count="1" /> <!-- Master's Book: Shield -->
+		</skill>
+		<!-- Acumen Lv. 4 -->
+		<skill name="Acumen" id="45104" level="4" required-level="76" sp="10200000">
+			<item id="94370" count="1" /> <!-- Master's Book: Acumen -->
+		</skill>
+		<!-- Empower Lv. 4 -->
+		<skill name="Empower" id="45105" level="4" required-level="76" sp="10200000">
+			<item id="94361" count="1" /> <!-- Master's Book: Empower -->
+		</skill>
+		<!-- Wild Magic Lv. 3 -->
+		<skill name="Wild Magic" id="45106" level="3" required-level="76" sp="10200000">
+			<item id="94368" count="1" /> <!-- Master's Book: Wild Magic -->
+		</skill>
+		<!-- Wind Walk Lv. 3 -->
+		<skill name="Wind Walk" id="45107" level="3" required-level="76" sp="10200000">
+			<item id="94365" count="1" /> <!-- Master's Book: Wind Walk -->
+		</skill>
+		<!-- Magic Barrier Lv. 3 -->
+		<skill name="Magic Barrier" id="45108" level="3" required-level="76" sp="10200000">
+			<item id="94362" count="1" /> <!-- Master's Book: Magic Barrier -->
+		</skill>
+		<!-- Focus Lv. 4 -->
+		<skill name="Focus" id="45109" level="4" required-level="76" sp="10200000">
+			<item id="94363" count="1" /> <!-- Master's Book: Focus -->
+		</skill>
+		<!-- Death Whisper Lv. 4 -->
+		<skill name="Death Whisper" id="45110" level="4" required-level="76" sp="10200000">
+			<item id="94364" count="1" /> <!-- Master's Book: Death Whisper -->
+		</skill>
+		<!-- Haste Lv. 3 -->
+		<skill name="Haste" id="45111" level="3" required-level="76" sp="10200000">
+			<item id="94369" count="1" /> <!-- Master's Book: Haste -->
+		</skill>
+		<!-- Berserker Spirit Lv. 3 -->
+		<skill name="Berserker Spirit" id="45112" level="3" required-level="76" sp="10200000">
+			<item id="94366" count="1" /> <!-- Master's Book: Berserker Spirit -->
+		</skill>
+		<!-- Clarity Lv. 4 -->
+		<skill name="Clarity" id="45113" level="4" required-level="76" sp="10200000">
+			<item id="94367" count="1" /> <!-- Master's Book: Clarity -->
+		</skill>
+		<skill name="Detection" id="45190" level="1" required-level="76" sp="10200000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Entangle" id="102" level="17" required-level="76" sp="10200000" />
 		<skill name="Mount Pegasus" id="1834" level="1" required-level="76">
-			<item id="90039"/> <!-- Spellbook: Mount Pegasus -->
+			<item id="90039" count="1" /> <!-- Spellbook - Ride Pegasus -->
 		</skill>
-		<skill name="Glory Ability" id="45361" level="1" required-level="86">
-			<item id="94046"/> <!-- Spellbook: Glory Ability Lv. 1 -->
-		</skill>
-		<skill name="Mount White Wings" id="54200" level="1" required-level="87">
-			<item id="93059"/> <!-- Spellbook: Summon White Wings -->
-		</skill>	
-		<skill name="Mount Shining Lady" id="54202" level="1" required-level="89">
-			<item id="93061"/> <!-- Spellbook: Summon Silver Saint -->
-		</skill>
-		
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="47" required-level="77" sp="10200000" />
+		<skill name="Slowdown" id="15" level="53" required-level="76" sp="10200000" />
+		<skill name="Symphony" id="98" level="6" required-level="76" sp="10200000" />
+		<skill name="Deadly Strike" id="1632" level="1" required-level="76" sp="10200000" />
+		<skill name="Emergency Rescue" id="70" level="46" required-level="76" sp="10200000" />
+
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="47" required-level="77" sp="10200000" />
 		<skill name="Heavy Armor Mastery" id="232" level="54" required-level="77" sp="10200000" />
+		<skill name="Shackle" id="402" level="12" required-level="77" sp="10200000" />
 		<skill name="Magic Resistance" id="147" level="53" required-level="77" sp="10200000" />
 		<skill name="Deadly Strike" id="1632" level="2" required-level="77" sp="10200000" />
-		<skill name="Song of Renewal" id="349" level="1" required-level="77" sp="10200000">
-			<item id="90090"/> <!-- Scroll: Song of Renewal -->
-		</skill>
-		
-		<skill name="Arrest" id="402" level="12" required-level="78" sp="23800000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="48" required-level="78" sp="23800000" />
+		<skill name="Emergency Rescue" id="70" level="47" required-level="77" sp="10200000" />
+
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="48" required-level="78" sp="23800000" />
 		<skill name="Heavy Armor Mastery" id="232" level="55" required-level="78" sp="23800000" />
+		<skill name="Shackle" id="402" level="13" required-level="78" sp="23800000" />
 		<skill name="Magic Resistance" id="147" level="54" required-level="78" sp="23800000" />
 		<skill name="Entangle" id="102" level="18" required-level="78" sp="23800000" />
-		<skill name="Charm" id="15" level="54" required-level="78" sp="23800000" />
+		<skill name="Slowdown" id="15" level="54" required-level="78" sp="23800000" />
 		<skill name="Deadly Strike" id="1632" level="3" required-level="78" sp="23800000" />
-		<skill name="Champion Song" id="364" level="1" required-level="78" sp="23800000">
-			<item id="90091"/> <!-- Scroll: Champion Song -->
-		</skill>
-		
-		<skill name="Song of Silence" id="437" level="1" required-level="79" sp="23800000">
-			<item id="90092"/>  <!-- Scroll: Song of Silence -->
-		</skill>
-		
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="49" required-level="80" sp="23800000" />
+		<skill name="Emergency Rescue" id="70" level="48" required-level="78" sp="23800000" />
+
+		<skill name="Song of Silence" id="437" level="1" required-level="79" sp="23800000" />
+		<skill name="Shackle" id="402" level="14" required-level="79" sp="23800000" />
+		<skill name="Entangle" id="102" level="19" required-level="79" sp="23800000" />
+		<skill name="Emergency Rescue" id="70" level="49" required-level="79" sp="23800000" />
+
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="49" required-level="80" sp="23800000" />
 		<skill name="Heavy Armor Mastery" id="232" level="56" required-level="80" sp="23800000" />
-		<skill name="Magic Resistance" id="147" level="55" required-level="80" sp="23800000" />
-		<skill name="Sword Symphony" id="98" level="7" required-level="80" sp="23800000" />
-		<skill name="Deadly Strike" id="1632" level="4" required-level="80" sp="23800000" />
-		<skill name="Song of Purification" id="914" level="1" required-level="80" sp="23800000">
-			<item id="90093"/> <!-- Scroll: Song of Purification -->
+		<skill name="Shackle" id="402" level="15" required-level="80" sp="23800000">
+			<item id="57" count="500000" /> <!-- Adena -->
 		</skill>
+		<skill name="Magic Resistance" id="147" level="55" required-level="80" sp="23800000" />
+		<skill name="Evolution Power" id="45189" level="1" required-level="80">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Entangle" id="102" level="20" required-level="80" sp="23800000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="55" required-level="80" sp="23800000" />
+		<skill name="Symphony" id="98" level="7" required-level="80" sp="23800000" />
+		<skill name="Deadly Strike" id="1632" level="4" required-level="80" sp="23800000" />
+		<skill name="White Guardian Transformation" id="54102" level="1" required-level="80">
+			<item id="92401" count="1" /> <!-- Spellbook - White Guardian -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="50" required-level="80" sp="23800000" />
 
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="50" required-level="81" sp="160000000" />
-		<skill name="Heavy Armor Mastery" id="232" level="57" required-level="81" sp="160000000" />
-		<skill name="Magic Resistance" id="147" level="56" required-level="81" sp="160000000" />
-		<skill name="Song of Wind" id="268" level="2" required-level="81" sp="160000000" />
 		<skill name="Song of Silence" id="437" level="2" required-level="81" sp="160000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="50" required-level="81" sp="160000000" />
+		<skill name="Heavy Armor Mastery" id="232" level="57" required-level="81" sp="160000000" />
+		<skill name="Shackle" id="402" level="16" required-level="81" sp="160000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Magic Resistance" id="147" level="56" required-level="81" sp="160000000" />
+		<skill name="Entangle" id="102" level="21" required-level="81" sp="160000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="56" required-level="81" sp="160000000" />
 		<skill name="Deadly Strike" id="1632" level="5" required-level="81" sp="160000000" />
+		<skill name="Emergency Rescue" id="70" level="51" required-level="81" sp="160000000" />
 
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="51" required-level="82" sp="170000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="51" required-level="82" sp="170000000" />
 		<skill name="Heavy Armor Mastery" id="232" level="58" required-level="82" sp="170000000" />
+		<skill name="Shackle" id="402" level="17" required-level="82" sp="170000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
 		<skill name="Magic Resistance" id="147" level="57" required-level="82" sp="170000000" />
-		<skill name="Song of Vitality" id="304" level="2" required-level="82" sp="170000000" />
+		<skill name="Entangle" id="102" level="22" required-level="82" sp="170000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="57" required-level="82" sp="170000000" />
 		<skill name="Deadly Strike" id="1632" level="6" required-level="82" sp="170000000" />
+		<skill name="Emergency Rescue" id="70" level="52" required-level="82" sp="170000000" />
 
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="52" required-level="83" sp="240000000" />
-		<skill name="Heavy Armor Mastery" id="232" level="59" required-level="83" sp="240000000" />
-		<skill name="Magic Resistance" id="147" level="58" required-level="83" sp="240000000" />
-		<skill name="Hunter's Song" id="269" level="2" required-level="83" sp="240000000" />
 		<skill name="Song of Silence" id="437" level="3" required-level="83" sp="240000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="52" required-level="83" sp="240000000" />
+		<skill name="Heavy Armor Mastery" id="232" level="59" required-level="83" sp="240000000" />
+		<skill name="Shackle" id="402" level="18" required-level="83" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Magic Resistance" id="147" level="58" required-level="83" sp="240000000" />
+		<skill name="Entangle" id="102" level="23" required-level="83" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="58" required-level="83" sp="240000000" />
 		<skill name="Deadly Strike" id="1632" level="7" required-level="83" sp="240000000" />
+		<skill name="Emergency Rescue" id="70" level="53" required-level="83" sp="240000000" />
 
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="53" required-level="84" sp="240000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="53" required-level="84" sp="240000000" />
 		<skill name="Heavy Armor Mastery" id="232" level="60" required-level="84" sp="240000000" />
+		<skill name="Shackle" id="402" level="19" required-level="84" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
 		<skill name="Magic Resistance" id="147" level="59" required-level="84" sp="240000000" />
-		<skill name="Song of Renewal" id="349" level="2" required-level="84" sp="240000000" />
-		<skill name="Sword Symphony" id="98" level="8" required-level="84" sp="240000000" />
+		<skill name="Entangle" id="102" level="24" required-level="84" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="59" required-level="84" sp="240000000" />
+		<skill name="Symphony" id="98" level="8" required-level="84" sp="240000000" />
 		<skill name="Deadly Strike" id="1632" level="8" required-level="84" sp="240000000" />
-		
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="54" required-level="85" sp="840000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="55" required-level="86" sp="924000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="56" required-level="87" sp="1016400000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="57" required-level="88" sp="1118040000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="58" required-level="89" sp="1229844000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="217" level="59" required-level="90" sp="1352828400" />
+		<skill name="Emergency Rescue" id="70" level="54" required-level="84" sp="240000000" />
+
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="54" required-level="85" sp="840000000" />
 		<skill name="Heavy Armor Mastery" id="232" level="61" required-level="85" sp="840000000" />
-		<skill name="Heavy Armor Mastery" id="232" level="62" required-level="86" sp="924000000" />
-		<skill name="Heavy Armor Mastery" id="232" level="63" required-level="87" sp="1016400000" />
-		<skill name="Heavy Armor Mastery" id="232" level="64" required-level="88" sp="1118040000" />
-		<skill name="Heavy Armor Mastery" id="232" level="65" required-level="89" sp="1229844000" />
-		<skill name="Heavy Armor Mastery" id="232" level="66" required-level="90" sp="1352828400" />
+		<skill name="Shackle" id="402" level="20" required-level="85" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
 		<skill name="Magic Resistance" id="147" level="60" required-level="85" sp="840000000" />
-		<skill name="Magic Resistance" id="147" level="61" required-level="86" sp="924000000" />
-		<skill name="Magic Resistance" id="147" level="62" required-level="87" sp="1016400000" />
-		<skill name="Magic Resistance" id="147" level="63" required-level="88" sp="1118040000" />
-		<skill name="Magic Resistance" id="147" level="64" required-level="89" sp="1229844000" />
-		<skill name="Magic Resistance" id="147" level="65" required-level="90" sp="1352828400" />
+		<skill name="Entangle" id="102" level="25" required-level="85" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="60" required-level="85" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="55" required-level="85" sp="840000000" />
+
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="55" required-level="86" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="232" level="62" required-level="86" sp="840000000" />
+		<skill name="Shackle" id="402" level="21" required-level="86" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Magic Resistance" id="147" level="61" required-level="86" sp="840000000" />
+		<skill name="Entangle" id="102" level="26" required-level="86" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="61" required-level="86" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="56" required-level="86" sp="840000000" />
+
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="56" required-level="87" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="232" level="63" required-level="87" sp="840000000" />
+		<skill name="Shackle" id="402" level="22" required-level="87" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Magic Resistance" id="147" level="62" required-level="87" sp="840000000" />
+		<skill name="Entangle" id="102" level="27" required-level="87" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="62" required-level="87" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="57" required-level="87" sp="840000000" />
+
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="57" required-level="88" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="232" level="64" required-level="88" sp="840000000" />
+		<skill name="Shackle" id="402" level="23" required-level="88" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Magic Resistance" id="147" level="63" required-level="88" sp="840000000" />
+		<skill name="Entangle" id="102" level="28" required-level="88" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="63" required-level="88" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="58" required-level="88" sp="840000000" />
+
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="58" required-level="89" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="232" level="65" required-level="89" sp="840000000" />
+		<skill name="Shackle" id="402" level="24" required-level="89" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Magic Resistance" id="147" level="64" required-level="89" sp="840000000" />
+		<skill name="Entangle" id="102" level="29" required-level="89" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="64" required-level="89" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="59" required-level="89" sp="840000000" />
+
+		<skill name="Sword / Blunt Weapon Mastery" id="217" level="59" required-level="90" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="232" level="66" required-level="90" sp="840000000" />
+		<skill name="Shackle" id="402" level="25" required-level="90" sp="840000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Magic Resistance" id="147" level="65" required-level="90" sp="840000000" />
+		<skill name="Entangle" id="102" level="30" required-level="90" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="65" required-level="90" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="60" required-level="90" sp="840000000" />
+
 	</skillTree>
 </list>

--- a/data/skillTrees/3rdClass/Titan.xml
+++ b/data/skillTrees/3rdClass/Titan.xml
@@ -1,176 +1,274 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="113" parentClassId="46">
-		<skill name="White Guardian" id="54102" level="1" required-level="80" >
-			<item id="92401"/>
+
+		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="5900000">
+			<item id="8620" count="1" /> <!-- Buff Expansion Book Lv. 3 -->
 		</skill>
-		<skill name="Immortal Life" id="1608" level="2" required-level="76" sp="5900000" />
-		<skill name="Spinning Slasher" id="36" level="38" required-level="76" sp="5900000" />
+		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="5900000">
+			<item id="8621" count="1" /> <!-- Buff Expansion Book Lv. 4 -->
+		</skill>
 		<skill name="Two-handed Weapon Mastery" id="293" level="21" required-level="76" sp="5900000" />
 		<skill name="Polearm Mastery" id="216" level="46" required-level="76" sp="5900000" />
 		<skill name="Light Armor Mastery" id="227" level="51" required-level="76" sp="5900000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="46" required-level="76" sp="5900000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="46" required-level="76" sp="5900000" />
+		<skill name="Weapon Mastery" id="141" level="5" required-level="76" sp="5900000" />
 		<skill name="Heavy Armor Mastery" id="231" level="51" required-level="76" sp="5900000" />
 		<skill name="Rage" id="94" level="3" required-level="76" sp="5900000" />
-		<skill name="Full Swing" id="814" level="1" required-level="76" sp="5900000" />
-		<skill name="Power Crush" id="260" level="38" required-level="76" sp="5900000" />
-		<skill name="Excruciating Strike" id="1607" level="38" required-level="76" sp="5900000" />
-		<skill name="Fatal Strike" id="190" level="38" required-level="76" sp="5900000" />
-		<skill name="Broad Sweep" id="1628" level="1" required-level="76" sp="5900000" />
-		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="5900000">
-			<item id="8620"/> <!-- Ancient Book: Divine Inspiration (Manuscript) -->
+		<skill name="Evolution Defense" id="45188" level="1" required-level="76">
+			<item id="57" count="5000000" /> <!-- Adena -->
 		</skill>
-		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="5900000">
-			<item id="8621"/> <!-- Ancient Book: Divine Inspiration (Original Version) -->
+		<skill name="Master of Combat" id="430" level="1" required-level="76" sp="5900000" />
+		<skill name="Chant of Might" id="45126" level="4" required-level="76" sp="5900000" />
+		<skill name="Chant of Shield" id="45127" level="4" required-level="76" sp="5900000" />
+		<skill name="Detection" id="45190" level="1" required-level="76" sp="5900000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<!-- Might Lv. 4 -->
+		<skill name="Chant of Might" id="45126" level="4" required-level="76" sp="5900000">
+			<item id="94135" count="1" /> <!-- Master's Book: Might -->
+		</skill>
+		<!-- Shield Lv. 4 -->
+		<skill name="Chant of Shield" id="45127" level="4" required-level="76" sp="5900000">
+			<item id="94136" count="1" /> <!-- Master's Book: Shield -->
+		</skill>
+		<!-- Acumen Lv. 4 -->
+		<skill name="Chant of Acumen" id="45135" level="4" required-level="76" sp="5900000">
+			<item id="94370" count="1" /> <!-- Master's Book: Acumen -->
+		</skill>
+		<!-- Empower Lv. 4 -->
+		<skill name="Chant of Empower" id="45136" level="4" required-level="76" sp="5900000">
+			<item id="94361" count="1" /> <!-- Master's Book: Empower -->
+		</skill>
+		<!-- Wild Magic Lv. 3 -->
+		<skill name="Chant of Wild Magic" id="45137" level="3" required-level="76" sp="5900000">
+			<item id="94368" count="1" /> <!-- Master's Book: Wild Magic -->
+		</skill>
+		<!-- Wind Walk Lv. 3 -->
+		<skill name="Chant of Wind Walk" id="45124" level="3" required-level="76" sp="5900000">
+			<item id="94365" count="1" /> <!-- Master's Book: Wind Walk -->
+		</skill>
+		<!-- Magic Barrier Lv. 3 -->
+		<skill name="Chant Of Magic Barrier" id="45125" level="3" required-level="76" sp="5900000">
+			<item id="94362" count="1" /> <!-- Master's Book: Magic Barrier -->
+		</skill>
+		<!-- Focus Lv. 4 -->
+		<skill name="Chant Of Focus" id="45121" level="4" required-level="76" sp="5900000">
+			<item id="94363" count="1" /> <!-- Master's Book: Focus -->
+		</skill>
+		<!-- Death Whisper Lv. 4 -->
+		<skill name="Chant Of Death Whisper" id="45122" level="4" required-level="76" sp="5900000">
+			<item id="94364" count="1" /> <!-- Master's Book: Death Whisper -->
+		</skill>
+		<!-- Haste Lv. 3 -->
+		<skill name="Chant of Haste" id="45123" level="3" required-level="76" sp="5900000">
+			<item id="94369" count="1" /> <!-- Master's Book: Haste -->
+		</skill>
+		<!-- Berserker Spirit Lv. 3 -->
+		<skill name="Chant Of Berserker Spirit" id="45128" level="3" required-level="76" sp="5900000">
+			<item id="94366" count="1" /> <!-- Master's Book: Berserker Spirit -->
+		</skill>
+		<!-- Clarity Lv. 4 -->
+		<skill name="Chant Of Clarity" id="45129" level="4" required-level="76" sp="5900000">
+			<item id="94367" count="1" /> <!-- Master's Book: Clarity -->
+		</skill>
+
+		<skill name="Final Secret" id="917" level="1" required-level="76" sp="5900000">
+			<item id="90080" count="1" /> <!-- Scroll: Final Secret -->
 		</skill>
 		<skill name="Mount Black Bear" id="1837" level="1" required-level="76">
-			<item id="90042"/> <!--  Spellbook: Mount Black Bear -->
+			<item id="90042" count="1" /> <!-- Spellbook - Mount Black Bear -->
 		</skill>
-		<skill name="Glory Ability" id="45361" level="1" required-level="86">
-			<item id="94046"/> <!-- Spellbook: Glory Ability Lv. 1 -->
+		<skill name="Full Swing" id="814" level="1" required-level="76" sp="5900000">
+			<item id="91486" count="1" /> <!-- Scroll: Full Swing -->
 		</skill>
-		<skill name="Mount White Wings" id="54200" level="1" required-level="87">
-			<item id="93059"/> <!-- Spellbook: Summon White Wings -->
-		</skill>	
-		<skill name="Mount Shining Lady" id="54202" level="1" required-level="89">
-			<item id="93061"/> <!-- Spellbook: Summon Silver Saint -->
+		<skill name="Power Break" id="260" level="38" required-level="76" sp="5900000" />
+		<skill name="Excruciating Strike" id="1607" level="38" required-level="76" sp="5900000" />
+		<skill name="Dynamic Recovery" id="1608" level="2" required-level="76" sp="5900000" />
+		<skill name="Rush" id="994" level="3" required-level="76" sp="5900000" />
+		<skill name="Demolition Impact" id="777" level="1" required-level="76" sp="5900000">
+			<item id="90075" count="1" /> <!-- Scroll: Demolition Impact -->
 		</skill>
-		
-		<skill name="Spinning Slasher" id="36" level="39" required-level="77" sp="5900000" />
+		<skill name="Fatal Strike" id="190" level="41" required-level="76" sp="5900000" />
+		<skill name="Wide Swing" id="1628" level="1" required-level="76" sp="5900000" />
+		<skill name="Emergency Rescue" id="70" level="46" required-level="76" sp="5900000" />
+
 		<skill name="Two-handed Weapon Mastery" id="293" level="22" required-level="77" sp="5900000" />
 		<skill name="Polearm Mastery" id="216" level="47" required-level="77" sp="5900000" />
 		<skill name="Light Armor Mastery" id="227" level="52" required-level="77" sp="5900000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="47" required-level="77" sp="5900000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="47" required-level="77" sp="5900000" />
 		<skill name="Heavy Armor Mastery" id="231" level="52" required-level="77" sp="5900000" />
 		<skill name="Full Swing" id="814" level="2" required-level="77" sp="5900000" />
-		<skill name="Power Crush" id="260" level="39" required-level="77" sp="5900000" />
-		<skill name="Excruciating Strike" id="1607" level="39" required-level="77" sp="5900000" />
-		<skill name="Fatal Strike" id="190" level="39" required-level="77" sp="5900000" />
-		<skill name="Armor Crush" id="362" level="1" required-level="77" sp="5900000">
-			<item id="90078"/> <!-- Scroll: Armor Crush -->
-		</skill>
 		<skill name="Destroyer's Roar" id="1627" level="1" required-level="77" sp="5900000">
-			<item id="90073"/> <!-- Scroll: Destroyer's Roar -->
+			<item id="90073" count="1" /> <!-- Scroll: Destroyer's Roar -->
 		</skill>
-		
-		<skill name="Spinning Slasher" id="36" level="40" required-level="78" sp="13700000" />
+		<skill name="Armor Crush" id="362" level="1" required-level="77" sp="5900000">
+			<item id="90078" count="1" /> <!-- Scroll: Armor Crush -->
+		</skill>
+		<skill name="Power Break" id="260" level="39" required-level="77" sp="5900000" />
+		<skill name="Excruciating Strike" id="1607" level="39" required-level="77" sp="5900000" />
+		<skill name="Demolition Impact" id="777" level="2" required-level="77" sp="5900000" />
+		<skill name="Fatal Strike" id="190" level="42" required-level="77" sp="5900000" />
+		<skill name="Emergency Rescue" id="70" level="47" required-level="77" sp="5900000" />
+
 		<skill name="Two-handed Weapon Mastery" id="293" level="23" required-level="78" sp="13700000" />
 		<skill name="Polearm Mastery" id="216" level="48" required-level="78" sp="13700000" />
 		<skill name="Light Armor Mastery" id="227" level="53" required-level="78" sp="13700000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="48" required-level="78" sp="13700000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="48" required-level="78" sp="13700000" />
 		<skill name="Heavy Armor Mastery" id="231" level="53" required-level="78" sp="13700000" />
 		<skill name="Rage" id="94" level="4" required-level="78" sp="13700000" />
-		<skill name="Master of Combat" id="430" level="1" required-level="78" sp="13700000" />
 		<skill name="Full Swing" id="814" level="3" required-level="78" sp="13700000" />
-		<skill name="Armor Crush" id="362" level="2" required-level="78" sp="13700000" />
-		<skill name="Power Crush" id="260" level="40" required-level="78" sp="13700000" />
-		<skill name="Excruciating Strike" id="1607" level="40" required-level="78" sp="13700000" />
-		<skill name="Rush" id="994" level="1" required-level="78" sp="13700000" />
-		<skill name="Fatal Strike" id="190" level="40" required-level="78" sp="13700000" />
-		<skill name="Braveheart" id="440" level="1" required-level="78" sp="13700000" />
-		<skill name="Broad Sweep" id="1628" level="2" required-level="78" sp="13700000" />
 		<skill name="Over the Body" id="536" level="1" required-level="78" sp="13700000">
-			<item id="900740"/> <!-- Scroll: Over the Body -->
+			<item id="90074" count="1" /> <!-- Scroll: Over the Body -->
 		</skill>
-		
+		<skill name="Armor Crush" id="362" level="2" required-level="78" sp="13700000" />
+		<skill name="Power Break" id="260" level="40" required-level="78" sp="13700000" />
+		<skill name="Excruciating Strike" id="1607" level="40" required-level="78" sp="13700000" />
+		<skill name="Demolition Impact" id="777" level="3" required-level="78" sp="13700000" />
+		<skill name="Fatal Strike" id="190" level="43" required-level="78" sp="13700000" />
+		<skill name="Braveheart" id="440" level="1" required-level="78" sp="13700000" />
+		<skill name="Wide Swing" id="1628" level="2" required-level="78" sp="13700000" />
+		<skill name="Emergency Rescue" id="70" level="48" required-level="78" sp="13700000" />
+
 		<skill name="Frenzy" id="176" level="6" required-level="79" sp="13700000" />
 		<skill name="Guts" id="139" level="6" required-level="79" sp="13700000" />
 		<skill name="Full Swing" id="814" level="4" required-level="79" sp="13700000" />
 		<skill name="Armor Crush" id="362" level="3" required-level="79" sp="13700000" />
-		<skill name="Final Secret" id="917" level="1" required-level="79" sp="13700000">
-			<item id="90080"/> <!-- Scroll: Final Secret -->
-		</skill>
+		<skill name="Demolition Impact" id="777" level="4" required-level="79" sp="13700000" />
+		<skill name="Fatal Strike" id="190" level="44" required-level="79" sp="13700000" />
+		<skill name="Emergency Rescue" id="70" level="49" required-level="79" sp="13700000" />
 
 		<skill name="Two-handed Weapon Mastery" id="293" level="24" required-level="80" sp="13700000" />
 		<skill name="Polearm Mastery" id="216" level="49" required-level="80" sp="13700000" />
 		<skill name="Light Armor Mastery" id="227" level="54" required-level="80" sp="13700000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="49" required-level="80" sp="13700000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="49" required-level="80" sp="13700000" />
 		<skill name="Heavy Armor Mastery" id="231" level="54" required-level="80" sp="13700000" />
 		<skill name="Rage" id="94" level="5" required-level="80" sp="13700000" />
+		<skill name="Master of Combat" id="430" level="2" required-level="80" sp="13700000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Evolution Power" id="45189" level="1" required-level="80">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Full Swing" id="814" level="5" required-level="80" sp="13700000" />
 		<skill name="Armor Crush" id="362" level="4" required-level="80" sp="13700000" />
 		<skill name="Excruciating Strike" id="1607" level="41" required-level="80" sp="13700000" />
-		<skill name="Fatal Strike" id="190" level="41" required-level="80" sp="13700000" />
-		<skill name="Broad Sweep" id="1628" level="3" required-level="80" sp="13700000" />
-		<skill name="Demolition Impact" id="777" level="1" required-level="80" sp="13700000">
-			<item id="90075"/>
+		<skill name="White Guardian Transformation" id="54102" level="1" required-level="80">
+			<item id="92401" count="1" /> <!-- Spellbook - White Guardian -->
 		</skill>
+		<skill name="Demolition Impact" id="777" level="5" required-level="80" sp="13700000" />
+		<skill name="Fatal Strike" id="190" level="45" required-level="80" sp="13700000" />
+		<skill name="Wide Swing" id="1628" level="3" required-level="80" sp="13700000" />
+		<skill name="Emergency Rescue" id="70" level="50" required-level="80" sp="13700000" />
 
 		<skill name="Two-handed Weapon Mastery" id="293" level="25" required-level="81" sp="160000000" />
 		<skill name="Polearm Mastery" id="216" level="50" required-level="81" sp="160000000" />
 		<skill name="Light Armor Mastery" id="227" level="55" required-level="81" sp="160000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="50" required-level="81" sp="160000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="50" required-level="81" sp="160000000" />
 		<skill name="Heavy Armor Mastery" id="231" level="55" required-level="81" sp="160000000" />
-		<skill name="Full Knockdown" id="1896" level="1" required-level="81" sp="160000000" />
+		<skill name="Full Knockdown" id="1896" level="1" required-level="81" sp="160000000">
+			<item id="91201" count="1" /> <!-- Scroll: Full Knockdown -->
+		</skill>
 		<skill name="Full Swing" id="814" level="6" required-level="81" sp="160000000" />
 		<skill name="Armor Crush" id="362" level="5" required-level="81" sp="160000000" />
 		<skill name="Excruciating Strike" id="1607" level="42" required-level="81" sp="160000000" />
-		<skill name="Fatal Strike" id="190" level="42" required-level="81" sp="160000000" />
+		<skill name="Demolition Impact" id="777" level="6" required-level="81" sp="160000000" />
+		<skill name="Fatal Strike" id="190" level="46" required-level="81" sp="160000000" />
+		<skill name="Emergency Rescue" id="70" level="51" required-level="81" sp="160000000" />
 
 		<skill name="Two-handed Weapon Mastery" id="293" level="26" required-level="82" sp="170000000" />
 		<skill name="Polearm Mastery" id="216" level="51" required-level="82" sp="170000000" />
 		<skill name="Light Armor Mastery" id="227" level="56" required-level="82" sp="170000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="51" required-level="82" sp="170000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="51" required-level="82" sp="170000000" />
 		<skill name="Heavy Armor Mastery" id="231" level="56" required-level="82" sp="170000000" />
 		<skill name="Full Knockdown" id="1896" level="2" required-level="82" sp="170000000" />
 		<skill name="Full Swing" id="814" level="7" required-level="82" sp="170000000" />
 		<skill name="Armor Crush" id="362" level="6" required-level="82" sp="170000000" />
 		<skill name="Excruciating Strike" id="1607" level="43" required-level="82" sp="170000000" />
-		<skill name="Fatal Strike" id="190" level="43" required-level="82" sp="170000000" />
-		<skill name="Broad Sweep" id="1628" level="4" required-level="82" sp="170000000" />
+		<skill name="Demolition Impact" id="777" level="7" required-level="82" sp="170000000" />
+		<skill name="Fatal Strike" id="190" level="47" required-level="82" sp="170000000" />
+		<skill name="Wide Swing" id="1628" level="4" required-level="82" sp="170000000" />
 		<skill name="Sword Expert" id="1609" level="4" required-level="82" sp="170000000" />
+		<skill name="Emergency Rescue" id="70" level="52" required-level="82" sp="170000000" />
 
 		<skill name="Two-handed Weapon Mastery" id="293" level="27" required-level="83" sp="240000000" />
 		<skill name="Polearm Mastery" id="216" level="52" required-level="83" sp="240000000" />
 		<skill name="Light Armor Mastery" id="227" level="57" required-level="83" sp="240000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="52" required-level="83" sp="240000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="52" required-level="83" sp="240000000" />
 		<skill name="Heavy Armor Mastery" id="231" level="57" required-level="83" sp="240000000" />
 		<skill name="Full Knockdown" id="1896" level="3" required-level="83" sp="240000000" />
 		<skill name="Full Swing" id="814" level="8" required-level="83" sp="240000000" />
 		<skill name="Armor Crush" id="362" level="7" required-level="83" sp="240000000" />
 		<skill name="Excruciating Strike" id="1607" level="44" required-level="83" sp="240000000" />
-		<skill name="Fatal Strike" id="190" level="44" required-level="83" sp="240000000" />
+		<skill name="Demolition Impact" id="777" level="8" required-level="83" sp="240000000" />
+		<skill name="Fatal Strike" id="190" level="48" required-level="83" sp="240000000" />
+		<skill name="Emergency Rescue" id="70" level="53" required-level="83" sp="240000000" />
 
 		<skill name="Two-handed Weapon Mastery" id="293" level="28" required-level="84" sp="240000000" />
 		<skill name="Polearm Mastery" id="216" level="53" required-level="84" sp="240000000" />
 		<skill name="Light Armor Mastery" id="227" level="58" required-level="84" sp="240000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="53" required-level="84" sp="240000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="53" required-level="84" sp="240000000" />
 		<skill name="Heavy Armor Mastery" id="231" level="58" required-level="84" sp="240000000" />
 		<skill name="Full Knockdown" id="1896" level="4" required-level="84" sp="240000000" />
 		<skill name="Full Swing" id="814" level="9" required-level="84" sp="240000000" />
 		<skill name="Armor Crush" id="362" level="8" required-level="84" sp="240000000" />
 		<skill name="Excruciating Strike" id="1607" level="45" required-level="84" sp="240000000" />
-		<skill name="Fatal Strike" id="190" level="45" required-level="84" sp="240000000" />
-		
+		<skill name="Demolition Impact" id="777" level="9" required-level="84" sp="240000000" />
+		<skill name="Fatal Strike" id="190" level="49" required-level="84" sp="240000000" />
+		<skill name="Emergency Rescue" id="70" level="54" required-level="84" sp="240000000" />
+
 		<skill name="Two-handed Weapon Mastery" id="293" level="29" required-level="85" sp="840000000" />
-		<skill name="Two-handed Weapon Mastery" id="293" level="30" required-level="86" sp="924000000" />
-		<skill name="Two-handed Weapon Mastery" id="293" level="31" required-level="87" sp="1016400000" />
-		<skill name="Two-handed Weapon Mastery" id="293" level="32" required-level="88" sp="1118040000" />
-		<skill name="Two-handed Weapon Mastery" id="293" level="33" required-level="89" sp="1229844000" />
-		<skill name="Two-handed Weapon Mastery" id="293" level="34" required-level="90" sp="1352828400" />
 		<skill name="Polearm Mastery" id="216" level="54" required-level="85" sp="840000000" />
-		<skill name="Polearm Mastery" id="216" level="55" required-level="86" sp="924000000" />
-		<skill name="Polearm Mastery" id="216" level="56" required-level="87" sp="1016400000" />
-		<skill name="Polearm Mastery" id="216" level="57" required-level="88" sp="1118040000" />
-		<skill name="Polearm Mastery" id="216" level="58" required-level="89" sp="1229844000" />
-		<skill name="Polearm Mastery" id="216" level="59" required-level="90" sp="1352828400" />
 		<skill name="Light Armor Mastery" id="227" level="59" required-level="85" sp="840000000" />
-		<skill name="Light Armor Mastery" id="227" level="60" required-level="86" sp="924000000" />
-		<skill name="Light Armor Mastery" id="227" level="61" required-level="87" sp="1016400000" />
-		<skill name="Light Armor Mastery" id="227" level="62" required-level="88" sp="1118040000" />
-		<skill name="Light Armor Mastery" id="227" level="63" required-level="89" sp="1229844000" />
-		<skill name="Light Armor Mastery" id="227" level="64" required-level="90" sp="1352828400" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="54" required-level="85" sp="840000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="55" required-level="86" sp="924000000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="56" required-level="87" sp="1016400000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="57" required-level="88" sp="1118040000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="58" required-level="89" sp="1229844000" />
-		<skill name="Sword/Blunt Weapon Mastery" id="257" level="59" required-level="90" sp="1352828400" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="54" required-level="85" sp="840000000" />
 		<skill name="Heavy Armor Mastery" id="231" level="59" required-level="85" sp="840000000" />
-		<skill name="Heavy Armor Mastery" id="231" level="60" required-level="86" sp="924000000" />
-		<skill name="Heavy Armor Mastery" id="231" level="61" required-level="87" sp="1016400000" />
-		<skill name="Heavy Armor Mastery" id="231" level="62" required-level="88" sp="1118040000" />
-		<skill name="Heavy Armor Mastery" id="231" level="63" required-level="89" sp="1229844000" />
-		<skill name="Heavy Armor Mastery" id="231" level="64" required-level="90" sp="1352828400" />
+		<skill name="Demolition Impact" id="777" level="10" required-level="85" sp="840000000" />
+		<skill name="Fatal Strike" id="190" level="50" required-level="85" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="55" required-level="85" sp="840000000" />
+
+		<skill name="Two-handed Weapon Mastery" id="293" level="30" required-level="86" sp="840000000" />
+		<skill name="Polearm Mastery" id="216" level="55" required-level="86" sp="840000000" />
+		<skill name="Light Armor Mastery" id="227" level="60" required-level="86" sp="840000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="55" required-level="86" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="231" level="60" required-level="86" sp="840000000" />
+		<skill name="Demolition Impact" id="777" level="11" required-level="86" sp="840000000" />
+		<skill name="Fatal Strike" id="190" level="51" required-level="86" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="56" required-level="86" sp="840000000" />
+
+		<skill name="Two-handed Weapon Mastery" id="293" level="31" required-level="87" sp="840000000" />
+		<skill name="Polearm Mastery" id="216" level="56" required-level="87" sp="840000000" />
+		<skill name="Light Armor Mastery" id="227" level="61" required-level="87" sp="840000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="56" required-level="87" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="231" level="61" required-level="87" sp="840000000" />
+		<skill name="Demolition Impact" id="777" level="12" required-level="87" sp="840000000" />
+		<skill name="Fatal Strike" id="190" level="52" required-level="87" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="57" required-level="87" sp="840000000" />
+
+		<skill name="Two-handed Weapon Mastery" id="293" level="32" required-level="88" sp="840000000" />
+		<skill name="Polearm Mastery" id="216" level="57" required-level="88" sp="840000000" />
+		<skill name="Light Armor Mastery" id="227" level="62" required-level="88" sp="840000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="57" required-level="88" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="231" level="62" required-level="88" sp="840000000" />
+		<skill name="Demolition Impact" id="777" level="13" required-level="88" sp="840000000" />
+		<skill name="Fatal Strike" id="190" level="53" required-level="88" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="58" required-level="88" sp="840000000" />
+
+		<skill name="Two-handed Weapon Mastery" id="293" level="33" required-level="89" sp="840000000" />
+		<skill name="Polearm Mastery" id="216" level="58" required-level="89" sp="840000000" />
+		<skill name="Light Armor Mastery" id="227" level="63" required-level="89" sp="840000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="58" required-level="89" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="231" level="63" required-level="89" sp="840000000" />
+		<skill name="Demolition Impact" id="777" level="14" required-level="89" sp="840000000" />
+		<skill name="Fatal Strike" id="190" level="54" required-level="89" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="59" required-level="89" sp="840000000" />
+
+		<skill name="Two-handed Weapon Mastery" id="293" level="34" required-level="90" sp="840000000" />
+		<skill name="Polearm Mastery" id="216" level="59" required-level="90" sp="840000000" />
+		<skill name="Light Armor Mastery" id="227" level="64" required-level="90" sp="840000000" />
+		<skill name="Sword / Blunt Weapon Mastery" id="257" level="59" required-level="90" sp="840000000" />
+		<skill name="Heavy Armor Mastery" id="231" level="64" required-level="90" sp="840000000" />
+		<skill name="Demolition Impact" id="777" level="15" required-level="90" sp="840000000" />
+		<skill name="Fatal Strike" id="190" level="55" required-level="90" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="60" required-level="90" sp="840000000" />
 	</skillTree>
 </list>

--- a/data/skillTrees/3rdClass/Trickster.xml
+++ b/data/skillTrees/3rdClass/Trickster.xml
@@ -1,116 +1,186 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
-    <skillTree type="classSkillTree" classId="134" parentClassId="130">
+	<skillTree type="classSkillTree" classId="134" parentClassId="130">
 
-        <skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="8000000">
-            <item id="8620"/> <!-- Ancient Book: Divine Inspiration (Manuscript) -->
-        </skill>
-        <skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="8000000">
-            <item id="8621"/> <!-- Ancient Book: Divine Inspiration (Original Version) -->
-        </skill>
-        <skill name="Armor Mastery" id="464" level="4" required-level="76" sp="8000000">
-            <item id="57" count="1000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Weapon Mastery" id="463" level="4" required-level="76" sp="8000000">
-            <item id="57" count="1000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Detect Darkness" id="53005" level="1" required-level="76" sp="8000000">
-            <item id="91482"/> <!-- Scroll - Detect Darkness -->
-        </skill>
-        <skill name="Mount Griffin" id="62002" level="1" required-level="76">
-            <item id="91946"/> <!-- Spellbook: Mount Griffin -->
-        </skill>
-		<skill name="Glory Ability" id="45361" level="1" required-level="86">
-			<item id="94046"/> <!-- Spellbook: Glory Ability Lv. 1 -->
+		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="8000000">
+			<item id="8620" count="1" /> <!-- Buff Expansion Book Lv. 3 -->
 		</skill>
-		<skill name="Mount White Wings" id="54200" level="1" required-level="87">
-			<item id="93059"/> <!-- Spellbook: Summon White Wings -->
-		</skill>	
-		<skill name="Mount Shining Lady" id="54202" level="1" required-level="89">
-			<item id="93061"/> <!-- Spellbook: Summon Silver Saint -->
+		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="8000000">
+			<item id="8621" count="1" /> <!-- Buff Expansion Book Lv. 4 -->
 		</skill>
-        <skill name="Soul Panic" id="627" level="1" required-level="76" sp="8000000">
-            <item id="91924"/> <!-- Scroll: Mental Panic -->
-        </skill>
-        <skill name="Collect Light Souls" id="45151" level="2" required-level="76" sp="8000000">
-            <item id="91942"/> <!-- Crystal of Light -->
-        </skill>
-        <skill name="Collect Shadow Souls" id="45152" level="2" required-level="76" sp="8000000">
-            <item id="91943"/> <!-- Crystal of Shadows -->
-        </skill>
-        <skill name="Soul Stigma" id="792" level="1" required-level="76" sp="8000000">
-            <item id="91925"/> <!-- Scroll: Soul Stigma -->
-        </skill>
+		<skill name="Armor Mastery" id="464" level="4" required-level="76" sp="8000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Weapon Mastery" id="463" level="4" required-level="76" sp="8000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Evolution Defense" id="45188" level="1" required-level="76">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Soul Might" id="45144" level="4" required-level="76" sp="8000000">
+			<item id="94135" count="1" /> <!-- Master's Book: Might -->
+		</skill>
+		<!-- Shield Lv. 4 -->
+		<skill name="Soul Shield" id="45145" level="4" required-level="76" sp="8000000">
+			<item id="94136" count="1" /> <!-- Master's Book: Shield -->
+		</skill>
+		<!-- Acumen Lv. 4 -->
+		<skill name="Soul Acumen" id="45146" level="4" required-level="76" sp="8000000">
+			<item id="94370" count="1" /> <!-- Master's Book: Acumen -->
+		</skill>
+		<!-- Empower Lv. 4 -->
+		<skill name="Soul Empower" id="45147" level="4" required-level="76" sp="8000000">
+			<item id="94361" count="1" /> <!-- Master's Book: Empower -->
+		</skill>
+		<!-- Wild Magic Lv. 3 -->
+		<skill name="Soul Wild Magic" id="45148" level="3" required-level="76" sp="8000000">
+			<item id="94368" count="1" /> <!-- Master's Book: Wild Magic -->
+		</skill>
+		<!-- Wind Walk Lv. 3 -->
+		<skill name="Soul Wind Walk" id="45142" level="3" required-level="76" sp="8000000">
+			<item id="94365" count="1" /> <!-- Master's Book: Wind Walk -->
+		</skill>
+		<!-- Magic Barrier Lv. 3 -->
+		<skill name="Soul Magic Barrier" id="45143" level="3" required-level="76" sp="8000000">
+			<item id="94362" count="1" /> <!-- Master's Book: Magic Barrier -->
+		</skill>
+		<!-- Focus Lv. 4 -->
+		<skill name="Soul Focus" id="45139" level="4" required-level="76" sp="8000000">
+			<item id="94363" count="1" /> <!-- Master's Book: Focus -->
+		</skill>
+		<!-- Death Whisper Lv. 4 -->
+		<skill name="Soul Death Whisper" id="45140" level="4" required-level="76" sp="8000000">
+			<item id="94364" count="1" /> <!-- Master's Book: Death Whisper -->
+		</skill>
+		<!-- Haste Lv. 3 -->
+		<skill name="Soul Haste" id="45141" level="3" required-level="76" sp="8000000">
+			<item id="94369" count="1" /> <!-- Master's Book: Haste -->
+		</skill>
+		<!-- Berserker Spirit Lv. 3 -->
+		<skill name="Soul Berserker Spirit" id="45149" level="3" required-level="76" sp="8000000">
+			<item id="94366" count="1" /> <!-- Master's Book: Berserker Spirit -->
+		</skill>
+		<!-- Clarity Lv. 4 -->
+		<skill name="Soul Clarity" id="45150" level="4" required-level="76" sp="8000000">
+			<item id="94367" count="1" /> <!-- Master's Book: Clarity -->
+		</skill>
+		<skill name="Detect Darkness" id="53005" level="1" required-level="76" sp="8000000">
+			<item id="91482" count="1" /> <!-- Scroll: Detect Darkness -->
+		</skill>
+		<skill name="Mount Griffin" id="62002" level="1" required-level="76">
+			<item id="91946" count="1" /> <!-- Spellbook - Mount Griffin -->
+		</skill>
+		<skill name="Mental Panic" id="627" level="1" required-level="76" sp="8000000">
+			<item id="91924" count="1" /> <!-- Scroll: Mental Panic -->
+		</skill>
+		<skill name="Collect Light Souls" id="45151" level="2" required-level="76" sp="8000000">
+			<item id="4347" count="1" /> <!-- Crystal of Light -->
+		</skill>
+		<skill name="Collect Shadow Souls" id="45152" level="2" required-level="76" sp="8000000">
+			<item id="91943" count="1" /> <!-- Crystal of Shadows -->
+		</skill>
+		<skill name="Soul Stigma" id="792" level="1" required-level="76" sp="8000000">
+			<item id="91925" count="1" /> <!-- Scroll: Soul Stigma -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="46" required-level="76" sp="8000000" />
 
-        <skill name="Critical Sense" id="626" level="4" required-level="78" sp="12000000" />
-        <skill name="Death Mark" id="1435" level="4" required-level="78" sp="12000000">
-            <item id="57" count="1000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Soul Panic" id="627" level="2" required-level="78" sp="12000000"/>
-        <skill name="Soul Stigma" id="792" level="2" required-level="78" sp="12000000"/>
+		<skill name="Emergency Rescue" id="70" level="47" required-level="77" sp="10000000" />
 
-        <skill name="Light Armor Mastery" id="465" level="8" required-level="80" sp="18000000">
-            <item id="57" count="1000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Bow Mastery" id="767" level="8" required-level="80" sp="18000000">
-            <item id="57" count="1000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Critical Shot" id="790" level="3" required-level="80" sp="18000000">
-            <item id="57" count="1000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Multiple Shot" id="45170" level="6" required-level="80" sp="18000000">
-            <item id="57" count="1000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Soul Panic" id="627" level="3" required-level="80" sp="18000000"/>
-        <skill name="Twin Shot" id="45168" level="8" required-level="80" sp="18000000">
-            <item id="57" count="1000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Soul Stigma" id="792" level="3" required-level="80" sp="18000000"/>
-        <skill name="Sharp Aiming" id="45172" level="9" required-level="80" sp="18000000">
-            <item id="57" count="1000000"/> <!-- Adena -->
-        </skill>
+		<skill name="Critical Sense" id="626" level="4" required-level="78" sp="12000000" />
+		<skill name="Death Mark" id="1435" level="4" required-level="78" sp="12000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Mental Panic" id="627" level="2" required-level="78" sp="12000000" />
+		<skill name="Soul Stigma" id="792" level="2" required-level="78" sp="12000000" />
+		<skill name="Emergency Rescue" id="70" level="48" required-level="78" sp="12000000" />
 
-        <skill name="Soul Panic" id="627" level="4" required-level="82" sp="170000000"/>
-        <skill name="Soul Stigma" id="792" level="4" required-level="82" sp="170000000"/>
+		<skill name="Emergency Rescue" id="70" level="49" required-level="79" sp="15000000" />
 
-        <skill name="Soul Panic" id="627" level="5" required-level="84" sp="240000000"/>
-        <skill name="Soul Stigma" id="792" level="5" required-level="84" sp="240000000"/>
+		<skill name="Light Armor Mastery" id="465" level="8" required-level="80" sp="18000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Bow Mastery" id="767" level="8" required-level="80" sp="18000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Critical Shot" id="790" level="3" required-level="80" sp="18000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Evolution Power" id="45189" level="1" required-level="80">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Multiple Shot" id="45170" level="6" required-level="80" sp="18000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Mental Panic" id="627" level="3" required-level="80" sp="18000000" />
+		<skill name="Twin Shot" id="45168" level="8" required-level="80" sp="18000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Soul Stigma" id="792" level="3" required-level="80" sp="18000000" />
+		<skill name="Sharp Aiming" id="45172" level="9" required-level="80" sp="18000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="50" required-level="80" sp="18000000" />
 
+		<skill name="Emergency Rescue" id="70" level="51" required-level="81" sp="160000000" />
 
-        <skill name="Armor Mastery" id="464" level="5" required-level="85" sp="840000000">
-            <item id="57" count="2000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Light Armor Mastery" id="465" level="9" required-level="85" sp="840000000">
-            <item id="57" count="5000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Light Armor Mastery" id="465" level="10" required-level="90" sp="1680000000">
-            <item id="57" count="10000000"/> <!-- Adena -->
-        </skill>	
-        <skill name="Bow Mastery" id="767" level="9" required-level="85" sp="840000000">
-            <item id="57" count="5000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Bow Mastery" id="767" level="10" required-level="90" sp="1680000000">
-            <item id="57" count="10000000"/> <!-- Adena -->
-        </skill>	
-        <skill name="Weapon Mastery" id="463" level="5" required-level="85" sp="840000000">
-            <item id="57" count="2000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Critical Sense" id="626" level="5" required-level="85" sp="840000000" />
-        <skill name="Death Mark" id="1435" level="5" required-level="85" sp="840000000">
-            <item id="57" count="2000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Multiple Shot" id="45170" level="7" required-level="85" sp="840000000">
-            <item id="57" count="5000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Multiple Shot" id="45170" level="8" required-level="90" sp="1680000000">
-            <item id="57" count="10000000"/> <!-- Adena -->
-        </skill>	
-        <skill name="Twin Shot" id="45168" level="9" required-level="85" sp="840000000">
-            <item id="57" count="5000000"/> <!-- Adena -->
-        </skill>
-        <skill name="Twin Shot" id="45168" level="10" required-level="90" sp="1680000000">
-            <item id="57" count="10000000"/> <!-- Adena -->
-        </skill>	
+		<skill name="Mental Panic" id="627" level="4" required-level="82" sp="170000000" />
+		<skill name="Soul Stigma" id="792" level="4" required-level="82" sp="170000000" />
+		<skill name="Emergency Rescue" id="70" level="52" required-level="82" sp="170000000" />
 
-    </skillTree>
+		<skill name="Emergency Rescue" id="70" level="53" required-level="83" sp="240000000" />
+
+		<skill name="Mental Panic" id="627" level="5" required-level="84" sp="240000000" />
+		<skill name="Soul Stigma" id="792" level="5" required-level="84" sp="240000000" />
+		<skill name="Emergency Rescue" id="70" level="54" required-level="84" sp="240000000" />
+
+		<skill name="Armor Mastery" id="464" level="5" required-level="85" sp="840000000">
+			<item id="57" count="2000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Light Armor Mastery" id="465" level="9" required-level="85" sp="840000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Bow Mastery" id="767" level="9" required-level="85" sp="840000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Weapon Mastery" id="463" level="5" required-level="85" sp="840000000">
+			<item id="57" count="2000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Critical Sense" id="626" level="5" required-level="85" sp="840000000" />
+		<skill name="Death Mark" id="1435" level="5" required-level="85" sp="840000000">
+			<item id="57" count="2000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Multiple Shot" id="45170" level="7" required-level="85" sp="840000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Twin Shot" id="45168" level="9" required-level="85" sp="840000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Sharp Aiming" id="45172" level="10" required-level="85" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="55" required-level="85" sp="840000000" />
+
+		<skill name="Emergency Rescue" id="70" level="56" required-level="86" sp="840000000" />
+
+		<skill name="Emergency Rescue" id="70" level="57" required-level="87" sp="840000000" />
+
+		<skill name="Emergency Rescue" id="70" level="58" required-level="88" sp="840000000" />
+
+		<skill name="Emergency Rescue" id="70" level="59" required-level="89" sp="840000000" />
+
+		<skill name="Light Armor Mastery" id="465" level="10" required-level="90" sp="840000000">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Bow Mastery" id="767" level="10" required-level="90" sp="840000000">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Multiple Shot" id="45170" level="8" required-level="90" sp="840000000">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Twin Shot" id="45168" level="10" required-level="90" sp="840000000">
+			<item id="57" count="10000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Emergency Rescue" id="70" level="60" required-level="90" sp="840000000" />
+
+	</skillTree>
 </list>

--- a/data/skillTrees/3rdClass/WindRider.xml
+++ b/data/skillTrees/3rdClass/WindRider.xml
@@ -1,126 +1,264 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="101" parentClassId="23">
-		<skill name="White Guardian" id="54102" level="1" required-level="80" >
-			<item id="92401"/>
+
+		<skill name="Bluff" id="358" level="1" required-level="76" sp="7000000">
+			<item id="91294" count="1" /> <!-- Scroll: Bluff -->
 		</skill>
-		<skill name="Bluff" id="358" level="1" required-level="76" sp="7000000" />
+		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="7000000">
+			<item id="8620" count="1" /> <!-- Buff Expansion Book Lv. 3 -->
+		</skill>
+		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="7000000">
+			<item id="8621" count="1" /> <!-- Buff Expansion Book Lv. 4 -->
+		</skill>
 		<skill name="Throw Dagger" id="10539" level="1" required-level="76" sp="7000000" />
 		<skill name="Dagger Mastery" id="209" level="46" required-level="76" sp="7000000" />
 		<skill name="Light Armor Mastery" id="233" level="48" required-level="76" sp="7000000" />
+		<skill name="Weapon Mastery" id="141" level="5" required-level="76" sp="7000000" />
+		<skill name="Evolution Defense" id="45188" level="1" required-level="76">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Bleed" id="96" level="7" required-level="76" sp="7000000" />
+		<!-- Might Lv. 4 -->
+		<skill name="Might" id="1068" level="4" required-level="76" sp="7000000">
+			<item id="94135" count="1" /> <!-- Master's Book: Might -->
+		</skill>
+		<!-- Shield Lv. 4 -->
+		<skill name="Shield" id="1040" level="4" required-level="76" sp="7000000">
+			<item id="94136" count="1" /> <!-- Master's Book: Shield -->
+		</skill>
+		<!-- Acumen Lv. 4 -->
+		<skill name="Acumen" id="45104" level="4" required-level="76" sp="7000000">
+			<item id="94370" count="1" /> <!-- Master's Book: Acumen -->
+		</skill>
+		<!-- Empower Lv. 4 -->
+		<skill name="Empower" id="45105" level="4" required-level="76" sp="7000000">
+			<item id="94361" count="1" /> <!-- Master's Book: Empower -->
+		</skill>
+		<!-- Wild Magic Lv. 3 -->
+		<skill name="Wild Magic" id="45106" level="3" required-level="76" sp="7000000">
+			<item id="94368" count="1" /> <!-- Master's Book: Wild Magic -->
+		</skill>
+		<!-- Wind Walk Lv. 3 -->
+		<skill name="Wind Walk" id="45107" level="3" required-level="76" sp="7000000">
+			<item id="94365" count="1" /> <!-- Master's Book: Wind Walk -->
+		</skill>
+		<!-- Magic Barrier Lv. 3 -->
+		<skill name="Magic Barrier" id="45108" level="3" required-level="76" sp="7000000">
+			<item id="94362" count="1" /> <!-- Master's Book: Magic Barrier -->
+		</skill>
+		<!-- Focus Lv. 4 -->
+		<skill name="Focus" id="45109" level="4" required-level="76" sp="7000000">
+			<item id="94363" count="1" /> <!-- Master's Book: Focus -->
+		</skill>
+		<!-- Death Whisper Lv. 4 -->
+		<skill name="Death Whisper" id="45110" level="4" required-level="76" sp="7000000">
+			<item id="94364" count="1" /> <!-- Master's Book: Death Whisper -->
+		</skill>
+		<!-- Haste Lv. 3 -->
+		<skill name="Haste" id="45111" level="3" required-level="76" sp="7000000">
+			<item id="94369" count="1" /> <!-- Master's Book: Haste -->
+		</skill>
+		<!-- Berserker Spirit Lv. 3 -->
+		<skill name="Berserker Spirit" id="45112" level="3" required-level="76" sp="7000000">
+			<item id="94366" count="1" /> <!-- Master's Book: Berserker Spirit -->
+		</skill>
+		<!-- Clarity Lv. 4 -->
+		<skill name="Clarity" id="45113" level="4" required-level="76" sp="7000000">
+			<item id="94367" count="1" /> <!-- Master's Book: Clarity -->
+		</skill>
+		<skill name="Detection" id="45190" level="1" required-level="76" sp="7000000">
+			<item id="57" count="5000000" /> <!-- Adena -->
+		</skill>
 		<skill name="Entangle" id="102" level="17" required-level="76" sp="7000000" />
-		<skill name="Charm" id="15" level="53" required-level="76" sp="7000000" />
-		<skill name="Deadly Blow" id="263" level="38" required-level="76" sp="7000000" />
+		<skill name="Mount Pegasus" id="1834" level="1" required-level="76">
+			<item id="90039" count="1" /> <!-- Spellbook - Ride Pegasus -->
+		</skill>
+		<skill name="Slowdown" id="15" level="53" required-level="76" sp="7000000" />
+		<skill name="Deadly Blow" id="263" level="41" required-level="76" sp="7000000" />
 		<skill name="Lethal Blow" id="344" level="1" required-level="76" sp="7000000" />
 		<skill name="Backstab" id="30" level="38" required-level="76" sp="7000000" />
-		<skill name="Divine Inspiration" id="1405" level="3" required-level="76" sp="7000000">
-			<item id="8620"/> <!-- Ancient Book: Divine Inspiration (Manuscript) -->
-		</skill>
-		<skill name="Divine Inspiration" id="1405" level="4" required-level="76" sp="7000000">
-			<item id="8621"/> <!-- Ancient Book: Divine Inspiration (Original Version) -->
-		</skill>
-		<skill name="Mount Pegasus" id="1834" level="1" required-level="76">
-			<item id="90039"/> <!-- Spellbook: Mount Pegasus -->
-		</skill>
-		<skill name="Glory Ability" id="45361" level="1" required-level="86">
-			<item id="94046"/> <!-- Spellbook: Glory Ability Lv. 1 -->
-		</skill>
-		<skill name="Mount White Wings" id="54200" level="1" required-level="87">
-			<item id="93059"/> <!-- Spellbook: Summon White Wings -->
-		</skill>	
-		<skill name="Mount Shining Lady" id="54202" level="1" required-level="89">
-			<item id="93061"/> <!-- Spellbook: Summon Silver Saint -->
-		</skill>
-		
+		<skill name="Emergency Rescue" id="70" level="46" required-level="76" sp="7000000" />
+
 		<skill name="Bluff" id="358" level="2" required-level="77" sp="7000000" />
 		<skill name="Dagger Mastery" id="209" level="47" required-level="77" sp="7000000" />
 		<skill name="Light Armor Mastery" id="233" level="49" required-level="77" sp="7000000" />
-		<skill name="Bleed" id="96" level="8" required-level="77" sp="7000000" />
-		<skill name="Deadly Blow" id="263" level="39" required-level="77" sp="7000000" />
-		<skill name="Backstab" id="30" level="39" required-level="77" sp="7000000" />
 		<skill name="Critical Wound" id="531" level="1" required-level="77" sp="7000000">
-			<item id="90055"/> <!-- Scroll: Critical Wound -->
+			<item id="90055" count="1" /> <!-- Scroll: Critical Wound -->
 		</skill>
+		<skill name="Bleed" id="96" level="8" required-level="77" sp="7000000" />
 		<skill name="Clear Movements" id="1631" level="1" required-level="77" sp="7000000">
-			<item id="90054"/> <!-- Scroll: Clear Movements -->
+			<item id="90054" count="1" /> <!-- Scroll: Clear Movements -->
 		</skill>
-		
+		<skill name="Deadly Blow" id="263" level="42" required-level="77" sp="7000000" />
+		<skill name="Lethal Blow" id="344" level="2" required-level="77" sp="7000000" />
+		<skill name="Backstab" id="30" level="39" required-level="77" sp="7000000" />
+		<skill name="Emergency Rescue" id="70" level="47" required-level="77" sp="7000000" />
+
 		<skill name="Bluff" id="358" level="3" required-level="78" sp="16400000" />
 		<skill name="Dagger Mastery" id="209" level="48" required-level="78" sp="16400000" />
 		<skill name="Light Armor Mastery" id="233" level="50" required-level="78" sp="16400000" />
 		<skill name="Bleed" id="96" level="9" required-level="78" sp="16400000" />
 		<skill name="Entangle" id="102" level="18" required-level="78" sp="16400000" />
-		<skill name="Charm" id="15" level="54" required-level="78" sp="16400000" />
+		<skill name="Slowdown" id="15" level="54" required-level="78" sp="16400000" />
 		<skill name="Sand Bomb" id="412" level="11" required-level="78" sp="16400000" />
-		<skill name="Deadly Blow" id="263" level="40" required-level="78" sp="16400000" />
+		<skill name="Deadly Blow" id="263" level="43" required-level="78" sp="16400000" />
+		<skill name="Lethal Blow" id="344" level="3" required-level="78" sp="16400000" />
 		<skill name="Backstab" id="30" level="40" required-level="78" sp="16400000" />
-		<skill name="Shadow Step" id="821" level="8" required-level="78" sp="16400000" />
 		<skill name="Focus Death" id="355" level="1" required-level="78" sp="16400000">
-			<item id="90058"/> <!-- Scroll: Focus Death -->
+			<item id="90058" count="1" /> <!-- Scroll: Focus Death -->
 		</skill>
 		<skill name="Focus Chance" id="356" level="1" required-level="78" sp="16400000">
-			<item id="90057"/> <!-- Scroll: Focus Chance -->
+			<item id="90057" count="1" /> <!-- Scroll: Focus Chance -->
 		</skill>
-		
+		<skill name="Shadow Step" id="821" level="8" required-level="78" sp="16400000" />
+		<skill name="Emergency Rescue" id="70" level="48" required-level="78" sp="16400000" />
+
 		<skill name="Bluff" id="358" level="4" required-level="79" sp="16400000" />
 		<skill name="Bleed" id="96" level="10" required-level="79" sp="16400000" />
+		<skill name="Entangle" id="102" level="19" required-level="79" sp="16400000" />
+		<skill name="Deadly Blow" id="263" level="44" required-level="79" sp="16400000" />
+		<skill name="Lethal Blow" id="344" level="4" required-level="79" sp="16400000" />
 		<skill name="Evasion" id="446" level="1" required-level="79" sp="16400000">
-			<item id="90060"/> <!-- Scroll: Evasion -->
+			<item id="90060" count="1" /> <!-- Scroll: Evasion -->
 		</skill>
-		
+		<skill name="Emergency Rescue" id="70" level="49" required-level="79" sp="16400000" />
+
 		<skill name="Bluff" id="358" level="5" required-level="80" sp="16400000" />
 		<skill name="Dagger Mastery" id="209" level="49" required-level="80" sp="16400000" />
 		<skill name="Light Armor Mastery" id="233" level="51" required-level="80" sp="16400000" />
 		<skill name="Bleed" id="96" level="11" required-level="80" sp="16400000" />
-		<skill name="Deadly Blow" id="263" level="41" required-level="80" sp="16400000" />
-		<skill name="Backstab" id="30" level="41" required-level="80" sp="16400000" />
-		<skill name="Wind Riding" id="769" level="1" required-level="80" sp="16400000">
-			<item id="90134"/> <!-- Scroll: Wind Riding -->
+		<skill name="Evolution Power" id="45189" level="1" required-level="80">
+			<item id="57" count="10000000" /> <!-- Adena -->
 		</skill>
+		<skill name="Entangle" id="102" level="20" required-level="80" sp="16400000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Wind Riding" id="769" level="1" required-level="80" sp="16400000">
+			<item id="90134" count="1" /> <!-- Scroll: Wind Riding -->
+		</skill>
+		<skill name="Slowdown" id="15" level="55" required-level="80" sp="16400000" />
+		<skill name="Deadly Blow" id="263" level="45" required-level="80" sp="16400000" />
+		<skill name="Lethal Blow" id="344" level="5" required-level="80" sp="16400000" />
+		<skill name="White Guardian Transformation" id="54102" level="1" required-level="80">
+			<item id="92401" count="1" /> <!-- Spellbook - White Guardian -->
+		</skill>
+		<skill name="Backstab" id="30" level="41" required-level="80" sp="16400000" />
+		<skill name="Emergency Rescue" id="70" level="50" required-level="80" sp="16400000" />
 
 		<skill name="Bluff" id="358" level="6" required-level="81" sp="160000000" />
 		<skill name="Dagger Mastery" id="209" level="50" required-level="81" sp="160000000" />
 		<skill name="Light Armor Mastery" id="233" level="52" required-level="81" sp="160000000" />
 		<skill name="Critical Wound" id="531" level="2" required-level="81" sp="160000000" />
 		<skill name="Bleed" id="96" level="12" required-level="81" sp="160000000" />
+		<skill name="Entangle" id="102" level="21" required-level="81" sp="160000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="56" required-level="81" sp="160000000" />
 		<skill name="Clear Movements" id="1631" level="2" required-level="81" sp="160000000" />
-		<skill name="Deadly Blow" id="263" level="42" required-level="81" sp="160000000" />
+		<skill name="Deadly Blow" id="263" level="46" required-level="81" sp="160000000" />
+		<skill name="Lethal Blow" id="344" level="6" required-level="81" sp="160000000" />
 		<skill name="Backstab" id="30" level="42" required-level="81" sp="160000000" />
+		<skill name="Emergency Rescue" id="70" level="51" required-level="81" sp="160000000" />
 
 		<skill name="Bluff" id="358" level="7" required-level="82" sp="170000000" />
 		<skill name="Dagger Mastery" id="209" level="51" required-level="82" sp="170000000" />
 		<skill name="Light Armor Mastery" id="233" level="53" required-level="82" sp="170000000" />
 		<skill name="Bleed" id="96" level="13" required-level="82" sp="170000000" />
-		<skill name="Deadly Blow" id="263" level="43" required-level="82" sp="170000000" />
-		<skill name="Lethal Blow" id="344" level="2" required-level="82" sp="170000000" />
+		<skill name="Entangle" id="102" level="22" required-level="82" sp="170000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="57" required-level="82" sp="170000000" />
+		<skill name="Deadly Blow" id="263" level="47" required-level="82" sp="170000000" />
+		<skill name="Lethal Blow" id="344" level="7" required-level="82" sp="170000000" />
 		<skill name="Backstab" id="30" level="43" required-level="82" sp="170000000" />
+		<skill name="Emergency Rescue" id="70" level="52" required-level="82" sp="170000000" />
 
 		<skill name="Bluff" id="358" level="8" required-level="83" sp="240000000" />
 		<skill name="Dagger Mastery" id="209" level="52" required-level="83" sp="240000000" />
 		<skill name="Light Armor Mastery" id="233" level="54" required-level="83" sp="240000000" />
 		<skill name="Bleed" id="96" level="14" required-level="83" sp="240000000" />
-		<skill name="Deadly Blow" id="263" level="44" required-level="83" sp="240000000" />
+		<skill name="Entangle" id="102" level="23" required-level="83" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="58" required-level="83" sp="240000000" />
+		<skill name="Deadly Blow" id="263" level="48" required-level="83" sp="240000000" />
+		<skill name="Lethal Blow" id="344" level="8" required-level="83" sp="240000000" />
 		<skill name="Backstab" id="30" level="44" required-level="83" sp="240000000" />
+		<skill name="Emergency Rescue" id="70" level="53" required-level="83" sp="240000000" />
 
 		<skill name="Bluff" id="358" level="9" required-level="84" sp="240000000" />
 		<skill name="Dagger Mastery" id="209" level="53" required-level="84" sp="240000000" />
 		<skill name="Light Armor Mastery" id="233" level="55" required-level="84" sp="240000000" />
 		<skill name="Bleed" id="96" level="15" required-level="84" sp="240000000" />
-		<skill name="Deadly Blow" id="263" level="45" required-level="84" sp="240000000" />
+		<skill name="Entangle" id="102" level="24" required-level="84" sp="240000000">
+			<item id="57" count="500000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="59" required-level="84" sp="240000000" />
+		<skill name="Deadly Blow" id="263" level="49" required-level="84" sp="240000000" />
+		<skill name="Lethal Blow" id="344" level="9" required-level="84" sp="240000000" />
 		<skill name="Backstab" id="30" level="45" required-level="84" sp="240000000" />
-		
+		<skill name="Emergency Rescue" id="70" level="54" required-level="84" sp="240000000" />
+
 		<skill name="Dagger Mastery" id="209" level="54" required-level="85" sp="840000000" />
-		<skill name="Dagger Mastery" id="209" level="55" required-level="86" sp="924000000" />
-		<skill name="Dagger Mastery" id="209" level="56" required-level="87" sp="1016400000" />
-		<skill name="Dagger Mastery" id="209" level="57" required-level="88" sp="1118040000" />
-		<skill name="Dagger Mastery" id="209" level="58" required-level="89" sp="1229844000" />
-		<skill name="Dagger Mastery" id="209" level="59" required-level="90" sp="1352828400" />
 		<skill name="Light Armor Mastery" id="233" level="56" required-level="85" sp="840000000" />
-		<skill name="Light Armor Mastery" id="233" level="57" required-level="86" sp="924000000" />
-		<skill name="Light Armor Mastery" id="233" level="58" required-level="87" sp="1016400000" />
-		<skill name="Light Armor Mastery" id="233" level="59" required-level="88" sp="1118040000" />
-		<skill name="Light Armor Mastery" id="233" level="60" required-level="89" sp="1229844000" />
-		<skill name="Light Armor Mastery" id="233" level="61" required-level="90" sp="1352828400" />
+		<skill name="Entangle" id="102" level="25" required-level="85" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="60" required-level="85" sp="840000000" />
+		<skill name="Deadly Blow" id="263" level="50" required-level="85" sp="840000000" />
+		<skill name="Lethal Blow" id="344" level="10" required-level="85" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="55" required-level="85" sp="840000000" />
+
+		<skill name="Dagger Mastery" id="209" level="55" required-level="86" sp="840000000" />
+		<skill name="Light Armor Mastery" id="233" level="57" required-level="86" sp="840000000" />
+		<skill name="Entangle" id="102" level="26" required-level="86" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="61" required-level="86" sp="840000000" />
+		<skill name="Deadly Blow" id="263" level="51" required-level="86" sp="840000000" />
+		<skill name="Lethal Blow" id="344" level="11" required-level="86" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="56" required-level="86" sp="840000000" />
+
+		<skill name="Dagger Mastery" id="209" level="56" required-level="87" sp="840000000" />
+		<skill name="Light Armor Mastery" id="233" level="58" required-level="87" sp="840000000" />
+		<skill name="Entangle" id="102" level="27" required-level="87" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="62" required-level="87" sp="840000000" />
+		<skill name="Deadly Blow" id="263" level="52" required-level="87" sp="840000000" />
+		<skill name="Lethal Blow" id="344" level="12" required-level="87" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="57" required-level="87" sp="840000000" />
+
+		<skill name="Dagger Mastery" id="209" level="57" required-level="88" sp="840000000" />
+		<skill name="Light Armor Mastery" id="233" level="59" required-level="88" sp="840000000" />
+		<skill name="Entangle" id="102" level="28" required-level="88" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="63" required-level="88" sp="840000000" />
+		<skill name="Deadly Blow" id="263" level="53" required-level="88" sp="840000000" />
+		<skill name="Lethal Blow" id="344" level="13" required-level="88" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="58" required-level="88" sp="840000000" />
+
+		<skill name="Dagger Mastery" id="209" level="58" required-level="89" sp="840000000" />
+		<skill name="Light Armor Mastery" id="233" level="60" required-level="89" sp="840000000" />
+		<skill name="Entangle" id="102" level="29" required-level="89" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="64" required-level="89" sp="840000000" />
+		<skill name="Deadly Blow" id="263" level="54" required-level="89" sp="840000000" />
+		<skill name="Lethal Blow" id="344" level="14" required-level="89" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="59" required-level="89" sp="840000000" />
+
+		<skill name="Dagger Mastery" id="209" level="59" required-level="90" sp="840000000" />
+		<skill name="Light Armor Mastery" id="233" level="61" required-level="90" sp="840000000" />
+		<skill name="Entangle" id="102" level="30" required-level="90" sp="840000000">
+			<item id="57" count="1000000" /> <!-- Adena -->
+		</skill>
+		<skill name="Slowdown" id="15" level="65" required-level="90" sp="840000000" />
+		<skill name="Deadly Blow" id="263" level="55" required-level="90" sp="840000000" />
+		<skill name="Lethal Blow" id="344" level="15" required-level="90" sp="840000000" />
+		<skill name="Emergency Rescue" id="70" level="60" required-level="90" sp="840000000" />
+
 	</skillTree>
 </list>

--- a/data/skillTrees/StartingClass/DarkElfDeathWalker.xml
+++ b/data/skillTrees/StartingClass/DarkElfDeathWalker.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
+	<skillTree type="classSkillTree" classId="204">
+
+		<!-- Starting Skills Lv1 -->
+		<skill name="Shadow Sense" id="294" level="1" required-level="1" auto-learn="true" />
+		<skill name="Change Armor" id="45355" level="1" required-level="1" auto-learn="true" />
+		<skill name="Appetite for Destruction" id="45351" level="1" required-level="1" auto-learn="true" />
+		<skill name="Death Points" id="45352" level="1" required-level="1" auto-learn="true" />
+		<skill name="Born To Be Dead" id="45349" level="1" required-level="1" auto-learn="true" />
+		<skill name="Undying Body" id="45350" level="1" required-level="1" auto-learn="true" />
+		
+		<!-- Inventory Expansion -->
+		<skill name="Extra Inventory" id="1372" level="1" required-level="1" >
+			<item id="92004" count="1"/> <!-- Inventory Expansion Ticket Lv. 1 -->
+		</skill>
+		<skill name="Extra Inventory" id="1372" level="2" required-level="1" >
+			<item id="92005" count="1"/>   <!-- Inventory Expansion Ticket Lv. 2 -->
+		</skill>
+		<skill name="Extra Inventory" id="1372" level="3" required-level="1" >
+			<item id="92006" count="1"/>  <!-- Inventory Expansion Ticket Lv. 3  -->
+		</skill>
+		<skill name="Extra Inventory" id="1372" level="4" required-level="1" >
+			<item id="92007" count="1"/>  <!-- Inventory Expansion Ticket Lv. 4 -->
+		</skill>
+		<skill name="Extra Inventory" id="1372" level="5" required-level="1" >
+			<item id="92008" count="1"/>  <!-- Inventory Expansion Ticket Lv. 5 -->
+		</skill>
+		
+		<!-- Skills Lv2 -->
+		<skill name="Shield" id="1040" level="1" required-level="2" sp="5" />
+
+		<!-- Skills Lv3 -->
+		<skill name="Might" id="1068" level="1" required-level="3" sp="5" />
+
+		<!-- Skills Lv5 -->		
+		<skill name="Death Armor Mastery" id="45354" level="1" required-level="5" sp="15" />
+		<skill name="Death Sword Mastery" id="45353" level="1" required-level="5" sp="15" />
+		<skill name="Ability to Protect" id="91" level="1" required-level="5" sp="15" />
+
+		<!-- Skills Lv10 -->
+		<skill name="Death Armor Mastery" id="45354" level="2" required-level="10" sp="100" />
+		<skill name="Death Sword Mastery" id="45353" level="2" required-level="10" sp="100" />
+		<skill name="Ability to Attack" id="77" level="1" required-level="10" sp="100" />
+		<skill name="Emergency Rescue" id="70" level="1" required-level="10" sp="100" />
+
+		<!-- Skills Lv15 -->
+		<skill name="Death Armor Mastery" id="45354" level="3" required-level="15" sp="500" />
+		<skill name="Death Sword Mastery" id="45353" level="3" required-level="15" sp="500" />
+		<skill name="Emergency Rescue" id="70" level="2" required-level="15" sp="500" />
+		
+	</skillTree>
+</list>

--- a/data/skillTrees/StartingClass/DarkFighter.xml
+++ b/data/skillTrees/StartingClass/DarkFighter.xml
@@ -1,72 +1,86 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="31">
-		<skill name="Extra Inventory" id="1372" level="1" required-level="1">
-			<item id="92004"/> <!-- Inventory Expansion Ticket Lv. 1 -->
+	
+		<!-- Starting Skills Lv1 -->
+		<skill name="Armor Mastery" id="142" level="1" required-level="1" auto-learn="true" />
+		<skill name="Weapon Mastery" id="141" level="1" required-level="1" auto-learn="true" />
+		<skill name="Shadow Sense" id="294" level="1" required-level="1" auto-learn="true" />
+	
+		<!-- Inventory Expansion -->
+		<skill name="Extra Inventory" id="1372" level="1" required-level="1" >
+			<item id="92004" count="1"/> <!-- Inventory Expansion Ticket Lv. 1 -->
 		</skill>
-		<skill name="Extra Inventory" id="1372" level="2" required-level="1">
-			<item id="92005"/>   <!-- Inventory Expansion Ticket Lv. 2 -->
+		<skill name="Extra Inventory" id="1372" level="2" required-level="1" >
+			<item id="92005" count="1"/>   <!-- Inventory Expansion Ticket Lv. 2 -->
 		</skill>
-		<skill name="Extra Inventory" id="1372" level="3" required-level="1">
-			<item id="92006"/>  <!-- Inventory Expansion Ticket Lv. 3  -->
+		<skill name="Extra Inventory" id="1372" level="3" required-level="1" >
+			<item id="92006" count="1"/>  <!-- Inventory Expansion Ticket Lv. 3  -->
 		</skill>
-		<skill name="Extra Inventory" id="1372" level="4" required-level="1">
-			<item id="92007"/>  <!-- Inventory Expansion Ticket Lv. 4 -->
+		<skill name="Extra Inventory" id="1372" level="4" required-level="1" >
+			<item id="92007" count="1"/>  <!-- Inventory Expansion Ticket Lv. 4 -->
 		</skill>
-		<skill name="Extra Inventory" id="1372" level="5" required-level="1">
-			<item id="92008"/>  <!-- Inventory Expansion Ticket Lv. 5 -->
+		<skill name="Extra Inventory" id="1372" level="5" required-level="1" >
+			<item id="92008" count="1"/>  <!-- Inventory Expansion Ticket Lv. 5 -->
 		</skill>
 
+		<!-- Skills Lv2 -->
+		<skill name="Shield" id="1040" level="1" required-level="2" sp="5" />
 
+		<!-- Skills Lv3 -->
+		<skill name="Might" id="1068" level="1" required-level="3" sp="5" />
 		<skill name="Power Shot" id="56" level="1" required-level="3" sp="5" />
 		<skill name="Power Strike" id="3" level="1" required-level="3" sp="5" />
 		<skill name="Mortal Blow" id="16" level="1" required-level="3" sp="5" />
-		
+
+		<!-- Skills Lv4 -->
 		<skill name="Power Shot" id="56" level="2" required-level="4" sp="10" />
 		<skill name="Power Strike" id="3" level="2" required-level="4" sp="10" />
 		<skill name="Mortal Blow" id="16" level="2" required-level="4" sp="10" />
-		
-		<skill name="Defense Aura" id="91" level="1" required-level="5" sp="15" />
-		<skill name="Armor Mastery" id="142" level="1" required-level="5" sp="15" />
-		<skill name="Weapon Mastery" id="141" level="1" required-level="5" sp="15" />
+
+		<!-- Skills Lv5 -->
 		<skill name="Power Shot" id="56" level="3" required-level="5" sp="15" />
 		<skill name="Power Strike" id="3" level="3" required-level="5" sp="15" />
 		<skill name="Mortal Blow" id="16" level="3" required-level="5" sp="15" />
-		
+		<skill name="Ability to Protect" id="91" level="1" required-level="5" sp="15" />
+
+		<!-- Skills Lv8 -->
 		<skill name="Armor Mastery" id="142" level="2" required-level="8" sp="100" />
 		<skill name="Power Shot" id="56" level="4" required-level="8" sp="100" />
 		<skill name="Power Strike" id="3" level="4" required-level="8" sp="100" />
 		<skill name="Mortal Blow" id="16" level="4" required-level="8" sp="100" />
-		
-		<skill name="Power Strike" id="3" level="5" required-level="9" sp="100" />
+
+		<!-- Skills Lv9 -->
 		<skill name="Power Shot" id="56" level="5" required-level="9" sp="100" />
+		<skill name="Power Strike" id="3" level="5" required-level="9" sp="100" />
 		<skill name="Mortal Blow" id="16" level="5" required-level="9" sp="100" />
-		
+
+		<!-- Skills Lv10 -->
 		<skill name="Armor Mastery" id="142" level="3" required-level="10" sp="100" />
 		<skill name="Weapon Mastery" id="141" level="2" required-level="10" sp="100" />
-		<skill name="Power Strike" id="3" level="6" required-level="10" sp="100" />
 		<skill name="Power Shot" id="56" level="6" required-level="10" sp="100" />
+		<skill name="Power Strike" id="3" level="6" required-level="10" sp="100" />
 		<skill name="Mortal Blow" id="16" level="6" required-level="10" sp="100" />
-		<skill name="Attack Aura" id="77" level="1" required-level="10" sp="100" />
-		
+		<skill name="Ability to Attack" id="77" level="1" required-level="10" sp="100" />
+		<skill name="Emergency Rescue" id="70" level="1" required-level="10" sp="100" />
+
+		<!-- Skills Lv13 -->
 		<skill name="Armor Mastery" id="142" level="4" required-level="13" sp="400" />
-		<skill name="Power Strike" id="3" level="7" required-level="13" sp="400" />
 		<skill name="Power Shot" id="56" level="7" required-level="13" sp="400" />
+		<skill name="Power Strike" id="3" level="7" required-level="13" sp="400" />
 		<skill name="Mortal Blow" id="16" level="7" required-level="13" sp="400" />
-		<skill name="Drain Energy" id="70" level="1" required-level="13" sp="400">
-			<item id="1097"/>
-		</skill>
-		
-		<skill name="Power Strike" id="3" level="8" required-level="14" sp="400" />
+
+		<!-- Skills Lv14 -->
 		<skill name="Power Shot" id="56" level="8" required-level="14" sp="400" />
+		<skill name="Power Strike" id="3" level="8" required-level="14" sp="400" />
 		<skill name="Mortal Blow" id="16" level="8" required-level="14" sp="400" />
-		
+
+		<!-- Skills Lv15 -->
 		<skill name="Armor Mastery" id="142" level="5" required-level="15" sp="400" />
 		<skill name="Weapon Mastery" id="141" level="3" required-level="15" sp="400" />
-		<skill name="Power Strike" id="3" level="9" required-level="15" sp="400" />
 		<skill name="Power Shot" id="56" level="9" required-level="15" sp="400" />
+		<skill name="Power Strike" id="3" level="9" required-level="15" sp="400" />
 		<skill name="Mortal Blow" id="16" level="9" required-level="15" sp="400" />
-		<skill name="Drain Energy" id="70" level="2" required-level="15" sp="400" />
-		<skill name="Shadow Sense" id="294" level="1" required-level="15" sp="400" />
+		<skill name="Emergency Rescue" id="70" level="2" required-level="15" sp="400" />
 	</skillTree>
 </list>

--- a/data/skillTrees/StartingClass/DarkMystic.xml
+++ b/data/skillTrees/StartingClass/DarkMystic.xml
@@ -1,70 +1,91 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="38">
-		<skill name="Spellcraft" id="163" level="1" required-level="1" auto-learn="true" />
-		<skill name="Magician's Movement" id="118" level="1" required-level="1" auto-learn="true" />
+	
+		<!-- Starting Skills Lv1 -->
+		<skill name="Children of Shillien" id="964" level="1" required-level="1" auto-learn="true" />
+		<skill name="Armor Mastery" id="244" level="1" required-level="1" auto-learn="true" />
+		<skill name="Weapon Mastery" id="249" level="1" required-level="1" auto-learn="true" />
 		<skill name="Mana Recovery" id="214" level="1" required-level="1" auto-learn="true" />
-		<skill name="Wind Strike" id="1177" level="1" required-level="1" auto-learn="true" />
+		<skill name="Magician's Attitude" id="118" level="1" required-level="1" auto-learn="true" />
+		<skill name="Spellcraft" id="163" level="1" required-level="1" auto-learn="true" />
+		<skill name="Ice Bolt" id="1184" level="1" required-level="1" auto-learn="true" />
+		<skill name="Fireball" id="1147" level="1" required-level="1" auto-learn="true" />
 		<skill name="Self Heal" id="1216" level="1" required-level="1" auto-learn="true" />
-		<skill name="Extra Inventory" id="1372" level="1" required-level="1">
-			<item id="92004"/> <!-- Inventory Expansion Ticket Lv. 1 -->
+		<skill name="Wind Strike" id="1177" level="1" required-level="1" auto-learn="true" />
+
+		<!-- Inventory Expansion -->		
+		<skill name="Extra Inventory" id="1372" level="1" required-level="1" >
+			<item id="92004" count="1"/> <!-- Inventory Expansion Ticket Lv. 1 -->
 		</skill>
-		<skill name="Extra Inventory" id="1372" level="2" required-level="1">
-			<item id="92005"/>   <!-- Inventory Expansion Ticket Lv. 2 -->
+		<skill name="Extra Inventory" id="1372" level="2" required-level="1" >
+			<item id="92005" count="1"/>   <!-- Inventory Expansion Ticket Lv. 2 -->
 		</skill>
-		<skill name="Extra Inventory" id="1372" level="3" required-level="1">
-			<item id="92006"/>  <!-- Inventory Expansion Ticket Lv. 3  -->
+		<skill name="Extra Inventory" id="1372" level="3" required-level="1" >
+			<item id="92006" count="1"/>  <!-- Inventory Expansion Ticket Lv. 3  -->
 		</skill>
-		<skill name="Extra Inventory" id="1372" level="4" required-level="1">
-			<item id="92007"/>  <!-- Inventory Expansion Ticket Lv. 4 -->
+		<skill name="Extra Inventory" id="1372" level="4" required-level="1" >
+			<item id="92007" count="1"/>  <!-- Inventory Expansion Ticket Lv. 4 -->
 		</skill>
-		<skill name="Extra Inventory" id="1372" level="5" required-level="1">
-			<item id="92008"/>  <!-- Inventory Expansion Ticket Lv. 5 -->
+		<skill name="Extra Inventory" id="1372" level="5" required-level="1" >
+			<item id="92008" count="1"/>  <!-- Inventory Expansion Ticket Lv. 5 -->
 		</skill>
 		
+		<!-- Skills Lv2 -->		
+		<skill name="Shield" id="1040" level="1" required-level="2" sp="5" />
+
+		<!-- Skills Lv3 -->
 		<skill name="Heal" id="1011" level="1" required-level="3" sp="10" />
-		
+		<skill name="Might" id="1068" level="1" required-level="3" sp="5" />
+
+		<!-- Skills Lv4 -->
 		<skill name="Anti Magic" id="146" level="1" required-level="4" sp="15" />
-		<skill name="Ice Bolt" id="1184" level="1" required-level="4" sp="15" />
+		<skill name="Ice Bolt" id="1184" level="2" required-level="4" sp="15" />
 		<skill name="Wind Strike" id="1177" level="2" required-level="4" sp="15" />
-		
+
+		<!-- Skills Lv5 -->
 		<skill name="Heal" id="1011" level="2" required-level="5" sp="20" />
-		
-		<skill name="Heal" id="1011" level="3" required-level="7" sp="25" />
+		<skill name="Self Heal" id="1216" level="2" required-level="5" sp="20" />
+
+		<!-- Skills Lv7 -->
 		<skill name="Anti Magic" id="146" level="2" required-level="7" sp="25" />
-		<skill name="Armor Mastery" id="244" level="1" required-level="7" sp="25" />
-		<skill name="Weapon Mastery" id="249" level="1" required-level="7" sp="25" />
-		<skill name="Cure Poison" id="1012" level="1" required-level="7" sp="25" />
-		<skill name="Ice Bolt" id="1184" level="2" required-level="7" sp="25" />
-		<skill name="Might" id="1068" level="1" required-level="7" sp="25" />
-		<skill name="Curse Poison" id="1168" level="1" required-level="7" sp="25" />
+		<skill name="Cure" id="1012" level="1" required-level="7" sp="25" />
+		<skill name="Ice Bolt" id="1184" level="3" required-level="7" sp="25" />
+		<skill name="Heal" id="1011" level="3" required-level="7" sp="25" />
 		<skill name="Wind Strike" id="1177" level="3" required-level="7" sp="25" />
-		<skill name="Shield" id="1040" level="1" required-level="7" sp="25" />
-		
-		<skill name="Heal" id="1011" level="4" required-level="10" sp="160" />
+
+		<!-- Skills Lv10 -->
 		<skill name="Battle Heal" id="1015" level="1" required-level="10" sp="160" />
 		<skill name="Group Heal" id="1027" level="1" required-level="10" sp="160" />
-		
-		<skill name="Anti Magic" id="146" level="3" required-level="11" sp="190" />
-		<skill name="Armor Mastery" id="244" level="2" required-level="11" sp="160" />
-		<skill name="Ice Bolt" id="1184" level="3" required-level="11" sp="160" />
-		<skill name="Wind Strike" id="1177" level="4" required-level="11" sp="160" />
-		<skill name="Vampiric Touch" id="1147" level="1" required-level="11" sp="160" />
+		<skill name="Heal" id="1011" level="4" required-level="10" sp="160" />
+		<skill name="Fireball" id="1147" level="2" required-level="10" sp="160" />
+		<skill name="Wind Shackle" id="1206" level="1" required-level="10" sp="200" />
+		<skill name="Poison" id="1168" level="1" required-level="10" sp="200" />
 
-		<skill name="Heal" id="1011" level="5" required-level="12" sp="190" />
+		<!-- Skills Lv11 -->
+		<skill name="Anti Magic" id="146" level="3" required-level="11" sp="160" />
+		<skill name="Armor Mastery" id="244" level="2" required-level="11" sp="160" />
+		<skill name="Ice Bolt" id="1184" level="4" required-level="11" sp="160" />
+		<skill name="Wind Strike" id="1177" level="4" required-level="11" sp="160" />
+
+		<!-- Skills Lv12 -->
 		<skill name="Battle Heal" id="1015" level="2" required-level="12" sp="190" />
 		<skill name="Group Heal" id="1027" level="2" required-level="12" sp="190" />
-		
-		<skill name="Heal" id="1011" level="6" required-level="14" sp="190" />
+		<skill name="Heal" id="1011" level="5" required-level="12" sp="190" />
+
+		<!-- Skills Lv14 -->
 		<skill name="Anti Magic" id="146" level="4" required-level="14" sp="190" />
+		<skill name="Battle Heal" id="1015" level="3" required-level="14" sp="190" />
 		<skill name="Armor Mastery" id="244" level="3" required-level="14" sp="190" />
 		<skill name="Weapon Mastery" id="249" level="2" required-level="14" sp="190" />
-		<skill name="Ice Bolt" id="1184" level="4" required-level="14" sp="190" />
-		<skill name="Wind Strike" id="1177" level="5" required-level="14" sp="190" />
-		<skill name="Battle Heal" id="1015" level="3" required-level="14" sp="190" />
 		<skill name="Group Heal" id="1027" level="3" required-level="14" sp="190" />
-		<skill name="Children of Shilen" id="964" level="1" required-level="14" sp="190" />
-		<skill name="Wind Shackle" id="1206" level="1" required-level="14" sp="190" />
-		<skill name="Vampiric Touch" id="1147" level="2" required-level="14" sp="190" />
+		<skill name="Ice Bolt" id="1184" level="5" required-level="14" sp="190" />
+		<skill name="Heal" id="1011" level="6" required-level="14" sp="190" />
+		<skill name="Wind Strike" id="1177" level="5" required-level="14" sp="190" />
+
+		<!-- Skills Lv15 -->
+		<skill name="Fireball" id="1147" level="3" required-level="15" sp="200" />
+		<skill name="Self Heal" id="1216" level="3" required-level="15" sp="250" />
+
 	</skillTree>
 </list>

--- a/data/skillTrees/StartingClass/DwarvenFighter.xml
+++ b/data/skillTrees/StartingClass/DwarvenFighter.xml
@@ -1,40 +1,71 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="53">
-		<skill name="Extra Inventory" id="1372" level="1" required-level="1">
-			<item id="92004"/> <!-- Inventory Expansion Ticket Lv. 1 -->
+	
+		<!-- Starting Skills Lv1 -->
+		<skill name="Armor Mastery" id="142" level="1" required-level="1" auto-learn="true" />
+		<skill name="Weapon Mastery" id="141" level="1" required-level="1" auto-learn="true" />
+	
+		<!-- Inventory Expansion -->
+		<skill name="Extra Inventory" id="1372" level="1" required-level="1" >
+			<item id="92004" count="1"/> <!-- Inventory Expansion Ticket Lv. 1 -->
 		</skill>
-		<skill name="Extra Inventory" id="1372" level="2" required-level="1">
-			<item id="92005"/>   <!-- Inventory Expansion Ticket Lv. 2 -->
+		<skill name="Extra Inventory" id="1372" level="2" required-level="1" >
+			<item id="92005" count="1"/>   <!-- Inventory Expansion Ticket Lv. 2 -->
 		</skill>
-		<skill name="Extra Inventory" id="1372" level="3" required-level="1">
-			<item id="92006"/>  <!-- Inventory Expansion Ticket Lv. 3  -->
+		<skill name="Extra Inventory" id="1372" level="3" required-level="1" >
+			<item id="92006" count="1"/>  <!-- Inventory Expansion Ticket Lv. 3  -->
 		</skill>
-		<skill name="Extra Inventory" id="1372" level="4" required-level="1">
-			<item id="92007"/>  <!-- Inventory Expansion Ticket Lv. 4 -->
+		<skill name="Extra Inventory" id="1372" level="4" required-level="1" >
+			<item id="92007" count="1"/>  <!-- Inventory Expansion Ticket Lv. 4 -->
 		</skill>
-		<skill name="Extra Inventory" id="1372" level="5" required-level="1">
-			<item id="92008"/>  <!-- Inventory Expansion Ticket Lv. 5 -->
+		<skill name="Extra Inventory" id="1372" level="5" required-level="1" >
+			<item id="92008" count="1"/>  <!-- Inventory Expansion Ticket Lv. 5 -->
 		</skill>
 
-		<skill name="Dwarven Craft" id="1321" level="1" required-level="1" auto-learn="true" />
-		<skill name="Armor Mastery" id="142" level="1" required-level="5" sp="15" />
-		<skill name="Weapon Mastery" id="141" level="1" required-level="5" sp="15" />
+		<!-- Skills Lv2 -->
+		<skill name="Maphr's Shield" id="45120" level="1" required-level="2" sp="5" />
+
+		<!-- Skills Lv3 -->
+		<skill name="Maphr's Might" id="45119" level="1" required-level="3" sp="5" />
+		<skill name="Power Strike" id="3" level="1" required-level="3" sp="5" />
+
+		<!-- Skills Lv4 -->
+		<skill name="Power Strike" id="3" level="2" required-level="4" sp="10" />
+
+		<!-- Skills Lv5 -->
+		<skill name="Power Strike" id="3" level="3" required-level="5" sp="15" />
 		<skill name="Spoil" id="254" level="1" required-level="5" sp="15" />
 		<skill name="Sweeper" id="42" level="1" required-level="5" sp="15" />
 		<skill name="Create Item" id="172" level="1" required-level="5" sp="15" />
-		
+		<skill name="Ability to Protect" id="91" level="1" required-level="5" sp="15" />
+
+		<!-- Skills Lv8 -->
 		<skill name="Armor Mastery" id="142" level="2" required-level="8" sp="100" />
-		
+		<skill name="Power Strike" id="3" level="4" required-level="8" sp="100" />
+
+		<!-- Skills Lv9 -->
+		<skill name="Power Strike" id="3" level="5" required-level="9" sp="100" />
+
+		<!-- Skills Lv10 -->
 		<skill name="Armor Mastery" id="142" level="3" required-level="10" sp="100" />
 		<skill name="Weapon Mastery" id="141" level="2" required-level="10" sp="100" />
 		<skill name="Weight Limit" id="150" level="1" required-level="10" sp="100" />
-		
-		<skill name="Armor Mastery" id="142" level="4" required-level="13" sp="400" />
-		
-		<skill name="Armor Mastery" id="142" level="5" required-level="10" sp="400" />
-		<skill name="Weapon Mastery" id="141" level="3" required-level="15" sp="400" />
-		<skill name="Collecting Mastery" id="45248" level="1" required-level="15" sp="500" />
+		<skill name="Power Strike" id="3" level="6" required-level="10" sp="100" />
+		<skill name="Ability to Attack" id="77" level="1" required-level="10" sp="100" />
+		<skill name="Emergency Rescue" id="70" level="1" required-level="10" sp="100" />
 
+		<!-- Skills Lv13 -->
+		<skill name="Armor Mastery" id="142" level="4" required-level="13" sp="400" />
+		<skill name="Power Strike" id="3" level="7" required-level="13" sp="400" />
+
+		<!-- Skills Lv14 -->
+		<skill name="Power Strike" id="3" level="8" required-level="14" sp="400" />
+
+		<!-- Skills Lv15 -->
+		<skill name="Armor Mastery" id="142" level="5" required-level="15" sp="400" />
+		<skill name="Weapon Mastery" id="141" level="3" required-level="15" sp="400" />
+		<skill name="Power Strike" id="3" level="9" required-level="15" sp="400" />
+		<skill name="Emergency Rescue" id="70" level="2" required-level="15" sp="400" />
 	</skillTree>
 </list>

--- a/data/skillTrees/StartingClass/ElfDeathWalker.xml
+++ b/data/skillTrees/StartingClass/ElfDeathWalker.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
+	<skillTree type="classSkillTree" classId="200">
+
+		<!-- Starting Skills Lv1 -->
+		<skill name="Elven Spirit" id="61" level="1" required-level="1" />
+		<skill name="Change Armor" id="45355" level="1" required-level="1" auto-learn="true" />
+		<skill name="Appetite for Destruction" id="45351" level="1" required-level="1" auto-learn="true" />
+		<skill name="Death Points" id="45352" level="1" required-level="1" auto-learn="true" />
+		<skill name="Born To Be Dead" id="45349" level="1" required-level="1" auto-learn="true" />
+		<skill name="Undying Body" id="45350" level="1" required-level="1" auto-learn="true" />
+		
+		<!-- Inventory Expansion -->
+		<skill name="Extra Inventory" id="1372" level="1" required-level="1" >
+			<item id="92004" count="1"/> <!-- Inventory Expansion Ticket Lv. 1 -->
+		</skill>
+		<skill name="Extra Inventory" id="1372" level="2" required-level="1" >
+			<item id="92005" count="1"/>   <!-- Inventory Expansion Ticket Lv. 2 -->
+		</skill>
+		<skill name="Extra Inventory" id="1372" level="3" required-level="1" >
+			<item id="92006" count="1"/>  <!-- Inventory Expansion Ticket Lv. 3  -->
+		</skill>
+		<skill name="Extra Inventory" id="1372" level="4" required-level="1" >
+			<item id="92007" count="1"/>  <!-- Inventory Expansion Ticket Lv. 4 -->
+		</skill>
+		<skill name="Extra Inventory" id="1372" level="5" required-level="1" >
+			<item id="92008" count="1"/>  <!-- Inventory Expansion Ticket Lv. 5 -->
+		</skill>
+		
+		<!-- Skills Lv2 -->
+		<skill name="Shield" id="1040" level="1" required-level="2" sp="5" />
+
+		<!-- Skills Lv3 -->
+		<skill name="Might" id="1068" level="1" required-level="3" sp="5" />
+
+		<!-- Skills Lv5 -->		
+		<skill name="Death Armor Mastery" id="45354" level="1" required-level="5" sp="15" />
+		<skill name="Death Sword Mastery" id="45353" level="1" required-level="5" sp="15" />
+		<skill name="Ability to Protect" id="91" level="1" required-level="5" sp="15" />
+
+		<!-- Skills Lv10 -->
+		<skill name="Death Armor Mastery" id="45354" level="2" required-level="10" sp="100" />
+		<skill name="Death Sword Mastery" id="45353" level="2" required-level="10" sp="100" />
+		<skill name="Ability to Attack" id="77" level="1" required-level="10" sp="100" />
+		<skill name="Emergency Rescue" id="70" level="1" required-level="10" sp="100" />
+
+		<!-- Skills Lv15 -->
+		<skill name="Death Armor Mastery" id="45354" level="3" required-level="15" sp="500" />
+		<skill name="Death Sword Mastery" id="45353" level="3" required-level="15" sp="500" />
+		<skill name="Emergency Rescue" id="70" level="2" required-level="15" sp="500" />
+
+		<!-- Skills Lv18 -->
+		<skill name="Slowdown" id="15" level="1" required-level="18" sp="1000" />
+
+		<!-- Skills Lv19 -->
+		<skill name="Slowdown" id="15" level="2" required-level="19" sp="1000" />
+	</skillTree>
+</list>

--- a/data/skillTrees/StartingClass/ElvenFighter.xml
+++ b/data/skillTrees/StartingClass/ElvenFighter.xml
@@ -1,70 +1,109 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="18">
+	
+		<!-- Starting Skills Lv1 -->
+		<skill name="Armor Mastery" id="142" level="1" required-level="1" auto-learn="true" />
+		<skill name="Weapon Mastery" id="141" level="1" required-level="1" auto-learn="true" />
+		<skill name="Elven Spirit" id="61" level="1" required-level="1" auto-learn="true" />
+		
+		<!-- Inventory Expansion -->
+		<skill name="Extra Inventory" id="1372" level="1" required-level="1" >
+			<item id="92004" count="1"/> <!-- Inventory Expansion Ticket Lv. 1 -->
+		</skill>
+		<skill name="Extra Inventory" id="1372" level="2" required-level="1" >
+			<item id="92005" count="1"/>   <!-- Inventory Expansion Ticket Lv. 2 -->
+		</skill>
+		<skill name="Extra Inventory" id="1372" level="3" required-level="1" >
+			<item id="92006" count="1"/>  <!-- Inventory Expansion Ticket Lv. 3  -->
+		</skill>
+		<skill name="Extra Inventory" id="1372" level="4" required-level="1" >
+			<item id="92007" count="1"/>  <!-- Inventory Expansion Ticket Lv. 4 -->
+		</skill>
+		<skill name="Extra Inventory" id="1372" level="5" required-level="1" >
+			<item id="92008" count="1"/>  <!-- Inventory Expansion Ticket Lv. 5 -->
+		</skill>
 
-		<skill name="Extra Inventory" id="1372" level="1" required-level="1">
-			<item id="92004"/> <!-- Inventory Expansion Ticket Lv. 1 -->
-		</skill>
-		<skill name="Extra Inventory" id="1372" level="2" required-level="1">
-			<item id="92005"/>   <!-- Inventory Expansion Ticket Lv. 2 -->
-		</skill>
-		<skill name="Extra Inventory" id="1372" level="3" required-level="1">
-			<item id="92006"/>  <!-- Inventory Expansion Ticket Lv. 3  -->
-		</skill>
-		<skill name="Extra Inventory" id="1372" level="4" required-level="1">
-			<item id="92007"/>  <!-- Inventory Expansion Ticket Lv. 4 -->
-		</skill>
-		<skill name="Extra Inventory" id="1372" level="5" required-level="1">
-			<item id="92008"/>  <!-- Inventory Expansion Ticket Lv. 5 -->
-		</skill>
-
+		<!-- Skills Lv2 -->
+		<skill name="Shield" id="1040" level="1" required-level="2" sp="5" />
+		
+		<!-- Skills Lv3 -->
+		<skill name="Might" id="1068" level="1" required-level="3" sp="5" />
 		<skill name="Power Shot" id="56" level="1" required-level="3" sp="5" />
 		<skill name="Power Strike" id="3" level="1" required-level="3" sp="5" />
 		<skill name="Mortal Blow" id="16" level="1" required-level="3" sp="5" />
-		
+
+		<!-- Skills Lv4 -->
 		<skill name="Power Shot" id="56" level="2" required-level="4" sp="10" />
 		<skill name="Power Strike" id="3" level="2" required-level="4" sp="10" />
 		<skill name="Mortal Blow" id="16" level="2" required-level="4" sp="10" />
-		
-		<skill name="Defense Aura" id="91" level="1" required-level="5" sp="15" />
-		<skill name="Armor Mastery" id="142" level="1" required-level="5" sp="15" />
-		<skill name="Weapon Mastery" id="141" level="1" required-level="5" sp="15" />
+
+		<!-- Skills Lv5 -->	
 		<skill name="Power Shot" id="56" level="3" required-level="5" sp="15" />
 		<skill name="Power Strike" id="3" level="3" required-level="5" sp="15" />
+		<skill name="Elemental Heal" id="58" level="1" required-level="5" sp="15" />
 		<skill name="Mortal Blow" id="16" level="3" required-level="5" sp="15" />
-		
+		<skill name="Ability to Protect" id="91" level="1" required-level="5" sp="15" />
+
+		<!-- Skills Lv7 -->	
+		<skill name="Elemental Heal" id="58" level="2" required-level="7" sp="100" />
+
+		<!-- Skills Lv8 -->	
 		<skill name="Armor Mastery" id="142" level="2" required-level="8" sp="100" />
 		<skill name="Power Shot" id="56" level="4" required-level="8" sp="100" />
 		<skill name="Power Strike" id="3" level="4" required-level="8" sp="100" />
 		<skill name="Mortal Blow" id="16" level="4" required-level="8" sp="100" />
-		
-		<skill name="Power Strike" id="3" level="5" required-level="9" sp="100" />
+
+		<!-- Skills Lv9 -->	
 		<skill name="Power Shot" id="56" level="5" required-level="9" sp="100" />
+		<skill name="Power Strike" id="3" level="5" required-level="9" sp="100" />
 		<skill name="Mortal Blow" id="16" level="5" required-level="9" sp="100" />
-		
+
+		<!-- Skills Lv10 -->	
 		<skill name="Armor Mastery" id="142" level="3" required-level="10" sp="100" />
 		<skill name="Weapon Mastery" id="141" level="2" required-level="10" sp="100" />
-		<skill name="Power Strike" id="3" level="6" required-level="10" sp="100" />
 		<skill name="Power Shot" id="56" level="6" required-level="10" sp="100" />
+		<skill name="Power Strike" id="3" level="6" required-level="10" sp="100" />
+		<skill name="Elemental Heal" id="58" level="3" required-level="10" sp="100" />
 		<skill name="Mortal Blow" id="16" level="6" required-level="10" sp="100" />
-		<skill name="Attack Aura" id="77" level="1" required-level="10" sp="100" />
-		
+		<skill name="Ability to Attack" id="77" level="1" required-level="10" sp="100" />
+		<skill name="Emergency Rescue" id="70" level="1" required-level="10" sp="100" />
+
+		<!-- Skills Lv12 -->	
+		<skill name="Elemental Heal" id="58" level="4" required-level="12" sp="400" />
+
+		<!-- Skills Lv13 -->	
 		<skill name="Armor Mastery" id="142" level="4" required-level="13" sp="400" />
-		<skill name="Power Strike" id="3" level="7" required-level="13" sp="400" />
 		<skill name="Power Shot" id="56" level="7" required-level="13" sp="400" />
+		<skill name="Power Strike" id="3" level="7" required-level="13" sp="400" />
 		<skill name="Mortal Blow" id="16" level="7" required-level="13" sp="400" />
-		<skill name="Elemental Heal" id="58" level="1" required-level="13" sp="400" />
-		
-		<skill name="Power Strike" id="3" level="8" required-level="14" sp="400" />
+
+		<!-- Skills Lv14 -->	
 		<skill name="Power Shot" id="56" level="8" required-level="14" sp="400" />
+		<skill name="Power Strike" id="3" level="8" required-level="14" sp="400" />
 		<skill name="Mortal Blow" id="16" level="8" required-level="14" sp="400" />
-		<skill name="Elemental Heal" id="58" level="2" required-level="14" sp="400" />
-		
+
+		<!-- Skills Lv15 -->	
 		<skill name="Armor Mastery" id="142" level="5" required-level="15" sp="400" />
 		<skill name="Weapon Mastery" id="141" level="3" required-level="15" sp="400" />
-		<skill name="Power Strike" id="3" level="9" required-level="15" sp="400" />
 		<skill name="Power Shot" id="56" level="9" required-level="15" sp="400" />
+		<skill name="Power Strike" id="3" level="9" required-level="15" sp="400" />
+		<skill name="Elemental Heal" id="58" level="5" required-level="15" sp="400" />
 		<skill name="Mortal Blow" id="16" level="9" required-level="15" sp="400" />
-		<skill name="Elemental Heal" id="58" level="3" required-level="15" sp="400" />
+		<skill name="Emergency Rescue" id="70" level="2" required-level="15" sp="400" />
+
+		<!-- Skills Lv16 -->	
+		<skill name="Elemental Heal" id="58" level="6" required-level="16" sp="1000" />
+
+		<!-- Skills Lv17 -->	
+		<skill name="Elemental Heal" id="58" level="7" required-level="17" sp="1000" />
+
+		<!-- Skills Lv18 -->	
+		<skill name="Slowdown" id="15" level="1" required-level="18" sp="1000" />
+		<skill name="Elemental Heal" id="58" level="8" required-level="18" sp="1000" />
+
+		<!-- Skills Lv. 19 -->
+		<skill name="Slowdown" id="15" level="2" required-level="19" sp="1000" />
+		<skill name="Elemental Heal" id="58" level="9" required-level="19" sp="1000" />
 	</skillTree>
 </list>

--- a/data/skillTrees/StartingClass/ElvenMystic.xml
+++ b/data/skillTrees/StartingClass/ElvenMystic.xml
@@ -1,67 +1,91 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="25">
-		<skill name="Spellcraft" id="163" level="1" required-level="1" auto-learn="true" />
-		<skill name="Magician's Movement" id="118" level="1" required-level="1" auto-learn="true" />
-		<skill name="Mana Recovery" id="214" level="1" required-level="1" auto-learn="true" />
+	
+		<!-- Starting Skills Lv1 -->
+		<skill name="Magician's Attitude" id="118" level="1" required-level="1" auto-learn="true" />
+		<skill name="Armor Mastery" id="244" level="1" required-level="1" auto-learn="true" />
+		<skill name="Weapon Mastery" id="249" level="1" required-level="1" auto-learn="true" />
+		<skill name="Fireball" id="1147" level="1" required-level="1" auto-learn="true" />
 		<skill name="Wind Strike" id="1177" level="1" required-level="1" auto-learn="true" />
+		<skill name="Ice Bolt" id="1184" level="1" required-level="1" auto-learn="true" />
 		<skill name="Self Heal" id="1216" level="1" required-level="1" auto-learn="true" />
-		<skill name="Extra Inventory" id="1372" level="1" required-level="1">
-			<item id="92004"/> <!-- Inventory Expansion Ticket Lv. 1 -->
+		<skill name="Children of Eva" id="53008" level="1" required-level="1" auto-learn="true" />
+		<skill name="Mana Recovery" id="214" level="1" required-level="1" auto-learn="true" />
+		<skill name="Spellcraft" id="163" level="1" required-level="1" auto-learn="true" />
+
+		<!-- Inventory Expansion -->		
+		<skill name="Extra Inventory" id="1372" level="1" required-level="1" >
+			<item id="92004" count="1"/> <!-- Inventory Expansion Ticket Lv. 1 -->
 		</skill>
-		<skill name="Extra Inventory" id="1372" level="2" required-level="1">
-			<item id="92005"/>   <!-- Inventory Expansion Ticket Lv. 2 -->
+		<skill name="Extra Inventory" id="1372" level="2" required-level="1" >
+			<item id="92005" count="1"/>   <!-- Inventory Expansion Ticket Lv. 2 -->
 		</skill>
-		<skill name="Extra Inventory" id="1372" level="3" required-level="1">
-			<item id="92006"/>  <!-- Inventory Expansion Ticket Lv. 3  -->
+		<skill name="Extra Inventory" id="1372" level="3" required-level="1" >
+			<item id="92006" count="1"/>  <!-- Inventory Expansion Ticket Lv. 3  -->
 		</skill>
-		<skill name="Extra Inventory" id="1372" level="4" required-level="1">
-			<item id="92007"/>  <!-- Inventory Expansion Ticket Lv. 4 -->
+		<skill name="Extra Inventory" id="1372" level="4" required-level="1" >
+			<item id="92007" count="1"/>  <!-- Inventory Expansion Ticket Lv. 4 -->
 		</skill>
-		<skill name="Extra Inventory" id="1372" level="5" required-level="1">
-			<item id="92008"/>  <!-- Inventory Expansion Ticket Lv. 5 -->
+		<skill name="Extra Inventory" id="1372" level="5" required-level="1" >
+			<item id="92008" count="1"/>  <!-- Inventory Expansion Ticket Lv. 5 -->
 		</skill>
 		
+		<!-- Skills Lv2 -->		
+		<skill name="Shield" id="1040" level="1" required-level="2" sp="5" />
+
+		<!-- Skills Lv3 -->
 		<skill name="Heal" id="1011" level="1" required-level="3" sp="10" />
-		
+		<skill name="Might" id="1068" level="1" required-level="3" sp="5" />
+
+		<!-- Skills Lv4 -->
 		<skill name="Anti Magic" id="146" level="1" required-level="4" sp="15" />
-		<skill name="Ice Bolt" id="1184" level="1" required-level="4" sp="15" />
+		<skill name="Ice Bolt" id="1184" level="2" required-level="4" sp="15" />
 		<skill name="Wind Strike" id="1177" level="2" required-level="4" sp="15" />
-		
+
+		<!-- Skills Lv5 -->
 		<skill name="Heal" id="1011" level="2" required-level="5" sp="20" />
-		
-		<skill name="Heal" id="1011" level="3" required-level="7" sp="25" />
+		<skill name="Self Heal" id="1216" level="2" required-level="5" sp="20" />
+
+		<!-- Skills Lv7 -->
 		<skill name="Anti Magic" id="146" level="2" required-level="7" sp="25" />
-		<skill name="Armor Mastery" id="244" level="1" required-level="7" sp="25" />
-		<skill name="Weapon Mastery" id="249" level="1" required-level="7" sp="25" />
-		<skill name="Cure Poison" id="1012" level="1" required-level="7" sp="25" />
-		<skill name="Ice Bolt" id="1184" level="2" required-level="7" sp="25" />
-		<skill name="Might" id="1068" level="1" required-level="7" sp="25" />
+		<skill name="Cure" id="1012" level="1" required-level="7" sp="25" />
+		<skill name="Ice Bolt" id="1184" level="3" required-level="7" sp="25" />
+		<skill name="Heal" id="1011" level="3" required-level="7" sp="25" />
 		<skill name="Wind Strike" id="1177" level="3" required-level="7" sp="25" />
-		<skill name="Shield" id="1040" level="1" required-level="7" sp="25" />
-		
-		<skill name="Heal" id="1011" level="4" required-level="10" sp="160" />
+
+		<!-- Skills Lv10 -->
 		<skill name="Battle Heal" id="1015" level="1" required-level="10" sp="160" />
 		<skill name="Group Heal" id="1027" level="1" required-level="10" sp="160" />
-		
-		<skill name="Anti Magic" id="146" level="3" required-level="11" sp="190" />
+		<skill name="Heal" id="1011" level="4" required-level="10" sp="160" />
+		<skill name="Fireball" id="1147" level="2" required-level="10" sp="160" />
+		<skill name="Wind Shackle" id="1206" level="1" required-level="10" sp="200" />
+		<skill name="Weakness" id="1164" level="1" required-level="10" sp="200" />
+
+		<!-- Skills Lv11 -->
+		<skill name="Anti Magic" id="146" level="3" required-level="11" sp="160" />
 		<skill name="Armor Mastery" id="244" level="2" required-level="11" sp="160" />
-		<skill name="Ice Bolt" id="1184" level="3" required-level="11" sp="160" />
+		<skill name="Ice Bolt" id="1184" level="4" required-level="11" sp="160" />
 		<skill name="Wind Strike" id="1177" level="4" required-level="11" sp="160" />
 
-		<skill name="Heal" id="1011" level="5" required-level="12" sp="190" />
+		<!-- Skills Lv12 -->
 		<skill name="Battle Heal" id="1015" level="2" required-level="12" sp="190" />
 		<skill name="Group Heal" id="1027" level="2" required-level="12" sp="190" />
-		
-		<skill name="Heal" id="1011" level="6" required-level="14" sp="190" />
+		<skill name="Heal" id="1011" level="5" required-level="12" sp="190" />
+
+		<!-- Skills Lv14 -->
 		<skill name="Anti Magic" id="146" level="4" required-level="14" sp="190" />
+		<skill name="Battle Heal" id="1015" level="3" required-level="14" sp="190" />
 		<skill name="Armor Mastery" id="244" level="3" required-level="14" sp="190" />
 		<skill name="Weapon Mastery" id="249" level="2" required-level="14" sp="190" />
-		<skill name="Ice Bolt" id="1184" level="4" required-level="14" sp="190" />
-		<skill name="Wind Strike" id="1177" level="5" required-level="14" sp="190" />
-		<skill name="Battle Heal" id="1015" level="3" required-level="14" sp="190" />
 		<skill name="Group Heal" id="1027" level="3" required-level="14" sp="190" />
-		<skill name="Wind Shackle" id="1206" level="1" required-level="14" sp="190" />
-		<skill name="Curse Weakness" id="1164" level="1" required-level="14" sp="190" />
+		<skill name="Ice Bolt" id="1184" level="5" required-level="14" sp="190" />
+		<skill name="Heal" id="1011" level="6" required-level="14" sp="190" />
+		<skill name="Wind Strike" id="1177" level="5" required-level="14" sp="190" />
+
+		<!-- Skills Lv15 -->
+		<skill name="Fireball" id="1147" level="3" required-level="15" sp="200" />
+		<skill name="Self Heal" id="1216" level="3" required-level="15" sp="250" />
+
 	</skillTree>
 </list>

--- a/data/skillTrees/StartingClass/HumanDeathWalker.xml
+++ b/data/skillTrees/StartingClass/HumanDeathWalker.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
+	<skillTree type="classSkillTree" classId="196">
+
+		<!-- Lv 1. Skills -->
+		<skill name="Change Armor" id="45355" level="1" required-level="1" auto-learn="true" />
+		<skill name="Appetite for Destruction" id="45351" level="1" required-level="1" auto-learn="true" />
+		<skill name="Death Points" id="45352" level="1" required-level="1" auto-learn="true" />
+		<skill name="Born To Be Dead" id="45349" level="1" required-level="1" auto-learn="true" />
+		<skill name="Undying Body" id="45350" level="1" required-level="1" auto-learn="true" />
+
+		<!-- Inventory Expansion -->
+		<skill name="Expand Inventory" id="1372" level="1" required-level="1">
+			<item id="92004" count="1" /> <!-- Inventory Expansion Coupon Lv. 1 -->
+		</skill>
+		<skill name="Expand Inventory" id="1372" level="2" required-level="1">
+			<item id="92005" count="1" /> <!-- Inventory Expansion Coupon Lv. 2 -->
+		</skill>
+		<skill name="Expand Inventory" id="1372" level="3" required-level="1">
+			<item id="92006" count="1" /> <!-- Inventory Expansion Coupon Lv. 3 -->
+		</skill>
+		<skill name="Expand Inventory" id="1372" level="4" required-level="1">
+			<item id="92007" count="1" /> <!-- Inventory Expansion Coupon Lv. 4 -->
+		</skill>
+		<skill name="Expand Inventory" id="1372" level="5" required-level="1">
+			<item id="92008" count="1" /> <!-- Inventory Expansion Coupon Lv. 5 -->
+		</skill>
+
+		<!-- Lv. 2 Skills -->
+		<skill name="Shield" id="1040" level="1" required-level="2" sp="5" />
+
+		<!-- Lv. 3 Skills -->
+		<skill name="Might" id="1068" level="1" required-level="3" sp="5" />
+
+		<!-- Lv. 5 Skills -->
+		<skill name="Death Armor Mastery" id="45354" level="1" required-level="5" sp="15" />
+		<skill name="Death Sword Mastery" id="45353" level="1" required-level="5" sp="15" />
+		<skill name="Ability to Protect" id="91" level="1" required-level="5" sp="15" />
+
+		<!-- Lv. 10 Skills -->
+		<skill name="Death Armor Mastery" id="45354" level="2" required-level="10" sp="100" />
+		<skill name="Death Sword Mastery" id="45353" level="2" required-level="10" sp="100" />
+		<skill name="Ability to Attack" id="77" level="1" required-level="10" sp="100" />
+		<skill name="Emergency Rescue" id="70" level="1" required-level="10" sp="100" />
+
+		<!-- Lv. 15 Skills -->
+		<skill name="Death Armor Mastery" id="45354" level="3" required-level="15" sp="500" />
+		<skill name="Death Sword Mastery" id="45353" level="3" required-level="15" sp="500" />
+		<skill name="Emergency Rescue" id="70" level="2" required-level="15" sp="500" />
+	</skillTree>
+</list>

--- a/data/skillTrees/StartingClass/HumanFighter.xml
+++ b/data/skillTrees/StartingClass/HumanFighter.xml
@@ -2,65 +2,86 @@
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="0">
 
-		<skill name="Extra Inventory" id="1372" level="1" required-level="1">
-			<item id="92004"/> <!-- Inventory Expansion Ticket Lv. 1 -->
-		</skill>
-		<skill name="Extra Inventory" id="1372" level="2" required-level="1">
-			<item id="92005"/>   <!-- Inventory Expansion Ticket Lv. 2 -->
-		</skill>
-		<skill name="Extra Inventory" id="1372" level="3" required-level="1">
-			<item id="92006"/>  <!-- Inventory Expansion Ticket Lv. 3  -->
-		</skill>
-		<skill name="Extra Inventory" id="1372" level="4" required-level="1">
-			<item id="92007"/>  <!-- Inventory Expansion Ticket Lv. 4 -->
-		</skill>
-		<skill name="Extra Inventory" id="1372" level="5" required-level="1">
-			<item id="92008"/>  <!-- Inventory Expansion Ticket Lv. 5 -->
-		</skill>
+		<!-- Starting Skills Lv1 -->
+		<skill name="Armor Mastery" id="142" level="1" required-level="1" auto-learn="true" />
+		<skill name="Weapon Mastery" id="141" level="1" required-level="1" auto-learn="true" />
 
-		<skill name="Power Shot" id="56" level="1" required-level="3" sp="5" />
-		<skill name="Power Strike" id="3" level="1" required-level="3" sp="5" />
-		<skill name="Mortal Blow" id="16" level="1" required-level="3" sp="5" />
+		<!-- Inventory Expansion -->
+		<skill name="Extra Inventory" id="1372" level="1" required-level="1" >
+			<item id="92004" count="1"/> <!-- Inventory Expansion Ticket Lv. 1 -->
+		</skill>
+		<skill name="Extra Inventory" id="1372" level="2" required-level="1" >
+			<item id="92005" count="1"/>   <!-- Inventory Expansion Ticket Lv. 2 -->
+		</skill>
+		<skill name="Extra Inventory" id="1372" level="3" required-level="1" >
+			<item id="92006" count="1"/>  <!-- Inventory Expansion Ticket Lv. 3  -->
+		</skill>
+		<skill name="Extra Inventory" id="1372" level="4" required-level="1" >
+			<item id="92007" count="1"/>  <!-- Inventory Expansion Ticket Lv. 4 -->
+		</skill>
+		<skill name="Extra Inventory" id="1372" level="5" required-level="1" >
+			<item id="92008" count="1"/>  <!-- Inventory Expansion Ticket Lv. 5 -->
+		</skill>
 		
+		<!-- Skills Lv2 -->
+		<skill name="Shield" id="1040" level="1" required-level="2" sp="5" />
+
+		<!-- Skills Lv3 -->
+		<skill name="Power Strike" id="3" level="1" required-level="3" sp="5" />
+		<skill name="Power Shot" id="56" level="1" required-level="3" sp="5" />
+		<skill name="Mortal Blow" id="16" level="1" required-level="3" sp="5" />
+		<skill name="Might" id="1068" level="1" required-level="3" sp="5" />
+
+
+		<!-- Skills Lv4 -->
 		<skill name="Power Shot" id="56" level="2" required-level="4" sp="10" />
 		<skill name="Power Strike" id="3" level="2" required-level="4" sp="10" />
 		<skill name="Mortal Blow" id="16" level="2" required-level="4" sp="10" />
-		
-		<skill name="Weapon Mastery" id="141" level="1" required-level="5" sp="15" />
-		<skill name="Armor Mastery" id="142" level="1" required-level="5" sp="15" />
+
+		<!-- Skills Lv5 -->
+		<skill name="Mortal Blow" id="16" level="3" required-level="5" sp="15" />
 		<skill name="Power Shot" id="56" level="3" required-level="5" sp="15" />
 		<skill name="Power Strike" id="3" level="3" required-level="5" sp="15" />
-		<skill name="Mortal Blow" id="16" level="3" required-level="5" sp="15" />
+		<skill name="Ability to Protect" id="91" level="1" required-level="5" sp="15" />
 		<skill name="Relax" id="226" level="1" required-level="5" sp="15" />
-		
-		<skill name="Armor Mastery" id="142" level="2" required-level="8" sp="100" />
-		<skill name="Power Shot" id="56" level="4" required-level="8" sp="100" />
+
+		<!-- Skills Lv8 -->
 		<skill name="Power Strike" id="3" level="4" required-level="8" sp="100" />
 		<skill name="Mortal Blow" id="16" level="4" required-level="8" sp="100" />
-		
+		<skill name="Power Shot" id="56" level="4" required-level="8" sp="100" />
+		<skill name="Armor Mastery" id="142" level="2" required-level="8" sp="100" />
+
+		<!-- Skills Lv9 -->
 		<skill name="Power Strike" id="3" level="5" required-level="9" sp="100" />
 		<skill name="Power Shot" id="56" level="5" required-level="9" sp="100" />
 		<skill name="Mortal Blow" id="16" level="5" required-level="9" sp="100" />
-		
+
+		<!-- Skills Lv10 -->
+		<skill name="Mortal Blow" id="16" level="6" required-level="10" sp="100" />
+		<skill name="Power Shot" id="56" level="6" required-level="10" sp="100" />
+		<skill name="Power Strike" id="3" level="6" required-level="10" sp="100" />
+		<skill name="Emergency Rescue" id="70" level="1" required-level="10" sp="100" />
+		<skill name="Ability to Attack" id="77" level="1" required-level="10" sp="100" />
 		<skill name="Weapon Mastery" id="141" level="2" required-level="10" sp="100" />
 		<skill name="Armor Mastery" id="142" level="3" required-level="10" sp="100" />
-		<skill name="Power Strike" id="3" level="6" required-level="10" sp="100" />
-		<skill name="Power Shot" id="56" level="6" required-level="10" sp="100" />
-		<skill name="Mortal Blow" id="16" level="6" required-level="10" sp="100" />
-		
+
+		<!-- Skills Lv13 -->
 		<skill name="Armor Mastery" id="142" level="4" required-level="13" sp="400" />
-		<skill name="Power Strike" id="3" level="7" required-level="13" sp="400" />
 		<skill name="Power Shot" id="56" level="7" required-level="13" sp="400" />
+		<skill name="Power Strike" id="3" level="7" required-level="13" sp="400" />
 		<skill name="Mortal Blow" id="16" level="7" required-level="13" sp="400" />
-		
+
+		<!-- Skills Lv14 -->
 		<skill name="Power Strike" id="3" level="8" required-level="14" sp="400" />
-		<skill name="Power Shot" id="56" level="8" required-level="14" sp="400" />
 		<skill name="Mortal Blow" id="16" level="8" required-level="14" sp="400" />
-		
-		<skill name="Armor Mastery" id="142" level="5" required-level="15" sp="400" />
-		<skill name="Weapon Mastery" id="141" level="3" required-level="15" sp="400" />
+		<skill name="Power Shot" id="56" level="8" required-level="14" sp="400" />
+
+		<!-- Skills Lv15 -->
 		<skill name="Power Strike" id="3" level="9" required-level="15" sp="400" />
-		<skill name="Power Shot" id="56" level="9" required-level="15" sp="400" />
 		<skill name="Mortal Blow" id="16" level="9" required-level="15" sp="400" />
+		<skill name="Power Shot" id="56" level="9" required-level="15" sp="400" />
+		<skill name="Emergency Rescue" id="70" level="2" required-level="15" sp="400" />
+		<skill name="Weapon Mastery" id="141" level="3" required-level="15" sp="400" />
+		<skill name="Armor Mastery" id="142" level="5" required-level="15" sp="400" />
 	</skillTree>
 </list>

--- a/data/skillTrees/StartingClass/HumanMystic.xml
+++ b/data/skillTrees/StartingClass/HumanMystic.xml
@@ -1,69 +1,91 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="10">
-		<skill name="Spellcraft" id="163" level="1" required-level="1" auto-learn="true" />
-		<skill name="Magician's Movement" id="118" level="1" required-level="1" auto-learn="true" />
-		<skill name="Mana Recovery" id="214" level="1" required-level="1" auto-learn="true" />
+	
+		<!-- Starting Skills Lv1 -->
+		<skill name="Magician's Attitude" id="118" level="1" required-level="1" auto-learn="true" />
+		<skill name="Armor Mastery" id="244" level="1" required-level="1" auto-learn="true" />
+		<skill name="Weapon Mastery" id="249" level="1" required-level="1" auto-learn="true" />
+		<skill name="Fireball" id="1147" level="1" required-level="1" auto-learn="true" />
 		<skill name="Wind Strike" id="1177" level="1" required-level="1" auto-learn="true" />
+		<skill name="Ice Bolt" id="1184" level="1" required-level="1" auto-learn="true" />
 		<skill name="Self Heal" id="1216" level="1" required-level="1" auto-learn="true" />
-		<skill name="Extra Inventory" id="1372" level="1" required-level="1">
-			<item id="92004"/> <!-- Inventory Expansion Ticket Lv. 1 -->
-		</skill>
-		<skill name="Extra Inventory" id="1372" level="2" required-level="1">
-			<item id="92005"/>   <!-- Inventory Expansion Ticket Lv. 2 -->
-		</skill>
-		<skill name="Extra Inventory" id="1372" level="3" required-level="1">
-			<item id="92006"/>  <!-- Inventory Expansion Ticket Lv. 3  -->
-		</skill>
-		<skill name="Extra Inventory" id="1372" level="4" required-level="1">
-			<item id="92007"/>  <!-- Inventory Expansion Ticket Lv. 4 -->
-		</skill>
-		<skill name="Extra Inventory" id="1372" level="5" required-level="1">
-			<item id="92008"/>  <!-- Inventory Expansion Ticket Lv. 5 -->
-		</skill>
+		<skill name="Einhasad's Blessing" id="45240" level="1" required-level="1" auto-learn="true" />
+		<skill name="Mana Recovery" id="214" level="1" required-level="1" auto-learn="true" />
+		<skill name="Spellcraft" id="163" level="1" required-level="1" auto-learn="true" />
 
+		<!-- Inventory Expansion -->		
+		<skill name="Extra Inventory" id="1372" level="1" required-level="1" >
+			<item id="92004" count="1"/> <!-- Inventory Expansion Ticket Lv. 1 -->
+		</skill>
+		<skill name="Extra Inventory" id="1372" level="2" required-level="1" >
+			<item id="92005" count="1"/>   <!-- Inventory Expansion Ticket Lv. 2 -->
+		</skill>
+		<skill name="Extra Inventory" id="1372" level="3" required-level="1" >
+			<item id="92006" count="1"/>  <!-- Inventory Expansion Ticket Lv. 3  -->
+		</skill>
+		<skill name="Extra Inventory" id="1372" level="4" required-level="1" >
+			<item id="92007" count="1"/>  <!-- Inventory Expansion Ticket Lv. 4 -->
+		</skill>
+		<skill name="Extra Inventory" id="1372" level="5" required-level="1" >
+			<item id="92008" count="1"/>  <!-- Inventory Expansion Ticket Lv. 5 -->
+		</skill>
+		
+		<!-- Skills Lv2 -->		
+		<skill name="Shield" id="1040" level="1" required-level="2" sp="5" />
+
+		<!-- Skills Lv3 -->
 		<skill name="Heal" id="1011" level="1" required-level="3" sp="10" />
-		
-		<skill name="Anti Magic" id="146" level="1" required-level="4" sp="15" />
-		<skill name="Ice Bolt" id="1184" level="1" required-level="4" sp="15" />
-		<skill name="Wind Strike" id="1177" level="2" required-level="4" sp="25" />
-		
-		<skill name="Heal" id="1011" level="2" required-level="5" sp="20" />
+		<skill name="Might" id="1068" level="1" required-level="3" sp="5" />
 
+		<!-- Skills Lv4 -->
+		<skill name="Anti Magic" id="146" level="1" required-level="4" sp="15" />
+		<skill name="Ice Bolt" id="1184" level="2" required-level="4" sp="15" />
+		<skill name="Wind Strike" id="1177" level="2" required-level="4" sp="15" />
+
+		<!-- Skills Lv5 -->
+		<skill name="Heal" id="1011" level="2" required-level="5" sp="20" />
+		<skill name="Self Heal" id="1216" level="2" required-level="5" sp="20" />
+
+		<!-- Skills Lv7 -->
 		<skill name="Anti Magic" id="146" level="2" required-level="7" sp="25" />
+		<skill name="Cure" id="1012" level="1" required-level="7" sp="25" />
+		<skill name="Ice Bolt" id="1184" level="3" required-level="7" sp="25" />
 		<skill name="Heal" id="1011" level="3" required-level="7" sp="25" />
-		<skill name="Armor Mastery" id="244" level="1" required-level="7" sp="25" />
-		<skill name="Weapon Mastery" id="249" level="1" required-level="7" sp="25" />
-		<skill name="Cure Poison" id="1012" level="1" required-level="7" sp="25" />
-		<skill name="Ice Bolt" id="1184" level="2" required-level="7" sp="25" />
-		<skill name="Might" id="1068" level="1" required-level="7" sp="25" />
-		<skill name="Curse Poison" id="1168" level="1" required-level="7" sp="25" />
 		<skill name="Wind Strike" id="1177" level="3" required-level="7" sp="25" />
-		<skill name="Shield" id="1040" level="1" required-level="7" sp="25" />
-		
-		<skill name="Heal" id="1011" level="4" required-level="10" sp="160" />
+
+		<!-- Skills Lv10 -->
 		<skill name="Battle Heal" id="1015" level="1" required-level="10" sp="160" />
 		<skill name="Group Heal" id="1027" level="1" required-level="10" sp="160" />
+		<skill name="Heal" id="1011" level="4" required-level="10" sp="160" />
+		<skill name="Fireball" id="1147" level="2" required-level="10" sp="160" />
+		<skill name="Poison" id="1168" level="1" required-level="10" sp="200" />
+		<skill name="Weakness" id="1164" level="1" required-level="10" sp="200" />
 
+		<!-- Skills Lv11 -->
 		<skill name="Anti Magic" id="146" level="3" required-level="11" sp="160" />
 		<skill name="Armor Mastery" id="244" level="2" required-level="11" sp="160" />
-		<skill name="Ice Bolt" id="1184" level="3" required-level="11" sp="160" />
+		<skill name="Ice Bolt" id="1184" level="4" required-level="11" sp="160" />
 		<skill name="Wind Strike" id="1177" level="4" required-level="11" sp="160" />
-		<skill name="Vampiric Touch" id="1147" level="1" required-level="11" sp="160" />
-		
-		<skill name="Heal" id="1011" level="5" required-level="12" sp="190" />
+
+		<!-- Skills Lv12 -->
 		<skill name="Battle Heal" id="1015" level="2" required-level="12" sp="190" />
 		<skill name="Group Heal" id="1027" level="2" required-level="12" sp="190" />
-		
+		<skill name="Heal" id="1011" level="5" required-level="12" sp="190" />
+
+		<!-- Skills Lv14 -->
 		<skill name="Anti Magic" id="146" level="4" required-level="14" sp="190" />
+		<skill name="Battle Heal" id="1015" level="3" required-level="14" sp="190" />
 		<skill name="Armor Mastery" id="244" level="3" required-level="14" sp="190" />
 		<skill name="Weapon Mastery" id="249" level="2" required-level="14" sp="190" />
-		<skill name="Ice Bolt" id="1184" level="4" required-level="14" sp="190" />
+		<skill name="Group Heal" id="1027" level="3" required-level="14" sp="190" />
+		<skill name="Ice Bolt" id="1184" level="5" required-level="14" sp="190" />
 		<skill name="Heal" id="1011" level="6" required-level="14" sp="190" />
 		<skill name="Wind Strike" id="1177" level="5" required-level="14" sp="190" />
-		<skill name="Battle Heal" id="1015" level="3" required-level="14" sp="190" />
-		<skill name="Group Heal" id="1027" level="3" required-level="14" sp="190" />
-		<skill name="Curse Weakness" id="1164" level="1" required-level="14" sp="190" />
-		<skill name="Vampiric Touch" id="1147" level="2" required-level="14" sp="190" />
+
+		<!-- Skills Lv15 -->
+		<skill name="Fireball" id="1147" level="3" required-level="15" sp="200" />
+		<skill name="Self Heal" id="1216" level="3" required-level="15" sp="250" />
+
 	</skillTree>
 </list>

--- a/data/skillTrees/StartingClass/JinKamaelSoldier.xml
+++ b/data/skillTrees/StartingClass/JinKamaelSoldier.xml
@@ -1,28 +1,46 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="192">
+	
+		<!-- Starting Skills Lv1 -->	
 		<skill name="Armor Mastery" id="464" level="1" required-level="1" auto-learn="true"/>
 		<skill name="Weapon Mastery" id="463" level="1" required-level="1" auto-learn="true"/>
-		<skill name="Extra Inventory" id="1372" level="1" required-level="1">
-			<item id="92004"/> <!-- Inventory Expansion Ticket Lv. 1 -->
+		<skill name="Kamael's Dignity" id="328" level="1" required-level="1" auto-learn="true" />
+		<skill name="Pride of Kamael" id="329" level="1" required-level="1" auto-learn="true" />
+	
+		<!-- Inventory Expansion -->	
+		<skill name="Extra Inventory" id="1372" level="1" required-level="1" >
+			<item id="92004" count="1"/> <!-- Inventory Expansion Ticket Lv. 1 -->
 		</skill>
-		<skill name="Extra Inventory" id="1372" level="2" required-level="1">
-			<item id="92005"/>   <!-- Inventory Expansion Ticket Lv. 2 -->
+		<skill name="Extra Inventory" id="1372" level="2" required-level="1" >
+			<item id="92005" count="1"/>   <!-- Inventory Expansion Ticket Lv. 2 -->
 		</skill>
-		<skill name="Extra Inventory" id="1372" level="3" required-level="1">
-			<item id="92006"/>  <!-- Inventory Expansion Ticket Lv. 3  -->
+		<skill name="Extra Inventory" id="1372" level="3" required-level="1" >
+			<item id="92006" count="1"/>  <!-- Inventory Expansion Ticket Lv. 3  -->
 		</skill>
-		<skill name="Extra Inventory" id="1372" level="4" required-level="1">
-			<item id="92007"/>  <!-- Inventory Expansion Ticket Lv. 4 -->
+		<skill name="Extra Inventory" id="1372" level="4" required-level="1" >
+			<item id="92007" count="1"/>  <!-- Inventory Expansion Ticket Lv. 4 -->
 		</skill>
-		<skill name="Extra Inventory" id="1372" level="5" required-level="1">
-			<item id="92008"/>  <!-- Inventory Expansion Ticket Lv. 5 -->
+		<skill name="Extra Inventory" id="1372" level="5" required-level="1" >
+			<item id="92008" count="1"/>  <!-- Inventory Expansion Ticket Lv. 5 -->
 		</skill>
 		
-		<skill name="Dignity of Kamael" id="328" level="1" required-level="10" sp="100"/>
-		<skill name="Pride of Kamael" id="329" level="1" required-level="10" sp="100"/>
+		<!-- Skills Lv2 -->		
+		<skill name="Soul Shield" id="45145" level="1" required-level="2" sp="5" />
 
-		<skill name="Death Mark" id="1435" level="1" required-level="15" sp="500"/>
+		<!-- Skills Lv3 -->
+		<skill name="Soul Might" id="45144" level="1" required-level="3" sp="5" />
+
+		<!-- Skills Lv5 -->
+		<skill name="Ability to Protect" id="91" level="1" required-level="5" sp="15" />
+
+		<!-- Skills Lv10 -->
+		<skill name="Ability to Attack" id="77" level="1" required-level="10" sp="100" />
+		<skill name="Emergency Rescue" id="70" level="1" required-level="10" sp="100" />
+
+		<!-- Skills Lv15 -->
+		<skill name="Death Mark" id="1435" level="1" required-level="15" sp="500" />
+		<skill name="Emergency Rescue" id="70" level="2" required-level="15" sp="500" />
 		
 	</skillTree>
 </list>

--- a/data/skillTrees/StartingClass/OrcFighter.xml
+++ b/data/skillTrees/StartingClass/OrcFighter.xml
@@ -1,58 +1,78 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="44">
-		<skill name="Extra Inventory" id="1372" level="1" required-level="1">
-			<item id="92004"/> <!-- Inventory Expansion Ticket Lv. 1 -->
+
+		<!-- Starting Skills Lv1 -->
+		<skill name="Armor Mastery" id="142" level="1" required-level="1" auto-learn="true" />
+		<skill name="Weapon Mastery" id="141" level="1" required-level="1" auto-learn="true" />
+		<skill name="Iron Body" id="295" level="1" required-level="1" auto-learn="true" />
+	
+		<!-- Inventory Expansion -->	
+		<skill name="Extra Inventory" id="1372" level="1" required-level="1" >
+			<item id="92004" count="1"/> <!-- Inventory Expansion Ticket Lv. 1 -->
 		</skill>
-		<skill name="Extra Inventory" id="1372" level="2" required-level="1">
-			<item id="92005"/>   <!-- Inventory Expansion Ticket Lv. 2 -->
+		<skill name="Extra Inventory" id="1372" level="2" required-level="1" >
+			<item id="92005" count="1"/>   <!-- Inventory Expansion Ticket Lv. 2 -->
 		</skill>
-		<skill name="Extra Inventory" id="1372" level="3" required-level="1">
-			<item id="92006"/>  <!-- Inventory Expansion Ticket Lv. 3  -->
+		<skill name="Extra Inventory" id="1372" level="3" required-level="1" >
+			<item id="92006" count="1"/>  <!-- Inventory Expansion Ticket Lv. 3  -->
 		</skill>
-		<skill name="Extra Inventory" id="1372" level="4" required-level="1">
-			<item id="92007"/>  <!-- Inventory Expansion Ticket Lv. 4 -->
+		<skill name="Extra Inventory" id="1372" level="4" required-level="1" >
+			<item id="92007" count="1"/>  <!-- Inventory Expansion Ticket Lv. 4 -->
 		</skill>
-		<skill name="Extra Inventory" id="1372" level="5" required-level="1">
-			<item id="92008"/>  <!-- Inventory Expansion Ticket Lv. 5 -->
+		<skill name="Extra Inventory" id="1372" level="5" required-level="1" >
+			<item id="92008" count="1"/>  <!-- Inventory Expansion Ticket Lv. 5 -->
 		</skill>
 
+		<!-- Skills Lv2 -->
+		<skill name="Chant of Shield" id="45127" level="1" required-level="2" sp="5" />
 
-		<skill name="Iron Punch" id="29" level="1" required-level="3" sp="15" />
-		<skill name="Power Strike" id="3" level="1" required-level="3" sp="15" />
-		
-		<skill name="Iron Punch" id="29" level="2" required-level="4" sp="15" />
-		<skill name="Power Strike" id="3" level="2" required-level="4" sp="15" />
-		
-		<skill name="Armor Mastery" id="142" level="1" required-level="5" sp="15" />
-		<skill name="Weapon Mastery" id="141" level="1" required-level="5" sp="15" />
+		<!-- Skills Lv3 -->
+		<skill name="Iron Punch" id="29" level="1" required-level="3" sp="5" />
+		<skill name="Power Strike" id="3" level="1" required-level="3" sp="5" />
+		<skill name="Chant of Might" id="45126" level="1" required-level="3" sp="5" />
+
+		<!-- Skills Lv4 -->
+		<skill name="Iron Punch" id="29" level="2" required-level="4" sp="10" />
+		<skill name="Power Strike" id="3" level="2" required-level="4" sp="10" />
+
+		<!-- Skills Lv5 -->
 		<skill name="Iron Punch" id="29" level="3" required-level="5" sp="15" />
 		<skill name="Power Strike" id="3" level="3" required-level="5" sp="15" />
 		<skill name="Relax" id="226" level="1" required-level="5" sp="15" />
-		
+		<skill name="Ability to Protect" id="91" level="1" required-level="5" sp="15" />
+
+		<!-- Skills Lv8 -->
 		<skill name="Armor Mastery" id="142" level="2" required-level="8" sp="100" />
 		<skill name="Iron Punch" id="29" level="4" required-level="8" sp="100" />
 		<skill name="Power Strike" id="3" level="4" required-level="8" sp="100" />
-		
+
+		<!-- Skills Lv9 -->
 		<skill name="Iron Punch" id="29" level="5" required-level="9" sp="100" />
 		<skill name="Power Strike" id="3" level="5" required-level="9" sp="100" />
-		
+
+		<!-- Skills Lv10 -->
 		<skill name="Armor Mastery" id="142" level="3" required-level="10" sp="100" />
 		<skill name="Weapon Mastery" id="141" level="2" required-level="10" sp="100" />
 		<skill name="Iron Punch" id="29" level="6" required-level="10" sp="100" />
 		<skill name="Power Strike" id="3" level="6" required-level="10" sp="100" />
-		
+		<skill name="Ability to Attack" id="77" level="1" required-level="10" sp="100" />
+		<skill name="Emergency Rescue" id="70" level="1" required-level="10" sp="100" />
+
+		<!-- Skills Lv13 -->
 		<skill name="Armor Mastery" id="142" level="4" required-level="13" sp="400" />
 		<skill name="Iron Punch" id="29" level="7" required-level="13" sp="400" />
 		<skill name="Power Strike" id="3" level="7" required-level="13" sp="400" />
-		
+
+		<!-- Skills Lv14 -->
 		<skill name="Iron Punch" id="29" level="8" required-level="14" sp="400" />
 		<skill name="Power Strike" id="3" level="8" required-level="14" sp="400" />
-		
+
+		<!-- Skills Lv15 -->
 		<skill name="Armor Mastery" id="142" level="5" required-level="15" sp="400" />
 		<skill name="Weapon Mastery" id="141" level="3" required-level="15" sp="400" />
 		<skill name="Iron Punch" id="29" level="9" required-level="15" sp="400" />
 		<skill name="Power Strike" id="3" level="9" required-level="15" sp="400" />
-		<skill name="Iron Body" id="295" level="1" required-level="15" sp="400" />
+		<skill name="Emergency Rescue" id="70" level="2" required-level="15" sp="400" />
 	</skillTree>
 </list>

--- a/data/skillTrees/StartingClass/OrcMystic.xml
+++ b/data/skillTrees/StartingClass/OrcMystic.xml
@@ -1,57 +1,85 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
 	<skillTree type="classSkillTree" classId="49">
-		<!-- Confirmed CT2.5 -->
+	
+		<!-- Starting Skills Lv1 -->
+		<skill name="Battle Cry" id="1001" level="1" required-level="1" auto-learn="true" />
+		<skill name="Weapon Mastery" id="250" level="1" required-level="1" auto-learn="true" />
 		<skill name="Mana Recovery" id="214" level="1" required-level="1" auto-learn="true" />
-		<skill name="Magician's Movement" id="118" level="1" required-level="1" auto-learn="true" />
+		<skill name="Magician's Attitude" id="118" level="1" required-level="1" auto-learn="true" />
 		<skill name="Spellcraft" id="163" level="1" required-level="1" auto-learn="true" />
-		<skill name="Soul Cry" id="1001" level="1" required-level="1" auto-learn="true" />
-		<skill name="Extra Inventory" id="1372" level="1" required-level="1">
-			<item id="92004"/> <!-- Inventory Expansion Ticket Lv. 1 -->
-		</skill>
-		<skill name="Extra Inventory" id="1372" level="2" required-level="1">
-			<item id="92005"/>   <!-- Inventory Expansion Ticket Lv. 2 -->
-		</skill>
-		<skill name="Extra Inventory" id="1372" level="3" required-level="1">
-			<item id="92006"/>  <!-- Inventory Expansion Ticket Lv. 3  -->
-		</skill>
-		<skill name="Extra Inventory" id="1372" level="4" required-level="1">
-			<item id="92007"/>  <!-- Inventory Expansion Ticket Lv. 4 -->
-		</skill>
-		<skill name="Extra Inventory" id="1372" level="5" required-level="1">
-			<item id="92008"/>  <!-- Inventory Expansion Ticket Lv. 5 -->
-		</skill>
+		<skill name="Drain Energy" id="1090" level="1" required-level="1" auto-learn="true" />
 		
+		<!-- Inventory Expansion -->
+		<skill name="Expand Inventory" id="1372" level="1" required-level="1">
+			<item id="92004" count="1"/> <!-- Inventory Expansion Ticket Lv. 1 -->
+			</skill>
+		<skill name="Extra Inventory" id="1372" level="2" required-level="1" >
+			<item id="92005" count="1"/>   <!-- Inventory Expansion Ticket Lv. 2 -->
+		</skill>
+		<skill name="Extra Inventory" id="1372" level="3" required-level="1" >
+			<item id="92006" count="1"/>  <!-- Inventory Expansion Ticket Lv. 3  -->
+		</skill>
+		<skill name="Extra Inventory" id="1372" level="4" required-level="1" >
+			<item id="92007" count="1"/>  <!-- Inventory Expansion Ticket Lv. 4 -->
+		</skill>
+		<skill name="Extra Inventory" id="1372" level="5" required-level="1" >
+			<item id="92008" count="1"/>  <!-- Inventory Expansion Ticket Lv. 5 -->
+		</skill>
+
+		<!-- Skills Lv2 -->			
+		<skill name="Chant of Shield" id="1009" level="1" required-level="2" sp="5" />
+
+		<!-- Skills Lv3 -->	
+		<skill name="Chant of Might" id="1007" level="1" required-level="3" sp="5" />
+
+		<!-- Skills Lv4 -->	
 		<skill name="Anti Magic" id="146" level="1" required-level="4" sp="15" />
 		<skill name="Light Armor Mastery" id="252" level="1" required-level="4" sp="15" />
 		<skill name="Robe Mastery" id="251" level="1" required-level="4" sp="15" />
-		
+
+		<!-- Skills Lv5 -->	
+		<skill name="Drain Energy" id="1090" level="2" required-level="5" sp="20" />
+
+		<!-- Skills Lv7 -->	
 		<skill name="Anti Magic" id="146" level="2" required-level="7" sp="25" />
-		<skill name="Venom" id="1095" level="1" required-level="7" sp="25" />
 		<skill name="Light Armor Mastery" id="252" level="2" required-level="7" sp="25" />
 		<skill name="Robe Mastery" id="251" level="2" required-level="7" sp="25" />
-		<skill name="Weapon Mastery" id="250" level="1" required-level="7" sp="25" />
-		<skill name="Drain Energy" id="1090" level="1" required-level="7" sp="25" />
+		<skill name="Spirit Shield" id="1010" level="1" required-level="7" sp="25" />
 		<skill name="Chill Flame" id="1100" level="1" required-level="7" sp="25" />
+		<skill name="Venom" id="1095" level="1" required-level="7" sp="25" />
 		<skill name="Dreaming Spirit" id="1097" level="1" required-level="7" sp="25" />
-		<skill name="Soul Shield" id="1010" level="1" required-level="7" sp="25" />
-		
+
+		<!-- Skills Lv8 -->	
+		<skill name="Drain Energy" id="1090" level="3" required-level="8" sp="25" />
+
+		<!-- Skills Lv10 -->	
+		<skill name="Eagle Spirit" id="1003" level="1" required-level="10" sp="100" />
+		<skill name="Soul Evasion" id="1005" level="1" required-level="10" sp="100" />
+
+		<!-- Skills Lv11 -->	
 		<skill name="Anti Magic" id="146" level="3" required-level="11" sp="160" />
 		<skill name="Light Armor Mastery" id="252" level="3" required-level="11" sp="160" />
 		<skill name="Robe Mastery" id="251" level="3" required-level="11" sp="160" />
 		<skill name="Heavy Armor Mastery" id="253" level="1" required-level="11" sp="160" />
-		
+
+		<!-- Skills Lv12 -->	
+		<skill name="Drain Energy" id="1090" level="4" required-level="12" sp="190" />
+
+		<!-- Skills Lv14 -->	
 		<skill name="Anti Magic" id="146" level="4" required-level="14" sp="190" />
-		<skill name="Venom" id="1095" level="2" required-level="14" sp="190" />
+		<skill name="Battle Cry" id="1001" level="2" required-level="14" sp="190" />
 		<skill name="Light Armor Mastery" id="252" level="4" required-level="14" sp="190" />
 		<skill name="Robe Mastery" id="251" level="4" required-level="14" sp="190" />
 		<skill name="Weapon Mastery" id="250" level="2" required-level="14" sp="190" />
-		<skill name="Drain Energy" id="1090" level="2" required-level="14" sp="190" />
-		<skill name="Chill Flame" id="1100" level="2" required-level="14" sp="190" />
-		<skill name="Dreaming Spirit" id="1097" level="2" required-level="14" sp="190" />
 		<skill name="Heavy Armor Mastery" id="253" level="2" required-level="14" sp="190" />
-		<skill name="Soul Cry" id="1001" level="2" required-level="14" sp="190" />
-		<skill name="Chant of Battle" id="1007" level="1" required-level="14" sp="190" />
+		<skill name="Chill Flame" id="1100" level="2" required-level="14" sp="190" />
+		<skill name="Venom" id="1095" level="2" required-level="14" sp="190" />
+		<skill name="Dreaming Spirit" id="1097" level="2" required-level="14" sp="190" />
 		<skill name="Fear" id="1092" level="1" required-level="14" sp="190" />
+
+		<!-- Skills Lv16 -->	
+		<skill name="Drain Energy" id="1090" level="5" required-level="16" sp="250" />
+		
 	</skillTree>
 </list>

--- a/data/skillTrees/StartingClass/SylphGunner.xml
+++ b/data/skillTrees/StartingClass/SylphGunner.xml
@@ -1,36 +1,49 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/skillTrees.xsd">
-    <skillTree type="classSkillTree" classId="208">
-        <skill name="Armor Mastery" id="142" level="1" required-level="1" auto-learn="true" />
-        <skill name="Weapon Mastery" id="141" level="1" required-level="1" auto-learn="true" />
-        <skill name="Elemental Spirit" id="47101" level="1" required-level="1" auto-learn="true"/>
-        <skill name="Elemental Connection" id="47104" level="1" required-level="1" auto-learn="true"/>
-        <skill name="Expand Inventory" id="1372" level="1" required-level="1">
-            <item id="92004" count="1" /> <!-- Inventory Expansion Coupon Lv. 1 -->
-        </skill>
-        <skill name="Expand Inventory" id="1372" level="2" required-level="1">
-            <item id="92005" count="1" /> <!-- Inventory Expansion Coupon Lv. 2 -->
-        </skill>
-        <skill name="Expand Inventory" id="1372" level="3" required-level="1">
-            <item id="92006" count="1" /> <!-- Inventory Expansion Coupon Lv. 3 -->
-        </skill>
-        <skill name="Expand Inventory" id="1372" level="4" required-level="1">
-            <item id="92007" count="1" /> <!-- Inventory Expansion Coupon Lv. 4 -->
-        </skill>
-        <skill name="Expand Inventory" id="1372" level="5" required-level="1">
-            <item id="92008" count="1" /> <!-- Inventory Expansion Coupon Lv. 5 -->
-        </skill>
+	<skillTree type="classSkillTree" classId="208">
+	
+		<!-- Starting Skills Lv1 -->	
+		<skill name="Weapon Mastery" id="141" level="1" required-level="1" auto-learn="true"/>
+		<skill name="Armor Mastery" id="142" level="1" required-level="1" auto-learn="true"/>
+		<skill name="Elemental Connection" id="47104" level="1" required-level="1" auto-learn="true" />
+		<skill name="Elemental Spirit" id="47101" level="1" required-level="1" auto-learn="true" />
+	
+		<!-- Inventory Expansion -->	
+		<skill name="Extra Inventory" id="1372" level="1" required-level="1" >
+			<item id="92004" count="1"/> <!-- Inventory Expansion Ticket Lv. 1 -->
+		</skill>
+		<skill name="Extra Inventory" id="1372" level="2" required-level="1" >
+			<item id="92005" count="1"/>   <!-- Inventory Expansion Ticket Lv. 2 -->
+		</skill>
+		<skill name="Extra Inventory" id="1372" level="3" required-level="1" >
+			<item id="92006" count="1"/>  <!-- Inventory Expansion Ticket Lv. 3  -->
+		</skill>
+		<skill name="Extra Inventory" id="1372" level="4" required-level="1" >
+			<item id="92007" count="1"/>  <!-- Inventory Expansion Ticket Lv. 4 -->
+		</skill>
+		<skill name="Extra Inventory" id="1372" level="5" required-level="1" >
+			<item id="92008" count="1"/>  <!-- Inventory Expansion Ticket Lv. 5 -->
+		</skill>
+		
+		<!-- Skills Lv2 -->		
+		<skill name="Elemental Shield" id="47027" level="1" required-level="2" sp="5" />
 
-        <skill name="Elemental Shield" id="47027" level="1" required-level="2" sp="5"/>
-        <skill name="Elemental Might" id="47026" level="1" required-level="2" sp="5"/>
+		<!-- Skills Lv3 -->
+		<skill name="Elemental Might" id="47026" level="1" required-level="3" sp="5" />
 
-        <skill name="Ability to Protect" id="91" level="1" required-level="5" sp="15" />
-        <skill name="Armor Mastery" id="142" level="2" required-level="8" sp="100" />
+		<!-- Skills Lv5 -->
+		<skill name="Ability to Protect" id="91" level="1" required-level="5" sp="15" />
 
-        <skill name="Ability to Attack" id="77" level="1" required-level="10" sp="100" />
-        <skill name="Weapon Mastery" id="141" level="2" required-level="10" sp="100" />
-        <skill name="Armor Mastery" id="142" level="3" required-level="10" sp="100" />
+		<!-- Skills Lv8 -->
+		<skill name="Armor Mastery" id="142" level="2" required-level="8" sp="100" />
+		
+		<!-- Skills Lv10 -->
+		<skill name="Ability to Attack" id="77" level="1" required-level="10" sp="100" />
+		<skill name="Armor Mastery" id="142" level="3" required-level="10" sp="100" />
+		<skill name="Weapon Mastery" id="141" level="2" required-level="10" sp="100" />
 
-        <skill name="Weapon Mastery" id="141" level="3" required-level="15" sp="500" />
-    </skillTree>
+		<!-- Skills Lv15 -->
+		<skill name="Weapon Mastery" id="141" level="3" required-level="15" sp="400" />
+		
+	</skillTree>
 </list>

--- a/data/skillTrees/documentation.txt
+++ b/data/skillTrees/documentation.txt
@@ -3,10 +3,13 @@ Freya Skill Trees created by Zoey76 (28/03/2011).
 Structure example:
 <list>
 	<skillTree type="" classId="" parentClassId="">
-		<skill skillName="" skillId="" skillLvl="" getLevel="" levelUpSp="" autoGet="" socialClass="" residenceSkill="" learnedByNpc="" />
-		<skill skillName="" skillId="" skillLvl="" getLevel="" levelUpSp="" autoGet="" socialClass="" residenceSkill="" learnedByNpc="" >
+		<skill name="" id="" level="" required-level="" sp="" auto-learn="" socialClass="" residenceSkill="" learnedByNpc="" learnedByFS="" />
+		<skill name="" id="" level="" required-level="" sp="" auto-learn="" socialClass="" residenceSkill="" learnedByNpc="" learnedByFS="">
 			<item id="" count="" />
+			<preRequisiteSkill id="" lvl="" />
 			<race>Human</race>
+			<residenceId>1</residenceId>
+			<subClassConditions slot="" lvl="" />
 		</skill>
 	</skillTree>
 </list>
@@ -32,13 +35,17 @@ It's possible to create custom skill trees in different files and add those skil
 It's possible to add a skill(s) common to all classes by omitting the classId attribute.
 
 Attribute description:
-autoGet = Boolean to define if skill is learned automatically.
-getLevel = Minimum player/clan level required to learn  the skill (depend of the skill tree type).
+auto-learn = Boolean to define if skill is learned automatically.
+required-level = Minimum player/clan level required to learn  the skill (depend of the skill tree type).
+learnedByFS = Boolean to identify if skill is learned by Forgotten Scroll.
 learnedByNpc = Boolean to identify if skill is learned by NPC.
-levelUpSp = SP or Reputation cost to learn skill (depend of the skill tree type).
+sp = SP or Reputation cost to learn skill (depend of the skill tree type).
+preRequisiteSkill = Skill Id and level of the required skill (this skill should be learned before).
 race = condition to learn skill for specific races.
+residenceId = Residence Id, condition to learn skill for specific residences.
 residenceSkill = Boolean to identify if a residential skill or not.
-skillId = Skill Id.
-skillLvl = Skill level.
+id = Skill Id.
+level = Skill level.
 skillName = Skill name.
 socialClass = Rank Id (like VASSAL, BARON, ELDER, and others).
+subClassConditions = condition for SubClass level and slot.

--- a/data/skillTrees/fishingSkillTree.xml
+++ b/data/skillTrees/fishingSkillTree.xml
@@ -22,28 +22,28 @@
 		<skill name="Expand Warehouse" id="1371" level="7" required-level="70" learned-by-npc="true">
 			<item id="45481" count="2822" /> <!--Fresh Blue Mackerel -->
 		</skill>
-		<skill name="Expand Dwarven Craft" id="1368" level="1" required-level="10" learned-by-npc="true" races="DWARF">
+		<skill name="Expand Dwarven Craft" id="1368" level="1" required-level="10" learned-by-npc="true">
 			<item id="45481" count="2822" /> <!--Fresh Blue Mackerel -->
 		</skill>
-		<skill name="Expand Dwarven Craft" id="1368" level="2" required-level="20" learned-by-npc="true" races="DWARF">
+		<skill name="Expand Dwarven Craft" id="1368" level="2" required-level="20" learned-by-npc="true">
 			<item id="45481" count="2822" /> <!--Fresh Blue Mackerel -->
 		</skill>
-		<skill name="Expand Dwarven Craft" id="1368" level="3" required-level="28" learned-by-npc="true" races="DWARF">
+		<skill name="Expand Dwarven Craft" id="1368" level="3" required-level="28" learned-by-npc="true">
 			<item id="45481" count="2822" /> <!--Fresh Blue Mackerel -->
 		</skill>
-		<skill name="Expand Dwarven Craft" id="1368" level="4" required-level="36" learned-by-npc="true" races="DWARF">
+		<skill name="Expand Dwarven Craft" id="1368" level="4" required-level="36" learned-by-npc="true">
 			<item id="45481" count="2822" /> <!--Fresh Blue Mackerel -->
 		</skill>
-		<skill name="Expand Dwarven Craft" id="1368" level="5" required-level="43" learned-by-npc="true" races="DWARF">
+		<skill name="Expand Dwarven Craft" id="1368" level="5" required-level="43" learned-by-npc="true">
 			<item id="45481" count="2822" /> <!--Fresh Blue Mackerel -->
 		</skill>
-		<skill name="Expand Dwarven Craft" id="1368" level="6" required-level="49" learned-by-npc="true" races="DWARF">
+		<skill name="Expand Dwarven Craft" id="1368" level="6" required-level="49" learned-by-npc="true">
 			<item id="45481" count="2822" /> <!--Fresh Blue Mackerel -->
 		</skill>
-		<skill name="Expand Dwarven Craft" id="1368" level="7" required-level="55" learned-by-npc="true" races="DWARF">
+		<skill name="Expand Dwarven Craft" id="1368" level="7" required-level="55" learned-by-npc="true">
 			<item id="45481" count="2822" /> <!--Fresh Blue Mackerel -->
 		</skill>
-		<skill name="Expand Dwarven Craft" id="1368" level="8" required-level="62" learned-by-npc="true" races="DWARF">
+		<skill name="Expand Dwarven Craft" id="1368" level="8" required-level="62" learned-by-npc="true">
 			<item id="45481" count="2822" /> <!--Fresh Blue Mackerel -->
 		</skill>
 		<skill name="Expand Trade" id="1370" level="1" required-level="40" learned-by-npc="true">

--- a/data/skillTrees/pledgeSkillTree.xml
+++ b/data/skillTrees/pledgeSkillTree.xml
@@ -1,18 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../xsd/skillTrees.xsd">
-	<skillTree type="pledgeSkillTree">		
-		<!-- Clan Skills --> <!-- Classic Kamael Ch. 4 -->
-		<skill name="Clan Luck" id="59328" level="1" required-level="1">
-			<item id="57" count="500000" />
-		</skill>
-		<skill name="Clan Luck" id="59328" level="2" required-level="2">
-			<item id="49758" count="10" />
-		</skill>
-		<skill name="Clan Luck" id="59328" level="3" required-level="3">
-			<item id="49758" count="20" />
-		</skill>
-		<skill name="Clan Luck" id="59328" level="4" required-level="4">
-			<item id="57" count="100000000" />
+<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../xsd/skillTrees.xsd">
+	<skillTree type="pledgeSkillTree">
+
+		<skill name="Clan Restore" id="390" level="1" required-level="1">
+			<item id="57" count="10000" />
 		</skill>
 
 		<skill name="Clan Fortune" id="392" level="1" required-level="1">
@@ -21,8 +12,8 @@
 		<skill name="Clan Fortune" id="392" level="2" required-level="2">
 			<item id="57" count="300000" />
 		</skill>
-		<skill name="Clan Fortune" id="392" level="3" required-level="3" sp="5000"/>
-		<skill name="Clan Fortune" id="392" level="4" required-level="3" sp="30000"/>
+		<skill name="Clan Fortune" id="392" level="3" required-level="3" sp="5000" />
+		<skill name="Clan Fortune" id="392" level="4" required-level="3" sp="30000" />
 
 		<skill name="Clan Body" id="370" level="1" required-level="3" sp="1800">
 			<item id="49758" count="2" />
@@ -33,8 +24,8 @@
 		<skill name="Clan Body" id="370" level="3" required-level="3" sp="7500">
 			<item id="49758" count="30" />
 		</skill>
-		
-		<skill name="Clan Imperium" id="391" level="1" required-level="4"/>
+
+		<skill name="Clan Imperium" id="391" level="1" required-level="3" />
 
 		<skill name="Clan Spirituality" id="371" level="1" required-level="3" sp="10000">
 			<item id="49758" count="10" />
@@ -45,14 +36,14 @@
 		<skill name="Clan Spirituality" id="371" level="3" required-level="3" sp="50000">
 			<item id="49758" count="30" />
 		</skill>
-		
+
 		<skill name="No Clan Return" id="19113" level="1" required-level="3">
 			<item id="57" count="200000000" />
 		</skill>
 		<skill name="No Clan Resurrection" id="19114" level="1" required-level="3">
 			<item id="57" count="200000000" />
 		</skill>
-		
+
 		<skill name="Clan Soul" id="372" level="1" required-level="4" sp="1800">
 			<item id="49758" count="2" />
 		</skill>
@@ -62,7 +53,7 @@
 		<skill name="Clan Soul" id="372" level="3" required-level="4" sp="7500">
 			<item id="49758" count="30" />
 		</skill>
-		
+
 		<skill name="Clan Regeneration" id="373" level="1" required-level="4" sp="1800">
 			<item id="49758" count="2" />
 		</skill>
@@ -72,7 +63,7 @@
 		<skill name="Clan Regeneration" id="373" level="3" required-level="4" sp="7500">
 			<item id="49758" count="30" />
 		</skill>
-		
+
 		<skill name="Clan Morale" id="374" level="1" required-level="3" sp="1800">
 			<item id="49758" count="2" />
 		</skill>
@@ -82,7 +73,7 @@
 		<skill name="Clan Morale" id="374" level="3" required-level="3" sp="7500">
 			<item id="49758" count="30" />
 		</skill>
-		
+
 		<skill name="Clan Clarity" id="375" level="1" required-level="3" sp="1800">
 			<item id="49758" count="2" />
 		</skill>
@@ -92,7 +83,7 @@
 		<skill name="Clan Clarity" id="375" level="3" required-level="3" sp="7500">
 			<item id="49758" count="30" />
 		</skill>
-		
+
 		<skill name="Clan Might" id="376" level="1" required-level="4" sp="1800">
 			<item id="49758" count="2" />
 		</skill>
@@ -102,7 +93,7 @@
 		<skill name="Clan Might" id="376" level="3" required-level="4" sp="7500">
 			<item id="49758" count="30" />
 		</skill>
-		
+
 		<skill name="Clan Shield" id="377" level="1" required-level="4" sp="1800">
 			<item id="49758" count="2" />
 		</skill>
@@ -112,7 +103,7 @@
 		<skill name="Clan Shield" id="377" level="3" required-level="4" sp="7500">
 			<item id="49758" count="30" />
 		</skill>
-		
+
 		<skill name="Clan Empower" id="378" level="1" required-level="4" sp="1800">
 			<item id="49758" count="2" />
 		</skill>
@@ -122,7 +113,7 @@
 		<skill name="Clan Empower" id="378" level="3" required-level="4" sp="7500">
 			<item id="49758" count="30" />
 		</skill>
-		
+
 		<skill name="Clan M. Def." id="379" level="1" required-level="3" sp="1800">
 			<item id="49758" count="2" />
 		</skill>
@@ -132,7 +123,7 @@
 		<skill name="Clan M. Def." id="379" level="3" required-level="3" sp="7500">
 			<item id="49758" count="30" />
 		</skill>
-		
+
 		<skill name="Clan Guidance" id="380" level="1" required-level="3" sp="1800">
 			<item id="49758" count="2" />
 		</skill>
@@ -142,7 +133,7 @@
 		<skill name="Clan Guidance" id="380" level="3" required-level="3" sp="7500">
 			<item id="49758" count="30" />
 		</skill>
-		
+
 		<skill name="Clan Agility" id="381" level="1" required-level="3" sp="1800">
 			<item id="49758" count="2" />
 		</skill>
@@ -152,7 +143,7 @@
 		<skill name="Clan Agility" id="381" level="3" required-level="3" sp="7500">
 			<item id="49758" count="30" />
 		</skill>
-		
+
 		<skill name="Clan Wind Walk" id="389" level="1" required-level="4" sp="1800">
 			<item id="49758" count="2" />
 		</skill>
@@ -161,7 +152,7 @@
 		</skill>
 		<skill name="Clan Wind Walk" id="389" level="3" required-level="4" sp="7500">
 			<item id="49758" count="30" />
-		</skill>		
+		</skill>
 
 	</skillTree>
 </list>

--- a/data/skills/04000-04099.xml
+++ b/data/skills/04000-04099.xml
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org skills.xsd">
     <skill id="4001" name="Gust" max-level="12" action="A1" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="10">
@@ -61,7 +60,6 @@
         </effects>
     </skill>
     <skill id="4002" name="Blood Siphon" max-level="12" action="A1" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="10">
@@ -118,27 +116,169 @@
             </hp-drain>
         </effects>
     </skill>
+    <skill id="4003" name="Golem Body">
+        <icon initial="icon.skill0000"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
+        <target/>
+        <effects>
+            <defence-trait>
+                <trait type="BOW">
+                    <power initial="70"/>
+                </trait>
+                <trait type="DAGGER">
+                    <power initial="30"/>
+                </trait>
+                <trait type="BLUNT">
+                    <power initial="-100"/>
+                </trait>
+                <trait type="DUAL_DAGGER">
+                    <power initial="30"/>
+                </trait>
+            </defence-trait>
+        </effects>
+    </skill>
+    <skill id="4004" name="Fragile Skull">
+        <icon initial="icon.skill0000"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
+        <target/>
+        <effects>
+            <defence-trait>
+                <trait type="BLUNT">
+                    <power initial="-10.0"/>
+                </trait>
+            </defence-trait>
+        </effects>
+    </skill>
+    <skill id="4005" name="Floating Target">
+        <icon initial="icon.skill0000"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
+        <target/>
+        <effects>
+            <defence-trait>
+                <trait type="BOW">
+                    <power initial="-10.0"/>
+                </trait>
+            </defence-trait>
+            <stat-modify stat="WIND_RES" stat-add="WIND_RES">
+                <power initial="-15.0"/>
+            </stat-modify>
+        </effects>
+    </skill>
+    <skill id="4006" name="Burning Wood">
+        <icon initial="icon.skill0000"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
+        <target/>
+        <effects>
+            <defence-trait>
+                <trait type="POISON">
+                    <power initial="50.0"/>
+                </trait>
+            </defence-trait>
+            <stat-modify stat="FIRE_RES" stat-add="FIRE_RES">
+                <power initial="-15.0"/>
+            </stat-modify>
+        </effects>
+    </skill>
+    <skill id="4007" name="Immortal Life">
+        <icon initial="icon.skill0000"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
+        <target/>
+        <effects>
+            <stat-modify stat="HOLY_RES" stat-add="HOLY_RES">
+                <power initial="20.0"/>
+            </stat-modify>
+            <stat-modify stat="DARK_POWER">
+                <power initial="-20.0"/>
+            </stat-modify>
+        </effects>
+    </skill>
+    <skill id="4008" name="Insect Skin">
+        <icon initial="icon.skill0000"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
+        <target/>
+        <effects>
+            <stat-modify stat="FIRE_RES" stat-add="FIRE_RES">
+                <power initial="-15.0"/>
+            </stat-modify>
+        </effects>
+    </skill>
+    <skill id="4009" name="Fire Resistance" max-level="5">
+        <!-- Increases Fire Resistance. -->
+        <icon initial="icon.skill4009"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
+        <target/>
+    </skill>
+    <skill id="4010" name="Water Resistance" max-level="5">
+        <!-- Strong Water attack resistance. -->
+        <icon initial="icon.skill4010"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
+        <target/>
+    </skill>
+    <skill id="4011" name="Wind Resistance" max-level="5">
+        <!-- Strong Wind attack resistance. -->
+        <icon initial="icon.skill4011"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
+        <target/>
+    </skill>
+    <skill id="4012" name="Earth Resistance" max-level="5">
+        <!-- Strong Earth attack resistance. -->
+        <icon initial="icon.skill4012"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
+        <target/>
+    </skill>
+    <skill id="4013" name="Strong against Fire attack and vulnerable to Water attack">
+        <icon initial="icon.skill0000"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
+        <target/>
+    </skill>
+    <skill id="4014" name="Strong against Water attack and vulnerable to Fire attack">
+        <icon initial="icon.skill0000"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
+        <target/>
+    </skill>
+    <skill id="4015" name="Strong against Wind attack and vulnerable to Earth attack">
+        <icon initial="icon.skill0000"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
+        <target/>
+    </skill>
+    <skill id="4016" name="Strong against Earth attack and vulnerable to Wind attack">
+        <icon initial="icon.skill0000"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
+        <target/>
+    </skill>
     <skill id="4017" name="Queen Ant's Blow" action="A1">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="40"/>
-            <cast-range initial="-1"/>
             <cool-time initial="500"/>
             <effect-point initial="-100"/>
             <hit-time initial="1300"/>
         </attributes>
-        <target object="NOT_FRIEND" range="250" scope="POINT_BLANK"/>
+        <target scope="POINT_BLANK" object="NOT_FRIEND" range="250"/>
         <effects>
-            <physical-attack>
+            <physical-attack critical-chance="0.0">
                 <power initial="271.0"/>
             </physical-attack>
         </effects>
     </skill>
-    <skill id="4018" name="Decrease Speed" action="A2" debuff="true">
-        <!-- Immediately target's Speed -30%%. -->
+    <skill id="4018" name="Decrease Speed" debuff="true" action="A2">
+        <!-- Movement Speed has momentarily decreased by 30%%. -->
         <icon initial="icon.skill4018"/>
-        <attributes level-bonus-rate="3" magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" level-bonus-rate="3">
             <magic-level initial="40"/>
             <cast-range initial="500"/>
             <cool-time initial="500"/>
@@ -153,7 +293,7 @@
             <chance initial="70"/>
         </abnormal>
         <effects>
-            <physical-attack>
+            <physical-attack critical-chance="0.0">
                 <power initial="542.0"/>
             </physical-attack>
             <speed mode="PER">
@@ -161,10 +301,10 @@
             </speed>
         </effects>
     </skill>
-    <skill id="4019" name="Decrease Speed" action="A2" debuff="true">
-        <!-- Immediately target's Speed -30%%, decreases character's HP. -->
+    <skill id="4019" name="Decrease Speed" debuff="true" action="A2">
+        <!-- Momentarily decreases Movement Speed by 30%% and continuously decreases HP. -->
         <icon initial="icon.skill4019"/>
-        <attributes level-bonus-rate="3" magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" level-bonus-rate="3">
             <magic-level initial="40"/>
             <cast-range initial="1000"/>
             <cool-time initial="500"/>
@@ -172,7 +312,7 @@
             <effect-range initial="1500"/>
             <hit-time initial="1700"/>
         </attributes>
-        <target object="NOT_FRIEND" range="200" scope="RANGE" type="ENEMY_ONLY"/>
+        <target type="ENEMY_ONLY" scope="RANGE" object="NOT_FRIEND" range="200"/>
         <abnormal type="SPEED_DOWN">
             <level initial="3"/>
             <time initial="60"/>
@@ -188,7 +328,6 @@
         </effects>
     </skill>
     <skill id="4020" name="Recovery" action="A1" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="35"/>
@@ -205,9 +344,10 @@
         </effects>
     </skill>
     <skill id="4021" name="Queen Ant">
-        <!-- The forbidden magic that the Ivory Tower's wizards used to seal Beleth also affected monsters from the Wasteland. The Queen Ant absorbed this power of chaos and spawned countless hordes of giant insects. -->
+        <!-- The prohibited magic used by the Ivory Tower Wizards to seal Beleth also affected the monsters near the area. The Queen Ant absorbed the prohibited power of chaos, produced the giant ants forming a big army and went underground in the Wasteland. -->
         <icon initial="icon.skillboss"/>
-        <attributes magic-critical-rate="-5.0"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
         <target/>
         <effects>
             <defence-trait>
@@ -218,19 +358,18 @@
         </effects>
     </skill>
     <skill id="4022" name="Body of Nurse Ant">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
-        <attributes magic-critical-rate="-5.0"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
         <target/>
     </skill>
     <skill id="4023" name="Body of Royal Guard Ant">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
-        <attributes magic-critical-rate="-5.0"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
         <target/>
     </skill>
     <skill id="4024" name="Recovery" action="A1" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="35"/>
@@ -247,10 +386,10 @@
         </effects>
     </skill>
     <skill id="4025" name="Master Recharge" max-level="12" action="A1" type="MAGIC">
-        <!-- 
-			level 1: none
-			level 2: Recovers MP.
-		-->
+        <!--
+		level 1: none
+		level 2: Recovers MP.
+	 -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="17">
@@ -325,7 +464,6 @@
         </effects>
     </skill>
     <skill id="4026" name="Gludio Flame" action="A1" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="60"/>
@@ -339,7 +477,7 @@
         <consume>
             <mana initial="28"/>
         </consume>
-        <target object="NOT_FRIEND" range="200" scope="RANGE" type="ENEMY"/>
+        <target type="ENEMY" scope="RANGE" object="NOT_FRIEND" range="200"/>
         <effects>
             <magical-attack>
                 <power initial="43.0"/>
@@ -347,7 +485,6 @@
         </effects>
     </skill>
     <skill id="4027" name="Gludio Heal" action="A1" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="60"/>
@@ -368,18 +505,17 @@
         </effects>
     </skill>
     <skill id="4028" name="Might" max-level="3" action="A2">
-        <!-- 
-			level 1: For 5 min., P. Atk. +8%.
-			level 2: For 5 min., P. Atk. +12%.
-			level 3: For 5 min., P. Atk. +15%.
-		-->
+        <!--
+		level 1: Increases P. Atk. by 8% for 5 minutes.
+		level 2: Increases P. Atk. by 12% for 5 minutes.
+		level 3: Increases P. Atk. by 15% for 5 minutes.
+	 -->
         <icon initial="icon.skill4028"/>
-        <attributes magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
             <magic-level initial="20">
                 <value level="2">40</value>
                 <value level="3">70</value>
             </magic-level>
-            <cast-range initial="-1"/>
             <reuse initial="8000"/>
             <effect-point initial="100"/>
             <hit-time initial="1800"/>
@@ -409,18 +545,17 @@
         </effects>
     </skill>
     <skill id="4029" name="Shield" max-level="3" action="A2">
-        <!-- 
-			level 1: For 5 min. P. Def. +100.
-			level 2: For 5 min. P. Def. +200.
-			level 3: For 5 min. P. Def. +300.
-		-->
+        <!--
+		level 1: Increases P. Def. by 8% for 5 minutes.
+		level 2: Increases P. Def. by 12% for 5 minutes.
+		level 3: Increases P. Def. by 15% for 5 minutes.
+	 -->
         <icon initial="icon.skill1040"/>
-        <attributes magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
             <magic-level initial="20">
                 <value level="2">40</value>
                 <value level="3">70</value>
             </magic-level>
-            <cast-range initial="-1"/>
             <reuse initial="8000"/>
             <effect-point initial="100"/>
             <hit-time initial="1800"/>
@@ -449,13 +584,13 @@
         </effects>
     </skill>
     <skill id="4030" name="Might" max-level="3" action="A2" type="MAGIC">
-        <!-- 
-			level 1: For 5 min., P. Atk. +8%.
-			level 2: For 5 min., P. Atk. +12%.
-			level 3: For 5 min., P. Atk. +15%.
-		-->
+        <!--
+		level 1: Increases P. Atk. by 8% for 5 minutes.
+		level 2: Increases P. Atk. by 12% for 5 minutes.
+		level 3: Increases P. Atk. by 15% for 5 minutes.
+	 -->
         <icon initial="icon.skill4028"/>
-        <attributes magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
             <magic-level initial="20">
                 <value level="2">40</value>
                 <value level="3">70</value>
@@ -490,14 +625,14 @@
         </effects>
     </skill>
     <skill id="4031" name="Clan Shield" max-level="4" action="A2" type="MAGIC">
-        <!-- 
-			level 1: For 5 min., P. Def. +8%.
-			level 2: For 5 min., P. Def. +12%.
-			level 3: For 5 min., P. Def. +15%.
-			level 4: For 5 min., P. Def. +30%.
-		-->
+        <!--
+		level 1: For 5 minutes P. Def. +8%.
+		level 2: For 5 minutes P. Def. +12%.
+		level 3: For 5 minutes P. Def. +15%.
+		level 4: For 5 minutes P. Def. +30%.
+	 -->
         <icon initial="icon.skill4031"/>
-        <attributes magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
             <magic-level initial="20">
                 <value level="2">40</value>
                 <value level="3">70</value>
@@ -533,7 +668,6 @@
         </effects>
     </skill>
     <skill id="4032" name="Power Strike" max-level="12" action="A1">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="10">
@@ -573,7 +707,7 @@
         </consume>
         <target type="ENEMY"/>
         <effects>
-            <physical-attack>
+            <physical-attack critical-chance="0.0">
                 <power initial="46.0">
                     <value level="2">105.0</value>
                     <value level="3">219.0</value>
@@ -591,9 +725,8 @@
         </effects>
     </skill>
     <skill id="4033" name="Aura Burn" max-level="12" action="A1" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
-        <attributes hit-cancel-time="3.5" magic-critical-rate="-5.0">
+        <attributes magic-critical-rate="-5.0" hit-cancel-time="3.5">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -607,7 +740,6 @@
                 <value level="11">90</value>
                 <value level="12">95</value>
             </magic-level>
-            <cast-range initial="-1"/>
             <reuse initial="8000"/>
             <effect-point initial="-100"/>
             <hit-time initial="4000"/>
@@ -627,7 +759,7 @@
                 <value level="12">117</value>
             </mana>
         </consume>
-        <target object="NOT_FRIEND" range="200" scope="POINT_BLANK"/>
+        <target scope="POINT_BLANK" object="NOT_FRIEND" range="200"/>
         <effects>
             <magical-attack>
                 <power initial="18.0">
@@ -646,10 +778,10 @@
             </magical-attack>
         </effects>
     </skill>
-    <skill id="4034" name="Ice Bolt" max-level="12" action="A2" debuff="true" type="MAGIC">
-        <!-- Immediately target's Speed -20%%. -->
+    <skill id="4034" name="Ice Bolt" max-level="12" debuff="true" action="A2" type="MAGIC">
+        <!-- Movement Speed momentarily decreased by 20%%. -->
         <icon initial="icon.skill1184"/>
-        <attributes level-bonus-rate="1" magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" level-bonus-rate="1">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -713,10 +845,10 @@
             </speed>
         </effects>
     </skill>
-    <skill id="4035" name="Poison" max-level="13" action="A2" debuff="true" type="MAGIC">
-        <!-- Instantly decreases HP. -->
+    <skill id="4035" name="Poison" max-level="13" debuff="true" action="A2" type="MAGIC">
+        <!-- HP has been momentarily decreased due to Poison. -->
         <icon initial="icon.skill4035"/>
-        <attributes hit-cancel-time="1.5" level-bonus-rate="1" magic-critical-rate="-5.0" trait="POISON">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" trait="POISON" hit-cancel-time="1.5" level-bonus-rate="1">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -753,7 +885,7 @@
             </mana>
         </consume>
         <target type="ENEMY_ONLY"/>
-        <abnormal subordination="POISON" type="POISON" visual="DOT_POISON">
+        <abnormal type="POISON" visual="DOT_POISON" subordination="POISON">
             <level initial="2">
                 <value level="2">3</value>
                 <value level="3">4</value>
@@ -782,10 +914,10 @@
             </damage-over-time>
         </effects>
     </skill>
-    <skill id="4036" name="Poison" max-level="12" action="A2" debuff="true" type="MAGIC">
-        <!-- Instantly decreases HP. -->
+    <skill id="4036" name="Poison" max-level="12" debuff="true" action="A2" type="MAGIC">
+        <!-- HP has been momentarily decreased due to Poison. -->
         <icon initial="icon.skill4036"/>
-        <attributes hit-cancel-time="1.5" level-bonus-rate="1" magic-critical-rate="-5.0" trait="POISON">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" trait="POISON" hit-cancel-time="1.5" level-bonus-rate="1">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -820,8 +952,8 @@
                 <value level="12">117</value>
             </mana>
         </consume>
-        <target object="NOT_FRIEND" range="200" scope="RANGE" type="ENEMY_ONLY"/>
-        <abnormal subordination="POISON" type="POISON" visual="DOT_POISON">
+        <target type="ENEMY_ONLY" scope="RANGE" object="NOT_FRIEND" range="200"/>
+        <abnormal type="POISON" visual="DOT_POISON" subordination="POISON">
             <level initial="2">
                 <value level="2">3</value>
                 <value level="3">4</value>
@@ -850,10 +982,10 @@
             </damage-over-time>
         </effects>
     </skill>
-    <skill id="4037" name="Weakness" max-level="3" action="A2" debuff="true" type="MAGIC">
-        <!-- Immediately P. Atk. -17%%. -->
+    <skill id="4037" name="Weakness" max-level="3" debuff="true" action="A2" type="MAGIC">
+        <!-- P. Atk. has been momentarily decreased by 17%%. -->
         <icon initial="icon.skill4037"/>
-        <attributes level-bonus-rate="1" magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" level-bonus-rate="1">
             <magic-level initial="20">
                 <value level="2">40</value>
                 <value level="3">70</value>
@@ -888,10 +1020,10 @@
             </stat-modify>
         </effects>
     </skill>
-    <skill id="4038" name="Shackle" max-level="5" action="A2" debuff="true" type="MAGIC">
-        <!-- Immediately Atk. Spd. -17%%. -->
+    <skill id="4038" name="Shackle" max-level="5" debuff="true" action="A2" type="MAGIC">
+        <!-- Atk. Spd. momentarily decreased by 17%%. -->
         <icon initial="icon.skill4038"/>
-        <attributes level-bonus-rate="1" magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" level-bonus-rate="1">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -930,8 +1062,7 @@
             </stat-modify>
         </effects>
     </skill>
-    <skill id="4039" name="Mana Drain" max-level="13" action="A1" type="MAGIC">
-        <!-- none -->
+    <skill id="4039" name="Mana Drain" max-level="12" action="A1" type="MAGIC">
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="10">
@@ -948,14 +1079,10 @@
                 <value level="12">95</value>
             </magic-level>
             <cast-range initial="600"/>
-            <reuse initial="8000">
-                <value level="13">4000</value>
-            </reuse>
+            <reuse initial="8000"/>
             <effect-point initial="-100"/>
             <effect-range initial="1100"/>
-            <hit-time initial="4000">
-                <value level="13">1500</value>
-            </hit-time>
+            <hit-time initial="4000"/>
         </attributes>
         <consume>
             <mana initial="13">
@@ -992,7 +1119,6 @@
         </effects>
     </skill>
     <skill id="4040" name="Power Shot" max-level="13" action="A1">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="10">
@@ -1029,12 +1155,11 @@
                 <value level="10">165</value>
                 <value level="11">168</value>
                 <value level="12">170</value>
-                <value level="13">30</value>
             </mana>
         </consume>
         <target type="ENEMY"/>
         <effects>
-            <physical-attack>
+            <physical-attack critical-chance="0.0">
                 <power initial="122.0">
                     <value level="2">279.0</value>
                     <value level="3">584.0</value>
@@ -1051,8 +1176,32 @@
             </physical-attack>
         </effects>
     </skill>
+    <skill id="4041" name="Cruma Blaze" max-level="2" action="A1" type="MAGIC">
+        <icon initial="icon.skill0000"/>
+        <attributes magic-critical-rate="-5.0">
+            <magic-level initial="45">
+                <value level="2">50</value>
+            </magic-level>
+            <cast-range initial="600"/>
+            <effect-point initial="-100"/>
+            <effect-range initial="1100"/>
+            <hit-time initial="4000"/>
+        </attributes>
+        <consume>
+            <mana initial="40">
+                <value level="2">45</value>
+            </mana>
+        </consume>
+        <target type="ENEMY"/>
+        <effects>
+            <magical-attack>
+                <power initial="60.0">
+                    <value level="2">68.0</value>
+                </power>
+            </magical-attack>
+        </effects>
+    </skill>
     <skill id="4042" name="Nurka Blaze" action="A1" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="45"/>
@@ -1072,7 +1221,6 @@
         </effects>
     </skill>
     <skill id="4043" name="Partisan Flame" action="A1" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="45"/>
@@ -1085,7 +1233,7 @@
         <consume>
             <mana initial="60"/>
         </consume>
-        <target object="NOT_FRIEND" range="200" scope="RANGE" type="ENEMY"/>
+        <target type="ENEMY" scope="RANGE" object="NOT_FRIEND" range="200"/>
         <effects>
             <magical-attack>
                 <power initial="30.0"/>
@@ -1093,7 +1241,6 @@
         </effects>
     </skill>
     <skill id="4044" name="Partisan Heal" action="A1" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="45"/>
@@ -1114,9 +1261,9 @@
         </effects>
     </skill>
     <skill id="4045" name="Full Magic Attack Resistance" max-level="2">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
-        <attributes magic-critical-rate="-5.0"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
         <target/>
         <effects>
             <defence-trait>
@@ -1174,10 +1321,10 @@
             </defence-trait>
         </effects>
     </skill>
-    <skill id="4046" name="Sleep" max-level="13" action="A2" debuff="true" type="MAGIC">
-        <!-- Immobilizes and puts a target into sleep. -->
+    <skill id="4046" name="Sleep" max-level="13" debuff="true" action="A2" type="MAGIC">
+        <!-- Momentarily immobile due to the Sleep effect. -->
         <icon initial="icon.skill4046"/>
-        <attributes hit-cancel-time="2.0" level-bonus-rate="2" magic-critical-rate="-5.0" remove-on-damage="true" trait="SLEEP">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" trait="SLEEP" hit-cancel-time="2.0" level-bonus-rate="2" remove-on-damage="true">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -1222,10 +1369,10 @@
             <block-all-actions/>
         </effects>
     </skill>
-    <skill id="4047" name="Hold" max-level="13" action="A2" debuff="true" type="MAGIC">
-        <!-- Holds the target. -->
+    <skill id="4047" name="Hold" max-level="13" debuff="true" action="A2" type="MAGIC">
+        <!-- Afflicted with Hold and unable to move momentarily. -->
         <icon initial="icon.skill4047"/>
-        <attributes level-bonus-rate="2" magic-critical-rate="-5.0" trait="HOLD">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" trait="HOLD" level-bonus-rate="2">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -1273,11 +1420,9 @@
         </effects>
     </skill>
     <skill id="4048" name="Dash" max-level="3" action="A2">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
-        <attributes magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
             <magic-level initial="10"/>
-            <cast-range initial="-1"/>
             <effect-point initial="-1"/>
             <hit-time initial="1000"/>
         </attributes>
@@ -1298,22 +1443,22 @@
             </speed>
         </effects>
     </skill>
-    <skill id="4049" name="Cubic Strike" max-level="13" action="A1" type="MAGIC">
-        <!-- 
-			level 1: Attacks the enemy with 436 power.
-			level 2: Attacks the enemy with 645 power.
-			level 3: Attacks the enemy with 936 power.
-			level 4: Attacks the enemy with 1242 power.
-			level 5: Attacks the enemy with 1520 power.
-			level 6: Attacks the enemy with 1792 power.
-			level 7: Attacks the enemy with 2086 power.
-			level 8: Attacks the enemy with 2399 power.
-			level 9: Attacks the enemy with 2459 power.
-			level 10: Attacks the enemy with 2542 power.
-			level 11: Attacks the enemy with 2626 power.
-			level 12: Attacks the enemy with 2710 power.
-			level 13: Attacks the enemy with 2794 power.
-		-->
+    <skill id="4049" name="Cubic Strike" max-level="13" action="A1">
+        <!--
+		level 1: Attacks the enemy with 436 Power.
+		level 2: Attacks the enemy with 645 Power.
+		level 3: Attacks the enemy with 936 Power.
+		level 4: Attacks the enemy with 1242 Power.
+		level 5: Attacks the enemy with 1520 Power.
+		level 6: Attacks the enemy with 1792 Power.
+		level 7: Attacks the enemy with 2086 Power.
+		level 8: Attacks the enemy with 2399 Power.
+		level 9: Attacks the enemy with 2459 Power.
+		level 10: Attacks the enemy with 2542 Power.
+		level 11: Attacks the enemy with 2626 Power.
+		level 12: Attacks the enemy with 2710 Power.
+		level 13: Attacks the enemy with 2794 Power.
+	 -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="40">
@@ -1330,20 +1475,18 @@
                 <value level="12">81</value>
                 <value level="13">82</value>
             </magic-level>
-            <cast-range initial="-1"/>
-            <effect-point initial="-400">
-                <value level="2">-460</value>
-                <value level="3">-520</value>
-                <value level="4">-580</value>
-                <value level="5">-620</value>
-                <value level="6">-660</value>
-                <value level="7">-700</value>
-                <value level="8">-740</value>
-                <value level="9">-760</value>
-                <value level="10">-780</value>
-                <value level="11">-800</value>
-                <value level="12">-820</value>
-                <value level="13">-840</value>
+            <effect-point initial="-379">
+                <value level="2">-438</value>
+                <value level="3">-495</value>
+                <value level="4">-549</value>
+                <value level="5">-590</value>
+                <value level="6">-611</value>
+                <value level="7">-635</value>
+                <value level="8">-655</value>
+                <value level="9">-662</value>
+                <value level="10">-669</value>
+                <value level="11">-679</value>
+                <value level="13">-681</value>
             </effect-point>
         </attributes>
         <target type="ENEMY"/>
@@ -1367,21 +1510,21 @@
         </effects>
     </skill>
     <skill id="4050" name="Cubic Drain" max-level="13" action="A1" type="MAGIC">
-        <!-- 
-			level 1: Has a chance to absorb enemy's HP. Power 543.
-			level 2: Has a chance to absorb enemy's HP. Power 760.
-			level 3: Has a chance to absorb enemy's HP. Power 1084.
-			level 4: Has a chance to absorb enemy's HP. Power 1377.
-			level 5: Has a chance to absorb enemy's HP. Power 1635.
-			level 6: Has a chance to absorb enemy's HP. Power 1955.
-			level 7: Has a chance to absorb enemy's HP. Power 2262.
-			level 8: Has a chance to absorb enemy's HP. Power 2386.
-			level 9: Has a chance to absorb enemy's HP. Power 2425.
-			level 10: Has a chance to absorb enemy's HP. Power 2524.
-			level 11: Has a chance to absorb enemy's HP. Power 2632.
-			level 12: Has a chance to absorb enemy's HP. Power 2722.
-			level 13: Has a chance to absorb enemy's HP. Power 2812.
-		-->
+        <!--
+		level 1: Has a chance to absorb HP by 543 Power when attacking.
+		level 2: Has a chance to absorb HP by 760 Power when attacking.
+		level 3: Has a chance to absorb HP by 1084 Power when attacking.
+		level 4: Has a chance to absorb HP by 1377 Power when attacking.
+		level 5: Has a chance to absorb HP by 1635 Power when attacking.
+		level 6: Has a chance to absorb HP by 1955 Power when attacking.
+		level 7: Has a chance to absorb HP by 2262 Power when attacking.
+		level 8: Has a chance to absorb HP by 2386 Power when attacking.
+		level 9: Has a chance to absorb HP by 2425 Power when attacking.
+		level 10: Has a chance to absorb HP by 2524 Power when attacking.
+		level 11: Has a chance to absorb HP by 2632 Power when attacking.
+		level 12: Has a chance to absorb HP by 2722 Power when attacking.
+		level 13: Has a chance to absorb HP by 2812 Power when attacking.
+	 -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="43">
@@ -1398,20 +1541,19 @@
                 <value level="12">81</value>
                 <value level="13">82</value>
             </magic-level>
-            <cast-range initial="-1"/>
             <effect-point initial="-408">
-                <value level="2">-490</value>
-                <value level="3">-550</value>
-                <value level="4">-600</value>
-                <value level="5">-640</value>
-                <value level="6">-680</value>
-                <value level="7">-720</value>
-                <value level="8">-740</value>
-                <value level="9">-760</value>
-                <value level="10">-780</value>
-                <value level="11">-800</value>
-                <value level="12">-820</value>
-                <value level="13">-840</value>
+                <value level="2">-467</value>
+                <value level="3">-523</value>
+                <value level="4">-566</value>
+                <value level="5">-597</value>
+                <value level="6">-624</value>
+                <value level="7">-646</value>
+                <value level="8">-655</value>
+                <value level="9">-662</value>
+                <value level="10">-669</value>
+                <value level="11">-676</value>
+                <value level="12">-679</value>
+                <value level="13">-681</value>
             </effect-point>
         </attributes>
         <target type="ENEMY"/>
@@ -1435,21 +1577,21 @@
         </effects>
     </skill>
     <skill id="4051" name="Cubic Heal" max-level="13" action="A1" type="MAGIC">
-        <!-- 
-			level 1: Restores HP with 201 Power.
-			level 2: Restores HP with 241 Power.
-			level 3: Restores HP with 281 Power.
-			level 4: Restores HP with 314 Power.
-			level 5: Restores HP with 339 Power.
-			level 6: Restores HP with 361 Power.
-			level 7: Restores HP with 382 Power.
-			level 8: Restores HP with 401 Power.
-			level 9: Restores HP with 410 Power.
-			level 10: Restores HP with 420 Power.
-			level 11: Restores HP with 430 Power.
-			level 12: Restores HP with 440 Power.
-			level 13: Restores HP with 450 Power.
-		-->
+        <!--
+		level 1: Recovers HP 201 Power.
+		level 2: Recovers HP 241 Power.
+		level 3: Recovers HP 281 Power.
+		level 4: Recovers HP 314 Power.
+		level 5: Recovers HP 339 Power.
+		level 6: Recovers HP 361 Power.
+		level 7: Recovers HP 382 Power.
+		level 8: Recovers HP 401 Power.
+		level 9: Recovers HP 410 Power.
+		level 10: Recovers HP 420 Power.
+		level 11: Recovers HP 430 Power.
+		level 12: Recovers HP 440 Power.
+		level 13: Recovers HP 450 Power.
+	 -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="43">
@@ -1503,10 +1645,10 @@
             </effect>
         </effects>
     </skill>
-    <skill id="4052" name="Cubic Poison" max-level="12" action="A2" debuff="true" type="MAGIC">
-        <!-- Inflicts Poison, constantly drains HP. -->
+    <skill id="4052" name="Cubic Poison" max-level="12" debuff="true" action="A2" type="MAGIC">
+        <!-- Poisoned and HP continuously decreases. -->
         <icon initial="icon.skill1168"/>
-        <attributes level-bonus-rate="1" magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" level-bonus-rate="1">
             <magic-level initial="49">
                 <value level="2">55</value>
                 <value level="3">60</value>
@@ -1520,7 +1662,6 @@
                 <value level="11">81</value>
                 <value level="12">82</value>
             </magic-level>
-            <cast-range initial="-1"/>
             <effect-point initial="-467">
                 <value level="2">-523</value>
                 <value level="3">-566</value>
@@ -1536,7 +1677,7 @@
             </effect-point>
         </attributes>
         <target type="ENEMY"/>
-        <abnormal subordination="POISON" type="POISON" visual="DOT_POISON">
+        <abnormal type="POISON" visual="DOT_POISON" subordination="POISON">
             <level initial="5">
                 <value level="2">6</value>
                 <value level="3">7</value>
@@ -1556,10 +1697,10 @@
             </damage-over-time>
         </effects>
     </skill>
-    <skill id="4053" name="Cubic Physical Weakness" max-level="13" action="A2" debuff="true" type="MAGIC">
-        <!-- Temporarily P. Atk. -23%%. -->
+    <skill id="4053" name="Cubic Weakness" max-level="13" debuff="true" action="A2" type="MAGIC">
+        <!-- P. Atk. momentarily decreased by 23%%. -->
         <icon initial="icon.skill1164"/>
-        <attributes level-bonus-rate="2" magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" level-bonus-rate="2">
             <magic-level initial="40">
                 <value level="2">46</value>
                 <value level="3">52</value>
@@ -1574,7 +1715,6 @@
                 <value level="12">81</value>
                 <value level="13">82</value>
             </magic-level>
-            <cast-range initial="-1"/>
             <effect-point initial="-379">
                 <value level="2">-438</value>
                 <value level="3">-495</value>
@@ -1602,10 +1742,10 @@
             </stat-modify>
         </effects>
     </skill>
-    <skill id="4054" name="Cubic Hex" max-level="13" action="A2" debuff="true" type="MAGIC">
-        <!-- Temporarily P. Def. -23%%. -->
+    <skill id="4054" name="Cubic Hex" max-level="13" debuff="true" action="A2" type="MAGIC">
+        <!-- P. Def momentarily decreased by 23%%. -->
         <icon initial="icon.skill0122"/>
-        <attributes level-bonus-rate="2" magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" level-bonus-rate="2">
             <magic-level initial="40">
                 <value level="2">46</value>
                 <value level="3">52</value>
@@ -1620,7 +1760,6 @@
                 <value level="12">81</value>
                 <value level="13">82</value>
             </magic-level>
-            <cast-range initial="-1"/>
             <effect-point initial="-379">
                 <value level="2">-438</value>
                 <value level="3">-495</value>
@@ -1648,10 +1787,10 @@
             </stat-modify>
         </effects>
     </skill>
-    <skill id="4055" name="Cubic Shackle" max-level="13" action="A2" debuff="true" type="MAGIC">
-        <!-- Temporarily Atk. Spd. -23%%. -->
+    <skill id="4055" name="Cubic Shackle" max-level="13" debuff="true" action="A2" type="MAGIC">
+        <!-- Atk. Spd. momentarily decreased by 23%%. -->
         <icon initial="icon.skill1206"/>
-        <attributes level-bonus-rate="2" magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" level-bonus-rate="2">
             <magic-level initial="40">
                 <value level="2">46</value>
                 <value level="3">52</value>
@@ -1666,7 +1805,6 @@
                 <value level="12">81</value>
                 <value level="13">82</value>
             </magic-level>
-            <cast-range initial="-1"/>
             <effect-point initial="-379">
                 <value level="2">-438</value>
                 <value level="3">-495</value>
@@ -1694,10 +1832,82 @@
             </stat-modify>
         </effects>
     </skill>
+    <skill id="4056" name="Immortal Attack">
+        <icon initial="icon.skill0000"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
+        <target/>
+    </skill>
+    <skill id="4057" name="Insect Vulnerability">
+        <icon initial="icon.skill0000"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
+        <target/>
+        <effects>
+            <defence-trait>
+                <trait type="BUG_WEAKNESS">
+                    <power initial="-0.15000000596046448"/>
+                </trait>
+            </defence-trait>
+        </effects>
+    </skill>
+    <skill id="4058" name="Animal Vulnerability">
+        <icon initial="icon.skill0000"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
+        <target/>
+        <effects>
+            <defence-trait>
+                <trait type="ANIMAL_WEAKNESS">
+                    <power initial="-0.15000000596046448"/>
+                </trait>
+            </defence-trait>
+        </effects>
+    </skill>
+    <skill id="4059" name="Plant Vulnerability">
+        <icon initial="icon.skill0000"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
+        <target/>
+        <effects>
+            <defence-trait>
+                <trait type="PLANT_WEAKNESS">
+                    <power initial="-0.15000000596046448"/>
+                </trait>
+            </defence-trait>
+        </effects>
+    </skill>
+    <skill id="4060" name="Beast Vulnerability">
+        <icon initial="icon.skill0000"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
+        <target/>
+        <effects>
+            <defence-trait>
+                <trait type="BEAST_WEAKNESS">
+                    <power initial="-0.15000000596046448"/>
+                </trait>
+            </defence-trait>
+        </effects>
+    </skill>
+    <skill id="4061" name="Dragon Vulnerability">
+        <icon initial="icon.skill0000"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
+        <target/>
+        <effects>
+            <defence-trait>
+                <trait type="DRAGON_WEAKNESS">
+                    <power initial="-0.15000000596046448"/>
+                </trait>
+            </defence-trait>
+        </effects>
+    </skill>
     <skill id="4062" name="Orfen">
         <!-- The youngest of the 3 Nerupa sisters. Ambitious unlike her sisters, she is amassing her power in the Sea of Spores. She threads the web of the Future. -->
         <icon initial="icon.skillboss"/>
-        <attributes magic-critical-rate="-5.0"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
         <target/>
         <effects>
             <defence-trait>
@@ -1707,10 +1917,10 @@
             </defence-trait>
         </effects>
     </skill>
-    <skill id="4063" name="Paralysis" action="A2" debuff="true">
+    <skill id="4063" name="Paralysis" debuff="true" action="A2">
         <!-- Paralyzed and unable to move temporarily. -->
         <icon initial="icon.skill1170"/>
-        <attributes magic-critical-rate="-5.0" trait="PARALYZE">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" trait="PARALYZE">
             <magic-level initial="50"/>
             <cast-range initial="50"/>
             <effect-point initial="-100"/>
@@ -1724,23 +1934,23 @@
             <chance initial="90"/>
         </abnormal>
         <effects>
-            <physical-attack>
+            <physical-attack critical-chance="0.0">
                 <power initial="916.0"/>
             </physical-attack>
             <block-all-actions/>
         </effects>
     </skill>
-    <skill id="4064" name="Paralysis" action="A2" debuff="true">
+    <skill id="4064" name="Paralysis" debuff="true" action="A2">
         <!-- Paralyzed and unable to move temporarily. -->
         <icon initial="icon.skill1170"/>
-        <attributes magic-critical-rate="-5.0" trait="PARALYZE">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" trait="PARALYZE">
             <magic-level initial="50"/>
             <cast-range initial="800"/>
             <effect-point initial="-100"/>
             <effect-range initial="1300"/>
             <hit-time initial="4000"/>
         </attributes>
-        <target object="NOT_FRIEND" range="200" scope="RANGE" type="ENEMY_ONLY"/>
+        <target type="ENEMY_ONLY" scope="RANGE" object="NOT_FRIEND" range="200"/>
         <abnormal type="PARALYZE" visual="PARALYZE">
             <level initial="1"/>
             <time initial="120"/>
@@ -1751,7 +1961,6 @@
         </effects>
     </skill>
     <skill id="4065" name="Heal" max-level="12" action="A1" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="10">
@@ -1807,7 +2016,6 @@
         </effects>
     </skill>
     <skill id="4066" name="Twister" max-level="12" action="A1" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="10">
@@ -1865,7 +2073,6 @@
         </effects>
     </skill>
     <skill id="4067" name="Blow" max-level="12" action="A1">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="10">
@@ -1905,7 +2112,7 @@
         </consume>
         <target type="ENEMY"/>
         <effects>
-            <fatal-blow chance-boost="200.0">
+            <fatal-blow chance-boost="200.0" over-hit="false">
                 <power initial="137.0">
                     <value level="2">314.0</value>
                     <value level="3">656.0</value>
@@ -1923,7 +2130,6 @@
         </effects>
     </skill>
     <skill id="4068" name="Mechanical Cannon" max-level="12" action="A1">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="10">
@@ -1966,7 +2172,7 @@
         </consume>
         <target type="ENEMY"/>
         <effects>
-            <physical-attack>
+            <physical-attack critical-chance="0.0">
                 <power initial="46.0">
                     <value level="2">105.0</value>
                     <value level="3">219.0</value>
@@ -1984,7 +2190,6 @@
         </effects>
     </skill>
     <skill id="4069" name="Curve Beam" max-level="12" action="A1" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="10">
@@ -2040,12 +2245,11 @@
             </magical-attack>
         </effects>
     </skill>
-    <skill id="4070" name="Decrease Atk. Spd." action="A2" debuff="true">
-        <!-- Immediately Atk. Spd. -23%%. -->
+    <skill id="4070" name="Decrease Atk. Spd." debuff="true" action="A2">
+        <!-- Atk. Spd. has momentarily decreased by 23%%. -->
         <icon initial="icon.skill1206"/>
-        <attributes level-bonus-rate="1" magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" level-bonus-rate="1">
             <magic-level initial="1"/>
-            <cast-range initial="-1"/>
             <effect-point initial="-100"/>
         </attributes>
         <target type="TARGET"/>
@@ -2060,12 +2264,13 @@
             </stat-modify>
         </effects>
     </skill>
-    <skill id="4071" name="Bow Resistance" max-level="5">
-        <!-- Increases resistance to bow attacks. -->
+    <skill id="4071" name="Bow Weapon Resistance" max-level="5">
+        <!-- Strong Bow resistance. -->
         <icon initial="icon.skill4071">
             <value level="4">icon.skill4272</value>
         </icon>
-        <attributes magic-critical-rate="-5.0"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
         <target/>
         <effects>
             <defence-trait>
@@ -2088,10 +2293,10 @@
             </defence-trait>
         </effects>
     </skill>
-    <skill id="4072" name="Stun" max-level="12" action="A2" debuff="true">
-        <!-- Immobilizes and stuns target. -->
+    <skill id="4072" name="Stun" max-level="12" debuff="true" action="A2">
+        <!-- Stunned and temporarily rendered immobile. -->
         <icon initial="icon.skill0100"/>
-        <attributes level-bonus-rate="1" magic-critical-rate="-5.0" trait="SHOCK">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" trait="SHOCK" level-bonus-rate="1">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -2105,7 +2310,6 @@
                 <value level="11">90</value>
                 <value level="12">95</value>
             </magic-level>
-            <cast-range initial="-1"/>
             <reuse initial="6000"/>
             <cool-time initial="800"/>
             <effect-point initial="-100"/>
@@ -2126,7 +2330,7 @@
                 <value level="12">85</value>
             </mana>
         </consume>
-        <target object="NOT_FRIEND" range="150" scope="POINT_BLANK"/>
+        <target scope="POINT_BLANK" object="NOT_FRIEND" range="150"/>
         <abnormal type="STUN" visual="STUN">
             <level initial="1"/>
             <time initial="3">
@@ -2135,7 +2339,7 @@
             <chance initial="30"/>
         </abnormal>
         <effects>
-            <physical-attack>
+            <physical-attack critical-chance="0.0">
                 <power initial="16.0">
                     <value level="2">35.0</value>
                     <value level="3">73.0</value>
@@ -2153,10 +2357,10 @@
             <block-all-actions/>
         </effects>
     </skill>
-    <skill id="4073" name="Stun" max-level="13" action="A2" debuff="true">
-        <!-- Immobilizes and stuns target. -->
+    <skill id="4073" name="Stun" max-level="13" debuff="true" action="A2">
+        <!-- Stunned and temporarily rendered immobile. -->
         <icon initial="icon.skill0100"/>
-        <attributes level-bonus-rate="1" magic-critical-rate="-5.0" trait="SHOCK">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" trait="SHOCK" level-bonus-rate="1">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -2203,7 +2407,7 @@
             <chance initial="50"/>
         </abnormal>
         <effects>
-            <physical-attack>
+            <physical-attack critical-chance="0.0">
                 <power initial="16.0">
                     <value level="2">35.0</value>
                     <value level="3">73.0</value>
@@ -2222,12 +2426,12 @@
         </effects>
     </skill>
     <skill id="4074" name="Haste" max-level="2" action="A2" type="MAGIC">
-        <!-- 
-			level 1: Atk. Spd. +15%.
-			level 2: Atk. Spd. +33%.
-		-->
+        <!--
+		level 1: Atk. Spd. +15%.
+		level 2: Atk. Spd. +33%.
+	 -->
         <icon initial="icon.skill1086"/>
-        <attributes magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
             <magic-level initial="30">
                 <value level="2">70</value>
             </magic-level>
@@ -2257,10 +2461,10 @@
             </stat-modify>
         </effects>
     </skill>
-    <skill id="4075" name="Stun" max-level="12" action="A2" debuff="true">
-        <!-- Immobilizes and stuns target. -->
+    <skill id="4075" name="Stun" max-level="12" debuff="true" action="A2">
+        <!-- Stunned and temporarily rendered immobile. -->
         <icon initial="icon.skill0092"/>
-        <attributes level-bonus-rate="2" magic-critical-rate="-5.0" trait="SHOCK">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" trait="SHOCK" level-bonus-rate="2">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -2306,10 +2510,10 @@
             <block-all-actions/>
         </effects>
     </skill>
-    <skill id="4076" name="Slow" max-level="3" action="A2" debuff="true" type="MAGIC">
-        <!-- Immediately target's Speed -10%%. -->
+    <skill id="4076" name="Decrease Speed" max-level="3" debuff="true" action="A2" type="MAGIC">
+        <!-- Movement Speed has been momentarily decreased by 10%%. -->
         <icon initial="icon.skill1160"/>
-        <attributes hit-cancel-time="1.5" level-bonus-rate="2" magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" hit-cancel-time="1.5" level-bonus-rate="2">
             <magic-level initial="20">
                 <value level="2">40</value>
                 <value level="3">70</value>
@@ -2345,9 +2549,8 @@
         </effects>
     </skill>
     <skill id="4077" name="Aura Burn" max-level="12" action="A1" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
-        <attributes hit-cancel-time="1.0" magic-critical-rate="-5.0">
+        <attributes magic-critical-rate="-5.0" hit-cancel-time="1.0">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -2402,7 +2605,6 @@
         </effects>
     </skill>
     <skill id="4078" name="Flame Strike" max-level="12" action="A1" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="10">
@@ -2440,7 +2642,7 @@
                 <value level="12">117</value>
             </mana>
         </consume>
-        <target object="NOT_FRIEND" range="200" scope="RANGE" type="ENEMY"/>
+        <target type="ENEMY" scope="RANGE" object="NOT_FRIEND" range="200"/>
         <effects>
             <magical-attack>
                 <power initial="9.0">
@@ -2472,13 +2674,12 @@
         </attributes>
         <target type="ENEMY"/>
         <effects>
-            <physical-attack>
+            <physical-attack critical-chance="0.0">
                 <power initial="665060.0"/>
             </physical-attack>
         </effects>
     </skill>
     <skill id="4080" name="Dark Heal" action="A1" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="60"/>
@@ -2498,7 +2699,6 @@
         </effects>
     </skill>
     <skill id="4081" name="Pretending to steal" action="A1" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="70"/>
@@ -2509,10 +2709,10 @@
         </attributes>
         <target type="ENEMY_ONLY"/>
     </skill>
-    <skill id="4082" name="Poison of Death" action="A2" debuff="true" type="MAGIC">
+    <skill id="4082" name="Poison of Death" debuff="true" action="A2" type="MAGIC">
         <!-- You have been infected by a fatal poison. -->
         <icon initial="icon.skill4082"/>
-        <attributes magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
             <cast-range initial="600"/>
             <effect-point initial="-100"/>
             <effect-range initial="1100"/>
@@ -2530,7 +2730,6 @@
         </effects>
     </skill>
     <skill id="4083" name="Kalis' Poison" action="A1" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="70"/>
@@ -2540,18 +2739,19 @@
         </attributes>
         <target type="ENEMY"/>
         <effects>
-            <physical-attack>
+            <physical-attack critical-chance="0.0">
                 <power initial="90000.0"/>
             </physical-attack>
         </effects>
     </skill>
     <skill id="4084" name="Physical Attack Resistance" max-level="11">
-        <!-- 
-			level 1: Resistant to physical attacks.
-			level 9: Provides very strong resistance against P. Atk.
-		-->
+        <!--
+		level 1: Strong Physical attack resistance.
+		level 9: Resistant to physical attacks.
+	 -->
         <icon initial="icon.skill4084"/>
-        <attributes magic-critical-rate="-5.0"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
         <target/>
         <effects>
             <stat-modify mode="PER" stat="PHYSICAL_DEFENCE" stat-add="PHYSICAL_DEFENCE">
@@ -2571,9 +2771,10 @@
         </effects>
     </skill>
     <skill id="4085" name="Critical Damage">
-        <!-- Increases P. Critical Damage. -->
+        <!-- Deals significant P. Critical Damage. -->
         <icon initial="icon.skill4085"/>
-        <attributes magic-critical-rate="-5.0"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
         <target/>
         <effects>
             <stat-modify mode="PER" stat="CRITICAL_DAMAGE" stat-add="CRITICAL_DAMAGE_ADD">
@@ -2582,9 +2783,10 @@
         </effects>
     </skill>
     <skill id="4086" name="Critical Chance">
-        <!-- Increases P. Critical Rate. -->
+        <!-- Has a high chance of P. Critical Rate. -->
         <icon initial="icon.skill4086"/>
-        <attributes magic-critical-rate="-5.0"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
         <target/>
         <effects>
             <stat-modify mode="PER" stat="CRITICAL_RATE" stat-add="CRITICAL_RATE">
@@ -2593,7 +2795,6 @@
         </effects>
     </skill>
     <skill id="4087" name="Blaze" max-level="12" action="A1" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="10">
@@ -2650,10 +2851,10 @@
             </magical-attack>
         </effects>
     </skill>
-    <skill id="4088" name="Bleed" max-level="13" action="A2" debuff="true" type="MAGIC">
-        <!-- Causes target to bleed severely, momentarily reducing HP. -->
+    <skill id="4088" name="Bleed" max-level="13" debuff="true" action="A2" type="MAGIC">
+        <!-- HP has been momentarily decreased due to Bleed. -->
         <icon initial="icon.skill0096"/>
-        <attributes level-bonus-rate="2" magic-critical-rate="-5.0" trait="BLEED">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" trait="BLEED" level-bonus-rate="2">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -2691,7 +2892,7 @@
             </mana>
         </consume>
         <target type="ENEMY_ONLY"/>
-        <abnormal subordination="BLEEDING" type="BLEEDING" visual="DOT_BLEEDING">
+        <abnormal type="BLEEDING" visual="DOT_BLEEDING" subordination="BLEEDING">
             <level initial="2">
                 <value level="2">3</value>
                 <value level="3">4</value>
@@ -2721,11 +2922,10 @@
         </effects>
     </skill>
     <skill id="4089" name="Spirit Bear" action="A2">
-        <!-- P. Atk. +15%% and Speed +15%%. -->
+        <!-- P. Atk. + 15%% and Speed + 15%%. -->
         <icon initial="icon.skill0076"/>
-        <attributes magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
             <magic-level initial="40"/>
-            <cast-range initial="-1"/>
             <reuse initial="8000"/>
             <effect-point initial="-100"/>
             <hit-time initial="1500"/>
@@ -2748,11 +2948,10 @@
         </effects>
     </skill>
     <skill id="4090" name="Spirit Wolf" action="A2">
-        <!-- Increases Speed by 40. -->
+        <!-- Increases Movement Speed +40. -->
         <icon initial="icon.skill0083"/>
-        <attributes magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
             <magic-level initial="40"/>
-            <cast-range initial="-1"/>
             <reuse initial="8000"/>
             <effect-point initial="-100"/>
             <hit-time initial="1500"/>
@@ -2772,18 +2971,17 @@
         </effects>
     </skill>
     <skill id="4091" name="Spirit Ogre" max-level="3" action="A2">
-        <!-- 
-			level 1: P. Atk. +5%, P. Def. +10%, P. Accuracy +3, Max HP +14%, P. Evasion -10 and Speed -15%.
-			level 2: P. Atk. +15%, P. Def. +30%, P. Accuracy +7, Max HP +21%, P. Evasion -10 and Speed -15%.
-			level 3: P. Atk. +15%, P. Def. +30%, P. Accuracy +7, Max HP +21%, P. Evasion -5 and Speed -10%.
-		-->
+        <!--
+		level 1: Increases P. Atk. +5%, P. Def. +10%, P. Accuracy +3, and Max HP +14%. Decreases P. evasion -10 and speed -15%.
+		level 2: Increases P. Atk. +15%, P. Def. +30%, P. Accuracy +7, and Max HP +21%. Decreases P. evasion -10 and speed -15%.
+		level 3: Increases P. Atk. +15%, P. Def. +30%, P. Accuracy +7, and Max HP +21%. Decreases P. evasion -5 and speed -10%.
+	 -->
         <icon initial="icon.skill0109"/>
-        <attributes magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
             <magic-level initial="40">
                 <value level="2">60</value>
                 <value level="3">75</value>
             </magic-level>
-            <cast-range initial="-1"/>
             <reuse initial="8000"/>
             <effect-point initial="-100"/>
             <hit-time initial="1500"/>
@@ -2833,11 +3031,10 @@
         </effects>
     </skill>
     <skill id="4092" name="Spirit Puma" action="A2">
-        <!-- Atk. Spd. +30%%, P. Evasion +4, P. Def. -20%%. -->
+        <!-- Increases Atk. Spd. +30%% and P. evasion +4. Decreases P. Def. -20%%. -->
         <icon initial="icon.skill0282"/>
-        <attributes magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
             <magic-level initial="40"/>
-            <cast-range initial="-1"/>
             <reuse initial="8000"/>
             <effect-point initial="-100"/>
             <hit-time initial="1500"/>
@@ -2865,7 +3062,8 @@
     <skill id="4093" name="Evasion">
         <!-- P. Evasion +4. -->
         <icon initial="icon.skill4093"/>
-        <attributes magic-critical-rate="-5.0"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
         <target/>
         <effects>
             <stat-modify stat="EVASION_RATE" stat-add="EVASION_RATE">
@@ -2874,7 +3072,6 @@
         </effects>
     </skill>
     <skill id="4094" name="Cancellation" max-level="12" action="A1" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="10">
@@ -2916,9 +3113,10 @@
         </effects>
     </skill>
     <skill id="4095" name="Damage Shield">
-        <!-- Reflects a portion of the received damage. -->
+        <!-- Reflects back a portion of damage inflicted by the enemy P. Atk. -->
         <icon initial="icon.skill4095"/>
-        <attributes magic-critical-rate="-5.0"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
         <target/>
         <effects>
             <stat-modify stat="REFLECT_DAMAGE_PERCENT" stat-add="REFLECT_DAMAGE_PERCENT">
@@ -2927,18 +3125,17 @@
         </effects>
     </skill>
     <skill id="4096" name="Hawk Eye" max-level="3" action="A2">
-        <!-- 
-			level 1: P. Def. -10%, P. Accuracy +6.
-			level 2: P. Def. -10%, P. Accuracy +8.
-			level 3: P. Def. -10%, P. Accuracy +10.
-		-->
+        <!--
+		level 1: P. Def. decreases momentarily. -10% and increases P. Accuracy +6.
+		level 2: P. Def. decreases momentarily. -10% and increases P. Accuracy +8.
+		level 3: P. Def. decreases momentarily. -10% and increases P. Accuracy +10.
+	 -->
         <icon initial="icon.skill0131"/>
-        <attributes magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
             <magic-level initial="20">
                 <value level="2">40</value>
                 <value level="3">70</value>
             </magic-level>
-            <cast-range initial="-1"/>
             <reuse initial="6000"/>
             <effect-point initial="100"/>
             <hit-time initial="1500"/>
@@ -2970,9 +3167,9 @@
         </effects>
     </skill>
     <skill id="4097" name="Chant of Life" max-level="12" action="A2" type="MAGIC">
-        <!-- HP is restored. -->
+        <!-- HP is recovered. -->
         <icon initial="icon.skill1229"/>
-        <attributes magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -3041,10 +3238,10 @@
             </effect>
         </effects>
     </skill>
-    <skill id="4098" name="Silence" max-level="12" action="A2" debuff="true" type="MAGIC">
+    <skill id="4098" name="Silence" max-level="12" debuff="true" action="A2" type="MAGIC">
         <!-- Magic skills are blocked momentarily. -->
         <icon initial="icon.skill1064"/>
-        <attributes hit-cancel-time="1.5" level-bonus-rate="2" magic-critical-rate="-5.0" trait="DERANGEMENT">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" trait="DERANGEMENT" hit-cancel-time="1.5" level-bonus-rate="2">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -3090,12 +3287,12 @@
         </effects>
     </skill>
     <skill id="4099" name="Berserker Spirit" max-level="2" action="A2" type="MAGIC">
-        <!-- 
-			level 1: For for a certain amount of time, Max HP/ MP -20%, P. Atk. +5%, M. Atk. +10%, Atk. Spd. +5%, Casting Spd. +5%, Speed +5.
-			level 2: For for a certain amount of time, Max HP/ MP -15%, P. Atk. +10%, M. Atk. +20%, Atk. Spd. +8%, Casting Spd. +8%, Speed +8.
-		-->
+        <!--
+		level 1: P. Atk. +5%, M. Atk. +10%, Atk. Spd. +2, Casting Spd. +5%, and Movement Speed +10%. P. Def. -5%, M. Def. -5%, and P. Evasion -5.
+		level 2: P. Atk. +8%, M. Atk. +16%, Atk. Spd. +4, Casting Spd. +8%, and Movement Speed +16%. P. Def. -8%, M. Def. -8%, and P. Evasion -8.
+	 -->
         <icon initial="icon.skill1062"/>
-        <attributes magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
             <magic-level initial="40">
                 <value level="2">70</value>
             </magic-level>

--- a/data/skills/04500-04599.xml
+++ b/data/skills/04500-04599.xml
@@ -1,105 +1,114 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org skills.xsd">
     <skill id="4500" name="Treasure Chest (Lv. 27)">
         <!-- A locked chest that could contain treasure or a nasty surprise. -->
         <icon initial="icon.skill0042"/>
-        <attributes magic-critical-rate="-5.0"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
         <target/>
     </skill>
     <skill id="4501" name="Treasure Chest (Lv. 29)">
         <!-- A locked chest that could contain treasure or a nasty surprise. -->
         <icon initial="icon.skill0042"/>
-        <attributes magic-critical-rate="-5.0"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
         <target/>
     </skill>
     <skill id="4502" name="Treasure Chest (Lv. 31)">
         <!-- A locked chest that could contain treasure or a nasty surprise. -->
         <icon initial="icon.skill0042"/>
-        <attributes magic-critical-rate="-5.0"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
         <target/>
     </skill>
     <skill id="4503" name="Treasure Chest (Lv. 32)">
         <!-- A locked chest that could contain treasure or a nasty surprise. -->
         <icon initial="icon.skill0042"/>
-        <attributes magic-critical-rate="-5.0"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
         <target/>
     </skill>
     <skill id="4504" name="Treasure Chest (Lv. 33)">
         <!-- A locked chest that could contain treasure or a nasty surprise. -->
         <icon initial="icon.skill0042"/>
-        <attributes magic-critical-rate="-5.0"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
         <target/>
     </skill>
     <skill id="4505" name="Treasure Chest (Lv. 35)">
         <!-- A locked chest that could contain treasure or a nasty surprise. -->
         <icon initial="icon.skill0042"/>
-        <attributes magic-critical-rate="-5.0"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
         <target/>
     </skill>
     <skill id="4506" name="Treasure Chest (Lv. 39)">
         <!-- A locked chest that could contain treasure or a nasty surprise. -->
         <icon initial="icon.skill0042"/>
-        <attributes magic-critical-rate="-5.0"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
         <target/>
     </skill>
     <skill id="4507" name="Treasure Chest (Lv. 42)">
         <!-- A locked chest that could contain treasure or a nasty surprise. -->
         <icon initial="icon.skill0042"/>
-        <attributes magic-critical-rate="-5.0"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
         <target/>
     </skill>
     <skill id="4508" name="Treasure Chest (Lv. 43)">
         <!-- A locked chest that could contain treasure or a nasty surprise. -->
         <icon initial="icon.skill0042"/>
-        <attributes magic-critical-rate="-5.0"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
         <target/>
     </skill>
     <skill id="4509" name="Treasure Chest (Lv. 45)">
         <!-- A locked chest that could contain treasure or a nasty surprise. -->
         <icon initial="icon.skill0042"/>
-        <attributes magic-critical-rate="-5.0"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
         <target/>
     </skill>
     <skill id="4510" name="Treasure Chest (Lv. 47)">
         <!-- A locked chest that could contain treasure or a nasty surprise. -->
         <icon initial="icon.skill0042"/>
-        <attributes magic-critical-rate="-5.0"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
         <target/>
     </skill>
     <skill id="4511" name="Treasure Chest (Lv. 49)">
         <!-- A locked chest that could contain treasure or a nasty surprise. -->
         <icon initial="icon.skill0042"/>
-        <attributes magic-critical-rate="-5.0"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
         <target/>
     </skill>
     <skill id="4512" name="Treasure Chest (Lv. 52)">
         <!-- A locked chest that could contain treasure or a nasty surprise. -->
         <icon initial="icon.skill0042"/>
-        <attributes magic-critical-rate="-5.0"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
         <target/>
     </skill>
     <skill id="4513" name="Squash - Level Up" action="A1">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="1"/>
-            <cast-range initial="-1"/>
         </attributes>
         <target scope="NONE"/>
     </skill>
     <skill id="4514" name="Squash - Poisoned" action="A1">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="1"/>
-            <cast-range initial="-1"/>
         </attributes>
         <target scope="NONE"/>
     </skill>
-    <skill id="4515" name="Raid Curse" action="A2" debuff="true" type="MAGIC">
-        <!-- The curse of the Raid Boss guardian spirit temporarily petrifies the target. This curse befalls those who attempt to challenge a raid boss who is 9 or more levels below their own, or those who do not meet the requirements for the raid. The curse is irreversible. -->
+    <skill id="4515" name="Raid Curse" debuff="true" action="A2" type="MAGIC">
+        <!-- The curse of the Raid Boss guardian spirit temporarily petrifies the target, immobilizing it like a stone. This curse befalls those who attempt to challenge a raid boss who is 9 or more Lv.s below their own, or those who do not meet the requirements for the raid. The curse is irreversible. -->
         <icon initial="icon.skill4111"/>
-        <attributes irreplacable="true" magic-critical-rate="-5.0" stay-after-death="true">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" stay-after-death="true" irreplacable="true">
             <cast-range initial="1500"/>
             <effect-point initial="-100"/>
             <effect-range initial="2000"/>
@@ -114,7 +123,6 @@
         </effects>
     </skill>
     <skill id="4516" name="Orfen Heal" action="A1" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="99"/>
@@ -135,11 +143,9 @@
         </effects>
     </skill>
     <skill id="4517" name="Shield" action="T">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="76"/>
-            <cast-range initial="-1"/>
         </attributes>
         <target/>
         <effects>
@@ -155,11 +161,9 @@
         </effects>
     </skill>
     <skill id="4518" name="Might" action="T">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="76"/>
-            <cast-range initial="-1"/>
         </attributes>
         <target/>
         <effects>
@@ -175,11 +179,9 @@
         </effects>
     </skill>
     <skill id="4519" name="Shield" action="T">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="76"/>
-            <cast-range initial="-1"/>
         </attributes>
         <target/>
         <effects>
@@ -194,11 +196,9 @@
         </effects>
     </skill>
     <skill id="4520" name="Might" action="T">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="76"/>
-            <cast-range initial="-1"/>
         </attributes>
         <target/>
         <effects>
@@ -212,10 +212,10 @@
             </speed>
         </effects>
     </skill>
-    <skill id="4521" name="Bow Resistance">
-        <!-- none -->
+    <skill id="4521" name="Bow Attack Resistance">
         <icon initial="icon.skill0000"/>
-        <attributes magic-critical-rate="-5.0"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
         <target/>
         <effects>
             <defence-trait>
@@ -244,9 +244,9 @@
         </effects>
     </skill>
     <skill id="4522" name="Eye of Assassin" action="A2" type="MAGIC">
-        <!-- Greatly increases the P. Critical Rate of dagger and rapier skills. -->
+        <!-- Assassin's senses are greatly heightened. Greatly increases the P. Crit. Rate when attacking from behind. -->
         <icon initial="icon.skill0016"/>
-        <attributes magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
             <magic-level initial="76"/>
             <cast-range initial="400"/>
             <effect-point initial="100"/>
@@ -264,11 +264,9 @@
         </effects>
     </skill>
     <skill id="4523" name="Ultimate Evasion" action="A2" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
-        <attributes magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
             <magic-level initial="76"/>
-            <cast-range initial="-1"/>
             <reuse initial="10000"/>
             <hit-time initial="10000"/>
         </attributes>
@@ -284,11 +282,9 @@
         </effects>
     </skill>
     <skill id="4524" name="Bluff" action="A2" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
-        <attributes magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
             <magic-level initial="76"/>
-            <cast-range initial="-1"/>
             <reuse initial="10000"/>
             <hit-time initial="10000"/>
         </attributes>
@@ -299,11 +295,9 @@
         </abnormal>
     </skill>
     <skill id="4525" name="Shield" action="T">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="76"/>
-            <cast-range initial="-1"/>
         </attributes>
         <target/>
         <effects>
@@ -321,11 +315,9 @@
         </effects>
     </skill>
     <skill id="4526" name="Summon" action="A1" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="76"/>
-            <cast-range initial="-1"/>
         </attributes>
         <target/>
         <effects>
@@ -335,9 +327,8 @@
         </effects>
     </skill>
     <skill id="4527" name="Restore" action="A2" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
-        <attributes magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
             <magic-level initial="76"/>
             <cast-range initial="600"/>
             <effect-point initial="100"/>
@@ -355,9 +346,8 @@
         </effects>
     </skill>
     <skill id="4528" name="Wind Walk" action="A2" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
-        <attributes magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
             <magic-level initial="76"/>
             <cast-range initial="400"/>
             <effect-point initial="100"/>
@@ -375,15 +365,13 @@
         </effects>
     </skill>
     <skill id="4529" name="Self-destruction" action="A1" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="76"/>
-            <cast-range initial="-1"/>
             <reuse initial="8000"/>
             <effect-point initial="-100"/>
         </attributes>
-        <target object="NOT_FRIEND" range="200" scope="POINT_BLANK"/>
+        <target scope="POINT_BLANK" object="NOT_FRIEND" range="200"/>
         <effects>
             <magical-attack>
                 <power initial="56.0"/>
@@ -391,15 +379,13 @@
         </effects>
     </skill>
     <skill id="4530" name="Heal" action="A1" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="76"/>
-            <cast-range initial="-1"/>
             <reuse initial="8000"/>
             <effect-point initial="-100"/>
         </attributes>
-        <target object="NOT_FRIEND" range="200" scope="POINT_BLANK"/>
+        <target scope="POINT_BLANK" object="NOT_FRIEND" range="200"/>
         <effects>
             <hp mode="PER">
                 <power initial="5.0"/>
@@ -407,15 +393,13 @@
         </effects>
     </skill>
     <skill id="4531" name="Heal" action="A1" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="76"/>
-            <cast-range initial="-1"/>
             <reuse initial="8000"/>
             <effect-point initial="-100"/>
         </attributes>
-        <target object="NOT_FRIEND" range="200" scope="POINT_BLANK"/>
+        <target scope="POINT_BLANK" object="NOT_FRIEND" range="200"/>
         <effects>
             <mp mode="PER">
                 <power initial="5.0"/>
@@ -423,11 +407,9 @@
         </effects>
     </skill>
     <skill id="4532" name="Reflect Damage" action="T">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="76"/>
-            <cast-range initial="-1"/>
         </attributes>
         <target/>
         <effects>
@@ -439,10 +421,10 @@
             </stat-modify>
         </effects>
     </skill>
-    <skill id="4533" name="Dance of Resistance" action="A2" debuff="true">
-        <!-- Temporarily decreases Speed and P. Accuracy. Dance of Inspiration can remove the curse. -->
+    <skill id="4533" name="Dance of Resistance" debuff="true" action="A2">
+        <!-- Momentarily decreases Movement Speed and P. Accuracy significantly. Dance of Inspiration can remove the curse. -->
         <icon initial="icon.skill0272"/>
-        <attributes magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
             <magic-level initial="76"/>
             <cast-range initial="400"/>
             <effect-point initial="-100"/>
@@ -463,10 +445,10 @@
             </stat-modify>
         </effects>
     </skill>
-    <skill id="4534" name="Nihilistic Dance" action="A2" debuff="true">
-        <!-- Temporarily decreases Atk. Spd. and P. Evasion. Dance of Fury can remove the curse. -->
+    <skill id="4534" name="Nihilistic Dance" debuff="true" action="A2">
+        <!-- Atk. Spd. decreases momentarily. and P. Evasion significantly. Dance of Fury can remove the curse. -->
         <icon initial="icon.skill0275"/>
-        <attributes magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
             <magic-level initial="76"/>
             <cast-range initial="400"/>
             <effect-point initial="-100"/>
@@ -487,10 +469,10 @@
             </stat-modify>
         </effects>
     </skill>
-    <skill id="4535" name="Dance of Weakness" action="A2" debuff="true">
-        <!-- Temporarily decreases P. Def. and P. Atk. Dance of the Vampire can remove the curse. -->
+    <skill id="4535" name="Dance of Weakness" debuff="true" action="A2">
+        <!-- P. Def. decreases momentarily. and P. Atk. significantly. Dance of the Vampire can remove the curse. -->
         <icon initial="icon.skill0310"/>
-        <attributes magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
             <magic-level initial="76"/>
             <cast-range initial="400"/>
             <effect-point initial="-100"/>
@@ -511,10 +493,10 @@
             </stat-modify>
         </effects>
     </skill>
-    <skill id="4536" name="Song of Seduction" action="A2" debuff="true">
-        <!-- Temporarily decreases Speed and P. Accuracy. Song of Wind can remove the curse. -->
+    <skill id="4536" name="Song of Seduction" debuff="true" action="A2">
+        <!-- Momentarily decreases Movement Speed and P. Accuracy significantly. Song of Wind can remove the curse. -->
         <icon initial="icon.skill0268"/>
-        <attributes magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
             <magic-level initial="76"/>
             <cast-range initial="400"/>
             <effect-point initial="-100"/>
@@ -535,10 +517,10 @@
             </stat-modify>
         </effects>
     </skill>
-    <skill id="4537" name="Song of Sweet Whispers" action="A2" debuff="true">
-        <!-- Temporarily decreases Atk. Spd. and P. Evasion. Song of Water can remove the curse. -->
+    <skill id="4537" name="Song of Sweet Whispers" debuff="true" action="A2">
+        <!-- Atk. Spd. decreases momentarily. and P. Evasion significantly. Song of Water can remove the curse. -->
         <icon initial="icon.skill0266"/>
-        <attributes magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
             <magic-level initial="76"/>
             <cast-range initial="400"/>
             <effect-point initial="-100"/>
@@ -559,10 +541,10 @@
             </stat-modify>
         </effects>
     </skill>
-    <skill id="4538" name="Song of Temptation" action="A2" debuff="true">
-        <!-- Temporarily decreases P. Def. and P. Atk. Song of Vengeance can remove the curse. -->
+    <skill id="4538" name="Song of Temptation" debuff="true" action="A2">
+        <!-- P. Def. decreases momentarily. and P. Atk. significantly. Song of Vengeance can remove the curse. -->
         <icon initial="icon.skill0305"/>
-        <attributes magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
             <magic-level initial="76"/>
             <cast-range initial="400"/>
             <effect-point initial="-100"/>
@@ -583,10 +565,10 @@
             </stat-modify>
         </effects>
     </skill>
-    <skill id="4539" name="Vague Curse" action="A2" debuff="true" type="MAGIC">
-        <!-- Temporarily decreases Speed and P. Accuracy. Guidance skill can remove the curse. -->
+    <skill id="4539" name="Vague Curse" debuff="true" action="A2" type="MAGIC">
+        <!-- Momentarily decreases Movement Speed and P. Accuracy significantly. Guidance spell can remove the curse. -->
         <icon initial="icon.skill1240"/>
-        <attributes magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
             <magic-level initial="76"/>
             <cast-range initial="400"/>
             <effect-point initial="-100"/>
@@ -607,10 +589,10 @@
             </stat-modify>
         </effects>
     </skill>
-    <skill id="4540" name="Curse Weakness" action="A2" debuff="true" type="MAGIC">
-        <!-- Temporarily decreases P. Def. and Speed. Shield skill can remove the curse. -->
+    <skill id="4540" name="Curse of Weakness" debuff="true" action="A2" type="MAGIC">
+        <!-- P. Def. decreases momentarily. and Movement Speed significantly. Shield spell can remove the curse. -->
         <icon initial="icon.skill1040"/>
-        <attributes magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
             <magic-level initial="76"/>
             <cast-range initial="400"/>
             <effect-point initial="-100"/>
@@ -631,10 +613,10 @@
             </stat-modify>
         </effects>
     </skill>
-    <skill id="4541" name="Nihilistic Curse" action="A2" debuff="true" type="MAGIC">
-        <!-- Temporarily decreases P. Atk., Atk. Spd. and M. Atk. The curse can be removed with the Might skill. -->
+    <skill id="4541" name="Nihilistic Curse" debuff="true" action="A2" type="MAGIC">
+        <!-- P. Atk. decreases momentarily., M. Atk. and Atk. Spd. significantly. Might spell can remove the curse. -->
         <icon initial="icon.skill1068"/>
-        <attributes magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
             <magic-level initial="76"/>
             <cast-range initial="400"/>
             <effect-point initial="-100"/>
@@ -658,10 +640,10 @@
             </stat-modify>
         </effects>
     </skill>
-    <skill id="4542" name="Sleep/ Stun Resistance">
-        <!-- none -->
+    <skill id="4542" name="Sleep/Stun Resistance">
         <icon initial="icon.skill0000"/>
-        <attributes magic-critical-rate="-5.0"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
         <target/>
         <effects>
             <defence-trait>
@@ -675,9 +657,9 @@
         </effects>
     </skill>
     <skill id="4543" name="Weakened Stun">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
-        <attributes magic-critical-rate="-5.0"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
         <target/>
         <effects>
             <defence-trait>
@@ -688,11 +670,9 @@
         </effects>
     </skill>
     <skill id="4544" name="Weakness" max-level="3" action="A2" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
-        <attributes magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
             <magic-level initial="76"/>
-            <cast-range initial="-1"/>
         </attributes>
         <target/>
         <abnormal type="PUBLIC_SLOT" visual="DOT_POISON">
@@ -724,11 +704,9 @@
         </effects>
     </skill>
     <skill id="4545" name="Reflect Damage" action="T">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="76"/>
-            <cast-range initial="-1"/>
         </attributes>
         <target/>
         <effects>
@@ -744,7 +722,6 @@
         </effects>
     </skill>
     <skill id="4546" name="Consume Slate" action="A1">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="99"/>
@@ -753,10 +730,9 @@
         </attributes>
         <target type="TARGET"/>
     </skill>
-    <skill id="4547" name="Watchman's Gaze" action="A2" debuff="true">
-        <!-- none -->
+    <skill id="4547" name="Watchman's Gaze" debuff="true" action="A2">
         <icon initial="icon.skill0131"/>
-        <attributes magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
             <cast-range initial="1000"/>
             <effect-range initial="1500"/>
         </attributes>
@@ -767,7 +743,6 @@
         </abnormal>
     </skill>
     <skill id="4548" name="Annulment" action="A1">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="99"/>
@@ -783,10 +758,334 @@
             </dispel>
         </effects>
     </skill>
-    <skill id="4560" name="Fire Burn" max-level="12" action="A1" type="MAGIC">
-        <!-- none -->
+    <skill id="4549" name="Quest - Unsealed Altar" action="A1">
         <icon initial="icon.skill0000"/>
-        <attributes hit-cancel-time="1.0" magic-critical-rate="-5.0">
+        <attributes magic-critical-rate="-5.0">
+            <magic-level initial="99"/>
+            <hit-time initial="3000"/>
+        </attributes>
+        <target type="TARGET"/>
+    </skill>
+    <skill id="4550" name="Quest - Cursed Altar" action="A1">
+        <icon initial="icon.skill0000"/>
+        <attributes magic-critical-rate="-5.0">
+            <magic-level initial="99"/>
+            <hit-time initial="3000"/>
+        </attributes>
+        <target type="TARGET"/>
+    </skill>
+    <skill id="4551" name="Hot Springs Rheumatism" max-level="10" debuff="true" action="A2" type="MAGIC">
+        <!--
+		level 1: Infected with Hot Springs Flu. P. Atk. momentarily increased by 3.
+		level 2: Infected with Hot Springs Flu. Momentarily P. Critical Rate increased by 5 and P. Def. decreased by 4%%.
+		level 6: Infected with Hot Springs Flu. P. Def. momentarily decreased by 8%%.
+	 -->
+        <icon initial="icon.skill1164"/>
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
+            <magic-level initial="75"/>
+            <cast-range initial="600"/>
+            <effect-point initial="-100"/>
+            <effect-range initial="1100"/>
+        </attributes>
+        <consume>
+            <mana initial="69"/>
+        </consume>
+        <target type="TARGET"/>
+        <abnormal type="SPA_DISEASE_A" visual="DOT_POISON">
+            <level initial="1">
+                <value level="2">2</value>
+                <value level="3">3</value>
+                <value level="4">4</value>
+                <value level="5">5</value>
+                <value level="6">6</value>
+                <value level="7">7</value>
+                <value level="8">8</value>
+                <value level="9">9</value>
+                <value level="10">10</value>
+            </level>
+            <time initial="600"/>
+        </abnormal>
+        <effects>
+            <stat-modify mode="PER" stat="PHYSICAL_DEFENCE" stat-add="PHYSICAL_DEFENCE">
+                <power>
+                    <value level="2">-4.0</value>
+                    <value level="5">-8.0</value>
+                    <value level="8">-12.0</value>
+                    <value level="10">-15.0</value>
+                </power>
+            </stat-modify>
+            <stat-modify stat="CRITICAL_RATE" stat-add="CRITICAL_RATE">
+                <power initial="30.0">
+                    <value level="2">50.0</value>
+                    <value level="3">80.0</value>
+                    <value level="4">100.0</value>
+                    <value level="5">50.0</value>
+                    <value level="6">0.0</value>
+                </power>
+            </stat-modify>
+        </effects>
+    </skill>
+    <skill id="4552" name="Hot Springs Cholera" max-level="10" debuff="true" action="A2" type="MAGIC">
+        <!--
+		level 1: Infected with Hot Springs Flu. P. Accuracy momentarily increased by 3.
+		level 2: Infected with Hot Springs Flu. Momentarily P. Accuracy increased by 6 and P. Evasion decreased by 3.
+		level 6: Infected with Hot Springs Flu. P. Evasion momentarily decreased by 5.
+	 -->
+        <icon initial="icon.skill1164"/>
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
+            <magic-level initial="75"/>
+            <cast-range initial="600"/>
+            <effect-point initial="-100"/>
+            <effect-range initial="1100"/>
+        </attributes>
+        <consume>
+            <mana initial="69"/>
+        </consume>
+        <target type="TARGET"/>
+        <abnormal type="SPA_DISEASE_B" visual="DOT_POISON">
+            <level initial="1">
+                <value level="2">2</value>
+                <value level="3">3</value>
+                <value level="4">4</value>
+                <value level="5">5</value>
+                <value level="6">6</value>
+                <value level="7">7</value>
+                <value level="8">8</value>
+                <value level="9">9</value>
+                <value level="10">10</value>
+            </level>
+            <time initial="600"/>
+        </abnormal>
+        <effects>
+            <stat-modify stat="EVASION_RATE" stat-add="EVASION_RATE">
+                <power initial="-0.0">
+                    <value level="2">-3.0</value>
+                    <value level="5">-5.0</value>
+                    <value level="8">-8.0</value>
+                    <value level="10">-10.0</value>
+                </power>
+            </stat-modify>
+            <stat-modify stat="ACCURACY" stat-add="ACCURACY">
+                <power initial="3.0">
+                    <value level="2">6.0</value>
+                    <value level="3">8.0</value>
+                    <value level="4">10.0</value>
+                    <value level="5">6.0</value>
+                    <value level="6">0.0</value>
+                </power>
+            </stat-modify>
+        </effects>
+    </skill>
+    <skill id="4553" name="Hot Springs Flu" max-level="10" debuff="true" action="A2" type="MAGIC">
+        <!--
+		level 1: Infected with Hot Springs Flu. While afflicted, Atk. Spd. increases for a set time.
+		level 2: Infected with Hot Springs Flu. Momentarily Atk. Spd. increased by 4%% and P. Atk. decreased.
+		level 6: Infected with Hot Springs Flu. P. Atk. momentarily decreased by 8%%.
+	 -->
+        <icon initial="icon.skill1164"/>
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
+            <magic-level initial="75"/>
+            <cast-range initial="600"/>
+            <effect-point initial="-100"/>
+            <effect-range initial="1100"/>
+        </attributes>
+        <consume>
+            <mana initial="69"/>
+        </consume>
+        <target type="TARGET"/>
+        <abnormal type="SPA_DISEASE_C" visual="DOT_POISON">
+            <level initial="1">
+                <value level="2">2</value>
+                <value level="3">3</value>
+                <value level="4">4</value>
+                <value level="5">5</value>
+                <value level="6">6</value>
+                <value level="7">7</value>
+                <value level="8">8</value>
+                <value level="9">9</value>
+                <value level="10">10</value>
+            </level>
+            <time initial="600"/>
+        </abnormal>
+        <effects>
+            <stat-modify mode="PER" stat="PHYSICAL_ATTACK" stat-add="PHYSICAL_ATTACK">
+                <power>
+                    <value level="2">-4.0</value>
+                    <value level="5">-8.0</value>
+                    <value level="8">-12.0</value>
+                    <value level="10">-15.0</value>
+                </power>
+            </stat-modify>
+            <stat-modify mode="PER" stat="PHYSICAL_ATTACK_SPEED">
+                <power initial="4.0">
+                    <value level="2">8.0</value>
+                    <value level="3">12.0</value>
+                    <value level="4">16.0</value>
+                    <value level="5">8.0</value>
+                    <value level="6">0.0</value>
+                </power>
+            </stat-modify>
+        </effects>
+    </skill>
+    <skill id="4554" name="Hot Spring Malaria" max-level="10" debuff="true" action="A2" type="MAGIC">
+        <!--
+		level 1: Infected with Hot Springs Flu. Casting Spd. momentarily decreased by 4%%.
+		level 2: Infected with Hot Springs Flu. Momentarily Casting Spd. decreased by 8%% and MP Consumption increased.
+		level 6: Infected with Hot Springs Flu. MP Consumption momentarily increased.
+	 -->
+        <icon initial="icon.skill1164"/>
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
+            <magic-level initial="75"/>
+            <cast-range initial="600"/>
+            <effect-point initial="-100"/>
+            <effect-range initial="1100"/>
+        </attributes>
+        <consume>
+            <mana initial="69"/>
+        </consume>
+        <target type="TARGET"/>
+        <abnormal type="SPA_DISEASE_D" visual="DOT_POISON">
+            <level initial="1">
+                <value level="2">2</value>
+                <value level="3">3</value>
+                <value level="4">4</value>
+                <value level="5">5</value>
+                <value level="6">6</value>
+                <value level="7">7</value>
+                <value level="8">8</value>
+                <value level="9">9</value>
+                <value level="10">10</value>
+            </level>
+            <time initial="600"/>
+        </abnormal>
+        <effects>
+            <stat-modify mode="PER" stat="MAGIC_ATTACK_SPEED" stat-add="MAGIC_ATTACK_SPEED">
+                <power initial="4.0">
+                    <value level="2">8.0</value>
+                    <value level="3">12.0</value>
+                    <value level="4">16.0</value>
+                    <value level="5">8.0</value>
+                    <value level="6">0.0</value>
+                </power>
+            </stat-modify>
+            <magic-cost>
+                <power>
+                    <value level="2">-4.0</value>
+                    <value level="5">-8.0</value>
+                    <value level="8">-12.0</value>
+                    <value level="10">-16.0</value>
+                </power>
+            </magic-cost>
+        </effects>
+    </skill>
+    <skill id="4555" name="Mutation Resistance">
+        <icon initial="icon.skill0000"/>
+        <attributes property="MAGIC" magic-critical-rate="-5.0">
+        </attributes>
+        <target/>
+        <effects>
+            <defence-trait>
+                <trait type="SHOCK">
+                    <power initial="20"/>
+                </trait>
+                <trait type="HOLD">
+                    <power initial="20"/>
+                </trait>
+                <trait type="BLEED">
+                    <power initial="20"/>
+                </trait>
+                <trait type="PARALYZE">
+                    <power initial="20"/>
+                </trait>
+                <trait type="POISON">
+                    <power initial="20"/>
+                </trait>
+            </defence-trait>
+        </effects>
+    </skill>
+    <skill id="4556" name="Dispel Hot Spring Disease A D" action="A1" type="MAGIC">
+        <icon initial="icon.skill0000"/>
+        <attributes magic-critical-rate="-5.0">
+            <magic-level initial="75"/>
+            <cast-range initial="600"/>
+            <effect-range initial="1100"/>
+        </attributes>
+        <consume>
+            <mana initial="69"/>
+        </consume>
+        <target type="TARGET"/>
+        <effects>
+            <dispel>
+                <abnormal type="SPA_DISEASE_D">
+                    <power initial="10.0"/>
+                </abnormal>
+                <abnormal type="SPA_DISEASE_A">
+                    <power initial="10.0"/>
+                </abnormal>
+            </dispel>
+        </effects>
+    </skill>
+    <skill id="4557" name="Dispel Hot Spring Disease B D" action="A1" type="MAGIC">
+        <icon initial="icon.skill0000"/>
+        <attributes magic-critical-rate="-5.0">
+            <magic-level initial="75"/>
+            <cast-range initial="600"/>
+            <effect-range initial="1100"/>
+        </attributes>
+        <consume>
+            <mana initial="69"/>
+        </consume>
+        <target type="TARGET"/>
+        <effects>
+            <dispel>
+                <abnormal type="SPA_DISEASE_B">
+                    <power initial="10.0"/>
+                </abnormal>
+                <abnormal type="SPA_DISEASE_D">
+                    <power initial="10.0"/>
+                </abnormal>
+            </dispel>
+        </effects>
+    </skill>
+    <skill id="4558" name="Dispel Hot Spring Disease C D" action="A1" type="MAGIC">
+        <icon initial="icon.skill0000"/>
+        <attributes magic-critical-rate="-5.0">
+            <magic-level initial="75"/>
+            <cast-range initial="600"/>
+            <effect-range initial="1100"/>
+        </attributes>
+        <consume>
+            <mana initial="69"/>
+        </consume>
+        <target type="TARGET"/>
+        <effects>
+            <dispel>
+                <abnormal type="SPA_DISEASE_D">
+                    <power initial="10.0"/>
+                </abnormal>
+                <abnormal type="SPA_DISEASE_C">
+                    <power initial="10.0"/>
+                </abnormal>
+            </dispel>
+        </effects>
+    </skill>
+    <skill id="4559" name="Hot Spring Illusion" action="A2">
+        <!-- Temporary optical illusion caused by the Hot Spring. -->
+        <icon initial="icon.skill0000"/>
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
+            <magic-level initial="1"/>
+            <cast-range initial="600"/>
+            <effect-range initial="1100"/>
+        </attributes>
+        <target type="TARGET"/>
+        <abnormal type="BIG_HEAD" visual="BIG_HEAD">
+            <level initial="1"/>
+            <time initial="600"/>
+        </abnormal>
+    </skill>
+    <skill id="4560" name="Fire Burn" max-level="12" action="A1" type="MAGIC">
+        <icon initial="icon.skill0000"/>
+        <attributes magic-critical-rate="-5.0" hit-cancel-time="1.0">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -842,9 +1141,8 @@
         </effects>
     </skill>
     <skill id="4561" name="Fire Burn" max-level="12" action="A1" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
-        <attributes hit-cancel-time="1.5" magic-critical-rate="-5.0">
+        <attributes magic-critical-rate="-5.0" hit-cancel-time="1.5">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -894,7 +1192,6 @@
         </effects>
     </skill>
     <skill id="4562" name="Solar Flare" max-level="12" action="A1" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="10">
@@ -952,9 +1249,8 @@
         </effects>
     </skill>
     <skill id="4563" name="Solar Flare" max-level="12" action="A1" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
-        <attributes hit-cancel-time="4.5" magic-critical-rate="-5.0">
+        <attributes magic-critical-rate="-5.0" hit-cancel-time="4.5">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -1008,9 +1304,8 @@
         </effects>
     </skill>
     <skill id="4564" name="Solar Flare" max-level="12" action="A1" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
-        <attributes hit-cancel-time="2.5" magic-critical-rate="-5.0">
+        <attributes magic-critical-rate="-5.0" hit-cancel-time="2.5">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -1065,7 +1360,6 @@
         </effects>
     </skill>
     <skill id="4565" name="Rain of Fire" max-level="12" action="A1" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="10">
@@ -1103,7 +1397,7 @@
                 <value level="12">78</value>
             </mana>
         </consume>
-        <target object="NOT_FRIEND" range="100" scope="RANGE" type="ENEMY"/>
+        <target type="ENEMY" scope="RANGE" object="NOT_FRIEND" range="100"/>
         <effects>
             <magical-attack>
                 <power initial="37.0">
@@ -1123,9 +1417,8 @@
         </effects>
     </skill>
     <skill id="4566" name="Rain of Fire" max-level="12" action="A1" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
-        <attributes hit-cancel-time="4.5" magic-critical-rate="-5.0">
+        <attributes magic-critical-rate="-5.0" hit-cancel-time="4.5">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -1159,7 +1452,7 @@
                 <value level="11">39</value>
             </mana>
         </consume>
-        <target object="NOT_FRIEND" range="100" scope="RANGE" type="ENEMY"/>
+        <target type="ENEMY" scope="RANGE" object="NOT_FRIEND" range="100"/>
         <effects>
             <magical-attack>
                 <power initial="37.0">
@@ -1179,9 +1472,8 @@
         </effects>
     </skill>
     <skill id="4567" name="Rain of Fire" max-level="12" action="A1" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
-        <attributes hit-cancel-time="2.5" magic-critical-rate="-5.0">
+        <attributes magic-critical-rate="-5.0" hit-cancel-time="2.5">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -1216,7 +1508,7 @@
                 <value level="12">78</value>
             </mana>
         </consume>
-        <target object="NOT_FRIEND" range="100" scope="RANGE" type="ENEMY"/>
+        <target type="ENEMY" scope="RANGE" object="NOT_FRIEND" range="100"/>
         <effects>
             <magical-attack>
                 <power initial="37.0">
@@ -1236,7 +1528,6 @@
         </effects>
     </skill>
     <skill id="4568" name="Solar Flare" max-level="12" action="A1" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="10">
@@ -1274,7 +1565,7 @@
                 <value level="12">145</value>
             </mana>
         </consume>
-        <target object="NOT_FRIEND" range="200" scope="RANGE" type="ENEMY"/>
+        <target type="ENEMY" scope="RANGE" object="NOT_FRIEND" range="200"/>
         <effects>
             <magical-attack>
                 <power initial="11.0">
@@ -1294,9 +1585,8 @@
         </effects>
     </skill>
     <skill id="4569" name="Solar Flare" max-level="12" action="A1" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
-        <attributes hit-cancel-time="4.5" magic-critical-rate="-5.0">
+        <attributes magic-critical-rate="-5.0" hit-cancel-time="4.5">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -1330,7 +1620,7 @@
                 <value level="11">73</value>
             </mana>
         </consume>
-        <target object="NOT_FRIEND" range="200" scope="RANGE" type="ENEMY"/>
+        <target type="ENEMY" scope="RANGE" object="NOT_FRIEND" range="200"/>
         <effects>
             <magical-attack>
                 <power initial="11.0">
@@ -1350,9 +1640,8 @@
         </effects>
     </skill>
     <skill id="4570" name="Solar Flare" max-level="12" action="A1" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
-        <attributes hit-cancel-time="2.5" magic-critical-rate="-5.0">
+        <attributes magic-critical-rate="-5.0" hit-cancel-time="2.5">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -1387,7 +1676,7 @@
                 <value level="12">145</value>
             </mana>
         </consume>
-        <target object="NOT_FRIEND" range="200" scope="RANGE" type="ENEMY"/>
+        <target type="ENEMY" scope="RANGE" object="NOT_FRIEND" range="200"/>
         <effects>
             <magical-attack>
                 <power initial="6.0">
@@ -1407,7 +1696,6 @@
         </effects>
     </skill>
     <skill id="4571" name="Blazing Circle" max-level="12" action="A1" type="MAGIC">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="10">
@@ -1423,7 +1711,6 @@
                 <value level="11">90</value>
                 <value level="12">95</value>
             </magic-level>
-            <cast-range initial="-1"/>
             <reuse initial="15000"/>
             <effect-point initial="-100"/>
             <hit-time initial="5000"/>
@@ -1444,7 +1731,7 @@
                 <value level="12">117</value>
             </mana>
         </consume>
-        <target object="NOT_FRIEND" range="200" scope="POINT_BLANK"/>
+        <target scope="POINT_BLANK" object="NOT_FRIEND" range="200"/>
         <effects>
             <magical-attack>
                 <power initial="42.0">
@@ -1464,7 +1751,6 @@
         </effects>
     </skill>
     <skill id="4572" name="Triple Sonic Slash" max-level="12" action="A1">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="10">
@@ -1503,7 +1789,7 @@
         </consume>
         <target type="ENEMY"/>
         <effects>
-            <physical-attack critical-chance="15.0" ignore-shield="false">
+            <physical-attack critical-chance="15.0" ignore-shield="true">
                 <power initial="92.0">
                     <value level="2">210.0</value>
                     <value level="3">438.0</value>
@@ -1521,7 +1807,6 @@
         </effects>
     </skill>
     <skill id="4573" name="Sonic Blaster" max-level="12" action="A1">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="10">
@@ -1578,7 +1863,6 @@
         </effects>
     </skill>
     <skill id="4574" name="Sonic Storm" max-level="12" action="A1">
-        <!-- none -->
         <icon initial="icon.skill0000"/>
         <attributes magic-critical-rate="-5.0">
             <magic-level initial="10">
@@ -1615,7 +1899,7 @@
                 <value level="12">57</value>
             </mana>
         </consume>
-        <target object="NOT_FRIEND" range="150" scope="RANGE" type="ENEMY"/>
+        <target type="ENEMY" scope="RANGE" object="NOT_FRIEND" range="150"/>
         <effects>
             <physical-attack critical-chance="15.0">
                 <power initial="31.0">
@@ -1635,16 +1919,15 @@
         </effects>
     </skill>
     <skill id="4575" name="Haste" max-level="2" action="A2" type="MAGIC">
-        <!-- 
-			level 1: Atk. Spd. +15%.
-			level 2: Atk. Spd. +33%.
-		-->
+        <!--
+		level 1: Atk. Spd. has been increased by 15%.
+		level 2: Atk. Spd. has been increased by 33%.
+	 -->
         <icon initial="icon.skill1086"/>
-        <attributes magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
             <magic-level initial="30">
                 <value level="2">70</value>
             </magic-level>
-            <cast-range initial="-1"/>
             <reuse initial="8000"/>
             <effect-point initial="100"/>
             <hit-time initial="2000"/>
@@ -1654,7 +1937,7 @@
                 <value level="2">49</value>
             </mana>
         </consume>
-        <target object="CLAN" range="900" scope="RANGE"/>
+        <target scope="RANGE" object="CLAN" range="900"/>
         <abnormal type="ATTACK_TIME_DOWN">
             <level initial="1">
                 <value level="2">2</value>
@@ -1670,18 +1953,17 @@
         </effects>
     </skill>
     <skill id="4576" name="Reflect Damage" max-level="3" action="A2" type="MAGIC">
-        <!-- 
-			level 1: Reflects 10% damage.
-			level 2: Reflects 15% damage.
-			level 3: Reflects 20% damage.
-		-->
+        <!--
+		level 1: 10% of received damage will be deflected.
+		level 2: 15% of received damage will be deflected.
+		level 3: 20% of received damage will be deflected.
+	 -->
         <icon initial="icon.skill0086"/>
-        <attributes magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
             <magic-level initial="20">
                 <value level="2">40</value>
                 <value level="3">70</value>
             </magic-level>
-            <cast-range initial="-1"/>
             <reuse initial="8000"/>
             <effect-point initial="100"/>
             <hit-time initial="2000"/>
@@ -1692,7 +1974,7 @@
                 <value level="3">49</value>
             </mana>
         </consume>
-        <target object="CLAN" range="900" scope="RANGE"/>
+        <target scope="RANGE" object="CLAN" range="900"/>
         <abnormal type="DMG_SHIELD">
             <level initial="1">
                 <value level="2">2</value>
@@ -1709,10 +1991,10 @@
             </stat-modify>
         </effects>
     </skill>
-    <skill id="4577" name="Decrease P. Accuracy" max-level="12" action="A2" debuff="true" type="MAGIC">
-        <!-- Immediately decreases P. Accuracy. -->
+    <skill id="4577" name="Decrease P. Accuracy" max-level="12" debuff="true" action="A2" type="MAGIC">
+        <!-- P. Accuracy has been momentarily decreased. -->
         <icon initial="icon.skill1222"/>
-        <attributes level-bonus-rate="1" magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" level-bonus-rate="1">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -1747,7 +2029,7 @@
                 <value level="12">117</value>
             </mana>
         </consume>
-        <target object="NOT_FRIEND" range="200" scope="RANGE" type="ENEMY_ONLY"/>
+        <target type="ENEMY_ONLY" scope="RANGE" object="NOT_FRIEND" range="200"/>
         <abnormal type="HIT_DOWN">
             <level initial="1">
                 <value level="2">2</value>
@@ -1774,10 +2056,10 @@
             </stat-modify>
         </effects>
     </skill>
-    <skill id="4578" name="Petrified" action="A2" debuff="true" type="MAGIC">
-        <!-- Momentarily petrifies the target. -->
+    <skill id="4578" name="Petrify" debuff="true" action="A2" type="MAGIC">
+        <!-- Petrified and unable to move momentarily. -->
         <icon initial="icon.skill4111"/>
-        <attributes magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
             <magic-level initial="80"/>
             <cast-range initial="600"/>
             <effect-point initial="-100"/>
@@ -1797,7 +2079,7 @@
             <block-all-actions>
                 <allowed-skills>35016</allowed-skills>
             </block-all-actions>
-            <damage-block block-hp="true" block-mp="false"/>
+            <damage-block block-hp="true"/>
             <effect name="BuffBlock"/>
             <effect name="DebuffBlock"/>
             <stat-modify mode="PER" stat="REGENERATE_HP_RATE" stat-add="REGENERATE_HP_RATE">
@@ -1805,10 +2087,10 @@
             </stat-modify>
         </effects>
     </skill>
-    <skill id="4579" name="Bleed" max-level="12" action="A2" debuff="true">
-        <!-- Causes target to bleed severely, momentarily reducing HP. -->
+    <skill id="4579" name="Bleed" max-level="12" debuff="true" action="A2">
+        <!-- HP has been momentarily decreased due to Bleed. -->
         <icon initial="icon.skill0096"/>
-        <attributes level-bonus-rate="2" magic-critical-rate="-5.0" trait="BLEED">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" trait="BLEED" level-bonus-rate="2">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -1844,7 +2126,7 @@
             </mana>
         </consume>
         <target type="ENEMY"/>
-        <abnormal subordination="BLEEDING" type="BLEEDING" visual="DOT_BLEEDING">
+        <abnormal type="BLEEDING" visual="DOT_BLEEDING" subordination="BLEEDING">
             <level initial="2">
                 <value level="2">3</value>
                 <value level="3">4</value>
@@ -1859,7 +2141,7 @@
             <chance initial="100"/>
         </abnormal>
         <effects>
-            <fatal-blow chance-boost="200.0">
+            <fatal-blow chance-boost="200.0" over-hit="false">
                 <power initial="137.0">
                     <value level="2">314.0</value>
                     <value level="3">656.0</value>
@@ -1888,10 +2170,10 @@
             </damage-over-time>
         </effects>
     </skill>
-    <skill id="4580" name="Decrease P. Atk." max-level="12" action="A2" debuff="true">
-        <!-- Immediately P. Atk. -17%%. -->
+    <skill id="4580" name="Decrease P. Atk." max-level="12" debuff="true" action="A2">
+        <!-- P. Atk. has been momentarily decreased by 17%%. -->
         <icon initial="icon.skill4037"/>
-        <attributes level-bonus-rate="2" magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" level-bonus-rate="2">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -1944,10 +2226,10 @@
             </stat-modify>
         </effects>
     </skill>
-    <skill id="4581" name="Hold" max-level="12" action="A2" debuff="true">
-        <!-- Holds the target. -->
+    <skill id="4581" name="Hold" max-level="12" debuff="true" action="A2">
+        <!-- Afflicted with Hold and unable to move momentarily. -->
         <icon initial="icon.skill4047"/>
-        <attributes level-bonus-rate="2" magic-critical-rate="-5.0" trait="HOLD">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" trait="HOLD" level-bonus-rate="2">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -1992,10 +2274,10 @@
             <effect name="Root"/>
         </effects>
     </skill>
-    <skill id="4582" name="Poison" max-level="12" action="A2" debuff="true">
-        <!-- Instantly decreases HP. -->
+    <skill id="4582" name="Poison" max-level="12" debuff="true" action="A2">
+        <!-- HP has been momentarily decreased due to Poison. -->
         <icon initial="icon.skill4035"/>
-        <attributes level-bonus-rate="2" magic-critical-rate="-5.0" trait="POISON">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" trait="POISON" level-bonus-rate="2">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -2031,7 +2313,7 @@
             </mana>
         </consume>
         <target type="ENEMY"/>
-        <abnormal subordination="POISON" type="POISON" visual="DOT_POISON">
+        <abnormal type="POISON" visual="DOT_POISON" subordination="POISON">
             <level initial="2">
                 <value level="2">3</value>
                 <value level="3">4</value>
@@ -2060,10 +2342,10 @@
             </damage-over-time>
         </effects>
     </skill>
-    <skill id="4583" name="Decrease Speed" max-level="12" action="A2" debuff="true">
-        <!-- Immediately target's Speed -10%%. -->
+    <skill id="4583" name="Decrease Speed" max-level="12" debuff="true" action="A2">
+        <!-- Movement Speed has been momentarily decreased by 10%%. -->
         <icon initial="icon.skill1160"/>
-        <attributes level-bonus-rate="2" magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" level-bonus-rate="2">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -2116,10 +2398,10 @@
             </speed>
         </effects>
     </skill>
-    <skill id="4584" name="Decrease P. Def. and Stun" max-level="12" action="A2" debuff="true">
-        <!-- Instantly decreases P. Def. Immobilizes and stuns target. -->
+    <skill id="4584" name="Stunned and P. Def. decreased." max-level="12" debuff="true" action="A2">
+        <!-- P. Def. has been momentarily decreased and immobile due to stun. -->
         <icon initial="icon.skill0100"/>
-        <attributes level-bonus-rate="2" magic-critical-rate="-5.0" trait="SHOCK">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" trait="SHOCK" level-bonus-rate="2">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -2167,7 +2449,7 @@
             <chance initial="80"/>
         </abnormal>
         <effects>
-            <physical-attack>
+            <physical-attack critical-chance="0.0">
                 <power/>
             </physical-attack>
             <block-all-actions/>
@@ -2179,19 +2461,18 @@
             </stat-modify>
         </effects>
     </skill>
-    <skill id="4585" name="Berserker's Might" max-level="3" action="A2" type="MAGIC">
-        <!-- 
-			level 1: P. Def. -5%, M. Def. -10%, P. Evasion -2, P. Atk. +13%, M. Atk. +10%, Atk. Spd. +5%, Casting Spd. +5%, Speed +5.
-			level 2: P. Def. -5%, M. Def. -10%, P. Evasion -2, P. Atk. +18%, M. Atk. +10%, Atk. Spd. +5%, Casting Spd. +5%, Speed +5.
-			level 3: P. Def. -8%, M. Def. -16%, P. Evasion -4, P. Atk. +24%, M. Atk. +16%, Atk. Spd. +8%, Casting Spd. +8%, Speed +8.
-		-->
+    <skill id="4585" name="Berserker Spirit" max-level="3" action="A2" type="MAGIC">
+        <!--
+		level 1: P. Atk. +5%, M. Atk. +10%, Atk. Spd. +2, Casting Spd. +13%, and Movement Speed +10%. P. Def. -5%, M. Def. -5%, and P. Evasion -5.
+		level 2: P. Atk. +5%, M. Atk. +10%, Atk. Spd. +2, Casting Spd. +18%, and Movement Speed +10%. P. Def. -5%, M. Def. -5%, and P. Evasion -5.
+		level 3: P. Atk. +8%, M. Atk. +16%, Atk. Spd. +4, Casting Spd. +24%, and Movement Speed +16%. P. Def. -8%, M. Def. -8%, and P. Evasion -8.
+	 -->
         <icon initial="icon.skill1062"/>
-        <attributes magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
             <magic-level initial="20">
                 <value level="2">40</value>
                 <value level="3">70</value>
             </magic-level>
-            <cast-range initial="-1"/>
             <reuse initial="8000"/>
             <effect-point initial="100"/>
             <hit-time initial="2000"/>
@@ -2202,7 +2483,7 @@
                 <value level="3">98</value>
             </mana>
         </consume>
-        <target object="CLAN" range="900" scope="RANGE"/>
+        <target scope="RANGE" object="CLAN" range="900"/>
         <abnormal type="MULTI_BUFF" visual="BIG_BODY">
             <level initial="1">
                 <value level="2">2</value>
@@ -2250,10 +2531,10 @@
             </stat-modify>
         </effects>
     </skill>
-    <skill id="4586" name="Decrease P. Evasion" max-level="12" action="A2" debuff="true" type="MAGIC">
-        <!-- Immediately P. Evasion -10. -->
+    <skill id="4586" name="Decrease P. Evasion" max-level="12" debuff="true" action="A2" type="MAGIC">
+        <!-- P. Evasion has been momentarily decreased by 10. -->
         <icon initial="icon.skill1222"/>
-        <attributes level-bonus-rate="2" magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" level-bonus-rate="2">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -2315,10 +2596,10 @@
             </stat-modify>
         </effects>
     </skill>
-    <skill id="4587" name="Decrease P. Atk." max-level="12" action="A2" debuff="true" type="MAGIC">
-        <!-- Immediately P. Atk. -17%%. -->
+    <skill id="4587" name="Decrease P. Atk." max-level="12" debuff="true" action="A2" type="MAGIC">
+        <!-- P. Atk. has been momentarily decreased by 17%%. -->
         <icon initial="icon.skill4037"/>
-        <attributes level-bonus-rate="1" magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" level-bonus-rate="1">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -2353,7 +2634,7 @@
                 <value level="12">117</value>
             </mana>
         </consume>
-        <target object="NOT_FRIEND" range="200" scope="RANGE" type="ENEMY_ONLY"/>
+        <target type="ENEMY_ONLY" scope="RANGE" object="NOT_FRIEND" range="200"/>
         <abnormal type="PA_DOWN">
             <level initial="1">
                 <value level="2">2</value>
@@ -2371,14 +2652,12 @@
             </stat-modify>
         </effects>
     </skill>
-    <skill id="4588" name="Berserker's Haste" max-level="2" action="A2" type="MAGIC">
-        <!-- none -->
+    <skill id="4588" name="Berserker Haste" max-level="2" action="A2" type="MAGIC">
         <icon initial="icon.skill0000"/>
-        <attributes magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
             <magic-level initial="30">
                 <value level="2">70</value>
             </magic-level>
-            <cast-range initial="-1"/>
             <reuse initial="8000"/>
             <effect-point initial="100"/>
             <hit-time initial="2000"/>
@@ -2388,7 +2667,7 @@
                 <value level="2">98</value>
             </mana>
         </consume>
-        <target object="CLAN" range="900" scope="RANGE"/>
+        <target scope="RANGE" object="CLAN" range="900"/>
         <abnormal type="MULTI_BUFF">
             <level initial="1">
                 <value level="2">2</value>
@@ -2433,10 +2712,10 @@
             </stat-modify>
         </effects>
     </skill>
-    <skill id="4589" name="Decrease Speed" max-level="12" action="A2" debuff="true" type="MAGIC">
-        <!-- Immediately target's Speed -10%%. -->
+    <skill id="4589" name="Decrease Speed" max-level="12" debuff="true" action="A2" type="MAGIC">
+        <!-- Movement Speed has been momentarily decreased by 10%%. -->
         <icon initial="icon.skill1160"/>
-        <attributes level-bonus-rate="1" magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" level-bonus-rate="1">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -2472,7 +2751,7 @@
                 <value level="12">233</value>
             </mana>
         </consume>
-        <target object="NOT_FRIEND" range="200" scope="RANGE" type="ENEMY"/>
+        <target type="ENEMY" scope="RANGE" object="NOT_FRIEND" range="200"/>
         <abnormal type="SPEED_DOWN">
             <level initial="1">
                 <value level="2">2</value>
@@ -2490,10 +2769,10 @@
             </speed>
         </effects>
     </skill>
-    <skill id="4590" name="Decrease Speed" max-level="12" action="A2" debuff="true" type="MAGIC">
-        <!-- Immediately target's Speed -10%%. -->
+    <skill id="4590" name="Decrease Speed" max-level="12" debuff="true" action="A2" type="MAGIC">
+        <!-- Movement Speed has been momentarily decreased by 10%%. -->
         <icon initial="icon.skill1160"/>
-        <attributes hit-cancel-time="3.5" level-bonus-rate="1" magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" hit-cancel-time="3.5" level-bonus-rate="1">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -2528,7 +2807,7 @@
                 <value level="12">117</value>
             </mana>
         </consume>
-        <target object="NOT_FRIEND" range="200" scope="RANGE" type="ENEMY"/>
+        <target type="ENEMY" scope="RANGE" object="NOT_FRIEND" range="200"/>
         <abnormal type="SPEED_DOWN">
             <level initial="1">
                 <value level="2">2</value>
@@ -2546,10 +2825,10 @@
             </speed>
         </effects>
     </skill>
-    <skill id="4591" name="Decrease Speed" max-level="12" action="A2" debuff="true" type="MAGIC">
-        <!-- Immediately target's Speed -10%%. -->
+    <skill id="4591" name="Decrease Speed" max-level="12" debuff="true" action="A2" type="MAGIC">
+        <!-- Movement Speed has been momentarily decreased by 10%%. -->
         <icon initial="icon.skill1160"/>
-        <attributes hit-cancel-time="2.0" level-bonus-rate="1" magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" hit-cancel-time="2.0" level-bonus-rate="1">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -2584,7 +2863,7 @@
                 <value level="12">233</value>
             </mana>
         </consume>
-        <target object="NOT_FRIEND" range="200" scope="RANGE" type="ENEMY"/>
+        <target type="ENEMY" scope="RANGE" object="NOT_FRIEND" range="200"/>
         <abnormal type="SPEED_DOWN">
             <level initial="1">
                 <value level="2">2</value>
@@ -2602,10 +2881,10 @@
             </speed>
         </effects>
     </skill>
-    <skill id="4592" name="Decrease P. Def." max-level="12" action="A2" debuff="true">
-        <!-- Decreases P. Def. -->
+    <skill id="4592" name="Decrease P. Def." max-level="12" debuff="true" action="A2">
+        <!-- P. Def has been momentarily decreased. -->
         <icon initial="icon.skill0122"/>
-        <attributes level-bonus-rate="2" magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" level-bonus-rate="2">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -2659,10 +2938,10 @@
             </stat-modify>
         </effects>
     </skill>
-    <skill id="4593" name="Decrease P. Def." max-level="12" action="A2" debuff="true">
-        <!-- Decreases P. Def. -->
+    <skill id="4593" name="Decrease P. Def." max-level="12" debuff="true" action="A2">
+        <!-- P. Def has been momentarily decreased. -->
         <icon initial="icon.skill0122"/>
-        <attributes hit-cancel-time="3.5" level-bonus-rate="2" magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" hit-cancel-time="3.5" level-bonus-rate="2">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -2715,10 +2994,10 @@
             </stat-modify>
         </effects>
     </skill>
-    <skill id="4594" name="Decrease P. Def." max-level="12" action="A2" debuff="true">
-        <!-- Decreases P. Def. -->
+    <skill id="4594" name="Decrease P. Def." max-level="12" debuff="true" action="A2">
+        <!-- P. Def has been momentarily decreased. -->
         <icon initial="icon.skill0122"/>
-        <attributes hit-cancel-time="2.0" level-bonus-rate="2" magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" hit-cancel-time="2.0" level-bonus-rate="2">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -2771,15 +3050,13 @@
             </stat-modify>
         </effects>
     </skill>
-    <skill id="4595" name="Acumen + Shield" max-level="3" action="A2" type="MAGIC">
-        <!-- none -->
+    <skill id="4595" name="Acumen Shield" max-level="3" action="A2" type="MAGIC">
         <icon initial="icon.skill0000"/>
-        <attributes magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0">
             <magic-level initial="20">
                 <value level="2">40</value>
                 <value level="3">70</value>
             </magic-level>
-            <cast-range initial="-1"/>
             <reuse initial="8000"/>
             <effect-point initial="100"/>
             <hit-time initial="2000"/>
@@ -2790,7 +3067,7 @@
                 <value level="3">98</value>
             </mana>
         </consume>
-        <target object="CLAN" range="900" scope="RANGE"/>
+        <target scope="RANGE" object="CLAN" range="900"/>
         <abnormal type="MULTI_BUFF">
             <level initial="1">
                 <value level="2">2</value>
@@ -2813,10 +3090,10 @@
             </stat-modify>
         </effects>
     </skill>
-    <skill id="4596" name="Bleed" max-level="12" action="A2" debuff="true" type="MAGIC">
-        <!-- Causes target to bleed severely, momentarily reducing HP. -->
+    <skill id="4596" name="Bleed" max-level="12" debuff="true" action="A2" type="MAGIC">
+        <!-- HP has been momentarily decreased due to Bleed. -->
         <icon initial="icon.skill0096"/>
-        <attributes level-bonus-rate="2" magic-critical-rate="-5.0" trait="BLEED">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" trait="BLEED" level-bonus-rate="2">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -2852,7 +3129,7 @@
             </mana>
         </consume>
         <target type="ENEMY"/>
-        <abnormal subordination="BLEEDING" type="BLEEDING" visual="DOT_BLEEDING">
+        <abnormal type="BLEEDING" visual="DOT_BLEEDING" subordination="BLEEDING">
             <level initial="2">
                 <value level="2">3</value>
                 <value level="3">4</value>
@@ -2881,10 +3158,10 @@
             </damage-over-time>
         </effects>
     </skill>
-    <skill id="4597" name="Bleed" max-level="12" action="A2" debuff="true" type="MAGIC">
-        <!-- Causes target to bleed severely, momentarily reducing HP. -->
+    <skill id="4597" name="Bleed" max-level="12" debuff="true" action="A2" type="MAGIC">
+        <!-- HP has been momentarily decreased due to Bleed. -->
         <icon initial="icon.skill0096"/>
-        <attributes hit-cancel-time="3.5" level-bonus-rate="2" magic-critical-rate="-5.0" trait="BLEED">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" trait="BLEED" hit-cancel-time="3.5" level-bonus-rate="2">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -2919,7 +3196,7 @@
             </mana>
         </consume>
         <target type="ENEMY"/>
-        <abnormal subordination="BLEEDING" type="BLEEDING" visual="DOT_BLEEDING">
+        <abnormal type="BLEEDING" visual="DOT_BLEEDING" subordination="BLEEDING">
             <level initial="2">
                 <value level="2">3</value>
                 <value level="3">4</value>
@@ -2948,10 +3225,10 @@
             </damage-over-time>
         </effects>
     </skill>
-    <skill id="4598" name="Bleed" max-level="12" action="A2" debuff="true" type="MAGIC">
-        <!-- Causes target to bleed severely, momentarily reducing HP. -->
+    <skill id="4598" name="Bleed" max-level="12" debuff="true" action="A2" type="MAGIC">
+        <!-- HP has been momentarily decreased due to Bleed. -->
         <icon initial="icon.skill0096"/>
-        <attributes hit-cancel-time="2.0" level-bonus-rate="2" magic-critical-rate="-5.0" trait="BLEED">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" trait="BLEED" hit-cancel-time="2.0" level-bonus-rate="2">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -2986,7 +3263,7 @@
             </mana>
         </consume>
         <target type="ENEMY"/>
-        <abnormal subordination="BLEEDING" type="BLEEDING" visual="DOT_BLEEDING">
+        <abnormal type="BLEEDING" visual="DOT_BLEEDING" subordination="BLEEDING">
             <level initial="2">
                 <value level="2">3</value>
                 <value level="3">4</value>
@@ -3015,10 +3292,10 @@
             </damage-over-time>
         </effects>
     </skill>
-    <skill id="4599" name="Decrease Speed" max-level="12" action="A2" debuff="true">
-        <!-- Speed decreased temporarily. -->
+    <skill id="4599" name="Decrease Speed" max-level="12" debuff="true" action="A2">
+        <!-- Movement Speed has been momentarily decreased. -->
         <icon initial="icon.skill1160"/>
-        <attributes level-bonus-rate="1" magic-critical-rate="-5.0">
+        <attributes property="PHYSIC" magic-critical-rate="-5.0" level-bonus-rate="1">
             <magic-level initial="10">
                 <value level="2">20</value>
                 <value level="3">30</value>
@@ -3053,7 +3330,7 @@
                 <value level="12">244</value>
             </mana>
         </consume>
-        <target object="NOT_FRIEND" range="20" scope="RANGE" type="ENEMY"/>
+        <target type="ENEMY" scope="RANGE" object="NOT_FRIEND" range="20"/>
         <abnormal type="SPEED_DOWN">
             <level initial="1">
                 <value level="2">2</value>

--- a/data/spawns/Aden/AdenMonsterSpawns.xml
+++ b/data/spawns/Aden/AdenMonsterSpawns.xml
@@ -40,8 +40,6 @@
             <npc id="20590" x="109820" y="41731" z="-4640" heading="51043" respawnTime="80sec"/>
             <npc id="20590" x="108062" y="41572" z="-4638" heading="1206" respawnTime="80sec"/>
             <npc id="20592" x="109587" y="42037" z="-4640" heading="8426" respawnTime="80sec"/>
-            <npc id="20589" x="104665" y="41443" z="-4634" heading="52358" respawnTime="80sec"/>
-            <npc id="20590" x="105237" y="41743" z="-4634" heading="26154" respawnTime="80sec"/>
             <npc id="20589" x="103538" y="40368" z="-4672" heading="0" respawnTime="80sec"/>
             <npc id="20589" x="104243" y="40546" z="-4672" heading="0" respawnTime="80sec"/>
             <npc id="20590" x="104041" y="40546" z="-4672" heading="0" respawnTime="80sec"/>
@@ -51,56 +49,13 @@
             <npc id="20591" x="104342" y="40368" z="-4672" heading="0" respawnTime="80sec"/>
             <npc id="20591" x="103739" y="40368" z="-4672" heading="0" respawnTime="80sec"/>
             <npc id="20592" x="103639" y="40902" z="-4672" heading="0" respawnTime="80sec"/>
-            <npc id="20592" x="103816" y="42076" z="-4633" heading="51707" respawnTime="80sec"/>
-            <npc id="20592" x="103735" y="43215" z="-4568" heading="50032" respawnTime="80sec"/>
-            <npc id="20590" x="103585" y="45966" z="-4578" heading="27848" respawnTime="80sec"/>
-            <npc id="20592" x="103390" y="44954" z="-4577" heading="46322" respawnTime="80sec"/>
-            <npc id="20590" x="105341" y="47587" z="-4578" heading="44190" respawnTime="80sec"/>
-            <npc id="20592" x="105659" y="48336" z="-4576" heading="45605" respawnTime="80sec"/>
-            <npc id="20592" x="105777" y="50606" z="-4497" heading="50078" respawnTime="80sec"/>
-            <npc id="20591" x="105809" y="49668" z="-4556" heading="0" respawnTime="80sec"/>
-            <npc id="20592" x="106174" y="55222" z="-4618" heading="12169" respawnTime="80sec"/>
-            <npc id="20592" x="105316" y="52572" z="-4633" heading="50934" respawnTime="80sec"/>
-            <npc id="20591" x="104192" y="54198" z="-4616" heading="40308" respawnTime="80sec"/>
             <npc id="20593" x="105749" y="51548" z="-4561" heading="52848" respawnTime="80sec"/>
-            <npc id="20592" x="105402" y="54057" z="-4633" heading="58717" respawnTime="80sec"/>
-            <npc id="20591" x="106633" y="54984" z="-4623" heading="5072" respawnTime="80sec"/>
-            <npc id="20593" x="105220" y="54536" z="-4633" heading="36568" respawnTime="80sec"/>
-            <npc id="20593" x="106832" y="54274" z="-4688" heading="0" respawnTime="80sec"/>
-            <npc id="20592" x="104322" y="60191" z="-4499" heading="14050" respawnTime="80sec"/>
-            <npc id="20592" x="103889" y="58083" z="-4615" heading="63197" respawnTime="80sec"/>
-            <npc id="20592" x="104577" y="58547" z="-4580" heading="12288" respawnTime="80sec"/>
-            <npc id="20591" x="103495" y="58274" z="-4612" heading="35386" respawnTime="80sec"/>
-            <npc id="20591" x="104693" y="59222" z="-4562" heading="38643" respawnTime="80sec"/>
-            <npc id="20591" x="103598" y="59019" z="-4584" heading="37922" respawnTime="80sec"/>
-            <npc id="20591" x="103095" y="57665" z="-4537" heading="34928" respawnTime="80sec"/>
-            <npc id="20593" x="104445" y="57424" z="-4624" heading="0" respawnTime="80sec"/>
-            <npc id="20593" x="104827" y="60178" z="-4446" heading="41745" respawnTime="80sec"/>
-            <npc id="20593" x="105496" y="61017" z="-4268" heading="39855" respawnTime="80sec"/>
-            <npc id="20590" x="110696" y="60902" z="-4578" heading="35129" respawnTime="80sec"/>
             <npc id="20590" x="111777" y="61537" z="-4577" heading="41431" respawnTime="80sec"/>
-            <npc id="20592" x="112318" y="62137" z="-4599" heading="39963" respawnTime="80sec"/>
-            <npc id="20589" x="112778" y="61262" z="-4224" heading="6712" respawnTime="80sec"/>
-            <npc id="20589" x="115886" y="62493" z="-4550" heading="24150" respawnTime="80sec"/>
-            <npc id="20590" x="114763" y="61385" z="-4227" heading="57411" respawnTime="80sec"/>
-            <npc id="20590" x="116449" y="60759" z="-4232" heading="59165" respawnTime="80sec"/>
-            <npc id="20591" x="113569" y="61528" z="-4246" heading="5795" respawnTime="80sec"/>
-            <npc id="20591" x="112169" y="60805" z="-4272" heading="42198" respawnTime="80sec"/>
-            <npc id="20592" x="114033" y="61569" z="-4248" heading="32721" respawnTime="80sec"/>
-            <npc id="20592" x="113815" y="62617" z="-4536" heading="28258" respawnTime="80sec"/>
-            <npc id="20592" x="106418" y="56848" z="-4538" heading="14326" respawnTime="80sec"/>
-            <npc id="20593" x="106525" y="56322" z="-4628" heading="0" respawnTime="80sec"/>
-            <npc id="20592" x="110707" y="57619" z="-4571" heading="636" respawnTime="80sec"/>
-            <npc id="20592" x="111813" y="57788" z="-4578" heading="34549" respawnTime="80sec"/>
-            <npc id="20593" x="109880" y="57641" z="-4546" heading="32270" respawnTime="80sec"/>
             <npc id="20592" x="113160" y="56676" z="-4620" heading="0" respawnTime="80sec"/>
             <npc id="20593" x="113361" y="56676" z="-4620" heading="0" respawnTime="80sec"/>
-            <npc id="20592" x="109012" y="52232" z="-4804" heading="0" respawnTime="80sec"/>
             <npc id="20594" x="109415" y="52232" z="-4804" heading="0" respawnTime="80sec"/>
             <npc id="20595" x="109617" y="52232" z="-4804" heading="0" respawnTime="80sec"/>
             <npc id="20595" x="109717" y="52410" z="-4804" heading="0" respawnTime="80sec"/>
-            <npc id="20592" x="114792" y="53756" z="-4612" heading="0" respawnTime="80sec"/>
-            <npc id="20594" x="114893" y="54290" z="-4612" heading="0" respawnTime="80sec"/>
             <npc id="20592" x="115014" y="50448" z="-4696" heading="0" respawnTime="80sec"/>
             <npc id="20594" x="115215" y="50448" z="-4696" heading="0" respawnTime="80sec"/>
             <npc id="20592" x="118673" y="48995" z="-4583" heading="24322" respawnTime="80sec"/>
@@ -110,29 +65,8 @@
             <npc id="20593" x="122174" y="47464" z="-3717" heading="28263" respawnTime="80sec"/>
             <npc id="20590" x="126143" y="47601" z="-4635" heading="14671" respawnTime="80sec"/>
             <npc id="20592" x="125816" y="48029" z="-4635" heading="29069" respawnTime="80sec"/>
-            <npc id="20589" x="127277" y="50612" z="-4632" heading="8393" respawnTime="80sec"/>
-            <npc id="20590" x="127690" y="50865" z="-4635" heading="62688" respawnTime="80sec"/>
-            <npc id="20590" x="127121" y="52198" z="-4588" heading="26627" respawnTime="80sec"/>
-            <npc id="20591" x="128090" y="51885" z="-4616" heading="45237" respawnTime="80sec"/>
-            <npc id="20592" x="126646" y="51377" z="-4608" heading="21902" respawnTime="80sec"/>
             <npc id="20592" x="128071" y="50374" z="-4692" heading="0" respawnTime="80sec"/>
-            <npc id="20589" x="126881" y="51944" z="-4588" heading="1440" respawnTime="80sec"/>
-            <npc id="20589" x="125355" y="52028" z="-4700" heading="0" respawnTime="80sec"/>
-            <npc id="20590" x="125254" y="52206" z="-4700" heading="0" respawnTime="80sec"/>
-            <npc id="20590" x="126092" y="52005" z="-4569" heading="42053" respawnTime="80sec"/>
-            <npc id="20590" x="123519" y="52071" z="-4632" heading="32194" respawnTime="80sec"/>
             <npc id="20591" x="124952" y="51316" z="-4700" heading="0" respawnTime="80sec"/>
-            <npc id="20591" x="126479" y="53300" z="-4606" heading="5960" respawnTime="80sec"/>
-            <npc id="20591" x="124705" y="52022" z="-4580" heading="59572" respawnTime="80sec"/>
-            <npc id="20592" x="125209" y="53073" z="-4633" heading="10822" respawnTime="80sec"/>
-            <npc id="20592" x="126306" y="52462" z="-4575" heading="51361" respawnTime="80sec"/>
-            <npc id="20589" x="120154" y="52216" z="-4696" heading="0" respawnTime="80sec"/>
-            <npc id="20590" x="120154" y="52572" z="-4696" heading="0" respawnTime="80sec"/>
-            <npc id="20589" x="117734" y="54581" z="-4632" heading="13401" respawnTime="80sec"/>
-            <npc id="20590" x="117749" y="55308" z="-4632" heading="21958" respawnTime="80sec"/>
-            <npc id="20592" x="117918" y="55697" z="-4632" heading="46506" respawnTime="80sec"/>
-            <npc id="20589" x="118064" y="57984" z="-4577" heading="47881" respawnTime="80sec"/>
-            <npc id="20590" x="118163" y="59221" z="-4578" heading="14537" respawnTime="80sec"/>
             <npc id="20589" x="120617" y="55413" z="-4569" heading="64557" respawnTime="80sec"/>
             <npc id="20590" x="121415" y="55767" z="-4575" heading="36543" respawnTime="80sec"/>
             <npc id="20589" x="123246" y="57607" z="-4549" heading="50220" respawnTime="80sec"/>
@@ -210,32 +144,9 @@
             <npc id="20595" x="123139" y="37345" z="-3723" heading="56415" respawnTime="80sec"/>
             <npc id="20595" x="122871" y="37954" z="-3768" heading="53995" respawnTime="80sec"/>
             <npc id="20596" x="123889" y="37594" z="-3723" heading="3325" respawnTime="80sec"/>
-            <npc id="20596" x="105830" y="42537" z="-4600" heading="63069" respawnTime="80sec"/>
-            <npc id="20596" x="109229" y="44449" z="-3531" heading="3099" respawnTime="80sec"/>
             <npc id="20596" x="108713" y="43286" z="-3562" heading="17600" respawnTime="80sec"/>
-            <npc id="20596" x="108337" y="45959" z="-3586" heading="26798" respawnTime="80sec"/>
-            <npc id="20596" x="109230" y="46215" z="-3723" heading="6199" respawnTime="80sec"/>
-            <npc id="20596" x="104539" y="41992" z="-4634" heading="33043" respawnTime="80sec"/>
-            <npc id="20596" x="106192" y="44728" z="-3629" heading="46325" respawnTime="80sec"/>
-            <npc id="20597" x="110072" y="44265" z="-3723" heading="3151" respawnTime="80sec"/>
-            <npc id="20597" x="105219" y="40888" z="-4634" heading="57086" respawnTime="80sec"/>
-            <npc id="20597" x="107570" y="45071" z="-3723" heading="42957" respawnTime="80sec"/>
-            <npc id="20597" x="106214" y="41347" z="-4634" heading="2452" respawnTime="80sec"/>
-            <npc id="20597" x="108387" y="43837" z="-3680" heading="62046" respawnTime="80sec"/>
-            <npc id="20597" x="108035" y="44936" z="-3723" heading="9923" respawnTime="80sec"/>
-            <npc id="20598" x="107265" y="46999" z="-3723" heading="39199" respawnTime="80sec"/>
-            <npc id="20598" x="105529" y="43034" z="-3888" heading="0" respawnTime="80sec"/>
             <npc id="20598" x="106704" y="43394" z="-3814" heading="63455" respawnTime="80sec"/>
-            <npc id="20598" x="105546" y="45531" z="-3723" heading="32432" respawnTime="80sec"/>
-            <npc id="20598" x="106574" y="46182" z="-3617" heading="11000" respawnTime="80sec"/>
-            <npc id="20598" x="104401" y="43234" z="-4587" heading="25393" respawnTime="80sec"/>
-            <npc id="20599" x="108658" y="47020" z="-3723" heading="5726" respawnTime="80sec"/>
-            <npc id="20599" x="109781" y="45847" z="-3723" heading="59647" respawnTime="80sec"/>
-            <npc id="20599" x="107277" y="45451" z="-3721" heading="44462" respawnTime="80sec"/>
-            <npc id="20599" x="106718" y="44292" z="-3607" heading="41927" respawnTime="80sec"/>
             <npc id="20599" x="107522" y="43038" z="-3720" heading="63676" respawnTime="80sec"/>
-            <npc id="20599" x="110137" y="45202" z="-3723" heading="61299" respawnTime="80sec"/>
-            <npc id="20599" x="106002" y="43807" z="-3829" heading="47622" respawnTime="80sec"/>
             <npc id="20594" x="111135" y="41588" z="-4644" heading="63717" respawnTime="80sec"/>
             <npc id="20594" x="112593" y="43055" z="-3853" heading="30919" respawnTime="80sec"/>
             <npc id="20594" x="112960" y="41328" z="-4608" heading="27999" respawnTime="80sec"/>
@@ -291,7 +202,6 @@
             <npc id="20596" x="121238" y="42455" z="-4558" heading="6802" respawnTime="80sec"/>
             <npc id="20596" x="123909" y="43678" z="-3948" heading="0" respawnTime="80sec"/>
             <npc id="20596" x="121741" y="44054" z="-4409" heading="744" respawnTime="80sec"/>
-            <npc id="20596" x="122702" y="44746" z="-3948" heading="0" respawnTime="80sec"/>
             <npc id="20597" x="123912" y="44746" z="-3948" heading="0" respawnTime="80sec"/>
             <npc id="20597" x="120215" y="44032" z="-4106" heading="51488" respawnTime="80sec"/>
             <npc id="20597" x="122473" y="43198" z="-4532" heading="4086" respawnTime="80sec"/>
@@ -311,50 +221,21 @@
             <npc id="20597" x="121129" y="47747" z="-3942" heading="2043" respawnTime="80sec"/>
             <npc id="20594" x="103204" y="48553" z="-3614" heading="15826" respawnTime="80sec"/>
             <npc id="20594" x="103081" y="47781" z="-3683" heading="46750" respawnTime="80sec"/>
-            <npc id="20594" x="103585" y="49347" z="-3540" heading="11571" respawnTime="80sec"/>
-            <npc id="20594" x="103833" y="50080" z="-3540" heading="13829" respawnTime="80sec"/>
             <npc id="20594" x="104018" y="48100" z="-3649" heading="53988" respawnTime="80sec"/>
-            <npc id="20595" x="103422" y="48613" z="-3573" heading="8192" respawnTime="80sec"/>
             <npc id="20595" x="103412" y="52105" z="-3733" heading="19668" respawnTime="80sec"/>
             <npc id="20595" x="102960" y="48729" z="-3637" heading="13500" respawnTime="80sec"/>
-            <npc id="20595" x="103994" y="49286" z="-3540" heading="6947" respawnTime="80sec"/>
             <npc id="20596" x="103908" y="46876" z="-3996" heading="0" respawnTime="80sec"/>
             <npc id="20596" x="103356" y="47881" z="-3671" heading="47523" respawnTime="80sec"/>
             <npc id="20596" x="102443" y="47266" z="-3656" heading="14553" respawnTime="80sec"/>
             <npc id="20596" x="102239" y="46379" z="-3738" heading="46178" respawnTime="80sec"/>
             <npc id="20596" x="103803" y="50752" z="-3546" heading="17860" respawnTime="80sec"/>
-            <npc id="20595" x="105042" y="55963" z="-3716" heading="44338" respawnTime="80sec"/>
-            <npc id="20595" x="105587" y="57618" z="-3738" heading="18561" respawnTime="80sec"/>
-            <npc id="20596" x="104893" y="56771" z="-3642" heading="5876" respawnTime="80sec"/>
-            <npc id="20597" x="104514" y="56304" z="-3828" heading="0" respawnTime="80sec"/>
-            <npc id="20597" x="104615" y="56126" z="-3828" heading="0" respawnTime="80sec"/>
-            <npc id="20595" x="107078" y="58684" z="-3820" heading="0" respawnTime="80sec"/>
-            <npc id="20595" x="106992" y="59265" z="-3358" heading="10310" respawnTime="80sec"/>
-            <npc id="20595" x="107279" y="58684" z="-3820" heading="0" respawnTime="80sec"/>
-            <npc id="20596" x="107311" y="57771" z="-4578" heading="34556" respawnTime="80sec"/>
-            <npc id="20596" x="108221" y="59510" z="-3682" heading="29302" respawnTime="80sec"/>
-            <npc id="20597" x="108802" y="58018" z="-4567" heading="31300" respawnTime="80sec"/>
-            <npc id="20597" x="106790" y="57538" z="-4541" heading="39625" respawnTime="80sec"/>
-            <npc id="20597" x="109182" y="59558" z="-3722" heading="32768" respawnTime="80sec"/>
-            <npc id="20595" x="107806" y="54052" z="-4008" heading="0" respawnTime="80sec"/>
-            <npc id="20595" x="107705" y="54230" z="-4008" heading="0" respawnTime="80sec"/>
-            <npc id="20595" x="108309" y="54230" z="-4008" heading="0" respawnTime="80sec"/>
-            <npc id="20596" x="108108" y="54230" z="-4008" heading="0" respawnTime="80sec"/>
-            <npc id="20596" x="105154" y="53408" z="-4633" heading="39194" respawnTime="80sec"/>
-            <npc id="20596" x="111499" y="56084" z="-3723" heading="10168" respawnTime="80sec"/>
-            <npc id="20597" x="107806" y="54408" z="-4008" heading="0" respawnTime="80sec"/>
-            <npc id="20597" x="108007" y="54052" z="-4008" heading="0" respawnTime="80sec"/>
-            <npc id="20597" x="109556" y="54589" z="-3544" heading="28964" respawnTime="80sec"/>
             <npc id="20595" x="110472" y="52956" z="-3784" heading="0" respawnTime="80sec"/>
             <npc id="20595" x="110976" y="53490" z="-3784" heading="0" respawnTime="80sec"/>
             <npc id="20595" x="109967" y="53846" z="-3784" heading="0" respawnTime="80sec"/>
-            <npc id="20595" x="112817" y="55472" z="-3722" heading="57407" respawnTime="80sec"/>
             <npc id="20596" x="110875" y="52956" z="-3784" heading="0" respawnTime="80sec"/>
             <npc id="20596" x="111177" y="53134" z="-3784" heading="0" respawnTime="80sec"/>
             <npc id="20596" x="112220" y="53732" z="-3723" heading="30651" respawnTime="80sec"/>
             <npc id="20596" x="110890" y="53730" z="-3723" heading="41061" respawnTime="80sec"/>
-            <npc id="20597" x="112105" y="54202" z="-3716" heading="59501" respawnTime="80sec"/>
-            <npc id="20597" x="110543" y="55003" z="-3720" heading="56672" respawnTime="80sec"/>
             <npc id="20597" x="111478" y="52956" z="-3784" heading="0" respawnTime="80sec"/>
             <npc id="20597" x="110875" y="53312" z="-3784" heading="0" respawnTime="80sec"/>
             <npc id="20595" x="114080" y="51816" z="-3912" heading="0" respawnTime="80sec"/>
@@ -363,22 +244,15 @@
             <npc id="20597" x="113839" y="53121" z="-3724" heading="54317" respawnTime="80sec"/>
             <npc id="20597" x="114684" y="52172" z="-3912" heading="0" respawnTime="80sec"/>
             <npc id="20595" x="112960" y="58568" z="-3936" heading="0" respawnTime="80sec"/>
-            <npc id="20595" x="114661" y="59948" z="-3718" heading="4132" respawnTime="80sec"/>
             <npc id="20596" x="112842" y="58961" z="-3557" heading="31262" respawnTime="80sec"/>
             <npc id="20597" x="113475" y="59328" z="-3725" heading="34766" respawnTime="80sec"/>
             <npc id="20597" x="115112" y="58833" z="-3723" heading="24642" respawnTime="80sec"/>
             <npc id="20595" x="116379" y="55230" z="-3723" heading="46716" respawnTime="80sec"/>
-            <npc id="20595" x="116764" y="57779" z="-3716" heading="14953" respawnTime="80sec"/>
-            <npc id="20595" x="116200" y="56088" z="-3592" heading="44295" respawnTime="80sec"/>
             <npc id="20595" x="115615" y="55424" z="-3710" heading="41872" respawnTime="80sec"/>
             <npc id="20596" x="115329" y="57836" z="-3723" heading="20915" respawnTime="80sec"/>
-            <npc id="20596" x="116947" y="55540" z="-3796" heading="0" respawnTime="80sec"/>
-            <npc id="20596" x="116547" y="56302" z="-3721" heading="16019" respawnTime="80sec"/>
             <npc id="20596" x="116581" y="54456" z="-3633" heading="25011" respawnTime="80sec"/>
             <npc id="20597" x="116135" y="55278" z="-3717" heading="27621" respawnTime="80sec"/>
-            <npc id="20597" x="116633" y="58783" z="-3704" heading="12418" respawnTime="80sec"/>
             <npc id="20597" x="115505" y="57224" z="-3723" heading="21969" respawnTime="80sec"/>
-            <npc id="20597" x="116214" y="56681" z="-3580" heading="46523" respawnTime="80sec"/>
             <npc id="20595" x="119528" y="50254" z="-3563" heading="52124" respawnTime="80sec"/>
             <npc id="20595" x="120140" y="50303" z="-3712" heading="42208" respawnTime="80sec"/>
             <npc id="20595" x="120619" y="51165" z="-3662" heading="10786" respawnTime="80sec"/>
@@ -397,21 +271,11 @@
             <npc id="20597" x="121590" y="49208" z="-4579" heading="29759" respawnTime="80sec"/>
             <npc id="20597" x="120584" y="48802" z="-4578" heading="35590" respawnTime="80sec"/>
             <npc id="20597" x="123933" y="49426" z="-3816" heading="0" respawnTime="80sec"/>
-            <npc id="20592" x="118948" y="52720" z="-3900" heading="0" respawnTime="80sec"/>
-            <npc id="20593" x="119049" y="52898" z="-3900" heading="0" respawnTime="80sec"/>
-            <npc id="20593" x="118646" y="53254" z="-3900" heading="0" respawnTime="80sec"/>
-            <npc id="20594" x="119551" y="52720" z="-3900" heading="0" respawnTime="80sec"/>
-            <npc id="20592" x="122702" y="53224" z="-3940" heading="0" respawnTime="80sec"/>
             <npc id="20592" x="122067" y="54711" z="-3723" heading="32167" respawnTime="80sec"/>
-            <npc id="20592" x="123507" y="53580" z="-3940" heading="0" respawnTime="80sec"/>
             <npc id="20593" x="124423" y="56432" z="-3712" heading="0" respawnTime="80sec"/>
-            <npc id="20593" x="123608" y="53402" z="-3940" heading="0" respawnTime="80sec"/>
             <npc id="20593" x="123002" y="55391" z="-3721" heading="41021" respawnTime="80sec"/>
             <npc id="20594" x="124472" y="57406" z="-3467" heading="12653" respawnTime="80sec"/>
-            <npc id="20594" x="124063" y="53961" z="-3900" heading="62111" respawnTime="80sec"/>
-            <npc id="20594" x="123176" y="54039" z="-3750" heading="39805" respawnTime="80sec"/>
             <npc id="20592" x="123750" y="55867" z="-3717" heading="5995" respawnTime="80sec"/>
-            <npc id="20592" x="126459" y="53996" z="-4604" heading="61567" respawnTime="80sec"/>
             <npc id="20592" x="124373" y="54785" z="-3723" heading="4721" respawnTime="80sec"/>
             <npc id="20592" x="126138" y="55708" z="-3703" heading="9318" respawnTime="80sec"/>
             <npc id="20593" x="122937" y="54434" z="-3722" heading="58347" respawnTime="80sec"/>
@@ -419,7 +283,6 @@
             <npc id="20593" x="125533" y="56083" z="-3594" heading="62490" respawnTime="80sec"/>
             <npc id="20594" x="126012" y="55075" z="-3722" heading="50937" respawnTime="80sec"/>
             <npc id="20594" x="124005" y="55335" z="-3426" heading="34508" respawnTime="80sec"/>
-            <npc id="20594" x="124768" y="54135" z="-4091" heading="1447" respawnTime="80sec"/>
             <npc id="20600" x="103632" y="79440" z="-2748" heading="0" respawnTime="25sec"/>
             <npc id="20600" x="104281" y="80375" z="-2483" heading="29974" respawnTime="25sec"/>
             <npc id="20601" x="103833" y="79440" z="-2748" heading="0" respawnTime="25sec"/>
@@ -555,7 +418,6 @@
             <npc id="20600" x="125942" y="79668" z="-2948" heading="0" respawnTime="25sec"/>
             <npc id="20600" x="126020" y="80566" z="-2252" heading="16448" respawnTime="25sec"/>
             <npc id="20601" x="125539" y="79668" z="-2948" heading="0" respawnTime="25sec"/>
-            <npc id="20601" x="126646" y="78082" z="-2077" heading="57419" respawnTime="25sec"/>
             <npc id="20601" x="126036" y="79046" z="-2213" heading="39226" respawnTime="25sec"/>
             <npc id="20602" x="125536" y="78972" z="-2348" heading="62224" respawnTime="25sec"/>
             <npc id="20602" x="126747" y="78956" z="-2948" heading="0" respawnTime="25sec"/>
@@ -2946,18 +2808,6 @@
 <npc id="20681" x="135272" y="26968" z="-3577" heading="0" respawnTime="12sec"/>
 <npc id="20684" x="134424" y="26568" z="-3751" heading="0" respawnTime="12sec"/>
 <npc id="20684" x="133800" y="26600" z="-3808" heading="0" respawnTime="12sec"/>
-
-
-
-
-
-
-
-
-
-
-
-
         </group>
     </spawn>
 </list>

--- a/data/spawns/Dion/ExecutionGrounds.xml
+++ b/data/spawns/Dion/ExecutionGrounds.xml
@@ -2,248 +2,1340 @@
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../xsd/spawns.xsd">
     <spawn name="ExecutionGrounds">
         <group>
-            <npc id="30631" x="44694" y="146500" z="-3682" heading="12288" respawnTime="60sec"/>
-            <npc id="30632" x="45411" y="149100" z="-3681" heading="42000" respawnTime="60sec"/>
-            <npc id="20223" x="37458" y="144529" z="-3861" heading="0" respawnTime="19sec"/>
-            <npc id="20223" x="37600" y="146225" z="-3676" heading="20506" respawnTime="19sec"/>
-            <npc id="20154" x="38123" y="145110" z="-3680" heading="4036" respawnTime="19sec"/>
-            <npc id="20154" x="38379" y="144506" z="-3706" heading="22568" respawnTime="19sec"/>
-            <npc id="20154" x="38729" y="144975" z="-3686" heading="17514" respawnTime="19sec"/>
-            <npc id="20154" x="38162" y="144351" z="-3861" heading="0" respawnTime="19sec"/>
-            <npc id="20223" x="36941" y="147326" z="-3655" heading="56531" respawnTime="19sec"/>
-            <npc id="20223" x="36963" y="148511" z="-3894" heading="0" respawnTime="19sec"/>
-            <npc id="20154" x="34595" y="148088" z="-3510" heading="16167" respawnTime="19sec"/>
-            <npc id="20154" x="37165" y="148511" z="-3894" heading="0" respawnTime="19sec"/>
-            <npc id="20154" x="36631" y="148269" z="-3671" heading="18571" respawnTime="19sec"/>
-            <npc id="20154" x="37625" y="150552" z="-3652" heading="9363" respawnTime="19sec"/>
-            <npc id="20155" x="39691" y="146658" z="-3891" heading="13841" respawnTime="19sec"/>
-            <npc id="20155" x="39326" y="146479" z="-3891" heading="26023" respawnTime="19sec"/>
-            <npc id="20156" x="39173" y="146806" z="-3891" heading="30097" respawnTime="19sec"/>
-            <npc id="20156" x="40152" y="146078" z="-3891" heading="59623" respawnTime="19sec"/>
-            <npc id="20156" x="40102" y="146561" z="-3891" heading="39879" respawnTime="19sec"/>
-            <npc id="20155" x="37958" y="148647" z="-3960" heading="0" respawnTime="19sec"/>
-            <npc id="20155" x="38844" y="149646" z="-3893" heading="65044" respawnTime="19sec"/>
-            <npc id="20155" x="38260" y="148469" z="-3960" heading="0" respawnTime="19sec"/>
-            <npc id="20156" x="38361" y="148647" z="-3960" heading="0" respawnTime="19sec"/>
-            <npc id="20156" x="39863" y="149636" z="-3898" heading="64737" respawnTime="19sec"/>
-            <npc id="20201" x="43416" y="145641" z="-3926" heading="0" respawnTime="19sec"/>
-            <npc id="20201" x="46724" y="148851" z="-3665" heading="7062" respawnTime="19sec"/>
-            <npc id="20201" x="43316" y="146531" z="-3926" heading="0" respawnTime="19sec"/>
-            <npc id="20201" x="44163" y="146696" z="-3629" heading="35959" respawnTime="19sec"/>
-            <npc id="20201" x="44563" y="149576" z="-3540" heading="10297" respawnTime="19sec"/>
-            <npc id="20083" x="43416" y="146709" z="-3926" heading="0" respawnTime="19sec"/>
-            <npc id="20083" x="43920" y="146531" z="-3926" heading="0" respawnTime="19sec"/>
-            <npc id="20083" x="45672" y="147745" z="-3681" heading="60783" respawnTime="19sec"/>
-            <npc id="20083" x="44997" y="149239" z="-3602" heading="14498" respawnTime="19sec"/>
-            <npc id="20083" x="45882" y="148441" z="-3658" heading="63147" respawnTime="19sec"/>
-            <npc id="20202" x="43215" y="146709" z="-3926" heading="0" respawnTime="19sec"/>
-            <npc id="20202" x="44646" y="148168" z="-3694" heading="53547" respawnTime="19sec"/>
-            <npc id="20202" x="43416" y="145997" z="-3926" heading="0" respawnTime="19sec"/>
-            <npc id="20202" x="45256" y="148229" z="-3685" heading="8341" respawnTime="19sec"/>
-            <npc id="20202" x="44021" y="146709" z="-3926" heading="0" respawnTime="19sec"/>
-            <npc id="20160" x="43490" y="140341" z="-3383" heading="0" respawnTime="19sec"/>
-            <npc id="20160" x="43795" y="142157" z="-3272" heading="57494" respawnTime="19sec"/>
-            <npc id="20160" x="42687" y="143472" z="-3257" heading="27544" respawnTime="19sec"/>
-            <npc id="20160" x="46881" y="140695" z="-3277" heading="63268" respawnTime="19sec"/>
-            <npc id="20198" x="44999" y="139807" z="-3383" heading="0" respawnTime="19sec"/>
-            <npc id="20198" x="48589" y="141767" z="-3275" heading="63967" respawnTime="19sec"/>
-            <npc id="20198" x="43993" y="140163" z="-3383" heading="0" respawnTime="19sec"/>
-            <npc id="20198" x="45229" y="141343" z="-3311" heading="55644" respawnTime="19sec"/>
-            <npc id="20199" x="42602" y="143827" z="-3251" heading="26703" respawnTime="19sec"/>
-            <npc id="20199" x="44982" y="143761" z="-3263" heading="26700" respawnTime="19sec"/>
-            <npc id="20199" x="45952" y="142896" z="-3256" heading="63401" respawnTime="19sec"/>
-            <npc id="20199" x="43667" y="142185" z="-3281" heading="53469" respawnTime="19sec"/>
-            <npc id="20199" x="42799" y="142857" z="-3276" heading="28623" respawnTime="19sec"/>
-            <npc id="20199" x="43624" y="143483" z="-3264" heading="57846" respawnTime="19sec"/>
-            <npc id="20200" x="46564" y="142417" z="-3278" heading="13146" respawnTime="19sec"/>
-            <npc id="20200" x="47800" y="142238" z="-3272" heading="61958" respawnTime="19sec"/>
-            <npc id="20200" x="43252" y="142895" z="-3276" heading="56571" respawnTime="19sec"/>
-            <npc id="20200" x="45000" y="142187" z="-3303" heading="23045" respawnTime="19sec"/>
-            <npc id="20200" x="43291" y="144318" z="-3237" heading="22201" respawnTime="19sec"/>
-            <npc id="20200" x="43703" y="143040" z="-3267" heading="59046" respawnTime="19sec"/>
-            <npc id="20083" x="46644" y="142988" z="-3838" heading="0" respawnTime="19sec"/>
-            <npc id="20083" x="46644" y="143344" z="-3838" heading="0" respawnTime="19sec"/>
-            <npc id="20083" x="47348" y="142810" z="-3838" heading="0" respawnTime="19sec"/>
-            <npc id="20083" x="49663" y="143996" z="-3676" heading="64605" respawnTime="19sec"/>
-            <npc id="20202" x="47959" y="143589" z="-3702" heading="27143" respawnTime="19sec"/>
-            <npc id="20202" x="47349" y="143522" z="-3838" heading="0" respawnTime="19sec"/>
-            <npc id="20202" x="47187" y="144488" z="-3685" heading="17784" respawnTime="19sec"/>
-            <npc id="20202" x="46139" y="143878" z="-3838" heading="0" respawnTime="19sec"/>
-            <npc id="20144" x="47247" y="142988" z="-3838" heading="0" respawnTime="19sec"/>
-            <npc id="20144" x="45938" y="143522" z="-3838" heading="0" respawnTime="19sec"/>
-            <npc id="20144" x="46241" y="143344" z="-3838" heading="0" respawnTime="19sec"/>
-            <npc id="20144" x="47469" y="146246" z="-3591" heading="11665" respawnTime="19sec"/>
-            <npc id="20144" x="47780" y="143469" z="-3756" heading="56547" respawnTime="19sec"/>
-            <npc id="20144" x="46644" y="143700" z="-3838" heading="0" respawnTime="19sec"/>
-            <npc id="20201" x="46625" y="145300" z="-3685" heading="62692" respawnTime="19sec"/>
-            <npc id="20201" x="47054" y="146669" z="-3838" heading="0" respawnTime="19sec"/>
-            <npc id="20083" x="47485" y="144662" z="-3685" heading="52862" respawnTime="19sec"/>
-            <npc id="20083" x="48001" y="144920" z="-3612" heading="59377" respawnTime="19sec"/>
-            <npc id="20202" x="47932" y="147800" z="-3485" heading="59493" respawnTime="19sec"/>
-            <npc id="20202" x="45746" y="146847" z="-3838" heading="0" respawnTime="19sec"/>
-            <npc id="20201" x="47919" y="145592" z="-3838" heading="0" respawnTime="19sec"/>
-            <npc id="20201" x="48120" y="145592" z="-3838" heading="0" respawnTime="19sec"/>
-            <npc id="20201" x="48423" y="146126" z="-3838" heading="0" respawnTime="19sec"/>
-            <npc id="20202" x="48522" y="145236" z="-3838" heading="0" respawnTime="19sec"/>
-            <npc id="20202" x="46174" y="145855" z="-3685" heading="30333" respawnTime="19sec"/>
-            <npc id="20202" x="49476" y="146727" z="-3464" heading="31210" respawnTime="19sec"/>
-            <npc id="20144" x="49734" y="146464" z="-3545" heading="33433" respawnTime="19sec"/>
-            <npc id="20144" x="49348" y="145168" z="-3628" heading="46679" respawnTime="19sec"/>
-            <npc id="20144" x="48422" y="145414" z="-3838" heading="0" respawnTime="19sec"/>
-            <npc id="20199" x="43142" y="152332" z="-2950" heading="0" respawnTime="19sec"/>
-            <npc id="20200" x="44320" y="154423" z="-2862" heading="18502" respawnTime="19sec"/>
-            <npc id="20200" x="45574" y="153870" z="-2717" heading="3411" respawnTime="19sec"/>
-            <npc id="20202" x="43444" y="152154" z="-2950" heading="0" respawnTime="19sec"/>
-            <npc id="20202" x="44151" y="152890" z="-2860" heading="63089" respawnTime="19sec"/>
-            <npc id="20202" x="46480" y="153573" z="-2720" heading="2300" respawnTime="19sec"/>
-            <npc id="20160" x="47085" y="150431" z="-2946" heading="0" respawnTime="19sec"/>
-            <npc id="20160" x="48940" y="152415" z="-2832" heading="45211" respawnTime="19sec"/>
-            <npc id="20160" x="47488" y="150787" z="-2946" heading="0" respawnTime="19sec"/>
-            <npc id="20160" x="49400" y="153448" z="-2842" heading="3244" respawnTime="19sec"/>
-            <npc id="20160" x="47098" y="151503" z="-2779" heading="38901" respawnTime="19sec"/>
-            <npc id="20160" x="46782" y="150965" z="-2946" heading="0" respawnTime="19sec"/>
-            <npc id="20160" x="47186" y="150609" z="-2946" heading="0" respawnTime="19sec"/>
-            <npc id="20198" x="44687" y="152232" z="-2826" heading="28495" respawnTime="19sec"/>
-            <npc id="20198" x="48200" y="153203" z="-2725" heading="40433" respawnTime="19sec"/>
-            <npc id="20198" x="45866" y="152233" z="-2803" heading="46206" respawnTime="19sec"/>
-            <npc id="20198" x="48955" y="154068" z="-2775" heading="50087" respawnTime="19sec"/>
-            <npc id="20198" x="48053" y="154211" z="-2730" heading="6147" respawnTime="19sec"/>
-            <npc id="20198" x="48305" y="151649" z="-2770" heading="9968" respawnTime="19sec"/>
-            <npc id="20198" x="47434" y="151299" z="-2806" heading="31847" respawnTime="19sec"/>
-            <npc id="20200" x="48699" y="149670" z="-3594" heading="17036" respawnTime="19sec"/>
-            <npc id="20200" x="49451" y="150732" z="-3570" heading="9773" respawnTime="19sec"/>
-            <npc id="20202" x="49994" y="151444" z="-3549" heading="11878" respawnTime="19sec"/>
-            <npc id="20200" x="50809" y="152895" z="-3544" heading="44613" respawnTime="19sec"/>
-            <npc id="20200" x="51247" y="152610" z="-3636" heading="0" respawnTime="19sec"/>
-            <npc id="20202" x="51347" y="152432" z="-3636" heading="0" respawnTime="19sec"/>
-            <npc id="20202" x="51548" y="152432" z="-3636" heading="0" respawnTime="19sec"/>
-            <npc id="20171" x="51908" y="147614" z="-2582" heading="0" respawnTime="19sec"/>
-            <npc id="20171" x="51909" y="148326" z="-2582" heading="0" respawnTime="19sec"/>
-            <npc id="20171" x="52009" y="148504" z="-2582" heading="0" respawnTime="19sec"/>
-            <npc id="20171" x="53525" y="150034" z="-2483" heading="49499" respawnTime="19sec"/>
-            <npc id="20171" x="54679" y="151916" z="-2458" heading="13411" respawnTime="19sec"/>
-            <npc id="20197" x="51706" y="148326" z="-2582" heading="0" respawnTime="19sec"/>
-            <npc id="20197" x="51840" y="152567" z="-2419" heading="16024" respawnTime="19sec"/>
-            <npc id="20197" x="53825" y="148826" z="-2472" heading="43137" respawnTime="19sec"/>
-            <npc id="20197" x="52249" y="149257" z="-2419" heading="24077" respawnTime="19sec"/>
-            <npc id="20160" x="53721" y="150900" z="-2476" heading="35250" respawnTime="19sec"/>
-            <npc id="20160" x="51863" y="150383" z="-2429" heading="47248" respawnTime="19sec"/>
-            <npc id="20160" x="54773" y="150909" z="-2411" heading="8746" respawnTime="19sec"/>
-            <npc id="20160" x="52190" y="151615" z="-2429" heading="32359" respawnTime="19sec"/>
-            <npc id="20160" x="53328" y="152779" z="-2375" heading="15445" respawnTime="19sec"/>
-            <npc id="20160" x="52009" y="147792" z="-2582" heading="0" respawnTime="19sec"/>
-            <npc id="20171" x="51556" y="144861" z="-2873" heading="23367" respawnTime="19sec"/>
-            <npc id="20171" x="53485" y="147017" z="-2883" heading="11304" respawnTime="19sec"/>
-            <npc id="20171" x="54092" y="146609" z="-2924" heading="3203" respawnTime="19sec"/>
-            <npc id="20171" x="52176" y="145746" z="-2888" heading="16402" respawnTime="19sec"/>
-            <npc id="20197" x="52252" y="144920" z="-2963" heading="966" respawnTime="19sec"/>
-            <npc id="20197" x="51475" y="143802" z="-2912" heading="24516" respawnTime="19sec"/>
-            <npc id="20197" x="54920" y="146298" z="-2974" heading="502" respawnTime="19sec"/>
-            <npc id="20197" x="52043" y="146554" z="-2872" heading="31320" respawnTime="19sec"/>
-            <npc id="20197" x="53461" y="146306" z="-2920" heading="55553" respawnTime="19sec"/>
-            <npc id="20171" x="55556" y="142398" z="-2974" heading="5348" respawnTime="19sec"/>
-            <npc id="20171" x="55757" y="147543" z="-2930" heading="17443" respawnTime="19sec"/>
-            <npc id="20171" x="55503" y="143311" z="-3024" heading="27557" respawnTime="19sec"/>
-            <npc id="20197" x="56033" y="143042" z="-2979" heading="3492" respawnTime="19sec"/>
-            <npc id="20197" x="56372" y="143960" z="-3076" heading="52068" respawnTime="19sec"/>
-            <npc id="20156" x="54688" y="139959" z="-2695" heading="48533" respawnTime="19sec"/>
-            <npc id="20156" x="55435" y="141168" z="-2820" heading="7687" respawnTime="19sec"/>
-            <npc id="20171" x="53936" y="141367" z="-2890" heading="39616" respawnTime="19sec"/>
-            <npc id="20171" x="54862" y="142033" z="-2973" heading="35633" respawnTime="19sec"/>
-            <npc id="20156" x="52081" y="140482" z="-3220" heading="0" respawnTime="19sec"/>
-            <npc id="20156" x="52887" y="140126" z="-3220" heading="0" respawnTime="19sec"/>
-            <npc id="20171" x="52383" y="140304" z="-3220" heading="0" respawnTime="19sec"/>
-            <npc id="20171" x="52484" y="140126" z="-3220" heading="0" respawnTime="19sec"/>
-            <npc id="20171" x="52182" y="140660" z="-3220" heading="0" respawnTime="19sec"/>
-            <npc id="20171" x="54862" y="140839" z="-2841" heading="47925" respawnTime="19sec"/>
-            <npc id="20171" x="53600" y="141786" z="-2992" heading="42576" respawnTime="19sec"/>
-            <npc id="20171" x="55640" y="141149" z="-2789" heading="58792" respawnTime="19sec"/>
-            <npc id="20197" x="52235" y="141887" z="-2942" heading="1723" respawnTime="19sec"/>
-            <npc id="20197" x="52066" y="143214" z="-3064" heading="15441" respawnTime="19sec"/>
-            <npc id="20200" x="44150" y="147167" z="-3583" heading="30156" respawnTime="19sec"/>
-            <npc id="20200" x="46420" y="147273" z="-3688" heading="54729" respawnTime="19sec"/>
-            <npc id="20201" x="43079" y="148808" z="-3674" heading="7490" respawnTime="19sec"/>
-            <npc id="20201" x="43595" y="149242" z="-3834" heading="0" respawnTime="19sec"/>
-            <npc id="20201" x="45536" y="146710" z="-3681" heading="38683" respawnTime="19sec"/>
-            <npc id="20201" x="46529" y="144937" z="-3805" heading="0" respawnTime="19sec"/>
-            <npc id="20144" x="48135" y="147090" z="-3444" heading="14646" respawnTime="19sec"/>
-            <npc id="20202" x="48861" y="143887" z="-3802" heading="0" respawnTime="19sec"/>
-            <npc id="20202" x="48458" y="144243" z="-3802" heading="0" respawnTime="19sec"/>
-            <npc id="20144" x="48760" y="144421" z="-3802" heading="0" respawnTime="19sec"/>
-            <npc id="20144" x="45494" y="144914" z="-3628" heading="24608" respawnTime="19sec"/>
-            <npc id="20200" x="43026" y="147521" z="-3686" heading="34042" respawnTime="19sec"/>
-            <npc id="20200" x="48484" y="148397" z="-3523" heading="47450" respawnTime="19sec"/>
-            <npc id="20200" x="46372" y="147813" z="-3831" heading="0" respawnTime="19sec"/>
-            <npc id="20144" x="48973" y="149998" z="-3571" heading="11725" respawnTime="19sec"/>
-            <npc id="20144" x="49615" y="147896" z="-3482" heading="56513" respawnTime="19sec"/>
-            <npc id="20144" x="50696" y="146472" z="-3621" heading="56321" respawnTime="19sec"/>
-            <npc id="20144" x="46649" y="152235" z="-2737" heading="51978" respawnTime="19sec"/>
-            <npc id="20144" x="43975" y="153895" z="-2823" heading="27202" respawnTime="19sec"/>
-            <npc id="20144" x="45204" y="153465" z="-2735" heading="27170" respawnTime="19sec"/>
-            <npc id="20202" x="45713" y="153196" z="-2723" heading="56771" respawnTime="19sec"/>
-            <npc id="20202" x="47558" y="152151" z="-2786" heading="36952" respawnTime="19sec"/>
-            <npc id="20201" x="47317" y="153280" z="-2780" heading="57288" respawnTime="19sec"/>
-            <npc id="20201" x="49339" y="154537" z="-2805" heading="2952" respawnTime="19sec"/>
-            <npc id="20198" x="46623" y="154108" z="-2721" heading="35526" respawnTime="19sec"/>
-            <npc id="20198" x="47358" y="154601" z="-2730" heading="14563" respawnTime="19sec"/>
-            <npc id="20144" x="43115" y="141996" z="-3382" heading="0" respawnTime="19sec"/>
-            <npc id="20144" x="42680" y="144321" z="-3231" heading="32928" respawnTime="19sec"/>
-            <npc id="20202" x="47547" y="141059" z="-3270" heading="30269" respawnTime="19sec"/>
-            <npc id="20202" x="45110" y="141660" z="-3307" heading="35323" respawnTime="19sec"/>
-            <npc id="20200" x="45585" y="142121" z="-3304" heading="25788" respawnTime="19sec"/>
-            <npc id="20200" x="46305" y="141584" z="-3271" heading="15824" respawnTime="19sec"/>
-            <npc id="20200" x="54320" y="152870" z="-2416" heading="9867" respawnTime="19sec"/>
-            <npc id="20200" x="51962" y="149200" z="-2584" heading="0" respawnTime="19sec"/>
-            <npc id="20200" x="51308" y="150398" z="-2419" heading="39814" respawnTime="19sec"/>
-            <npc id="20198" x="52754" y="150128" z="-2584" heading="0" respawnTime="19sec"/>
-            <npc id="20198" x="54367" y="149530" z="-2508" heading="19771" respawnTime="19sec"/>
-			<npc id="20202" x="52289" y="140115" z="-2594" heading="0" respawnTime="19sec"/>
-			<npc id="20202" x="52041" y="140397" z="-2593" heading="0" respawnTime="19sec"/>
-			<npc id="20202" x="51747" y="140399" z="-2593" heading="0" respawnTime="19sec"/>
-			<npc id="20202" x="51292" y="140280" z="-2593" heading="35323" respawnTime="19sec"/>
-			<npc id="20200" x="46821" y="142121" z="-3118" heading="0" respawnTime="19sec"/>
-			<npc id="20200" x="47135" y="141039" z="-3122" heading="0" respawnTime="19sec"/>
-			<npc id="20200" x="48123" y="141041" z="-3118" heading="0" respawnTime="19sec"/>
-			<npc id="20200" x="47834" y="142095" z="-3120" heading="0" respawnTime="19sec"/>
-			<npc id="20200" x="43599" y="141066" z="-3084" heading="0" respawnTime="19sec"/>
-			<npc id="20200" x="42311" y="140664" z="-3098" heading="0" respawnTime="19sec"/>
-			<npc id="20200" x="42016" y="143172" z="-3033" heading="0" respawnTime="19sec"/>
-			<npc id="20200" x="51381" y="139946" z="-2575" heading="0" respawnTime="19sec"/>
-			<npc id="20200" x="52188" y="139666" z="-2593" heading="0" respawnTime="19sec"/>
-			<npc id="20200" x="51853" y="139897" z="-2576" heading="0" respawnTime="19sec"/>
-			<npc id="20200" x="51859" y="140376" z="-2593" heading="0" respawnTime="19sec"/>
-			<npc id="20200" x="51469" y="140443" z="-2594" heading="0" respawnTime="19sec"/>
-			<npc id="20200" x="51189" y="140168" z="-2593" heading="0" respawnTime="19sec"/>
-			<npc id="20160" x="42365" y="141127" z="-3067" heading="0" respawnTime="19sec"/>
-			<npc id="20160" x="41924" y="140928" z="-3035" heading="0" respawnTime="19sec"/>
-			<npc id="20160" x="43121" y="141388" z="-3091" heading="0" respawnTime="19sec"/>
-            <npc id="20160" x="55211" y="146801" z="-2947" heading="3929" respawnTime="19sec"/>
-            <npc id="20160" x="53105" y="145700" z="-2983" heading="38359" respawnTime="19sec"/>
-            <npc id="20197" x="52599" y="140953" z="-3185" heading="0" respawnTime="19sec"/>
-            <npc id="20197" x="53202" y="140953" z="-3185" heading="0" respawnTime="19sec"/>
-			<npc id="20198" x="51376" y="139988" z="-2576" heading="0" respawnTime="19sec"/>
-			<npc id="20198" x="51467" y="139719" z="-2576" heading="0" respawnTime="19sec"/>
-			<npc id="20198" x="52108" y="140247" z="-2593" heading="0" respawnTime="19sec"/>
-			<npc id="20202" x="51128" y="140018" z="-2593" heading="35323" respawnTime="19sec"/>
-			<npc id="20202" x="51288" y="139713" z="-2578" heading="35323" respawnTime="19sec"/>
-			<npc id="20202" x="51671" y="139622" z="-2576" heading="35323" respawnTime="19sec"/>
-			<npc id="20202" x="51785" y="139846" z="-2576" heading="35323" respawnTime="19sec"/>
-            <npc id="27099" x="58003" y="141934" z="-2088" heading="51707" respawnTime="60sec"/>
-            <npc id="27099" x="56527" y="142222" z="-2574" heading="37199" respawnTime="60sec"/>
-            <npc id="27099" x="56713" y="141936" z="-2478" heading="37345" respawnTime="60sec"/>
-            <npc id="27099" x="57085" y="142244" z="-2401" heading="27505" respawnTime="60sec"/>
-            <npc id="27099" x="57981" y="143790" z="-2681" heading="6212" respawnTime="60sec"/>
-            <npc id="27099" x="57050" y="143335" z="-2746" heading="7193" respawnTime="60sec"/>
-            <npc id="27099" x="56893" y="141692" z="-2430" heading="44616" respawnTime="60sec"/>
-            <npc id="27099" x="57732" y="142739" z="-2391" heading="5555" respawnTime="60sec"/>
-            <npc id="27099" x="53213" y="142949" z="-3907" heading="0" respawnTime="60sec"/>
-            <npc id="27099" x="53716" y="143127" z="-3907" heading="0" respawnTime="60sec"/>
-            <npc id="27099" x="53817" y="143305" z="-3907" heading="0" respawnTime="60sec"/>
-            <npc id="27099" x="53817" y="142949" z="-3907" heading="0" respawnTime="60sec"/>
-            <npc id="27099" x="54320" y="143483" z="-3907" heading="0" respawnTime="60sec"/>
-            <npc id="27099" x="53314" y="143127" z="-3907" heading="0" respawnTime="60sec"/>
-            <npc id="27099" x="53817" y="143661" z="-3907" heading="0" respawnTime="60sec"/>
-            <npc id="27099" x="53112" y="143483" z="-3907" heading="0" respawnTime="60sec"/>
+            <npc id="22183" x="46448" y="153592" z="-2736" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="46448" y="153712" z="-2728" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="46448" y="153832" z="-2728" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="46448" y="153952" z="-2728" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="46568" y="153592" z="-2736" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="46568" y="153712" z="-2728" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="46568" y="153832" z="-2728" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="46568" y="153952" z="-2728" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="46688" y="153592" z="-2736" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="46688" y="153712" z="-2728" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="46688" y="153832" z="-2728" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="46688" y="153952" z="-2728" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="46808" y="153592" z="-2744" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="46808" y="153712" z="-2728" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="46808" y="153832" z="-2728" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="46808" y="153952" z="-2728" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="46928" y="153592" z="-2736" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="46928" y="153712" z="-2728" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="46928" y="153832" z="-2728" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="46928" y="153952" z="-2728" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="47048" y="153592" z="-2736" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="47048" y="153712" z="-2728" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="47048" y="153832" z="-2728" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="47048" y="153952" z="-2728" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="47168" y="153592" z="-2728" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="47168" y="153712" z="-2728" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="47168" y="153832" z="-2728" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="47168" y="153952" z="-2728" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="47547" y="150699" z="-2752" heading="29554" respawnTime="10Sec" />
+            <npc id="22183" x="47667" y="150699" z="-2752" heading="29554" respawnTime="10Sec" />
+            <npc id="22183" x="47667" y="150819" z="-2752" heading="29554" respawnTime="10Sec" />
+            <npc id="22183" x="47768" y="153592" z="-2728" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="47768" y="153712" z="-2728" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="47768" y="153832" z="-2728" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="47768" y="153952" z="-2728" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="47787" y="150699" z="-2752" heading="29554" respawnTime="10Sec" />
+            <npc id="22183" x="47787" y="150819" z="-2752" heading="29554" respawnTime="10Sec" />
+            <npc id="22183" x="47787" y="150939" z="-2752" heading="29554" respawnTime="10Sec" />
+            <npc id="22183" x="47888" y="153592" z="-2728" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="47888" y="153712" z="-2728" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="47888" y="153832" z="-2728" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="47888" y="153952" z="-2728" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="47907" y="150819" z="-2752" heading="29554" respawnTime="10Sec" />
+            <npc id="22183" x="47907" y="150939" z="-2752" heading="29554" respawnTime="10Sec" />
+            <npc id="22183" x="47907" y="151059" z="-2752" heading="29554" respawnTime="10Sec" />
+            <npc id="22183" x="48008" y="153592" z="-2720" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="48008" y="153712" z="-2720" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="48008" y="153832" z="-2720" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="48008" y="153952" z="-2720" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="48027" y="150939" z="-2752" heading="29554" respawnTime="10Sec" />
+            <npc id="22183" x="48027" y="151059" z="-2752" heading="29554" respawnTime="10Sec" />
+            <npc id="22183" x="48027" y="151179" z="-2752" heading="29554" respawnTime="10Sec" />
+            <npc id="22183" x="48128" y="153592" z="-2720" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="48128" y="153712" z="-2720" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="48128" y="153832" z="-2720" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="48128" y="153952" z="-2720" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="48147" y="151059" z="-2752" heading="29554" respawnTime="10Sec" />
+            <npc id="22183" x="48147" y="151179" z="-2752" heading="29554" respawnTime="10Sec" />
+            <npc id="22183" x="48147" y="151299" z="-2752" heading="29554" respawnTime="10Sec" />
+            <npc id="22183" x="48248" y="153592" z="-2720" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="48248" y="153712" z="-2720" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="48248" y="153832" z="-2720" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="48248" y="153952" z="-2720" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="48267" y="151179" z="-2752" heading="29554" respawnTime="10Sec" />
+            <npc id="22183" x="48267" y="151299" z="-2744" heading="29554" respawnTime="10Sec" />
+            <npc id="22183" x="48267" y="151419" z="-2744" heading="29554" respawnTime="10Sec" />
+            <npc id="22183" x="48368" y="153592" z="-2720" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="48368" y="153712" z="-2720" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="48368" y="153832" z="-2720" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="48368" y="153952" z="-2720" heading="46113" respawnTime="10Sec" />
+            <npc id="22183" x="48387" y="151299" z="-2752" heading="29554" respawnTime="10Sec" />
+            <npc id="22183" x="48387" y="151419" z="-2752" heading="29554" respawnTime="10Sec" />
+            <npc id="22183" x="48387" y="151539" z="-2752" heading="29554" respawnTime="10Sec" />
+            <npc id="22183" x="48507" y="151419" z="-2752" heading="29554" respawnTime="10Sec" />
+            <npc id="22183" x="48507" y="151539" z="-2752" heading="29554" respawnTime="10Sec" />
+            <npc id="22183" x="48507" y="151659" z="-2752" heading="29554" respawnTime="10Sec" />
+            <npc id="22183" x="48627" y="151539" z="-2752" heading="29554" respawnTime="10Sec" />
+            <npc id="22183" x="48627" y="151659" z="-2744" heading="29554" respawnTime="10Sec" />
+            <npc id="22183" x="48627" y="151779" z="-2744" heading="29554" respawnTime="10Sec" />
+            <npc id="22183" x="48747" y="151659" z="-2744" heading="29554" respawnTime="10Sec" />
+            <npc id="22183" x="48747" y="151779" z="-2744" heading="29554" respawnTime="10Sec" />
+            <npc id="22183" x="48747" y="151899" z="-2752" heading="29554" respawnTime="10Sec" />
+            <npc id="22184" x="38347" y="149186" z="-3832" heading="31238" respawnTime="60Sec" />
+            <npc id="22184" x="38356" y="148996" z="-3832" heading="21396" respawnTime="60Sec" />
+            <npc id="22184" x="38471" y="146877" z="-3816" heading="25843" respawnTime="60Sec" />
+            <npc id="22184" x="38731" y="149544" z="-3888" heading="26109" respawnTime="60Sec" />
+            <npc id="22184" x="38871" y="150019" z="-3896" heading="30667" respawnTime="60Sec" />
+            <npc id="22184" x="38902" y="150114" z="-3896" heading="38974" respawnTime="60Sec" />
+            <npc id="22184" x="38902" y="150399" z="-3832" heading="33116" respawnTime="60Sec" />
+            <npc id="22184" x="38902" y="150399" z="-3832" heading="34930" respawnTime="60Sec" />
+            <npc id="22184" x="38902" y="150399" z="-3832" heading="52498" respawnTime="60Sec" />
+            <npc id="22184" x="39055" y="145533" z="-3768" heading="49727" respawnTime="60Sec" />
+            <npc id="22184" x="39055" y="146429" z="-3896" heading="2480" respawnTime="60Sec" />
+            <npc id="22184" x="39080" y="146332" z="-3896" heading="13898" respawnTime="60Sec" />
+            <npc id="22184" x="39107" y="149406" z="-3896" heading="32511" respawnTime="60Sec" />
+            <npc id="22184" x="39330" y="149449" z="-3896" heading="23502" respawnTime="60Sec" />
+            <npc id="22184" x="39470" y="146104" z="-3888" heading="419" respawnTime="60Sec" />
+            <npc id="22184" x="39508" y="147071" z="-3840" heading="1843" respawnTime="60Sec" />
+            <npc id="22184" x="39523" y="149146" z="-3896" heading="3664" respawnTime="60Sec" />
+            <npc id="22184" x="39549" y="148712" z="-3824" heading="32097" respawnTime="60Sec" />
+            <npc id="22184" x="39626" y="145343" z="-3816" heading="39785" respawnTime="60Sec" />
+            <npc id="22184" x="39792" y="146032" z="-3888" heading="61848" respawnTime="60Sec" />
+            <npc id="22184" x="39832" y="145404" z="-3800" heading="41747" respawnTime="60Sec" />
+            <npc id="22184" x="39858" y="146052" z="-3888" heading="55016" respawnTime="60Sec" />
+            <npc id="22184" x="39891" y="149451" z="-3896" heading="23502" respawnTime="60Sec" />
+            <npc id="22184" x="39925" y="146044" z="-3888" heading="11650" respawnTime="60Sec" />
+            <npc id="22184" x="39965" y="148937" z="-3832" heading="31613" respawnTime="60Sec" />
+            <npc id="22184" x="39971" y="147209" z="-3816" heading="378" respawnTime="60Sec" />
+            <npc id="22184" x="40062" y="149376" z="-3896" heading="39633" respawnTime="60Sec" />
+            <npc id="22184" x="40293" y="148746" z="-3808" heading="45435" respawnTime="60Sec" />
+            <npc id="22184" x="40390" y="146813" z="-3888" heading="10640" respawnTime="60Sec" />
+            <npc id="22184" x="40436" y="145499" z="-3808" heading="41730" respawnTime="60Sec" />
+            <npc id="22184" x="40515" y="145645" z="-3808" heading="25090" respawnTime="60Sec" />
+            <npc id="22184" x="40515" y="146653" z="-3880" heading="31066" respawnTime="60Sec" />
+            <npc id="22184" x="40556" y="149518" z="-3896" heading="6851" respawnTime="60Sec" />
+            <npc id="22184" x="40609" y="145689" z="-3808" heading="37556" respawnTime="60Sec" />
+            <npc id="22184" x="40661" y="145645" z="-3808" heading="11185" respawnTime="60Sec" />
+            <npc id="22184" x="40661" y="145981" z="-3816" heading="56374" respawnTime="60Sec" />
+            <npc id="22184" x="40746" y="149009" z="-3840" heading="49622" respawnTime="60Sec" />
+            <npc id="22184" x="40842" y="148919" z="-3816" heading="6261" respawnTime="60Sec" />
+            <npc id="22184" x="40955" y="149242" z="-3840" heading="53725" respawnTime="60Sec" />
+            <npc id="22184" x="41139" y="146521" z="-3800" heading="25651" respawnTime="60Sec" />
+            <npc id="22184" x="42560" y="146905" z="-3688" heading="59773" respawnTime="60Sec" />
+            <npc id="22184" x="42582" y="146894" z="-3688" heading="32281" respawnTime="60Sec" />
+            <npc id="22184" x="42737" y="149250" z="-3696" heading="32839" respawnTime="60Sec" />
+            <npc id="22184" x="42748" y="148989" z="-3704" heading="5281" respawnTime="60Sec" />
+            <npc id="22184" x="42788" y="149542" z="-3696" heading="20003" respawnTime="60Sec" />
+            <npc id="22184" x="42796" y="148832" z="-3672" heading="36300" respawnTime="60Sec" />
+            <npc id="22184" x="42804" y="149059" z="-3704" heading="8190" respawnTime="60Sec" />
+            <npc id="22184" x="42914" y="147207" z="-3680" heading="36892" respawnTime="60Sec" />
+            <npc id="22184" x="42945" y="147120" z="-3680" heading="421" respawnTime="60Sec" />
+            <npc id="22184" x="42964" y="147214" z="-3680" heading="52781" respawnTime="60Sec" />
+            <npc id="22184" x="42965" y="149301" z="-3680" heading="9164" respawnTime="60Sec" />
+            <npc id="22184" x="42965" y="149334" z="-3680" heading="13758" respawnTime="60Sec" />
+            <npc id="22184" x="42966" y="149058" z="-3696" heading="7300" respawnTime="60Sec" />
+            <npc id="22184" x="42974" y="146716" z="-3656" heading="62778" respawnTime="60Sec" />
+            <npc id="22184" x="43054" y="146632" z="-3640" heading="3115" respawnTime="60Sec" />
+            <npc id="22184" x="43054" y="147308" z="-3664" heading="25321" respawnTime="60Sec" />
+            <npc id="22184" x="43056" y="148787" z="-3664" heading="20991" respawnTime="60Sec" />
+            <npc id="22184" x="43072" y="148683" z="-3664" heading="18244" respawnTime="60Sec" />
+            <npc id="22184" x="43082" y="148901" z="-3680" heading="47452" respawnTime="60Sec" />
+            <npc id="22184" x="43098" y="146430" z="-3664" heading="4822" respawnTime="60Sec" />
+            <npc id="22184" x="43152" y="146345" z="-3664" heading="44317" respawnTime="60Sec" />
+            <npc id="22184" x="43222" y="147339" z="-3648" heading="46862" respawnTime="60Sec" />
+            <npc id="22184" x="43255" y="147117" z="-3632" heading="12740" respawnTime="60Sec" />
+            <npc id="22184" x="43329" y="149479" z="-3664" heading="23443" respawnTime="60Sec" />
+            <npc id="22184" x="43355" y="147337" z="-3624" heading="0" respawnTime="60Sec" />
+            <npc id="22184" x="43367" y="149390" z="-3664" heading="51038" respawnTime="60Sec" />
+            <npc id="22184" x="43400" y="146650" z="-3624" heading="7189" respawnTime="60Sec" />
+            <npc id="22184" x="43434" y="149445" z="-3664" heading="52312" respawnTime="60Sec" />
+            <npc id="22184" x="43476" y="146410" z="-3648" heading="25350" respawnTime="60Sec" />
+            <npc id="22184" x="43490" y="147487" z="-3624" heading="471" respawnTime="60Sec" />
+            <npc id="22184" x="43540" y="147413" z="-3600" heading="35602" respawnTime="60Sec" />
+            <npc id="22184" x="43628" y="147103" z="-3584" heading="43018" respawnTime="60Sec" />
+            <npc id="22184" x="43704" y="146777" z="-3600" heading="63900" respawnTime="60Sec" />
+            <npc id="22184" x="43712" y="149173" z="-3656" heading="30612" respawnTime="60Sec" />
+            <npc id="22184" x="43744" y="149022" z="-3672" heading="49773" respawnTime="60Sec" />
+            <npc id="22184" x="43758" y="146904" z="-3584" heading="5539" respawnTime="60Sec" />
+            <npc id="22184" x="43816" y="149345" z="-3624" heading="54548" respawnTime="60Sec" />
+            <npc id="22184" x="43826" y="149035" z="-3664" heading="58319" respawnTime="60Sec" />
+            <npc id="22184" x="43835" y="149027" z="-3664" heading="39251" respawnTime="60Sec" />
+            <npc id="22184" x="43972" y="149269" z="-3616" heading="30654" respawnTime="60Sec" />
+            <npc id="22184" x="44456" y="150079" z="-3640" heading="37071" respawnTime="60Sec" />
+            <npc id="22184" x="44556" y="147119" z="-3640" heading="16383" respawnTime="60Sec" />
+            <npc id="22184" x="44608" y="149992" z="-3584" heading="36373" respawnTime="60Sec" />
+            <npc id="22184" x="44636" y="147167" z="-3640" heading="9510" respawnTime="60Sec" />
+            <npc id="22184" x="44647" y="147223" z="-3656" heading="942" respawnTime="60Sec" />
+            <npc id="22184" x="44667" y="147394" z="-3664" heading="29147" respawnTime="60Sec" />
+            <npc id="22184" x="44786" y="146977" z="-3672" heading="9667" respawnTime="60Sec" />
+            <npc id="22184" x="44926" y="146840" z="-3688" heading="39369" respawnTime="60Sec" />
+            <npc id="22184" x="44973" y="145163" z="-3736" heading="41304" respawnTime="60Sec" />
+            <npc id="22184" x="45033" y="150774" z="-3756" heading="48458" respawnTime="60Sec" />
+            <npc id="22184" x="45055" y="147575" z="-3696" heading="12778" respawnTime="60Sec" />
+            <npc id="22184" x="45060" y="150072" z="-3576" heading="31722" respawnTime="60Sec" />
+            <npc id="22184" x="45087" y="145512" z="-3728" heading="41840" respawnTime="60Sec" />
+            <npc id="22184" x="45102" y="149478" z="-3568" heading="36699" respawnTime="60Sec" />
+            <npc id="22184" x="45116" y="149994" z="-3568" heading="33186" respawnTime="60Sec" />
+            <npc id="22184" x="45138" y="149483" z="-3576" heading="49257" respawnTime="60Sec" />
+            <npc id="22184" x="45142" y="149466" z="-3584" heading="46412" respawnTime="60Sec" />
+            <npc id="22184" x="45145" y="149482" z="-3576" heading="52838" respawnTime="60Sec" />
+            <npc id="22184" x="45148" y="150554" z="-3704" heading="61339" respawnTime="60Sec" />
+            <npc id="22184" x="45162" y="150711" z="-3756" heading="4149" respawnTime="60Sec" />
+            <npc id="22184" x="45189" y="149493" z="-3592" heading="52113" respawnTime="60Sec" />
+            <npc id="22184" x="45193" y="149503" z="-3592" heading="37047" respawnTime="60Sec" />
+            <npc id="22184" x="45207" y="149486" z="-3600" heading="58304" respawnTime="60Sec" />
+            <npc id="22184" x="45254" y="145234" z="-3680" heading="59710" respawnTime="60Sec" />
+            <npc id="22184" x="45254" y="147324" z="-3664" heading="15298" respawnTime="60Sec" />
+            <npc id="22184" x="45277" y="145932" z="-3752" heading="36463" respawnTime="60Sec" />
+            <npc id="22184" x="45291" y="150774" z="-3736" heading="8413" respawnTime="60Sec" />
+            <npc id="22184" x="45305" y="150056" z="-3584" heading="56325" respawnTime="60Sec" />
+            <npc id="22184" x="45310" y="150297" z="-3616" heading="42309" respawnTime="60Sec" />
+            <npc id="22184" x="45327" y="147517" z="-3672" heading="58384" respawnTime="60Sec" />
+            <npc id="22184" x="45332" y="147386" z="-3672" heading="43607" respawnTime="60Sec" />
+            <npc id="22184" x="45412" y="147606" z="-3672" heading="18335" respawnTime="60Sec" />
+            <npc id="22184" x="45435" y="149800" z="-3640" heading="20138" respawnTime="60Sec" />
+            <npc id="22184" x="45450" y="150070" z="-3648" heading="38253" respawnTime="60Sec" />
+            <npc id="22184" x="45469" y="145463" z="-3696" heading="31934" respawnTime="60Sec" />
+            <npc id="22184" x="45510" y="145590" z="-3712" heading="62493" respawnTime="60Sec" />
+            <npc id="22184" x="45554" y="147499" z="-3672" heading="9629" respawnTime="60Sec" />
+            <npc id="22184" x="45571" y="145211" z="-3648" heading="44966" respawnTime="60Sec" />
+            <npc id="22184" x="45590" y="147500" z="-3672" heading="63978" respawnTime="60Sec" />
+            <npc id="22184" x="45602" y="147609" z="-3672" heading="44318" respawnTime="60Sec" />
+            <npc id="22184" x="45603" y="145211" z="-3648" heading="33571" respawnTime="60Sec" />
+            <npc id="22184" x="45606" y="149784" z="-3704" heading="16804" respawnTime="60Sec" />
+            <npc id="22184" x="45618" y="145831" z="-3728" heading="63472" respawnTime="60Sec" />
+            <npc id="22184" x="45621" y="146759" z="-3680" heading="1258" respawnTime="60Sec" />
+            <npc id="22184" x="45624" y="145804" z="-3728" heading="44193" respawnTime="60Sec" />
+            <npc id="22184" x="45658" y="145440" z="-3704" heading="36308" respawnTime="60Sec" />
+            <npc id="22184" x="45662" y="145213" z="-3648" heading="5285" respawnTime="60Sec" />
+            <npc id="22184" x="45668" y="145720" z="-3736" heading="33394" respawnTime="60Sec" />
+            <npc id="22184" x="45675" y="147323" z="-3680" heading="49144" respawnTime="60Sec" />
+            <npc id="22184" x="45729" y="147214" z="-3688" heading="32056" respawnTime="60Sec" />
+            <npc id="22184" x="45753" y="145089" z="-3656" heading="9157" respawnTime="60Sec" />
+            <npc id="22184" x="45755" y="147540" z="-3680" heading="61451" respawnTime="60Sec" />
+            <npc id="22184" x="45796" y="147169" z="-3688" heading="13699" respawnTime="60Sec" />
+            <npc id="22184" x="45817" y="146858" z="-3688" heading="2859" respawnTime="60Sec" />
+            <npc id="22184" x="45964" y="145521" z="-3696" heading="61065" respawnTime="60Sec" />
+            <npc id="22184" x="45985" y="145276" z="-3720" heading="61782" respawnTime="60Sec" />
+            <npc id="22184" x="46032" y="145275" z="-3720" heading="10845" respawnTime="60Sec" />
+            <npc id="22184" x="46038" y="145527" z="-3696" heading="45468" respawnTime="60Sec" />
+            <npc id="22184" x="46069" y="145635" z="-3688" heading="12142" respawnTime="60Sec" />
+            <npc id="22184" x="46113" y="148721" z="-3648" heading="25387" respawnTime="60Sec" />
+            <npc id="22184" x="46168" y="145652" z="-3688" heading="18209" respawnTime="60Sec" />
+            <npc id="22184" x="46215" y="148254" z="-3672" heading="11713" respawnTime="60Sec" />
+            <npc id="22184" x="46225" y="148053" z="-3688" heading="16873" respawnTime="60Sec" />
+            <npc id="22184" x="46226" y="148079" z="-3688" heading="2217" respawnTime="60Sec" />
+            <npc id="22184" x="46326" y="148140" z="-3688" heading="27908" respawnTime="60Sec" />
+            <npc id="22184" x="46337" y="148078" z="-3688" heading="48165" respawnTime="60Sec" />
+            <npc id="22184" x="46406" y="146028" z="-3656" heading="18812" respawnTime="60Sec" />
+            <npc id="22184" x="46427" y="146589" z="-3736" heading="35123" respawnTime="60Sec" />
+            <npc id="22184" x="46442" y="148407" z="-3664" heading="37145" respawnTime="60Sec" />
+            <npc id="22184" x="46467" y="148776" z="-3664" heading="209" respawnTime="60Sec" />
+            <npc id="22184" x="46492" y="147797" z="-3688" heading="30278" respawnTime="60Sec" />
+            <npc id="22184" x="46558" y="146693" z="-3720" heading="0" respawnTime="60Sec" />
+            <npc id="22184" x="46620" y="146206" z="-3616" heading="42288" respawnTime="60Sec" />
+            <npc id="22184" x="46624" y="148134" z="-3688" heading="26999" respawnTime="60Sec" />
+            <npc id="22184" x="46632" y="144711" z="-3688" heading="34543" respawnTime="60Sec" />
+            <npc id="22184" x="46635" y="147729" z="-3688" heading="27559" respawnTime="60Sec" />
+            <npc id="22184" x="46689" y="148441" z="-3680" heading="32767" respawnTime="60Sec" />
+            <npc id="22184" x="46724" y="144688" z="-3688" heading="9137" respawnTime="60Sec" />
+            <npc id="22184" x="46773" y="147737" z="-3688" heading="11916" respawnTime="60Sec" />
+            <npc id="22184" x="46798" y="144450" z="-3688" heading="3527" respawnTime="60Sec" />
+            <npc id="22184" x="46815" y="148276" z="-3688" heading="23763" respawnTime="60Sec" />
+            <npc id="22184" x="46921" y="144417" z="-3688" heading="62677" respawnTime="60Sec" />
+            <npc id="22184" x="46952" y="144426" z="-3688" heading="3230" respawnTime="60Sec" />
+            <npc id="22184" x="46977" y="146397" z="-3584" heading="48632" respawnTime="60Sec" />
+            <npc id="22184" x="46980" y="145997" z="-3584" heading="36384" respawnTime="60Sec" />
+            <npc id="22184" x="46986" y="145896" z="-3584" heading="43622" respawnTime="60Sec" />
+            <npc id="22184" x="46989" y="146974" z="-3752" heading="37600" respawnTime="60Sec" />
+            <npc id="22184" x="47042" y="148341" z="-3704" heading="7404" respawnTime="60Sec" />
+            <npc id="22184" x="47094" y="148717" z="-3680" heading="56966" respawnTime="60Sec" />
+            <npc id="22184" x="47096" y="148457" z="-3680" heading="61306" respawnTime="60Sec" />
+            <npc id="22184" x="47118" y="144670" z="-3688" heading="45687" respawnTime="60Sec" />
+            <npc id="22184" x="47124" y="148102" z="-3736" heading="4617" respawnTime="60Sec" />
+            <npc id="22184" x="47140" y="146924" z="-3680" heading="0" respawnTime="60Sec" />
+            <npc id="22184" x="47175" y="145791" z="-3584" heading="25156" respawnTime="60Sec" />
+            <npc id="22184" x="47181" y="146755" z="-3624" heading="39039" respawnTime="60Sec" />
+            <npc id="22184" x="47196" y="148522" z="-3688" heading="9370" respawnTime="60Sec" />
+            <npc id="22184" x="47208" y="145719" z="-3584" heading="57936" respawnTime="60Sec" />
+            <npc id="22184" x="47217" y="148315" z="-3720" heading="20480" respawnTime="60Sec" />
+            <npc id="22184" x="47224" y="146277" z="-3584" heading="48010" respawnTime="60Sec" />
+            <npc id="22184" x="47259" y="146657" z="-3600" heading="9164" respawnTime="60Sec" />
+            <npc id="22184" x="47270" y="146807" z="-3600" heading="58905" respawnTime="60Sec" />
+            <npc id="22184" x="47291" y="146282" z="-3584" heading="65327" respawnTime="60Sec" />
+            <npc id="22184" x="47323" y="146611" z="-3592" heading="61684" respawnTime="60Sec" />
+            <npc id="22184" x="47326" y="145811" z="-3576" heading="10458" respawnTime="60Sec" />
+            <npc id="22184" x="47333" y="145268" z="-3664" heading="11151" respawnTime="60Sec" />
+            <npc id="22184" x="47339" y="146228" z="-3584" heading="44780" respawnTime="60Sec" />
+            <npc id="22184" x="47399" y="146663" z="-3592" heading="62710" respawnTime="60Sec" />
+            <npc id="22184" x="47458" y="145264" z="-3648" heading="1791" respawnTime="60Sec" />
+            <npc id="22184" x="47502" y="145068" z="-3656" heading="58590" respawnTime="60Sec" />
+            <npc id="22184" x="47503" y="144619" z="-3680" heading="18775" respawnTime="60Sec" />
+            <npc id="22184" x="47522" y="144967" z="-3664" heading="63960" respawnTime="60Sec" />
+            <npc id="22184" x="47528" y="145062" z="-3656" heading="49570" respawnTime="60Sec" />
+            <npc id="22184" x="47537" y="145343" z="-3616" heading="59505" respawnTime="60Sec" />
+            <npc id="22184" x="47666" y="144931" z="-3648" heading="60701" respawnTime="60Sec" />
+            <npc id="22184" x="47767" y="145141" z="-3624" heading="62669" respawnTime="60Sec" />
+            <npc id="22184" x="47805" y="144642" z="-3632" heading="1663" respawnTime="60Sec" />
+            <npc id="22184" x="47834" y="144613" z="-3640" heading="61004" respawnTime="60Sec" />
+            <npc id="22184" x="47842" y="144797" z="-3632" heading="17329" respawnTime="60Sec" />
+            <npc id="22184" x="47876" y="144645" z="-3608" heading="8792" respawnTime="60Sec" />
+            <npc id="22184" x="47929" y="144722" z="-3608" heading="52048" respawnTime="60Sec" />
+            <npc id="22184" x="48478" y="146321" z="-3528" heading="57673" respawnTime="60Sec" />
+            <npc id="22184" x="48535" y="145069" z="-3560" heading="34859" respawnTime="60Sec" />
+            <npc id="22184" x="48579" y="148417" z="-3496" heading="12580" respawnTime="60Sec" />
+            <npc id="22184" x="48607" y="148805" z="-3568" heading="12198" respawnTime="60Sec" />
+            <npc id="22184" x="48669" y="148345" z="-3488" heading="54807" respawnTime="60Sec" />
+            <npc id="22184" x="48682" y="145868" z="-3576" heading="6202" respawnTime="60Sec" />
+            <npc id="22184" x="48700" y="146420" z="-3488" heading="3686" respawnTime="60Sec" />
+            <npc id="22184" x="48729" y="146741" z="-3408" heading="28467" respawnTime="60Sec" />
+            <npc id="22184" x="48730" y="144587" z="-3576" heading="16173" respawnTime="60Sec" />
+            <npc id="22184" x="48811" y="146095" z="-3536" heading="62148" respawnTime="60Sec" />
+            <npc id="22184" x="48827" y="146297" z="-3512" heading="50786" respawnTime="60Sec" />
+            <npc id="22184" x="48873" y="144867" z="-3576" heading="18346" respawnTime="60Sec" />
+            <npc id="22184" x="48882" y="146120" z="-3536" heading="23595" respawnTime="60Sec" />
+            <npc id="22184" x="48904" y="149126" z="-3632" heading="61792" respawnTime="60Sec" />
+            <npc id="22184" x="48910" y="145901" z="-3296" heading="8908" respawnTime="60Sec" />
+            <npc id="22184" x="48930" y="145864" z="-3584" heading="48611" respawnTime="60Sec" />
+            <npc id="22184" x="48931" y="148590" z="-3520" heading="28952" respawnTime="60Sec" />
+            <npc id="22184" x="48936" y="148676" z="-3544" heading="19987" respawnTime="60Sec" />
+            <npc id="22184" x="48950" y="148900" z="-3568" heading="60203" respawnTime="60Sec" />
+            <npc id="22184" x="48982" y="146041" z="-3040" heading="14852" respawnTime="60Sec" />
+            <npc id="22184" x="49009" y="144165" z="-3656" heading="21932" respawnTime="60Sec" />
+            <npc id="22184" x="49038" y="145209" z="-3592" heading="27396" respawnTime="60Sec" />
+            <npc id="22184" x="49071" y="146770" z="-3400" heading="46931" respawnTime="60Sec" />
+            <npc id="22184" x="49083" y="146646" z="-3432" heading="30374" respawnTime="60Sec" />
+            <npc id="22184" x="49099" y="146813" z="-3400" heading="59201" respawnTime="60Sec" />
+            <npc id="22184" x="49106" y="148783" z="-3560" heading="29807" respawnTime="60Sec" />
+            <npc id="22184" x="49115" y="144549" z="-3608" heading="42212" respawnTime="60Sec" />
+            <npc id="22184" x="49118" y="148780" z="-3560" heading="46849" respawnTime="60Sec" />
+            <npc id="22184" x="49123" y="149142" z="-3600" heading="31145" respawnTime="60Sec" />
+            <npc id="22184" x="49126" y="146601" z="-3456" heading="45823" respawnTime="60Sec" />
+            <npc id="22184" x="49132" y="144814" z="-3600" heading="15834" respawnTime="60Sec" />
+            <npc id="22184" x="49155" y="148103" z="-3424" heading="45030" respawnTime="60Sec" />
+            <npc id="22184" x="49195" y="145154" z="-3608" heading="19142" respawnTime="60Sec" />
+            <npc id="22184" x="49205" y="148267" z="-3472" heading="48628" respawnTime="60Sec" />
+            <npc id="22184" x="49235" y="148473" z="-3528" heading="19641" respawnTime="60Sec" />
+            <npc id="22184" x="49236" y="145262" z="-3608" heading="7648" respawnTime="60Sec" />
+            <npc id="22184" x="49240" y="148704" z="-3544" heading="7803" respawnTime="60Sec" />
+            <npc id="22184" x="49243" y="144552" z="-3624" heading="62863" respawnTime="60Sec" />
+            <npc id="22184" x="49248" y="144498" z="-3640" heading="9685" respawnTime="60Sec" />
+            <npc id="22184" x="49251" y="146362" z="-3496" heading="766" respawnTime="60Sec" />
+            <npc id="22184" x="49255" y="146369" z="-3496" heading="14662" respawnTime="60Sec" />
+            <npc id="22184" x="49259" y="145263" z="-3608" heading="63642" respawnTime="60Sec" />
+            <npc id="22184" x="49261" y="144256" z="-3688" heading="7497" respawnTime="60Sec" />
+            <npc id="22184" x="49265" y="144236" z="-3704" heading="44316" respawnTime="60Sec" />
+            <npc id="22184" x="49293" y="144287" z="-3688" heading="55531" respawnTime="60Sec" />
+            <npc id="22184" x="49317" y="148796" z="-3568" heading="3432" respawnTime="60Sec" />
+            <npc id="22184" x="49329" y="144393" z="-3656" heading="57381" respawnTime="60Sec" />
+            <npc id="22184" x="49342" y="145831" z="-3216" heading="63600" respawnTime="60Sec" />
+            <npc id="22184" x="49360" y="148202" z="-3480" heading="53989" respawnTime="60Sec" />
+            <npc id="22184" x="49376" y="144382" z="-3688" heading="25944" respawnTime="60Sec" />
+            <npc id="22184" x="49397" y="146048" z="-3584" heading="25016" respawnTime="60Sec" />
+            <npc id="22184" x="49399" y="149024" z="-3560" heading="56612" respawnTime="60Sec" />
+            <npc id="22184" x="49401" y="148778" z="-3576" heading="43622" respawnTime="60Sec" />
+            <npc id="22184" x="49407" y="148214" z="-3488" heading="62842" respawnTime="60Sec" />
+            <npc id="22184" x="49448" y="146348" z="-3520" heading="11359" respawnTime="60Sec" />
+            <npc id="22184" x="49450" y="144066" z="-3752" heading="52213" respawnTime="60Sec" />
+            <npc id="22184" x="49483" y="146231" z="-3544" heading="26422" respawnTime="60Sec" />
+            <npc id="22184" x="49504" y="144748" z="-3688" heading="42291" respawnTime="60Sec" />
+            <npc id="22184" x="49510" y="144534" z="-3728" heading="61284" respawnTime="60Sec" />
+            <npc id="22184" x="49605" y="147129" z="-3440" heading="12418" respawnTime="60Sec" />
+            <npc id="22184" x="49614" y="148345" z="-3552" heading="1039" respawnTime="60Sec" />
+            <npc id="22184" x="49654" y="147166" z="-3456" heading="49153" respawnTime="60Sec" />
+            <npc id="22184" x="49756" y="147363" z="-3472" heading="21750" respawnTime="60Sec" />
+            <npc id="22184" x="49810" y="147330" z="-3480" heading="9802" respawnTime="60Sec" />
+            <npc id="22184" x="49894" y="147792" z="-3496" heading="62719" respawnTime="60Sec" />
+            <npc id="22184" x="49944" y="146850" z="-3544" heading="7923" respawnTime="60Sec" />
+            <npc id="22184" x="50001" y="147349" z="-3520" heading="21032" respawnTime="60Sec" />
+            <npc id="22184" x="50069" y="147168" z="-3552" heading="54225" respawnTime="60Sec" />
+            <npc id="22184" x="50071" y="146698" z="-3584" heading="6638" respawnTime="60Sec" />
+            <npc id="22184" x="50087" y="147838" z="-3544" heading="2859" respawnTime="60Sec" />
+            <npc id="22184" x="50122" y="147394" z="-3544" heading="14385" respawnTime="60Sec" />
+            <npc id="22184" x="50257" y="146805" z="-3624" heading="37977" respawnTime="60Sec" />
+            <npc id="22184" x="50373" y="147486" z="-3576" heading="51203" respawnTime="60Sec" />
+            <npc id="22184" x="50461" y="147795" z="-3576" heading="56227" respawnTime="60Sec" />
+            <npc id="22184" x="50562" y="147711" z="-3584" heading="7004" respawnTime="60Sec" />
+            <npc id="22184" x="50610" y="146894" z="-3736" heading="41010" respawnTime="60Sec" />
+            <npc id="22184" x="50686" y="147521" z="-3608" heading="61246" respawnTime="60Sec" />
+            <npc id="22184" x="50743" y="147137" z="-3680" heading="55559" respawnTime="60Sec" />
+            <npc id="22184" x="50841" y="147448" z="-3624" heading="15651" respawnTime="60Sec" />
+            <npc id="22184" x="50878" y="147446" z="-3632" heading="12133" respawnTime="60Sec" />
+            <npc id="22185" x="38184" y="149491" z="-3832" heading="13394" respawnTime="60Sec" />
+            <npc id="22185" x="38463" y="146871" z="-3816" heading="13955" respawnTime="60Sec" />
+            <npc id="22185" x="38471" y="146317" z="-3760" heading="50835" respawnTime="60Sec" />
+            <npc id="22185" x="38729" y="146303" z="-3816" heading="38156" respawnTime="60Sec" />
+            <npc id="22185" x="38731" y="149924" z="-3896" heading="1914" respawnTime="60Sec" />
+            <npc id="22185" x="38763" y="145869" z="-3776" heading="14440" respawnTime="60Sec" />
+            <npc id="22185" x="38802" y="146745" z="-3856" heading="5636" respawnTime="60Sec" />
+            <npc id="22185" x="38886" y="149040" z="-3864" heading="61801" respawnTime="60Sec" />
+            <npc id="22185" x="38886" y="150093" z="-3896" heading="42919" respawnTime="60Sec" />
+            <npc id="22185" x="38894" y="146454" z="-3856" heading="41040" respawnTime="60Sec" />
+            <npc id="22185" x="38902" y="149639" z="-3888" heading="59241" respawnTime="60Sec" />
+            <npc id="22185" x="38902" y="150304" z="-3880" heading="47387" respawnTime="60Sec" />
+            <npc id="22185" x="38910" y="149626" z="-3888" heading="8896" respawnTime="60Sec" />
+            <npc id="22185" x="38951" y="148821" z="-3832" heading="41499" respawnTime="60Sec" />
+            <npc id="22185" x="39150" y="147120" z="-3840" heading="43825" respawnTime="60Sec" />
+            <npc id="22185" x="39287" y="145958" z="-3840" heading="36481" respawnTime="60Sec" />
+            <npc id="22185" x="39347" y="146653" z="-3888" heading="41044" respawnTime="60Sec" />
+            <npc id="22185" x="39493" y="145591" z="-3816" heading="56121" respawnTime="60Sec" />
+            <npc id="22185" x="39559" y="149257" z="-3896" heading="58032" respawnTime="60Sec" />
+            <npc id="22185" x="39561" y="148695" z="-3816" heading="27938" respawnTime="60Sec" />
+            <npc id="22185" x="39575" y="146661" z="-3888" heading="31328" respawnTime="60Sec" />
+            <npc id="22185" x="39744" y="146182" z="-3888" heading="13404" respawnTime="60Sec" />
+            <npc id="22185" x="39747" y="149558" z="-3896" heading="22430" respawnTime="60Sec" />
+            <npc id="22185" x="39800" y="149321" z="-3896" heading="7103" respawnTime="60Sec" />
+            <npc id="22185" x="39930" y="146171" z="-3888" heading="16485" respawnTime="60Sec" />
+            <npc id="22185" x="40036" y="146218" z="-3888" heading="12404" respawnTime="60Sec" />
+            <npc id="22185" x="40223" y="146765" z="-3888" heading="50725" respawnTime="60Sec" />
+            <npc id="22185" x="40258" y="149343" z="-3896" heading="41401" respawnTime="60Sec" />
+            <npc id="22185" x="40270" y="149577" z="-3896" heading="26170" respawnTime="60Sec" />
+            <npc id="22185" x="40270" y="150494" z="-3824" heading="24400" respawnTime="60Sec" />
+            <npc id="22185" x="40341" y="149617" z="-3896" heading="21781" respawnTime="60Sec" />
+            <npc id="22185" x="40661" y="145645" z="-3808" heading="58695" respawnTime="60Sec" />
+            <npc id="22185" x="40753" y="145804" z="-3808" heading="37508" respawnTime="60Sec" />
+            <npc id="22185" x="40772" y="149441" z="-3896" heading="26055" respawnTime="60Sec" />
+            <npc id="22185" x="40776" y="149346" z="-3896" heading="2318" respawnTime="60Sec" />
+            <npc id="22185" x="40835" y="146840" z="-3808" heading="1258" respawnTime="60Sec" />
+            <npc id="22185" x="40908" y="146227" z="-3816" heading="35013" respawnTime="60Sec" />
+            <npc id="22185" x="40914" y="149580" z="-3856" heading="17221" respawnTime="60Sec" />
+            <npc id="22185" x="41009" y="146327" z="-3816" heading="41304" respawnTime="60Sec" />
+            <npc id="22185" x="41049" y="149308" z="-3840" heading="33602" respawnTime="60Sec" />
+            <npc id="22185" x="42530" y="146977" z="-3688" heading="13689" respawnTime="60Sec" />
+            <npc id="22185" x="42803" y="146992" z="-3680" heading="62181" respawnTime="60Sec" />
+            <npc id="22185" x="42818" y="149025" z="-3704" heading="14114" respawnTime="60Sec" />
+            <npc id="22185" x="42890" y="147222" z="-3680" heading="59577" respawnTime="60Sec" />
+            <npc id="22185" x="42890" y="149143" z="-3680" heading="54896" respawnTime="60Sec" />
+            <npc id="22185" x="42932" y="149604" z="-3696" heading="31659" respawnTime="60Sec" />
+            <npc id="22185" x="42946" y="148728" z="-3664" heading="21407" respawnTime="60Sec" />
+            <npc id="22185" x="42959" y="146663" z="-3656" heading="52136" respawnTime="60Sec" />
+            <npc id="22185" x="42978" y="148854" z="-3672" heading="18654" respawnTime="60Sec" />
+            <npc id="22185" x="43042" y="148988" z="-3680" heading="59810" respawnTime="60Sec" />
+            <npc id="22185" x="43059" y="147235" z="-3664" heading="51366" respawnTime="60Sec" />
+            <npc id="22185" x="43086" y="146531" z="-3648" heading="7285" respawnTime="60Sec" />
+            <npc id="22185" x="43109" y="147156" z="-3656" heading="32520" respawnTime="60Sec" />
+            <npc id="22185" x="43127" y="149208" z="-3672" heading="7674" respawnTime="60Sec" />
+            <npc id="22185" x="43133" y="148628" z="-3664" heading="35532" respawnTime="60Sec" />
+            <npc id="22185" x="43154" y="149259" z="-3672" heading="57308" respawnTime="60Sec" />
+            <npc id="22185" x="43163" y="149457" z="-3672" heading="40961" respawnTime="60Sec" />
+            <npc id="22185" x="43185" y="147266" z="-3640" heading="17491" respawnTime="60Sec" />
+            <npc id="22185" x="43207" y="147279" z="-3640" heading="43018" respawnTime="60Sec" />
+            <npc id="22185" x="43219" y="147070" z="-3632" heading="15824" respawnTime="60Sec" />
+            <npc id="22185" x="43282" y="147234" z="-3616" heading="55614" respawnTime="60Sec" />
+            <npc id="22185" x="43286" y="146284" z="-3680" heading="59132" respawnTime="60Sec" />
+            <npc id="22185" x="43299" y="146311" z="-3680" heading="12226" respawnTime="60Sec" />
+            <npc id="22185" x="43340" y="148844" z="-3672" heading="54329" respawnTime="60Sec" />
+            <npc id="22185" x="43348" y="149462" z="-3664" heading="55344" respawnTime="60Sec" />
+            <npc id="22185" x="43365" y="146381" z="-3664" heading="2056" respawnTime="60Sec" />
+            <npc id="22185" x="43437" y="146978" z="-3600" heading="11571" respawnTime="60Sec" />
+            <npc id="22185" x="43495" y="146694" z="-3616" heading="54671" respawnTime="60Sec" />
+            <npc id="22185" x="43513" y="149339" z="-3664" heading="13580" respawnTime="60Sec" />
+            <npc id="22185" x="43519" y="149365" z="-3664" heading="9194" respawnTime="60Sec" />
+            <npc id="22185" x="43566" y="146630" z="-3616" heading="48115" respawnTime="60Sec" />
+            <npc id="22185" x="43718" y="149471" z="-3632" heading="52399" respawnTime="60Sec" />
+            <npc id="22185" x="43746" y="147161" z="-3576" heading="53896" respawnTime="60Sec" />
+            <npc id="22185" x="43755" y="149388" z="-3632" heading="59115" respawnTime="60Sec" />
+            <npc id="22185" x="43759" y="146845" z="-3584" heading="18149" respawnTime="60Sec" />
+            <npc id="22185" x="43789" y="149360" z="-3624" heading="48424" respawnTime="60Sec" />
+            <npc id="22185" x="43813" y="146754" z="-3592" heading="64700" respawnTime="60Sec" />
+            <npc id="22185" x="43823" y="149182" z="-3640" heading="46686" respawnTime="60Sec" />
+            <npc id="22185" x="43873" y="149016" z="-3664" heading="18999" respawnTime="60Sec" />
+            <npc id="22185" x="43992" y="149453" z="-3608" heading="4718" respawnTime="60Sec" />
+            <npc id="22185" x="44391" y="150106" z="-3680" heading="13249" respawnTime="60Sec" />
+            <npc id="22185" x="44488" y="150024" z="-3616" heading="42812" respawnTime="60Sec" />
+            <npc id="22185" x="44808" y="150074" z="-3568" heading="2200" respawnTime="60Sec" />
+            <npc id="22185" x="44811" y="150424" z="-3656" heading="64905" respawnTime="60Sec" />
+            <npc id="22185" x="44826" y="147267" z="-3680" heading="47430" respawnTime="60Sec" />
+            <npc id="22185" x="45029" y="147012" z="-3688" heading="19343" respawnTime="60Sec" />
+            <npc id="22185" x="45035" y="149503" z="-3552" heading="50301" respawnTime="60Sec" />
+            <npc id="22185" x="45046" y="145517" z="-3744" heading="51179" respawnTime="60Sec" />
+            <npc id="22185" x="45052" y="149492" z="-3552" heading="34848" respawnTime="60Sec" />
+            <npc id="22185" x="45058" y="146760" z="-3680" heading="46522" respawnTime="60Sec" />
+            <npc id="22185" x="45068" y="149487" z="-3560" heading="36354" respawnTime="60Sec" />
+            <npc id="22185" x="45133" y="149497" z="-3568" heading="53212" respawnTime="60Sec" />
+            <npc id="22185" x="45154" y="147576" z="-3688" heading="62392" respawnTime="60Sec" />
+            <npc id="22185" x="45159" y="149480" z="-3584" heading="53335" respawnTime="60Sec" />
+            <npc id="22185" x="45176" y="149476" z="-3584" heading="45841" respawnTime="60Sec" />
+            <npc id="22185" x="45181" y="145312" z="-3704" heading="7921" respawnTime="60Sec" />
+            <npc id="22185" x="45187" y="147587" z="-3672" heading="3432" respawnTime="60Sec" />
+            <npc id="22185" x="45200" y="149891" z="-3576" heading="57123" respawnTime="60Sec" />
+            <npc id="22185" x="45213" y="145804" z="-3736" heading="4471" respawnTime="60Sec" />
+            <npc id="22185" x="45221" y="145644" z="-3736" heading="14489" respawnTime="60Sec" />
+            <npc id="22185" x="45221" y="145799" z="-3744" heading="44539" respawnTime="60Sec" />
+            <npc id="22185" x="45225" y="144909" z="-3632" heading="11704" respawnTime="60Sec" />
+            <npc id="22185" x="45229" y="147673" z="-3672" heading="59270" respawnTime="60Sec" />
+            <npc id="22185" x="45234" y="150294" z="-3616" heading="6967" respawnTime="60Sec" />
+            <npc id="22185" x="45247" y="147055" z="-3672" heading="62517" respawnTime="60Sec" />
+            <npc id="22185" x="45260" y="147142" z="-3664" heading="12223" respawnTime="60Sec" />
+            <npc id="22185" x="45261" y="146619" z="-3680" heading="9231" respawnTime="60Sec" />
+            <npc id="22185" x="45272" y="149767" z="-3568" heading="33121" respawnTime="60Sec" />
+            <npc id="22185" x="45277" y="145239" z="-3672" heading="38672" respawnTime="60Sec" />
+            <npc id="22185" x="45278" y="147577" z="-3672" heading="52969" respawnTime="60Sec" />
+            <npc id="22185" x="45281" y="149679" z="-3568" heading="59577" respawnTime="60Sec" />
+            <npc id="22185" x="45284" y="150180" z="-3600" heading="4929" respawnTime="60Sec" />
+            <npc id="22185" x="45286" y="145838" z="-3756" heading="42876" respawnTime="60Sec" />
+            <npc id="22185" x="45299" y="149820" z="-3568" heading="61542" respawnTime="60Sec" />
+            <npc id="22185" x="45322" y="145382" z="-3696" heading="45471" respawnTime="60Sec" />
+            <npc id="22185" x="45349" y="145309" z="-3672" heading="9881" respawnTime="60Sec" />
+            <npc id="22185" x="45424" y="150178" z="-3624" heading="8522" respawnTime="60Sec" />
+            <npc id="22185" x="45434" y="150115" z="-3608" heading="32488" respawnTime="60Sec" />
+            <npc id="22185" x="45495" y="145249" z="-3648" heading="33813" respawnTime="60Sec" />
+            <npc id="22185" x="45525" y="149908" z="-3680" heading="6264" respawnTime="60Sec" />
+            <npc id="22185" x="45533" y="145396" z="-3656" heading="58157" respawnTime="60Sec" />
+            <npc id="22185" x="45541" y="147211" z="-3672" heading="58450" respawnTime="60Sec" />
+            <npc id="22185" x="45559" y="147070" z="-3680" heading="28558" respawnTime="60Sec" />
+            <npc id="22185" x="45582" y="150460" z="-3756" heading="62643" respawnTime="60Sec" />
+            <npc id="22185" x="45593" y="147287" z="-3680" heading="26055" respawnTime="60Sec" />
+            <npc id="22185" x="45597" y="147327" z="-3680" heading="43872" respawnTime="60Sec" />
+            <npc id="22185" x="45625" y="145592" z="-3720" heading="5177" respawnTime="60Sec" />
+            <npc id="22185" x="45642" y="146744" z="-3680" heading="27041" respawnTime="60Sec" />
+            <npc id="22185" x="45711" y="146949" z="-3688" heading="47482" respawnTime="60Sec" />
+            <npc id="22185" x="45738" y="146818" z="-3688" heading="4664" respawnTime="60Sec" />
+            <npc id="22185" x="45749" y="145984" z="-3704" heading="53148" respawnTime="60Sec" />
+            <npc id="22185" x="45764" y="147351" z="-3688" heading="60234" respawnTime="60Sec" />
+            <npc id="22185" x="45802" y="145347" z="-3720" heading="30718" respawnTime="60Sec" />
+            <npc id="22185" x="45804" y="147066" z="-3688" heading="59287" respawnTime="60Sec" />
+            <npc id="22185" x="45826" y="146831" z="-3688" heading="6774" respawnTime="60Sec" />
+            <npc id="22185" x="45864" y="145598" z="-3704" heading="4511" respawnTime="60Sec" />
+            <npc id="22185" x="45986" y="145386" z="-3720" heading="19574" respawnTime="60Sec" />
+            <npc id="22185" x="45991" y="145439" z="-3696" heading="10155" respawnTime="60Sec" />
+            <npc id="22185" x="46025" y="148219" z="-3672" heading="23039" respawnTime="60Sec" />
+            <npc id="22185" x="46093" y="145254" z="-3720" heading="13640" respawnTime="60Sec" />
+            <npc id="22185" x="46130" y="145114" z="-3704" heading="1258" respawnTime="60Sec" />
+            <npc id="22185" x="46171" y="148456" z="-3664" heading="17485" respawnTime="60Sec" />
+            <npc id="22185" x="46207" y="148362" z="-3664" heading="10814" respawnTime="60Sec" />
+            <npc id="22185" x="46246" y="148619" z="-3664" heading="11367" respawnTime="60Sec" />
+            <npc id="22185" x="46250" y="148165" z="-3688" heading="16395" respawnTime="60Sec" />
+            <npc id="22185" x="46271" y="147914" z="-3688" heading="21219" respawnTime="60Sec" />
+            <npc id="22185" x="46314" y="148102" z="-3688" heading="17011" respawnTime="60Sec" />
+            <npc id="22185" x="46319" y="148445" z="-3664" heading="7550" respawnTime="60Sec" />
+            <npc id="22185" x="46334" y="146389" z="-3752" heading="7924" respawnTime="60Sec" />
+            <npc id="22185" x="46554" y="148448" z="-3680" heading="47899" respawnTime="60Sec" />
+            <npc id="22185" x="46582" y="148736" z="-3664" heading="5432" respawnTime="60Sec" />
+            <npc id="22185" x="46618" y="147881" z="-3688" heading="3438" respawnTime="60Sec" />
+            <npc id="22185" x="46629" y="146799" z="-3736" heading="21266" respawnTime="60Sec" />
+            <npc id="22185" x="46676" y="145004" z="-3688" heading="13689" respawnTime="60Sec" />
+            <npc id="22185" x="46676" y="148083" z="-3688" heading="64785" respawnTime="60Sec" />
+            <npc id="22185" x="46688" y="146528" z="-3704" heading="14909" respawnTime="60Sec" />
+            <npc id="22185" x="46705" y="146860" z="-3744" heading="14540" respawnTime="60Sec" />
+            <npc id="22185" x="46712" y="146613" z="-3728" heading="34843" respawnTime="60Sec" />
+            <npc id="22185" x="46742" y="148750" z="-3664" heading="23095" respawnTime="60Sec" />
+            <npc id="22185" x="46767" y="146088" z="-3600" heading="315" respawnTime="60Sec" />
+            <npc id="22185" x="46820" y="146837" z="-3728" heading="37601" respawnTime="60Sec" />
+            <npc id="22185" x="46871" y="147878" z="-3688" heading="23871" respawnTime="60Sec" />
+            <npc id="22185" x="46883" y="146489" z="-3624" heading="14652" respawnTime="60Sec" />
+            <npc id="22185" x="46885" y="144410" z="-3688" heading="29340" respawnTime="60Sec" />
+            <npc id="22185" x="46900" y="148410" z="-3680" heading="4486" respawnTime="60Sec" />
+            <npc id="22185" x="46912" y="144586" z="-3688" heading="57050" respawnTime="60Sec" />
+            <npc id="22185" x="46914" y="144808" z="-3688" heading="12298" respawnTime="60Sec" />
+            <npc id="22185" x="46921" y="145144" z="-3688" heading="21582" respawnTime="60Sec" />
+            <npc id="22185" x="46930" y="144659" z="-3688" heading="17715" respawnTime="60Sec" />
+            <npc id="22185" x="46943" y="145887" z="-3592" heading="2538" respawnTime="60Sec" />
+            <npc id="22185" x="47008" y="148626" z="-3680" heading="29017" respawnTime="60Sec" />
+            <npc id="22185" x="47011" y="146081" z="-3584" heading="28694" respawnTime="60Sec" />
+            <npc id="22185" x="47124" y="145040" z="-3680" heading="38700" respawnTime="60Sec" />
+            <npc id="22185" x="47125" y="145108" z="-3680" heading="17853" respawnTime="60Sec" />
+            <npc id="22185" x="47152" y="146684" z="-3600" heading="10134" respawnTime="60Sec" />
+            <npc id="22185" x="47156" y="144448" z="-3688" heading="22110" respawnTime="60Sec" />
+            <npc id="22185" x="47163" y="145178" z="-3680" heading="11552" respawnTime="60Sec" />
+            <npc id="22185" x="47166" y="148486" z="-3688" heading="55041" respawnTime="60Sec" />
+            <npc id="22185" x="47179" y="148510" z="-3688" heading="14859" respawnTime="60Sec" />
+            <npc id="22185" x="47197" y="148264" z="-3720" heading="53211" respawnTime="60Sec" />
+            <npc id="22185" x="47207" y="146900" z="-3648" heading="54642" respawnTime="60Sec" />
+            <npc id="22185" x="47220" y="146793" z="-3624" heading="19574" respawnTime="60Sec" />
+            <npc id="22185" x="47222" y="146692" z="-3608" heading="9727" respawnTime="60Sec" />
+            <npc id="22185" x="47258" y="144507" z="-3688" heading="15647" respawnTime="60Sec" />
+            <npc id="22185" x="47288" y="146113" z="-3576" heading="61981" respawnTime="60Sec" />
+            <npc id="22185" x="47292" y="148673" z="-3696" heading="33863" respawnTime="60Sec" />
+            <npc id="22185" x="47339" y="146399" z="-3584" heading="42594" respawnTime="60Sec" />
+            <npc id="22185" x="47344" y="146638" z="-3592" heading="8998" respawnTime="60Sec" />
+            <npc id="22185" x="47391" y="144435" z="-3688" heading="59278" respawnTime="60Sec" />
+            <npc id="22185" x="47393" y="146057" z="-3584" heading="50824" respawnTime="60Sec" />
+            <npc id="22185" x="47425" y="145873" z="-3584" heading="35466" respawnTime="60Sec" />
+            <npc id="22185" x="47442" y="144301" z="-3688" heading="42212" respawnTime="60Sec" />
+            <npc id="22185" x="47456" y="146109" z="-3584" heading="26055" respawnTime="60Sec" />
+            <npc id="22185" x="47491" y="144476" z="-3680" heading="17508" respawnTime="60Sec" />
+            <npc id="22185" x="47507" y="144339" z="-3688" heading="63857" respawnTime="60Sec" />
+            <npc id="22185" x="47545" y="145076" z="-3656" heading="58536" respawnTime="60Sec" />
+            <npc id="22185" x="47635" y="145170" z="-3648" heading="17064" respawnTime="60Sec" />
+            <npc id="22185" x="47716" y="144877" z="-3656" heading="12223" respawnTime="60Sec" />
+            <npc id="22185" x="47854" y="144907" z="-3624" heading="63113" respawnTime="60Sec" />
+            <npc id="22185" x="47921" y="144664" z="-3608" heading="11782" respawnTime="60Sec" />
+            <npc id="22185" x="48306" y="146678" z="-3472" heading="19243" respawnTime="60Sec" />
+            <npc id="22185" x="48401" y="144392" z="-3584" heading="31302" respawnTime="60Sec" />
+            <npc id="22185" x="48480" y="148830" z="-3600" heading="8638" respawnTime="60Sec" />
+            <npc id="22185" x="48522" y="146070" z="-3544" heading="62462" respawnTime="60Sec" />
+            <npc id="22185" x="48538" y="144754" z="-3560" heading="16489" respawnTime="60Sec" />
+            <npc id="22185" x="48551" y="144738" z="-3560" heading="38672" respawnTime="60Sec" />
+            <npc id="22185" x="48569" y="144951" z="-3560" heading="17568" respawnTime="60Sec" />
+            <npc id="22185" x="48604" y="148759" z="-3568" heading="14813" respawnTime="60Sec" />
+            <npc id="22185" x="48612" y="148638" z="-3552" heading="25190" respawnTime="60Sec" />
+            <npc id="22185" x="48614" y="148146" z="-3432" heading="19070" respawnTime="60Sec" />
+            <npc id="22185" x="48627" y="148338" z="-3464" heading="16593" respawnTime="60Sec" />
+            <npc id="22185" x="48698" y="144117" z="-3616" heading="20501" respawnTime="60Sec" />
+            <npc id="22185" x="48732" y="145677" z="-3584" heading="21919" respawnTime="60Sec" />
+            <npc id="22185" x="48745" y="148338" z="-3488" heading="33186" respawnTime="60Sec" />
+            <npc id="22185" x="48755" y="144748" z="-3568" heading="30939" respawnTime="60Sec" />
+            <npc id="22185" x="48761" y="145658" z="-3584" heading="48840" respawnTime="60Sec" />
+            <npc id="22185" x="48771" y="148795" z="-3560" heading="5631" respawnTime="60Sec" />
+            <npc id="22185" x="48785" y="148330" z="-3480" heading="27227" respawnTime="60Sec" />
+            <npc id="22185" x="48797" y="145031" z="-3576" heading="44875" respawnTime="60Sec" />
+            <npc id="22185" x="48800" y="146643" z="-3416" heading="9403" respawnTime="60Sec" />
+            <npc id="22185" x="48800" y="148842" z="-3560" heading="36451" respawnTime="60Sec" />
+            <npc id="22185" x="48828" y="144878" z="-3576" heading="33255" respawnTime="60Sec" />
+            <npc id="22185" x="48838" y="146951" z="-3400" heading="64042" respawnTime="60Sec" />
+            <npc id="22185" x="48840" y="148837" z="-3560" heading="836" respawnTime="60Sec" />
+            <npc id="22185" x="48855" y="144332" z="-3592" heading="35968" respawnTime="60Sec" />
+            <npc id="22185" x="48855" y="148173" z="-3424" heading="7004" respawnTime="60Sec" />
+            <npc id="22185" x="48863" y="148478" z="-3488" heading="3754" respawnTime="60Sec" />
+            <npc id="22185" x="48873" y="146731" z="-3400" heading="1791" respawnTime="60Sec" />
+            <npc id="22185" x="48889" y="144960" z="-3576" heading="33814" respawnTime="60Sec" />
+            <npc id="22185" x="48894" y="146070" z="-3536" heading="2217" respawnTime="60Sec" />
+            <npc id="22185" x="48935" y="148189" z="-3440" heading="57123" respawnTime="60Sec" />
+            <npc id="22185" x="48942" y="146764" z="-3400" heading="15894" respawnTime="60Sec" />
+            <npc id="22185" x="48966" y="148854" z="-3560" heading="47714" respawnTime="60Sec" />
+            <npc id="22185" x="49026" y="148281" z="-3456" heading="37977" respawnTime="60Sec" />
+            <npc id="22185" x="49042" y="146053" z="-3568" heading="36673" respawnTime="60Sec" />
+            <npc id="22185" x="49044" y="146871" z="-3400" heading="43178" respawnTime="60Sec" />
+            <npc id="22185" x="49085" y="146190" z="-3536" heading="33724" respawnTime="60Sec" />
+            <npc id="22185" x="49093" y="148135" z="-3432" heading="37110" respawnTime="60Sec" />
+            <npc id="22185" x="49126" y="146811" z="-3400" heading="60749" respawnTime="60Sec" />
+            <npc id="22185" x="49135" y="146522" z="-3456" heading="21625" respawnTime="60Sec" />
+            <npc id="22185" x="49177" y="144718" z="-3616" heading="36911" respawnTime="60Sec" />
+            <npc id="22185" x="49207" y="144635" z="-3624" heading="54549" respawnTime="60Sec" />
+            <npc id="22185" x="49210" y="149048" z="-3576" heading="47999" respawnTime="60Sec" />
+            <npc id="22185" x="49212" y="148076" z="-3424" heading="5457" respawnTime="60Sec" />
+            <npc id="22185" x="49240" y="146374" z="-3496" heading="62166" respawnTime="60Sec" />
+            <npc id="22185" x="49280" y="146533" z="-3480" heading="104" respawnTime="60Sec" />
+            <npc id="22185" x="49284" y="144400" z="-3656" heading="33290" respawnTime="60Sec" />
+            <npc id="22185" x="49398" y="144145" z="-3756" heading="10139" respawnTime="60Sec" />
+            <npc id="22185" x="49416" y="144916" z="-3648" heading="3418" respawnTime="60Sec" />
+            <npc id="22185" x="49429" y="148426" z="-3536" heading="58104" respawnTime="60Sec" />
+            <npc id="22185" x="49455" y="146148" z="-3568" heading="16943" respawnTime="60Sec" />
+            <npc id="22185" x="49458" y="146174" z="-3568" heading="38717" respawnTime="60Sec" />
+            <npc id="22185" x="49465" y="146200" z="-3544" heading="61451" respawnTime="60Sec" />
+            <npc id="22185" x="49483" y="146361" z="-3520" heading="28866" respawnTime="60Sec" />
+            <npc id="22185" x="49511" y="144501" z="-3728" heading="35360" respawnTime="60Sec" />
+            <npc id="22185" x="49545" y="148245" z="-3528" heading="27510" respawnTime="60Sec" />
+            <npc id="22185" x="49552" y="144266" z="-3752" heading="31086" respawnTime="60Sec" />
+            <npc id="22185" x="49611" y="144785" z="-3720" heading="5342" respawnTime="60Sec" />
+            <npc id="22185" x="49614" y="145074" z="-3688" heading="6743" respawnTime="60Sec" />
+            <npc id="22185" x="49627" y="144631" z="-3752" heading="44564" respawnTime="60Sec" />
+            <npc id="22185" x="49736" y="147334" z="-3472" heading="105" respawnTime="60Sec" />
+            <npc id="22185" x="49747" y="147244" z="-3456" heading="24218" respawnTime="60Sec" />
+            <npc id="22185" x="49968" y="147384" z="-3520" heading="37921" respawnTime="60Sec" />
+            <npc id="22185" x="49977" y="147537" z="-3512" heading="8453" respawnTime="60Sec" />
+            <npc id="22185" x="50015" y="147301" z="-3520" heading="17427" respawnTime="60Sec" />
+            <npc id="22185" x="50049" y="146947" z="-3560" heading="11385" respawnTime="60Sec" />
+            <npc id="22185" x="50313" y="147357" z="-3576" heading="43163" respawnTime="60Sec" />
+            <npc id="22185" x="50334" y="147505" z="-3576" heading="43020" respawnTime="60Sec" />
+            <npc id="22185" x="50360" y="147401" z="-3576" heading="45780" respawnTime="60Sec" />
+            <npc id="22185" x="50362" y="146892" z="-3640" heading="52239" respawnTime="60Sec" />
+            <npc id="22185" x="50459" y="147518" z="-3592" heading="27027" respawnTime="60Sec" />
+            <npc id="22185" x="50526" y="146805" z="-3728" heading="11818" respawnTime="60Sec" />
+            <npc id="22185" x="50533" y="147888" z="-3560" heading="15177" respawnTime="60Sec" />
+            <npc id="22185" x="50548" y="146813" z="-3744" heading="53247" respawnTime="60Sec" />
+            <npc id="22185" x="50573" y="147496" z="-3600" heading="14666" respawnTime="60Sec" />
+            <npc id="22185" x="50596" y="147096" z="-3656" heading="17040" respawnTime="60Sec" />
+            <npc id="22185" x="50664" y="147468" z="-3608" heading="24871" respawnTime="60Sec" />
+            <npc id="22185" x="50681" y="146959" z="-3736" heading="10328" respawnTime="60Sec" />
+            <npc id="22185" x="50767" y="147060" z="-3720" heading="2644" respawnTime="60Sec" />
+            <npc id="22185" x="50851" y="147541" z="-3608" heading="34493" respawnTime="60Sec" />
+            <npc id="22186" x="41127" y="141130" z="-2792" heading="27725" respawnTime="60Sec" />
+            <npc id="22186" x="41619" y="141801" z="-2776" heading="16850" respawnTime="60Sec" />
+            <npc id="22186" x="41629" y="141483" z="-2856" heading="64219" respawnTime="60Sec" />
+            <npc id="22186" x="41635" y="141757" z="-2792" heading="45397" respawnTime="60Sec" />
+            <npc id="22186" x="41730" y="140306" z="-2960" heading="56027" respawnTime="60Sec" />
+            <npc id="22186" x="41740" y="141952" z="-2784" heading="38017" respawnTime="60Sec" />
+            <npc id="22186" x="41752" y="141286" z="-2936" heading="40418" respawnTime="60Sec" />
+            <npc id="22186" x="41818" y="141678" z="-2856" heading="7297" respawnTime="60Sec" />
+            <npc id="22186" x="41850" y="141246" z="-2976" heading="8597" respawnTime="60Sec" />
+            <npc id="22186" x="41875" y="143014" z="-2976" heading="60684" respawnTime="60Sec" />
+            <npc id="22186" x="41918" y="142992" z="-2976" heading="3538" respawnTime="60Sec" />
+            <npc id="22186" x="41924" y="142928" z="-2960" heading="40586" respawnTime="60Sec" />
+            <npc id="22186" x="41934" y="142847" z="-2936" heading="64485" respawnTime="60Sec" />
+            <npc id="22186" x="41977" y="142868" z="-2952" heading="27827" respawnTime="60Sec" />
+            <npc id="22186" x="42097" y="140764" z="-3072" heading="27470" respawnTime="60Sec" />
+            <npc id="22186" x="42121" y="143323" z="-3032" heading="26345" respawnTime="60Sec" />
+            <npc id="22186" x="42127" y="141442" z="-2984" heading="50666" respawnTime="60Sec" />
+            <npc id="22186" x="42146" y="141084" z="-3040" heading="862" respawnTime="60Sec" />
+            <npc id="22186" x="42241" y="142686" z="-2960" heading="20280" respawnTime="60Sec" />
+            <npc id="22186" x="42271" y="140444" z="-3072" heading="20712" respawnTime="60Sec" />
+            <npc id="22186" x="42273" y="141722" z="-2968" heading="37441" respawnTime="60Sec" />
+            <npc id="22186" x="42280" y="143580" z="-3064" heading="11562" respawnTime="60Sec" />
+            <npc id="22186" x="42319" y="141359" z="-3024" heading="59323" respawnTime="60Sec" />
+            <npc id="22186" x="42342" y="142579" z="-2944" heading="63242" respawnTime="60Sec" />
+            <npc id="22186" x="42343" y="140934" z="-3064" heading="12519" respawnTime="60Sec" />
+            <npc id="22186" x="42347" y="143323" z="-3032" heading="3467" respawnTime="60Sec" />
+            <npc id="22186" x="42383" y="140981" z="-3088" heading="30436" respawnTime="60Sec" />
+            <npc id="22186" x="42400" y="141170" z="-3064" heading="58290" respawnTime="60Sec" />
+            <npc id="22186" x="42431" y="143363" z="-3040" heading="15009" respawnTime="60Sec" />
+            <npc id="22186" x="42463" y="143650" z="-3072" heading="31082" respawnTime="60Sec" />
+            <npc id="22186" x="42490" y="142510" z="-2960" heading="28104" respawnTime="60Sec" />
+            <npc id="22186" x="42544" y="140931" z="-3088" heading="23877" respawnTime="60Sec" />
+            <npc id="22186" x="42661" y="142822" z="-2960" heading="5527" respawnTime="60Sec" />
+            <npc id="22186" x="42665" y="142640" z="-2960" heading="7492" respawnTime="60Sec" />
+            <npc id="22186" x="42727" y="143126" z="-2960" heading="3723" respawnTime="60Sec" />
+            <npc id="22186" x="42784" y="143520" z="-3048" heading="57755" respawnTime="60Sec" />
+            <npc id="22186" x="42818" y="142788" z="-2960" heading="53315" respawnTime="60Sec" />
+            <npc id="22186" x="42825" y="143335" z="-3024" heading="49269" respawnTime="60Sec" />
+            <npc id="22186" x="42917" y="143270" z="-3008" heading="21841" respawnTime="60Sec" />
+            <npc id="22186" x="42928" y="141243" z="-3072" heading="51559" respawnTime="60Sec" />
+            <npc id="22186" x="43363" y="140835" z="-3088" heading="25451" respawnTime="60Sec" />
+            <npc id="22186" x="43493" y="140700" z="-3088" heading="27725" respawnTime="60Sec" />
+            <npc id="22186" x="43533" y="142505" z="-3000" heading="28398" respawnTime="60Sec" />
+            <npc id="22186" x="43535" y="142720" z="-2952" heading="20690" respawnTime="60Sec" />
+            <npc id="22186" x="43556" y="141166" z="-3072" heading="18882" respawnTime="60Sec" />
+            <npc id="22186" x="43557" y="140900" z="-3088" heading="8233" respawnTime="60Sec" />
+            <npc id="22186" x="43581" y="140493" z="-3072" heading="15452" respawnTime="60Sec" />
+            <npc id="22186" x="43593" y="140989" z="-3080" heading="31606" respawnTime="60Sec" />
+            <npc id="22186" x="43698" y="141031" z="-3064" heading="1529" respawnTime="60Sec" />
+            <npc id="22186" x="43708" y="140218" z="-3008" heading="42204" respawnTime="60Sec" />
+            <npc id="22186" x="43734" y="140552" z="-3096" heading="13658" respawnTime="60Sec" />
+            <npc id="22186" x="43738" y="140488" z="-3080" heading="27827" respawnTime="60Sec" />
+            <npc id="22186" x="43848" y="142346" z="-3032" heading="35573" respawnTime="60Sec" />
+            <npc id="22186" x="43857" y="140582" z="-3104" heading="42293" respawnTime="60Sec" />
+            <npc id="22186" x="43871" y="142404" z="-3032" heading="57549" respawnTime="60Sec" />
+            <npc id="22186" x="43884" y="142781" z="-2992" heading="44086" respawnTime="60Sec" />
+            <npc id="22186" x="43897" y="142644" z="-3016" heading="4514" respawnTime="60Sec" />
+            <npc id="22186" x="43921" y="140743" z="-3112" heading="53968" respawnTime="60Sec" />
+            <npc id="22186" x="44005" y="140571" z="-3104" heading="61959" respawnTime="60Sec" />
+            <npc id="22186" x="44051" y="140859" z="-3088" heading="16402" respawnTime="60Sec" />
+            <npc id="22186" x="44053" y="143219" z="-3032" heading="29241" respawnTime="60Sec" />
+            <npc id="22186" x="44062" y="140787" z="-3088" heading="13193" respawnTime="60Sec" />
+            <npc id="22186" x="44072" y="142284" z="-3032" heading="10612" respawnTime="60Sec" />
+            <npc id="22186" x="44119" y="143014" z="-3024" heading="43988" respawnTime="60Sec" />
+            <npc id="22186" x="44152" y="140129" z="-3032" heading="41185" respawnTime="60Sec" />
+            <npc id="22186" x="44198" y="142404" z="-3032" heading="41711" respawnTime="60Sec" />
+            <npc id="22186" x="44203" y="142584" z="-3048" heading="60002" respawnTime="60Sec" />
+            <npc id="22186" x="44236" y="142764" z="-3048" heading="19918" respawnTime="60Sec" />
+            <npc id="22186" x="44239" y="140150" z="-3048" heading="31044" respawnTime="60Sec" />
+            <npc id="22186" x="44243" y="140397" z="-3088" heading="61442" respawnTime="60Sec" />
+            <npc id="22186" x="44251" y="140224" z="-3072" heading="23998" respawnTime="60Sec" />
+            <npc id="22186" x="44379" y="142729" z="-3040" heading="12446" respawnTime="60Sec" />
+            <npc id="22186" x="44395" y="140678" z="-3080" heading="32325" respawnTime="60Sec" />
+            <npc id="22186" x="44433" y="142674" z="-3040" heading="18483" respawnTime="60Sec" />
+            <npc id="22186" x="44437" y="143273" z="-3040" heading="61740" respawnTime="60Sec" />
+            <npc id="22186" x="44483" y="143247" z="-3040" heading="47994" respawnTime="60Sec" />
+            <npc id="22186" x="44543" y="142930" z="-3032" heading="4694" respawnTime="60Sec" />
+            <npc id="22186" x="44613" y="143275" z="-3040" heading="24780" respawnTime="60Sec" />
+            <npc id="22186" x="44615" y="142650" z="-3032" heading="19067" respawnTime="60Sec" />
+            <npc id="22186" x="44723" y="142475" z="-3032" heading="14386" respawnTime="60Sec" />
+            <npc id="22186" x="45060" y="142006" z="-3032" heading="22933" respawnTime="60Sec" />
+            <npc id="22186" x="45080" y="140520" z="-3112" heading="43020" respawnTime="60Sec" />
+            <npc id="22186" x="45189" y="141651" z="-3064" heading="57508" respawnTime="60Sec" />
+            <npc id="22186" x="45233" y="141593" z="-3064" heading="57341" respawnTime="60Sec" />
+            <npc id="22186" x="45244" y="141771" z="-3056" heading="544" respawnTime="60Sec" />
+            <npc id="22186" x="45262" y="139936" z="-3112" heading="56142" respawnTime="60Sec" />
+            <npc id="22186" x="45321" y="140207" z="-3112" heading="9437" respawnTime="60Sec" />
+            <npc id="22186" x="45349" y="140864" z="-3072" heading="29228" respawnTime="60Sec" />
+            <npc id="22186" x="45393" y="140720" z="-3088" heading="62404" respawnTime="60Sec" />
+            <npc id="22186" x="45419" y="140116" z="-3112" heading="771" respawnTime="60Sec" />
+            <npc id="22186" x="45436" y="140794" z="-3072" heading="21236" respawnTime="60Sec" />
+            <npc id="22186" x="45470" y="140540" z="-3112" heading="62403" respawnTime="60Sec" />
+            <npc id="22186" x="45475" y="139819" z="-3072" heading="11547" respawnTime="60Sec" />
+            <npc id="22186" x="45477" y="141768" z="-3064" heading="53107" respawnTime="60Sec" />
+            <npc id="22186" x="45533" y="141312" z="-3072" heading="63602" respawnTime="60Sec" />
+            <npc id="22186" x="45538" y="140121" z="-3112" heading="22886" respawnTime="60Sec" />
+            <npc id="22186" x="45600" y="141629" z="-3072" heading="6618" respawnTime="60Sec" />
+            <npc id="22186" x="45623" y="140825" z="-3072" heading="16078" respawnTime="60Sec" />
+            <npc id="22186" x="45789" y="141328" z="-3072" heading="13658" respawnTime="60Sec" />
+            <npc id="22186" x="45806" y="139951" z="-3088" heading="22193" respawnTime="60Sec" />
+            <npc id="22186" x="45807" y="142179" z="-3104" heading="63319" respawnTime="60Sec" />
+            <npc id="22186" x="45812" y="141696" z="-3104" heading="62944" respawnTime="60Sec" />
+            <npc id="22186" x="45826" y="140920" z="-3072" heading="30118" respawnTime="60Sec" />
+            <npc id="22186" x="45873" y="140768" z="-3072" heading="20769" respawnTime="60Sec" />
+            <npc id="22186" x="45922" y="140197" z="-3112" heading="49153" respawnTime="60Sec" />
+            <npc id="22186" x="45931" y="140178" z="-3112" heading="56443" respawnTime="60Sec" />
+            <npc id="22186" x="45939" y="142266" z="-3096" heading="58562" respawnTime="60Sec" />
+            <npc id="22186" x="45942" y="141889" z="-3112" heading="9785" respawnTime="60Sec" />
+            <npc id="22186" x="45987" y="140284" z="-3104" heading="20622" respawnTime="60Sec" />
+            <npc id="22186" x="46016" y="141620" z="-3104" heading="10266" respawnTime="60Sec" />
+            <npc id="22186" x="46029" y="140591" z="-3072" heading="19445" respawnTime="60Sec" />
+            <npc id="22186" x="46055" y="142469" z="-3112" heading="56399" respawnTime="60Sec" />
+            <npc id="22186" x="46110" y="140248" z="-3104" heading="23176" respawnTime="60Sec" />
+            <npc id="22186" x="46198" y="140130" z="-3080" heading="25521" respawnTime="60Sec" />
+            <npc id="22186" x="46227" y="141435" z="-3096" heading="59870" respawnTime="60Sec" />
+            <npc id="22186" x="46230" y="142230" z="-3104" heading="56934" respawnTime="60Sec" />
+            <npc id="22186" x="46283" y="141475" z="-3112" heading="1952" respawnTime="60Sec" />
+            <npc id="22186" x="46315" y="141708" z="-3112" heading="7656" respawnTime="60Sec" />
+            <npc id="22186" x="46319" y="141889" z="-3112" heading="54273" respawnTime="60Sec" />
+            <npc id="22186" x="46330" y="141948" z="-3112" heading="17896" respawnTime="60Sec" />
+            <npc id="22186" x="47126" y="141399" z="-3112" heading="48305" respawnTime="60Sec" />
+            <npc id="22186" x="47136" y="141198" z="-3112" heading="56745" respawnTime="60Sec" />
+            <npc id="22186" x="47192" y="141173" z="-3120" heading="35394" respawnTime="60Sec" />
+            <npc id="22186" x="47579" y="141036" z="-3112" heading="13960" respawnTime="60Sec" />
+            <npc id="22186" x="47592" y="141541" z="-3112" heading="20730" respawnTime="60Sec" />
+            <npc id="22186" x="47672" y="141867" z="-3112" heading="8688" respawnTime="60Sec" />
+            <npc id="22186" x="47744" y="141551" z="-3112" heading="55478" respawnTime="60Sec" />
+            <npc id="22186" x="47795" y="140761" z="-3112" heading="16996" respawnTime="60Sec" />
+            <npc id="22186" x="47815" y="140802" z="-3112" heading="60633" respawnTime="60Sec" />
+            <npc id="22186" x="47887" y="141437" z="-3112" heading="28393" respawnTime="60Sec" />
+            <npc id="22186" x="47895" y="141489" z="-3112" heading="9002" respawnTime="60Sec" />
+            <npc id="22186" x="47911" y="141652" z="-3112" heading="23354" respawnTime="60Sec" />
+            <npc id="22186" x="48030" y="140827" z="-3112" heading="31056" respawnTime="60Sec" />
+            <npc id="22186" x="48100" y="141423" z="-3112" heading="50774" respawnTime="60Sec" />
+            <npc id="22186" x="48202" y="140967" z="-3112" heading="65185" respawnTime="60Sec" />
+            <npc id="22186" x="48240" y="141537" z="-3112" heading="44009" respawnTime="60Sec" />
+            <npc id="22186" x="48256" y="141187" z="-3112" heading="52125" respawnTime="60Sec" />
+            <npc id="22186" x="48265" y="141081" z="-3112" heading="10137" respawnTime="60Sec" />
+            <npc id="22186" x="48290" y="141265" z="-3112" heading="54532" respawnTime="60Sec" />
+            <npc id="22186" x="48306" y="141175" z="-3112" heading="8082" respawnTime="60Sec" />
+            <npc id="22186" x="51333" y="150357" z="-2416" heading="10001" respawnTime="60Sec" />
+            <npc id="22186" x="51413" y="150303" z="-2416" heading="64251" respawnTime="60Sec" />
+            <npc id="22186" x="51434" y="150824" z="-2416" heading="23593" respawnTime="60Sec" />
+            <npc id="22186" x="51458" y="150952" z="-2416" heading="9067" respawnTime="60Sec" />
+            <npc id="22186" x="51579" y="150211" z="-2424" heading="28475" respawnTime="60Sec" />
+            <npc id="22186" x="51580" y="151034" z="-2416" heading="31599" respawnTime="60Sec" />
+            <npc id="22186" x="51675" y="151165" z="-2416" heading="49732" respawnTime="60Sec" />
+            <npc id="22186" x="51700" y="150830" z="-2424" heading="10604" respawnTime="60Sec" />
+            <npc id="22186" x="51791" y="143025" z="-2800" heading="22935" respawnTime="60Sec" />
+            <npc id="22186" x="51797" y="151147" z="-2424" heading="33078" respawnTime="60Sec" />
+            <npc id="22186" x="51876" y="150851" z="-2432" heading="23590" respawnTime="60Sec" />
+            <npc id="22186" x="51896" y="151080" z="-2424" heading="30493" respawnTime="60Sec" />
+            <npc id="22186" x="51956" y="151118" z="-2424" heading="36891" respawnTime="60Sec" />
+            <npc id="22186" x="51985" y="150129" z="-2384" heading="43020" respawnTime="60Sec" />
+            <npc id="22186" x="51986" y="151079" z="-2424" heading="17623" respawnTime="60Sec" />
+            <npc id="22186" x="51993" y="143393" z="-2832" heading="52479" respawnTime="60Sec" />
+            <npc id="22186" x="51993" y="144037" z="-2856" heading="9600" respawnTime="60Sec" />
+            <npc id="22186" x="52005" y="150882" z="-2432" heading="9346" respawnTime="60Sec" />
+            <npc id="22186" x="52009" y="148862" z="-2408" heading="46584" respawnTime="60Sec" />
+            <npc id="22186" x="52089" y="150193" z="-2400" heading="4662" respawnTime="60Sec" />
+            <npc id="22186" x="52090" y="149211" z="-2416" heading="3096" respawnTime="60Sec" />
+            <npc id="22186" x="52094" y="144313" z="-2880" heading="55593" respawnTime="60Sec" />
+            <npc id="22186" x="52098" y="148516" z="-2408" heading="40960" respawnTime="60Sec" />
+            <npc id="22186" x="52137" y="150426" z="-2408" heading="22593" respawnTime="60Sec" />
+            <npc id="22186" x="52195" y="142933" z="-2800" heading="45083" respawnTime="60Sec" />
+            <npc id="22186" x="52195" y="143301" z="-2840" heading="36303" respawnTime="60Sec" />
+            <npc id="22186" x="52222" y="149214" z="-2416" heading="7340" respawnTime="60Sec" />
+            <npc id="22186" x="52227" y="149176" z="-2416" heading="52326" respawnTime="60Sec" />
+            <npc id="22186" x="52259" y="148473" z="-2408" heading="5641" respawnTime="60Sec" />
+            <npc id="22186" x="52296" y="142841" z="-2784" heading="30037" respawnTime="60Sec" />
+            <npc id="22186" x="52296" y="144405" z="-2904" heading="55615" respawnTime="60Sec" />
+            <npc id="22186" x="52308" y="150365" z="-2400" heading="56312" respawnTime="60Sec" />
+            <npc id="22186" x="52346" y="149235" z="-2416" heading="22311" respawnTime="60Sec" />
+            <npc id="22186" x="52351" y="141822" z="-2776" heading="35453" respawnTime="60Sec" />
+            <npc id="22186" x="52397" y="144129" z="-2912" heading="40863" respawnTime="60Sec" />
+            <npc id="22186" x="52419" y="150399" z="-2400" heading="30268" respawnTime="60Sec" />
+            <npc id="22186" x="52421" y="149217" z="-2416" heading="59820" respawnTime="60Sec" />
+            <npc id="22186" x="52468" y="141294" z="-2776" heading="22122" respawnTime="60Sec" />
+            <npc id="22186" x="52498" y="142841" z="-2776" heading="14876" respawnTime="60Sec" />
+            <npc id="22186" x="52522" y="149410" z="-2416" heading="57867" respawnTime="60Sec" />
+            <npc id="22186" x="52544" y="150852" z="-2448" heading="59661" respawnTime="60Sec" />
+            <npc id="22186" x="52585" y="141382" z="-2776" heading="25489" respawnTime="60Sec" />
+            <npc id="22186" x="52585" y="141646" z="-2776" heading="8978" respawnTime="60Sec" />
+            <npc id="22186" x="52599" y="143853" z="-2936" heading="14491" respawnTime="60Sec" />
+            <npc id="22186" x="52599" y="144221" z="-2928" heading="43530" respawnTime="60Sec" />
+            <npc id="22186" x="52676" y="148835" z="-2432" heading="12044" respawnTime="60Sec" />
+            <npc id="22186" x="52692" y="145235" z="-2944" heading="44040" respawnTime="60Sec" />
+            <npc id="22186" x="52700" y="142933" z="-2784" heading="4500" respawnTime="60Sec" />
+            <npc id="22186" x="52709" y="145348" z="-2952" heading="50192" respawnTime="60Sec" />
+            <npc id="22186" x="52717" y="149080" z="-2424" heading="58716" respawnTime="60Sec" />
+            <npc id="22186" x="52771" y="148954" z="-2432" heading="34203" respawnTime="60Sec" />
+            <npc id="22186" x="52775" y="149107" z="-2432" heading="50850" respawnTime="60Sec" />
+            <npc id="22186" x="52819" y="141294" z="-2712" heading="45879" respawnTime="60Sec" />
+            <npc id="22186" x="52819" y="148706" z="-2432" heading="53455" respawnTime="60Sec" />
+            <npc id="22186" x="52829" y="148495" z="-2432" heading="59434" respawnTime="60Sec" />
+            <npc id="22186" x="52902" y="143209" z="-2824" heading="2039" respawnTime="60Sec" />
+            <npc id="22186" x="52907" y="148543" z="-2432" heading="55837" respawnTime="60Sec" />
+            <npc id="22186" x="52936" y="141382" z="-2728" heading="16841" respawnTime="60Sec" />
+            <npc id="22186" x="52941" y="145381" z="-2984" heading="49075" respawnTime="60Sec" />
+            <npc id="22186" x="52987" y="145378" z="-2984" heading="31367" respawnTime="60Sec" />
+            <npc id="22186" x="52997" y="145331" z="-3008" heading="49616" respawnTime="60Sec" />
+            <npc id="22186" x="53015" y="148589" z="-2432" heading="55932" respawnTime="60Sec" />
+            <npc id="22186" x="53053" y="141030" z="-2632" heading="27777" respawnTime="60Sec" />
+            <npc id="22186" x="53104" y="143669" z="-2952" heading="37294" respawnTime="60Sec" />
+            <npc id="22186" x="53104" y="144221" z="-2976" heading="59790" respawnTime="60Sec" />
+            <npc id="22186" x="53104" y="144405" z="-3008" heading="33749" respawnTime="60Sec" />
+            <npc id="22186" x="53106" y="148938" z="-2432" heading="19873" respawnTime="60Sec" />
+            <npc id="22186" x="53116" y="145615" z="-2968" heading="51317" respawnTime="60Sec" />
+            <npc id="22186" x="53116" y="146894" z="-2856" heading="48563" respawnTime="60Sec" />
+            <npc id="22186" x="53123" y="148473" z="-2432" heading="6325" respawnTime="60Sec" />
+            <npc id="22186" x="53164" y="149074" z="-2448" heading="16849" respawnTime="60Sec" />
+            <npc id="22186" x="53170" y="141470" z="-2712" heading="8228" respawnTime="60Sec" />
+            <npc id="22186" x="53170" y="142086" z="-2776" heading="43593" respawnTime="60Sec" />
+            <npc id="22186" x="53170" y="142262" z="-2776" heading="33452" respawnTime="60Sec" />
+            <npc id="22186" x="53205" y="143301" z="-2896" heading="24735" respawnTime="60Sec" />
+            <npc id="22186" x="53222" y="145318" z="-3032" heading="11824" respawnTime="60Sec" />
+            <npc id="22186" x="53225" y="141398" z="-2696" heading="47071" respawnTime="60Sec" />
+            <npc id="22186" x="53252" y="147366" z="-2728" heading="58516" respawnTime="60Sec" />
+            <npc id="22186" x="53265" y="145250" z="-3032" heading="6545" respawnTime="60Sec" />
+            <npc id="22186" x="53266" y="147334" z="-2744" heading="61115" respawnTime="60Sec" />
+            <npc id="22186" x="53301" y="147326" z="-2760" heading="28241" respawnTime="60Sec" />
+            <npc id="22186" x="53306" y="143117" z="-2848" heading="46737" respawnTime="60Sec" />
+            <npc id="22186" x="53306" y="143117" z="-2848" heading="52994" respawnTime="60Sec" />
+            <npc id="22186" x="53322" y="147043" z="-2856" heading="14251" respawnTime="60Sec" />
+            <npc id="22186" x="53330" y="144925" z="-3016" heading="15238" respawnTime="60Sec" />
+            <npc id="22186" x="53344" y="145056" z="-3016" heading="28378" respawnTime="60Sec" />
+            <npc id="22186" x="53357" y="146023" z="-2944" heading="6665" respawnTime="60Sec" />
+            <npc id="22186" x="53387" y="141487" z="-2704" heading="35058" respawnTime="60Sec" />
+            <npc id="22186" x="53404" y="141910" z="-2752" heading="61030" respawnTime="60Sec" />
+            <npc id="22186" x="53417" y="145389" z="-3064" heading="38198" respawnTime="60Sec" />
+            <npc id="22186" x="53422" y="142368" z="-2776" heading="63097" respawnTime="60Sec" />
+            <npc id="22186" x="53458" y="144948" z="-3016" heading="13306" respawnTime="60Sec" />
+            <npc id="22186" x="53478" y="145380" z="-3064" heading="29590" respawnTime="60Sec" />
+            <npc id="22186" x="53542" y="142183" z="-2776" heading="57048" respawnTime="60Sec" />
+            <npc id="22186" x="53554" y="147377" z="-2768" heading="8207" respawnTime="60Sec" />
+            <npc id="22186" x="53555" y="145289" z="-3072" heading="41076" respawnTime="60Sec" />
+            <npc id="22186" x="53622" y="146933" z="-2896" heading="38881" respawnTime="60Sec" />
+            <npc id="22186" x="53635" y="144958" z="-3032" heading="60185" respawnTime="60Sec" />
+            <npc id="22186" x="53675" y="146635" z="-2888" heading="55542" respawnTime="60Sec" />
+            <npc id="22186" x="53692" y="145512" z="-3088" heading="22389" respawnTime="60Sec" />
+            <npc id="22186" x="53708" y="147010" z="-2864" heading="5703" respawnTime="60Sec" />
+            <npc id="22186" x="53718" y="147177" z="-2840" heading="11478" respawnTime="60Sec" />
+            <npc id="22186" x="53743" y="146563" z="-2888" heading="33602" respawnTime="60Sec" />
+            <npc id="22186" x="53752" y="146430" z="-2920" heading="23501" respawnTime="60Sec" />
+            <npc id="22186" x="53791" y="146761" z="-2880" heading="28806" respawnTime="60Sec" />
+            <npc id="22186" x="53798" y="146982" z="-2864" heading="39819" respawnTime="60Sec" />
+            <npc id="22186" x="53804" y="145309" z="-3080" heading="27086" respawnTime="60Sec" />
+            <npc id="22186" x="53863" y="140768" z="-2696" heading="26290" respawnTime="60Sec" />
+            <npc id="22186" x="53891" y="145662" z="-3088" heading="31526" respawnTime="60Sec" />
+            <npc id="22186" x="53922" y="146788" z="-2896" heading="11287" respawnTime="60Sec" />
+            <npc id="22186" x="53957" y="145403" z="-3080" heading="15453" respawnTime="60Sec" />
+            <npc id="22186" x="54032" y="147613" z="-2720" heading="10640" respawnTime="60Sec" />
+            <npc id="22186" x="54037" y="141215" z="-2720" heading="10713" respawnTime="60Sec" />
+            <npc id="22186" x="54045" y="140808" z="-2704" heading="61022" respawnTime="60Sec" />
+            <npc id="22186" x="54096" y="141556" z="-2752" heading="40144" respawnTime="60Sec" />
+            <npc id="22186" x="54106" y="141206" z="-2744" heading="9645" respawnTime="60Sec" />
+            <npc id="22186" x="54178" y="147615" z="-2760" heading="18412" respawnTime="60Sec" />
+            <npc id="22186" x="54229" y="146990" z="-2888" heading="44282" respawnTime="60Sec" />
+            <npc id="22186" x="54267" y="142876" z="-2888" heading="60837" respawnTime="60Sec" />
+            <npc id="22186" x="54333" y="147144" z="-2880" heading="32490" respawnTime="60Sec" />
+            <npc id="22186" x="54408" y="143228" z="-2992" heading="3242" respawnTime="60Sec" />
+            <npc id="22186" x="54448" y="142796" z="-2904" heading="26996" respawnTime="60Sec" />
+            <npc id="22186" x="54548" y="143327" z="-3000" heading="38609" respawnTime="60Sec" />
+            <npc id="22186" x="54615" y="145045" z="-3008" heading="61171" respawnTime="60Sec" />
+            <npc id="22186" x="54657" y="144302" z="-3024" heading="51736" respawnTime="60Sec" />
+            <npc id="22186" x="54672" y="142375" z="-2856" heading="35615" respawnTime="60Sec" />
+            <npc id="22186" x="54695" y="142952" z="-2928" heading="8095" respawnTime="60Sec" />
+            <npc id="22186" x="54705" y="143141" z="-2968" heading="29483" respawnTime="60Sec" />
+            <npc id="22186" x="54742" y="142519" z="-2872" heading="46433" respawnTime="60Sec" />
+            <npc id="22186" x="54747" y="144734" z="-3000" heading="36092" respawnTime="60Sec" />
+            <npc id="22186" x="54789" y="144909" z="-3000" heading="59170" respawnTime="60Sec" />
+            <npc id="22186" x="54819" y="144643" z="-3000" heading="21456" respawnTime="60Sec" />
+            <npc id="22186" x="54843" y="142514" z="-2864" heading="4174" respawnTime="60Sec" />
+            <npc id="22186" x="54900" y="143063" z="-2952" heading="39505" respawnTime="60Sec" />
+            <npc id="22186" x="54921" y="142593" z="-2880" heading="29288" respawnTime="60Sec" />
+            <npc id="22186" x="54991" y="145213" z="-3024" heading="3252" respawnTime="60Sec" />
+            <npc id="22186" x="55008" y="143468" z="-3024" heading="21077" respawnTime="60Sec" />
+            <npc id="22186" x="55061" y="144942" z="-3000" heading="42158" respawnTime="60Sec" />
+            <npc id="22186" x="55080" y="143398" z="-3032" heading="27554" respawnTime="60Sec" />
+            <npc id="22186" x="55085" y="142857" z="-2936" heading="38616" respawnTime="60Sec" />
+            <npc id="22186" x="55100" y="140789" z="-2776" heading="56144" respawnTime="60Sec" />
+            <npc id="22186" x="55124" y="144786" z="-3000" heading="4074" respawnTime="60Sec" />
+            <npc id="22186" x="55125" y="142926" z="-2936" heading="63054" respawnTime="60Sec" />
+            <npc id="22186" x="55151" y="144773" z="-3000" heading="58835" respawnTime="60Sec" />
+            <npc id="22186" x="55161" y="140703" z="-2776" heading="49458" respawnTime="60Sec" />
+            <npc id="22186" x="55175" y="142936" z="-2928" heading="30829" respawnTime="60Sec" />
+            <npc id="22186" x="55179" y="143358" z="-3024" heading="51408" respawnTime="60Sec" />
+            <npc id="22186" x="55222" y="140706" z="-2776" heading="9985" respawnTime="60Sec" />
+            <npc id="22186" x="55296" y="142488" z="-2832" heading="29590" respawnTime="60Sec" />
+            <npc id="22186" x="55314" y="146623" z="-2944" heading="61985" respawnTime="60Sec" />
+            <npc id="22186" x="55368" y="143118" z="-3000" heading="22292" respawnTime="60Sec" />
+            <npc id="22186" x="55373" y="146980" z="-2936" heading="5746" respawnTime="60Sec" />
+            <npc id="22186" x="55405" y="140531" z="-2776" heading="23562" respawnTime="60Sec" />
+            <npc id="22186" x="55406" y="146382" z="-2976" heading="59870" respawnTime="60Sec" />
+            <npc id="22186" x="55407" y="144135" z="-3008" heading="5064" respawnTime="60Sec" />
+            <npc id="22186" x="55407" y="144205" z="-3008" heading="8964" respawnTime="60Sec" />
+            <npc id="22186" x="55407" y="144835" z="-3008" heading="15024" respawnTime="60Sec" />
+            <npc id="22186" x="55407" y="145185" z="-3040" heading="11215" respawnTime="60Sec" />
+            <npc id="22186" x="55430" y="145272" z="-3048" heading="740" respawnTime="60Sec" />
+            <npc id="22186" x="55440" y="142558" z="-2824" heading="17251" respawnTime="60Sec" />
+            <npc id="22186" x="55466" y="140789" z="-2776" heading="50379" respawnTime="60Sec" />
+            <npc id="22186" x="55479" y="144065" z="-3008" heading="15118" respawnTime="60Sec" />
+            <npc id="22186" x="55484" y="147102" z="-2936" heading="13765" respawnTime="60Sec" />
+            <npc id="22186" x="55515" y="147096" z="-2936" heading="65340" respawnTime="60Sec" />
+            <npc id="22186" x="55527" y="141477" z="-2776" heading="28248" respawnTime="60Sec" />
+            <npc id="22186" x="55527" y="141649" z="-2776" heading="8716" respawnTime="60Sec" />
+            <npc id="22186" x="55556" y="146192" z="-2976" heading="23554" respawnTime="60Sec" />
+            <npc id="22186" x="55588" y="140703" z="-2776" heading="46110" respawnTime="60Sec" />
+            <npc id="22186" x="55588" y="141391" z="-2776" heading="16558" respawnTime="60Sec" />
+            <npc id="22186" x="55588" y="141649" z="-2776" heading="52634" respawnTime="60Sec" />
+            <npc id="22186" x="55623" y="144415" z="-3000" heading="10946" respawnTime="60Sec" />
+            <npc id="22186" x="55628" y="146122" z="-2984" heading="35859" respawnTime="60Sec" />
+            <npc id="22186" x="55649" y="141735" z="-2776" heading="58205" respawnTime="60Sec" />
+            <npc id="22186" x="55695" y="144975" z="-3056" heading="30772" respawnTime="60Sec" />
+            <npc id="22186" x="55697" y="141672" z="-2776" heading="47132" respawnTime="60Sec" />
+            <npc id="22186" x="55700" y="146052" z="-2984" heading="40853" respawnTime="60Sec" />
+            <npc id="22186" x="55700" y="146262" z="-2968" heading="39793" respawnTime="60Sec" />
+            <npc id="22186" x="55710" y="141821" z="-2776" heading="40927" respawnTime="60Sec" />
+            <npc id="22186" x="55767" y="144835" z="-3032" heading="41417" respawnTime="60Sec" />
+            <npc id="22186" x="55771" y="140875" z="-2776" heading="40160" respawnTime="60Sec" />
+            <npc id="22186" x="55788" y="147276" z="-2936" heading="38770" respawnTime="60Sec" />
+            <npc id="22186" x="55832" y="142079" z="-2768" heading="4794" respawnTime="60Sec" />
+            <npc id="22186" x="55839" y="144415" z="-3016" heading="333" respawnTime="60Sec" />
+            <npc id="22186" x="55839" y="144485" z="-3016" heading="39807" respawnTime="60Sec" />
+            <npc id="22186" x="55844" y="146612" z="-2944" heading="2293" respawnTime="60Sec" />
+            <npc id="22186" x="55844" y="147312" z="-2936" heading="28534" respawnTime="60Sec" />
+            <npc id="22186" x="55893" y="141219" z="-2776" heading="40872" respawnTime="60Sec" />
+            <npc id="22186" x="55954" y="140961" z="-2776" heading="55645" respawnTime="60Sec" />
+            <npc id="22186" x="56015" y="141133" z="-2776" heading="57829" respawnTime="60Sec" />
+            <npc id="22186" x="56076" y="141219" z="-2776" heading="21190" respawnTime="60Sec" />
+            <npc id="22186" x="56082" y="147212" z="-2920" heading="25546" respawnTime="60Sec" />
+            <npc id="22186" x="56132" y="146752" z="-2912" heading="2400" respawnTime="60Sec" />
+            <npc id="22186" x="56137" y="141305" z="-2776" heading="53326" respawnTime="60Sec" />
+            <npc id="22186" x="56204" y="146682" z="-2896" heading="64226" respawnTime="60Sec" />
+            <npc id="22186" x="56204" y="146892" z="-2880" heading="42034" respawnTime="60Sec" />
+            <npc id="22186" x="56204" y="146962" z="-2912" heading="23907" respawnTime="60Sec" />
+            <npc id="22186" x="56276" y="146542" z="-2912" heading="9763" respawnTime="60Sec" />
+            <npc id="22186" x="56276" y="146682" z="-2896" heading="23789" respawnTime="60Sec" />
+            <npc id="22186" x="56276" y="146682" z="-2896" heading="40239" respawnTime="60Sec" />
+            <npc id="22187" x="41272" y="141094" z="-2848" heading="10699" respawnTime="60Sec" />
+            <npc id="22187" x="41315" y="140660" z="-2896" heading="47990" respawnTime="60Sec" />
+            <npc id="22187" x="41446" y="141517" z="-2792" heading="8315" respawnTime="60Sec" />
+            <npc id="22187" x="41461" y="140983" z="-2928" heading="39978" respawnTime="60Sec" />
+            <npc id="22187" x="41518" y="140901" z="-2952" heading="20546" respawnTime="60Sec" />
+            <npc id="22187" x="41635" y="140794" z="-3008" heading="56883" respawnTime="60Sec" />
+            <npc id="22187" x="41657" y="141075" z="-2968" heading="13470" respawnTime="60Sec" />
+            <npc id="22187" x="41668" y="142928" z="-2928" heading="27793" respawnTime="60Sec" />
+            <npc id="22187" x="41709" y="140449" z="-3000" heading="40267" respawnTime="60Sec" />
+            <npc id="22187" x="41746" y="142000" z="-2784" heading="49570" respawnTime="60Sec" />
+            <npc id="22187" x="41858" y="140912" z="-3024" heading="50535" respawnTime="60Sec" />
+            <npc id="22187" x="41880" y="142974" z="-2968" heading="40361" respawnTime="60Sec" />
+            <npc id="22187" x="41933" y="142960" z="-2976" heading="6782" respawnTime="60Sec" />
+            <npc id="22187" x="42031" y="140346" z="-3024" heading="40185" respawnTime="60Sec" />
+            <npc id="22187" x="42034" y="141131" z="-3008" heading="18941" respawnTime="60Sec" />
+            <npc id="22187" x="42058" y="142886" z="-2968" heading="15803" respawnTime="60Sec" />
+            <npc id="22187" x="42103" y="141884" z="-2896" heading="41426" respawnTime="60Sec" />
+            <npc id="22187" x="42140" y="140597" z="-3072" heading="51132" respawnTime="60Sec" />
+            <npc id="22187" x="42163" y="143395" z="-3056" heading="45184" respawnTime="60Sec" />
+            <npc id="22187" x="42166" y="141140" z="-3040" heading="48516" respawnTime="60Sec" />
+            <npc id="22187" x="42194" y="141594" z="-2976" heading="45312" respawnTime="60Sec" />
+            <npc id="22187" x="42204" y="143713" z="-3080" heading="51534" respawnTime="60Sec" />
+            <npc id="22187" x="42206" y="140618" z="-3072" heading="40015" respawnTime="60Sec" />
+            <npc id="22187" x="42216" y="142909" z="-2976" heading="18816" respawnTime="60Sec" />
+            <npc id="22187" x="42266" y="142510" z="-2944" heading="27568" respawnTime="60Sec" />
+            <npc id="22187" x="42277" y="142613" z="-2960" heading="54195" respawnTime="60Sec" />
+            <npc id="22187" x="42341" y="142588" z="-2944" heading="814" respawnTime="60Sec" />
+            <npc id="22187" x="42430" y="141808" z="-2968" heading="234" respawnTime="60Sec" />
+            <npc id="22187" x="42434" y="142725" z="-2960" heading="3467" respawnTime="60Sec" />
+            <npc id="22187" x="42467" y="142912" z="-2960" heading="60978" respawnTime="60Sec" />
+            <npc id="22187" x="42468" y="143249" z="-3016" heading="47498" respawnTime="60Sec" />
+            <npc id="22187" x="42476" y="141387" z="-3024" heading="31990" respawnTime="60Sec" />
+            <npc id="22187" x="42543" y="143557" z="-3048" heading="29387" respawnTime="60Sec" />
+            <npc id="22187" x="42609" y="143050" z="-2960" heading="63093" respawnTime="60Sec" />
+            <npc id="22187" x="42650" y="142972" z="-2960" heading="20622" respawnTime="60Sec" />
+            <npc id="22187" x="42723" y="143370" z="-3024" heading="1167" respawnTime="60Sec" />
+            <npc id="22187" x="42753" y="143469" z="-3024" heading="63136" respawnTime="60Sec" />
+            <npc id="22187" x="42757" y="143139" z="-2968" heading="25451" respawnTime="60Sec" />
+            <npc id="22187" x="42773" y="142730" z="-2960" heading="40920" respawnTime="60Sec" />
+            <npc id="22187" x="42851" y="141462" z="-3040" heading="6256" respawnTime="60Sec" />
+            <npc id="22187" x="43343" y="141119" z="-3096" heading="15627" respawnTime="60Sec" />
+            <npc id="22187" x="43454" y="140443" z="-3048" heading="33463" respawnTime="60Sec" />
+            <npc id="22187" x="43511" y="141209" z="-3080" heading="33078" respawnTime="60Sec" />
+            <npc id="22187" x="43652" y="140852" z="-3080" heading="38472" respawnTime="60Sec" />
+            <npc id="22187" x="43659" y="142551" z="-3000" heading="14791" respawnTime="60Sec" />
+            <npc id="22187" x="43714" y="142356" z="-3024" heading="31470" respawnTime="60Sec" />
+            <npc id="22187" x="43762" y="140464" z="-3072" heading="23172" respawnTime="60Sec" />
+            <npc id="22187" x="43782" y="141156" z="-3048" heading="64056" respawnTime="60Sec" />
+            <npc id="22187" x="43788" y="142773" z="-2968" heading="37295" respawnTime="60Sec" />
+            <npc id="22187" x="43817" y="142222" z="-3048" heading="29594" respawnTime="60Sec" />
+            <npc id="22187" x="43842" y="140078" z="-2976" heading="53239" respawnTime="60Sec" />
+            <npc id="22187" x="43861" y="141127" z="-3048" heading="54770" respawnTime="60Sec" />
+            <npc id="22187" x="43901" y="140795" z="-3104" heading="27992" respawnTime="60Sec" />
+            <npc id="22187" x="43939" y="142836" z="-3000" heading="8423" respawnTime="60Sec" />
+            <npc id="22187" x="43965" y="142257" z="-3040" heading="51121" respawnTime="60Sec" />
+            <npc id="22187" x="43967" y="143210" z="-3016" heading="52245" respawnTime="60Sec" />
+            <npc id="22187" x="43983" y="140367" z="-3072" heading="12419" respawnTime="60Sec" />
+            <npc id="22187" x="44014" y="140401" z="-3096" heading="3687" respawnTime="60Sec" />
+            <npc id="22187" x="44039" y="142160" z="-3024" heading="30674" respawnTime="60Sec" />
+            <npc id="22187" x="44108" y="141088" z="-3040" heading="4070" respawnTime="60Sec" />
+            <npc id="22187" x="44111" y="140348" z="-3104" heading="26714" respawnTime="60Sec" />
+            <npc id="22187" x="44115" y="140102" z="-3008" heading="14029" respawnTime="60Sec" />
+            <npc id="22187" x="44130" y="140540" z="-3104" heading="3319" respawnTime="60Sec" />
+            <npc id="22187" x="44183" y="143210" z="-3032" heading="7666" respawnTime="60Sec" />
+            <npc id="22187" x="44183" y="143350" z="-3040" heading="25125" respawnTime="60Sec" />
+            <npc id="22187" x="44184" y="140299" z="-3088" heading="36222" respawnTime="60Sec" />
+            <npc id="22187" x="44197" y="142320" z="-3024" heading="60146" respawnTime="60Sec" />
+            <npc id="22187" x="44260" y="143049" z="-3032" heading="12303" respawnTime="60Sec" />
+            <npc id="22187" x="44296" y="140211" z="-3048" heading="4314" respawnTime="60Sec" />
+            <npc id="22187" x="44302" y="140513" z="-3104" heading="3577" respawnTime="60Sec" />
+            <npc id="22187" x="44366" y="142390" z="-3024" heading="15101" respawnTime="60Sec" />
+            <npc id="22187" x="44366" y="142608" z="-3048" heading="25720" respawnTime="60Sec" />
+            <npc id="22187" x="44418" y="143352" z="-3040" heading="30674" respawnTime="60Sec" />
+            <npc id="22187" x="44443" y="143309" z="-3040" heading="23095" respawnTime="60Sec" />
+            <npc id="22187" x="44451" y="142410" z="-3024" heading="61456" respawnTime="60Sec" />
+            <npc id="22187" x="44487" y="140759" z="-3088" heading="32814" respawnTime="60Sec" />
+            <npc id="22187" x="44594" y="140508" z="-3096" heading="47411" respawnTime="60Sec" />
+            <npc id="22187" x="44687" y="143158" z="-3040" heading="27592" respawnTime="60Sec" />
+            <npc id="22187" x="44744" y="142843" z="-3032" heading="26968" respawnTime="60Sec" />
+            <npc id="22187" x="44759" y="143070" z="-3032" heading="25782" respawnTime="60Sec" />
+            <npc id="22187" x="45159" y="140265" z="-3112" heading="9601" respawnTime="60Sec" />
+            <npc id="22187" x="45206" y="141730" z="-3056" heading="15917" respawnTime="60Sec" />
+            <npc id="22187" x="45261" y="140421" z="-3112" heading="31919" respawnTime="60Sec" />
+            <npc id="22187" x="45282" y="141485" z="-3072" heading="57794" respawnTime="60Sec" />
+            <npc id="22187" x="45314" y="141449" z="-3072" heading="48767" respawnTime="60Sec" />
+            <npc id="22187" x="45375" y="141559" z="-3072" heading="42487" respawnTime="60Sec" />
+            <npc id="22187" x="45426" y="139936" z="-3112" heading="53057" respawnTime="60Sec" />
+            <npc id="22187" x="45462" y="141575" z="-3072" heading="21567" respawnTime="60Sec" />
+            <npc id="22187" x="45466" y="141413" z="-3072" heading="42025" respawnTime="60Sec" />
+            <npc id="22187" x="45536" y="140502" z="-3112" heading="25068" respawnTime="60Sec" />
+            <npc id="22187" x="45551" y="140279" z="-3112" heading="45870" respawnTime="60Sec" />
+            <npc id="22187" x="45551" y="141513" z="-3072" heading="6293" respawnTime="60Sec" />
+            <npc id="22187" x="45556" y="140542" z="-3112" heading="59380" respawnTime="60Sec" />
+            <npc id="22187" x="45589" y="140118" z="-3112" heading="64369" respawnTime="60Sec" />
+            <npc id="22187" x="45609" y="141499" z="-3072" heading="15332" respawnTime="60Sec" />
+            <npc id="22187" x="45690" y="141398" z="-3072" heading="2400" respawnTime="60Sec" />
+            <npc id="22187" x="45701" y="141303" z="-3072" heading="52606" respawnTime="60Sec" />
+            <npc id="22187" x="45719" y="141983" z="-3104" heading="56910" respawnTime="60Sec" />
+            <npc id="22187" x="45735" y="141281" z="-3072" heading="36417" respawnTime="60Sec" />
+            <npc id="22187" x="45759" y="140348" z="-3112" heading="13800" respawnTime="60Sec" />
+            <npc id="22187" x="45787" y="140258" z="-3112" heading="51008" respawnTime="60Sec" />
+            <npc id="22187" x="45871" y="141340" z="-3072" heading="468" respawnTime="60Sec" />
+            <npc id="22187" x="45887" y="141870" z="-3112" heading="34027" respawnTime="60Sec" />
+            <npc id="22187" x="45930" y="141530" z="-3088" heading="52746" respawnTime="60Sec" />
+            <npc id="22187" x="45934" y="140974" z="-3072" heading="27209" respawnTime="60Sec" />
+            <npc id="22187" x="46014" y="140735" z="-3064" heading="1556" respawnTime="60Sec" />
+            <npc id="22187" x="46027" y="142030" z="-3104" heading="63843" respawnTime="60Sec" />
+            <npc id="22187" x="46078" y="140598" z="-3072" heading="20839" respawnTime="60Sec" />
+            <npc id="22187" x="46125" y="140767" z="-3072" heading="20585" respawnTime="60Sec" />
+            <npc id="22187" x="46142" y="139910" z="-3056" heading="43903" respawnTime="60Sec" />
+            <npc id="22187" x="46169" y="140026" z="-3088" heading="46039" respawnTime="60Sec" />
+            <npc id="22187" x="46215" y="142042" z="-3096" heading="13545" respawnTime="60Sec" />
+            <npc id="22187" x="46218" y="142330" z="-3104" heading="40574" respawnTime="60Sec" />
+            <npc id="22187" x="46227" y="140808" z="-3080" heading="13913" respawnTime="60Sec" />
+            <npc id="22187" x="46231" y="141520" z="-3112" heading="24994" respawnTime="60Sec" />
+            <npc id="22187" x="46234" y="140104" z="-3080" heading="36394" respawnTime="60Sec" />
+            <npc id="22187" x="46241" y="141454" z="-3112" heading="61481" respawnTime="60Sec" />
+            <npc id="22187" x="46249" y="140591" z="-3096" heading="22119" respawnTime="60Sec" />
+            <npc id="22187" x="46259" y="140069" z="-3080" heading="53937" respawnTime="60Sec" />
+            <npc id="22187" x="46332" y="140618" z="-3096" heading="10008" respawnTime="60Sec" />
+            <npc id="22187" x="47095" y="141379" z="-3112" heading="44884" respawnTime="60Sec" />
+            <npc id="22187" x="47201" y="141294" z="-3112" heading="4488" respawnTime="60Sec" />
+            <npc id="22187" x="47231" y="141611" z="-3112" heading="26473" respawnTime="60Sec" />
+            <npc id="22187" x="47362" y="141587" z="-3112" heading="57386" respawnTime="60Sec" />
+            <npc id="22187" x="47415" y="141206" z="-3112" heading="46234" respawnTime="60Sec" />
+            <npc id="22187" x="47496" y="141137" z="-3112" heading="19497" respawnTime="60Sec" />
+            <npc id="22187" x="47500" y="140769" z="-3112" heading="52326" respawnTime="60Sec" />
+            <npc id="22187" x="47552" y="141935" z="-3112" heading="29100" respawnTime="60Sec" />
+            <npc id="22187" x="47611" y="140900" z="-3112" heading="7695" respawnTime="60Sec" />
+            <npc id="22187" x="47673" y="141540" z="-3112" heading="55865" respawnTime="60Sec" />
+            <npc id="22187" x="47746" y="141523" z="-3112" heading="64369" respawnTime="60Sec" />
+            <npc id="22187" x="47772" y="140757" z="-3112" heading="6782" respawnTime="60Sec" />
+            <npc id="22187" x="47800" y="140998" z="-3112" heading="31522" respawnTime="60Sec" />
+            <npc id="22187" x="47917" y="140978" z="-3112" heading="64605" respawnTime="60Sec" />
+            <npc id="22187" x="48079" y="141394" z="-3112" heading="56877" respawnTime="60Sec" />
+            <npc id="22187" x="48099" y="140918" z="-3112" heading="11551" respawnTime="60Sec" />
+            <npc id="22187" x="48139" y="141252" z="-3112" heading="7315" respawnTime="60Sec" />
+            <npc id="22187" x="48166" y="141224" z="-3112" heading="39819" respawnTime="60Sec" />
+            <npc id="22187" x="48169" y="141101" z="-3112" heading="17546" respawnTime="60Sec" />
+            <npc id="22187" x="48216" y="140921" z="-3112" heading="23683" respawnTime="60Sec" />
+            <npc id="22187" x="51238" y="150454" z="-2416" heading="54472" respawnTime="60Sec" />
+            <npc id="22187" x="51364" y="151038" z="-2416" heading="64277" respawnTime="60Sec" />
+            <npc id="22187" x="51619" y="151007" z="-2424" heading="10557" respawnTime="60Sec" />
+            <npc id="22187" x="51662" y="150079" z="-2424" heading="59710" respawnTime="60Sec" />
+            <npc id="22187" x="51690" y="144129" z="-2808" heading="59638" respawnTime="60Sec" />
+            <npc id="22187" x="51791" y="142933" z="-2792" heading="36704" respawnTime="60Sec" />
+            <npc id="22187" x="51860" y="150878" z="-2432" heading="17781" respawnTime="60Sec" />
+            <npc id="22187" x="51863" y="150608" z="-2432" heading="33463" respawnTime="60Sec" />
+            <npc id="22187" x="51892" y="144313" z="-2824" heading="5094" respawnTime="60Sec" />
+            <npc id="22187" x="51925" y="150080" z="-2400" heading="34850" respawnTime="60Sec" />
+            <npc id="22187" x="51964" y="150176" z="-2408" heading="25451" respawnTime="60Sec" />
+            <npc id="22187" x="51993" y="143025" z="-2808" heading="51483" respawnTime="60Sec" />
+            <npc id="22187" x="51993" y="144037" z="-2856" heading="23973" respawnTime="60Sec" />
+            <npc id="22187" x="51994" y="150895" z="-2432" heading="155" respawnTime="60Sec" />
+            <npc id="22187" x="51997" y="149060" z="-2416" heading="26554" respawnTime="60Sec" />
+            <npc id="22187" x="52029" y="150991" z="-2424" heading="35435" respawnTime="60Sec" />
+            <npc id="22187" x="52094" y="142933" z="-2792" heading="25392" respawnTime="60Sec" />
+            <npc id="22187" x="52094" y="143577" z="-2840" heading="17237" respawnTime="60Sec" />
+            <npc id="22187" x="52105" y="148960" z="-2416" heading="26055" respawnTime="60Sec" />
+            <npc id="22187" x="52114" y="148679" z="-2416" heading="7641" respawnTime="60Sec" />
+            <npc id="22187" x="52176" y="150115" z="-2376" heading="38148" respawnTime="60Sec" />
+            <npc id="22187" x="52186" y="150222" z="-2392" heading="42441" respawnTime="60Sec" />
+            <npc id="22187" x="52188" y="148942" z="-2416" heading="7585" respawnTime="60Sec" />
+            <npc id="22187" x="52195" y="143117" z="-2824" heading="35455" respawnTime="60Sec" />
+            <npc id="22187" x="52212" y="149011" z="-2416" heading="33809" respawnTime="60Sec" />
+            <npc id="22187" x="52218" y="150718" z="-2432" heading="13913" respawnTime="60Sec" />
+            <npc id="22187" x="52263" y="149054" z="-2416" heading="56854" respawnTime="60Sec" />
+            <npc id="22187" x="52296" y="142841" z="-2784" heading="30674" respawnTime="60Sec" />
+            <npc id="22187" x="52296" y="150791" z="-2432" heading="7393" respawnTime="60Sec" />
+            <npc id="22187" x="52313" y="149170" z="-2416" heading="59243" respawnTime="60Sec" />
+            <npc id="22187" x="52343" y="150530" z="-2424" heading="49462" respawnTime="60Sec" />
+            <npc id="22187" x="52351" y="141558" z="-2784" heading="11082" respawnTime="60Sec" />
+            <npc id="22187" x="52351" y="142174" z="-2776" heading="43981" respawnTime="60Sec" />
+            <npc id="22187" x="52351" y="150824" z="-2432" heading="11105" respawnTime="60Sec" />
+            <npc id="22187" x="52356" y="148916" z="-2424" heading="30274" respawnTime="60Sec" />
+            <npc id="22187" x="52360" y="149336" z="-2416" heading="31919" respawnTime="60Sec" />
+            <npc id="22187" x="52368" y="150895" z="-2440" heading="57290" respawnTime="60Sec" />
+            <npc id="22187" x="52380" y="148285" z="-2416" heading="1282" respawnTime="60Sec" />
+            <npc id="22187" x="52397" y="143577" z="-2912" heading="61825" respawnTime="60Sec" />
+            <npc id="22187" x="52397" y="144405" z="-2920" heading="29150" respawnTime="60Sec" />
+            <npc id="22187" x="52447" y="149450" z="-2408" heading="65462" respawnTime="60Sec" />
+            <npc id="22187" x="52468" y="142262" z="-2776" heading="10803" respawnTime="60Sec" />
+            <npc id="22187" x="52468" y="142262" z="-2776" heading="24312" respawnTime="60Sec" />
+            <npc id="22187" x="52498" y="143393" z="-2880" heading="32402" respawnTime="60Sec" />
+            <npc id="22187" x="52498" y="150524" z="-2416" heading="3096" respawnTime="60Sec" />
+            <npc id="22187" x="52503" y="149064" z="-2416" heading="59532" respawnTime="60Sec" />
+            <npc id="22187" x="52514" y="150614" z="-2424" heading="64601" respawnTime="60Sec" />
+            <npc id="22187" x="52568" y="150636" z="-2424" heading="27423" respawnTime="60Sec" />
+            <npc id="22187" x="52585" y="141118" z="-2760" heading="14356" respawnTime="60Sec" />
+            <npc id="22187" x="52585" y="141646" z="-2776" heading="22260" respawnTime="60Sec" />
+            <npc id="22187" x="52596" y="149101" z="-2416" heading="28655" respawnTime="60Sec" />
+            <npc id="22187" x="52597" y="149203" z="-2416" heading="53851" respawnTime="60Sec" />
+            <npc id="22187" x="52660" y="145347" z="-2936" heading="40635" respawnTime="60Sec" />
+            <npc id="22187" x="52667" y="148994" z="-2424" heading="3503" respawnTime="60Sec" />
+            <npc id="22187" x="52699" y="145238" z="-2944" heading="9148" respawnTime="60Sec" />
+            <npc id="22187" x="52700" y="144405" z="-2976" heading="34733" respawnTime="60Sec" />
+            <npc id="22187" x="52702" y="141382" z="-2744" heading="17122" respawnTime="60Sec" />
+            <npc id="22187" x="52702" y="142086" z="-2776" heading="57755" respawnTime="60Sec" />
+            <npc id="22187" x="52765" y="148669" z="-2432" heading="20751" respawnTime="60Sec" />
+            <npc id="22187" x="52798" y="148664" z="-2432" heading="22967" respawnTime="60Sec" />
+            <npc id="22187" x="52801" y="143485" z="-2928" heading="47238" respawnTime="60Sec" />
+            <npc id="22187" x="52819" y="141118" z="-2680" heading="13881" respawnTime="60Sec" />
+            <npc id="22187" x="52819" y="141206" z="-2688" heading="62612" respawnTime="60Sec" />
+            <npc id="22187" x="52835" y="148333" z="-2424" heading="59317" respawnTime="60Sec" />
+            <npc id="22187" x="52980" y="148405" z="-2432" heading="53756" respawnTime="60Sec" />
+            <npc id="22187" x="53003" y="143669" z="-2952" heading="65013" respawnTime="60Sec" />
+            <npc id="22187" x="53056" y="145508" z="-3000" heading="21288" respawnTime="60Sec" />
+            <npc id="22187" x="53059" y="145308" z="-3008" heading="45251" respawnTime="60Sec" />
+            <npc id="22187" x="53104" y="142933" z="-2784" heading="17642" respawnTime="60Sec" />
+            <npc id="22187" x="53104" y="143945" z="-2976" heading="7230" respawnTime="60Sec" />
+            <npc id="22187" x="53104" y="145423" z="-3032" heading="8238" respawnTime="60Sec" />
+            <npc id="22187" x="53127" y="147009" z="-2840" heading="55237" respawnTime="60Sec" />
+            <npc id="22187" x="53131" y="145168" z="-3024" heading="7663" respawnTime="60Sec" />
+            <npc id="22187" x="53141" y="149005" z="-2448" heading="37636" respawnTime="60Sec" />
+            <npc id="22187" x="53143" y="145261" z="-3024" heading="28774" respawnTime="60Sec" />
+            <npc id="22187" x="53147" y="145136" z="-3016" heading="38071" respawnTime="60Sec" />
+            <npc id="22187" x="53170" y="142174" z="-2776" heading="63713" respawnTime="60Sec" />
+            <npc id="22187" x="53170" y="142262" z="-2776" heading="36732" respawnTime="60Sec" />
+            <npc id="22187" x="53171" y="146900" z="-2872" heading="10646" respawnTime="60Sec" />
+            <npc id="22187" x="53176" y="143077" z="-2808" heading="61362" respawnTime="60Sec" />
+            <npc id="22187" x="53203" y="145238" z="-3024" heading="51250" respawnTime="60Sec" />
+            <npc id="22187" x="53205" y="143853" z="-2976" heading="28592" respawnTime="60Sec" />
+            <npc id="22187" x="53205" y="144129" z="-2992" heading="19636" respawnTime="60Sec" />
+            <npc id="22187" x="53212" y="144872" z="-2992" heading="9799" respawnTime="60Sec" />
+            <npc id="22187" x="53285" y="147070" z="-2856" heading="52679" respawnTime="60Sec" />
+            <npc id="22187" x="53287" y="141734" z="-2760" heading="62915" respawnTime="60Sec" />
+            <npc id="22187" x="53287" y="146846" z="-2872" heading="57549" respawnTime="60Sec" />
+            <npc id="22187" x="53291" y="141593" z="-2720" heading="12954" respawnTime="60Sec" />
+            <npc id="22187" x="53317" y="145217" z="-3032" heading="21721" respawnTime="60Sec" />
+            <npc id="22187" x="53351" y="145294" z="-3048" heading="56770" respawnTime="60Sec" />
+            <npc id="22187" x="53351" y="146968" z="-2856" heading="0" respawnTime="60Sec" />
+            <npc id="22187" x="53366" y="146577" z="-2896" heading="15168" respawnTime="60Sec" />
+            <npc id="22187" x="53391" y="146670" z="-2896" heading="25342" respawnTime="60Sec" />
+            <npc id="22187" x="53434" y="145824" z="-3000" heading="2583" respawnTime="60Sec" />
+            <npc id="22187" x="53495" y="146464" z="-2896" heading="32709" respawnTime="60Sec" />
+            <npc id="22187" x="53507" y="141649" z="-2704" heading="40109" respawnTime="60Sec" />
+            <npc id="22187" x="53513" y="146847" z="-2896" heading="54403" respawnTime="60Sec" />
+            <npc id="22187" x="53521" y="142262" z="-2776" heading="30550" respawnTime="60Sec" />
+            <npc id="22187" x="53556" y="145162" z="-3064" heading="56638" respawnTime="60Sec" />
+            <npc id="22187" x="53570" y="141295" z="-2704" heading="43710" respawnTime="60Sec" />
+            <npc id="22187" x="53576" y="147139" z="-2840" heading="2668" respawnTime="60Sec" />
+            <npc id="22187" x="53577" y="145968" z="-2976" heading="3207" respawnTime="60Sec" />
+            <npc id="22187" x="53578" y="146878" z="-2896" heading="47231" respawnTime="60Sec" />
+            <npc id="22187" x="53612" y="145667" z="-3080" heading="61453" respawnTime="60Sec" />
+            <npc id="22187" x="53656" y="147112" z="-2840" heading="62793" respawnTime="60Sec" />
+            <npc id="22187" x="53693" y="145375" z="-3072" heading="40185" respawnTime="60Sec" />
+            <npc id="22187" x="53843" y="145365" z="-3080" heading="58662" respawnTime="60Sec" />
+            <npc id="22187" x="53847" y="146568" z="-2896" heading="56087" respawnTime="60Sec" />
+            <npc id="22187" x="53892" y="145344" z="-3080" heading="49384" respawnTime="60Sec" />
+            <npc id="22187" x="53932" y="145327" z="-3080" heading="46234" respawnTime="60Sec" />
+            <npc id="22187" x="53936" y="147138" z="-2864" heading="50951" respawnTime="60Sec" />
+            <npc id="22187" x="53949" y="146446" z="-2912" heading="61978" respawnTime="60Sec" />
+            <npc id="22187" x="54021" y="146709" z="-2904" heading="18740" respawnTime="60Sec" />
+            <npc id="22187" x="54106" y="140854" z="-2704" heading="53268" respawnTime="60Sec" />
+            <npc id="22187" x="54106" y="141382" z="-2768" heading="23180" respawnTime="60Sec" />
+            <npc id="22187" x="54153" y="140767" z="-2728" heading="57006" respawnTime="60Sec" />
+            <npc id="22187" x="54199" y="147277" z="-2856" heading="45627" respawnTime="60Sec" />
+            <npc id="22187" x="54230" y="146776" z="-2904" heading="233" respawnTime="60Sec" />
+            <npc id="22187" x="54288" y="142908" z="-2904" heading="29184" respawnTime="60Sec" />
+            <npc id="22187" x="54350" y="142933" z="-2904" heading="51727" respawnTime="60Sec" />
+            <npc id="22187" x="54387" y="143119" z="-2960" heading="174" respawnTime="60Sec" />
+            <npc id="22187" x="54535" y="143171" z="-2968" heading="51186" respawnTime="60Sec" />
+            <npc id="22187" x="54580" y="142699" z="-2888" heading="65114" respawnTime="60Sec" />
+            <npc id="22187" x="54595" y="144385" z="-3016" heading="48286" respawnTime="60Sec" />
+            <npc id="22187" x="54607" y="144605" z="-3000" heading="41099" respawnTime="60Sec" />
+            <npc id="22187" x="54662" y="142682" z="-2888" heading="39711" respawnTime="60Sec" />
+            <npc id="22187" x="54677" y="142487" z="-2872" heading="32908" respawnTime="60Sec" />
+            <npc id="22187" x="54705" y="142383" z="-2856" heading="51020" respawnTime="60Sec" />
+            <npc id="22187" x="54746" y="142511" z="-2872" heading="53399" respawnTime="60Sec" />
+            <npc id="22187" x="54783" y="142608" z="-2888" heading="44180" respawnTime="60Sec" />
+            <npc id="22187" x="54783" y="144764" z="-3000" heading="59764" respawnTime="60Sec" />
+            <npc id="22187" x="54831" y="145115" z="-3000" heading="22940" respawnTime="60Sec" />
+            <npc id="22187" x="54944" y="143320" z="-3008" heading="582" respawnTime="60Sec" />
+            <npc id="22187" x="54944" y="143449" z="-3024" heading="4047" respawnTime="60Sec" />
+            <npc id="22187" x="54952" y="144730" z="-3000" heading="5767" respawnTime="60Sec" />
+            <npc id="22187" x="55034" y="143045" z="-2952" heading="39689" respawnTime="60Sec" />
+            <npc id="22187" x="55079" y="142724" z="-2904" heading="8677" respawnTime="60Sec" />
+            <npc id="22187" x="55103" y="144205" z="-3016" heading="32767" respawnTime="60Sec" />
+            <npc id="22187" x="55110" y="144545" z="-3000" heading="58467" respawnTime="60Sec" />
+            <npc id="22187" x="55161" y="140961" z="-2776" heading="61544" respawnTime="60Sec" />
+            <npc id="22187" x="55161" y="143216" z="-2984" heading="23074" respawnTime="60Sec" />
+            <npc id="22187" x="55218" y="140798" z="-2776" heading="9012" respawnTime="60Sec" />
+            <npc id="22187" x="55271" y="144667" z="-3000" heading="42744" respawnTime="60Sec" />
+            <npc id="22187" x="55291" y="143116" z="-2992" heading="32973" respawnTime="60Sec" />
+            <npc id="22187" x="55296" y="142978" z="-2960" heading="37146" respawnTime="60Sec" />
+            <npc id="22187" x="55335" y="144625" z="-3000" heading="2956" respawnTime="60Sec" />
+            <npc id="22187" x="55335" y="144765" z="-3000" heading="34556" respawnTime="60Sec" />
+            <npc id="22187" x="55335" y="145255" z="-3040" heading="63301" respawnTime="60Sec" />
+            <npc id="22187" x="55344" y="140789" z="-2776" heading="46724" respawnTime="60Sec" />
+            <npc id="22187" x="55344" y="141219" z="-2776" heading="47236" respawnTime="60Sec" />
+            <npc id="22187" x="55368" y="142698" z="-2888" heading="54303" respawnTime="60Sec" />
+            <npc id="22187" x="55368" y="143398" z="-3032" heading="34130" respawnTime="60Sec" />
+            <npc id="22187" x="55382" y="146232" z="-2984" heading="58112" respawnTime="60Sec" />
+            <npc id="22187" x="55399" y="146863" z="-2936" heading="60817" respawnTime="60Sec" />
+            <npc id="22187" x="55401" y="146578" z="-2944" heading="931" respawnTime="60Sec" />
+            <npc id="22187" x="55405" y="140875" z="-2776" heading="4488" respawnTime="60Sec" />
+            <npc id="22187" x="55409" y="144653" z="-3000" heading="4406" respawnTime="60Sec" />
+            <npc id="22187" x="55412" y="147172" z="-2936" heading="46916" respawnTime="60Sec" />
+            <npc id="22187" x="55440" y="142908" z="-2936" heading="17317" respawnTime="60Sec" />
+            <npc id="22187" x="55479" y="144415" z="-3000" heading="18586" respawnTime="60Sec" />
+            <npc id="22187" x="55484" y="146402" z="-2976" heading="47468" respawnTime="60Sec" />
+            <npc id="22187" x="55484" y="147242" z="-2936" heading="1469" respawnTime="60Sec" />
+            <npc id="22187" x="55508" y="141128" z="-2776" heading="3604" respawnTime="60Sec" />
+            <npc id="22187" x="55527" y="141563" z="-2776" heading="3592" respawnTime="60Sec" />
+            <npc id="22187" x="55551" y="144415" z="-3000" heading="49022" respawnTime="60Sec" />
+            <npc id="22187" x="55588" y="141305" z="-2776" heading="22078" respawnTime="60Sec" />
+            <npc id="22187" x="55623" y="144555" z="-3008" heading="29653" respawnTime="60Sec" />
+            <npc id="22187" x="55628" y="146262" z="-2976" heading="34598" respawnTime="60Sec" />
+            <npc id="22187" x="55628" y="146612" z="-2944" heading="54455" respawnTime="60Sec" />
+            <npc id="22187" x="55628" y="147032" z="-2936" heading="13489" respawnTime="60Sec" />
+            <npc id="22187" x="55650" y="144786" z="-3024" heading="41374" respawnTime="60Sec" />
+            <npc id="22187" x="55700" y="146752" z="-2944" heading="57382" respawnTime="60Sec" />
+            <npc id="22187" x="55700" y="147382" z="-2928" heading="11906" respawnTime="60Sec" />
+            <npc id="22187" x="55710" y="141563" z="-2776" heading="42570" respawnTime="60Sec" />
+            <npc id="22187" x="55767" y="144205" z="-3008" heading="3586" respawnTime="60Sec" />
+            <npc id="22187" x="55767" y="144205" z="-3008" heading="91" respawnTime="60Sec" />
+            <npc id="22187" x="55767" y="144485" z="-3008" heading="10014" respawnTime="60Sec" />
+            <npc id="22187" x="55767" y="145045" z="-3064" heading="23564" respawnTime="60Sec" />
+            <npc id="22187" x="55771" y="140961" z="-2776" heading="7391" respawnTime="60Sec" />
+            <npc id="22187" x="55771" y="141047" z="-2776" heading="55994" respawnTime="60Sec" />
+            <npc id="22187" x="55817" y="147043" z="-2936" heading="44767" respawnTime="60Sec" />
+            <npc id="22187" x="55832" y="140961" z="-2776" heading="14429" respawnTime="60Sec" />
+            <npc id="22187" x="55832" y="141047" z="-2776" heading="686" respawnTime="60Sec" />
+            <npc id="22187" x="55832" y="141907" z="-2776" heading="41191" respawnTime="60Sec" />
+            <npc id="22187" x="55832" y="142079" z="-2768" heading="4391" respawnTime="60Sec" />
+            <npc id="22187" x="55852" y="146531" z="-2944" heading="34556" respawnTime="60Sec" />
+            <npc id="22187" x="55893" y="141047" z="-2776" heading="29133" respawnTime="60Sec" />
+            <npc id="22187" x="55954" y="141047" z="-2776" heading="15517" respawnTime="60Sec" />
+            <npc id="22187" x="55954" y="141391" z="-2776" heading="19406" respawnTime="60Sec" />
+            <npc id="22187" x="55956" y="141794" z="-2776" heading="37227" respawnTime="60Sec" />
+            <npc id="22187" x="55988" y="147102" z="-2936" heading="59676" respawnTime="60Sec" />
+            <npc id="22187" x="56029" y="146528" z="-2936" heading="21550" respawnTime="60Sec" />
+            <npc id="22187" x="56076" y="141907" z="-2776" heading="65512" respawnTime="60Sec" />
+            <npc id="22187" x="56132" y="146752" z="-2912" heading="18916" respawnTime="60Sec" />
+            <npc id="22187" x="56204" y="146402" z="-2920" heading="59939" respawnTime="60Sec" />
+            <npc id="22187" x="56204" y="146892" z="-2880" heading="32407" respawnTime="60Sec" />
+            <npc id="22187" x="56204" y="146892" z="-2880" heading="33946" respawnTime="60Sec" />
+            <npc id="22187" x="56204" y="146962" z="-2912" heading="65493" respawnTime="60Sec" />
+            <npc id="27099" x="56758" y="142060" z="-2632" heading="27522" respawnTime="60Sec" />
+            <npc id="27099" x="56841" y="142173" z="-2584" heading="30399" respawnTime="60Sec" />
+            <npc id="27099" x="56985" y="142527" z="-2504" heading="57729" respawnTime="60Sec" />
+            <npc id="27099" x="56985" y="142999" z="-2576" heading="32767" respawnTime="60Sec" />
+            <npc id="27099" x="57417" y="142999" z="-2512" heading="4099" respawnTime="60Sec" />
+            <npc id="27099" x="57417" y="143589" z="-2568" heading="26212" respawnTime="60Sec" />
+            <npc id="27099" x="57489" y="142291" z="-2320" heading="6132" respawnTime="60Sec" />
+            <npc id="27099" x="57561" y="142881" z="-2464" heading="39501" respawnTime="60Sec" />
+            <npc id="32478" x="49089" y="152604" z="-2744" heading="28257" respawnTime="60Sec" />
+            <npc id="34138" x="47500" y="153749" z="-2720" heading="48656" respawnTime="60Sec" /> <!-- Kilemanja -->
+            <npc id="34139" x="45984" y="152695" z="-2752" heading="58088" respawnTime="60Sec" /> <!-- Mattehoren -->
+            <npc id="34140" x="46099" y="152952" z="-2728" heading="58278" respawnTime="60Sec" /> <!-- Marillia -->
+            <npc id="34141" x="48943" y="152336" z="-2752" heading="27309" respawnTime="60Sec" /> <!-- Lucia -->
+            <npc id="34149" x="46227" y="150970" z="-2760" heading="7718" respawnTime="60Sec" /> <!-- Erest -->
+            <npc id="34150" x="46772" y="150667" z="-2760" heading="4136" respawnTime="60Sec" /> <!-- Altaid -->
         </group>
     </spawn>
 </list>

--- a/data/spawns/Others/22_22.xml
+++ b/data/spawns/Others/22_22.xml
@@ -19,7 +19,6 @@
             <npc id="20176" x="98109" y="132266" z="-3483" heading="30889" respawnTime="60sec" /> <!-- Wyrm -->
             <npc id="20176" x="97364" y="132853" z="-3544" heading="19664" respawnTime="60sec" /> <!-- Wyrm -->
             <npc id="20176" x="98069" y="134836" z="-3644" heading="9720" respawnTime="60sec" /> <!-- Wyrm -->
-            <npc id="34292" x="83332" y="149160" z="-3390" heading="61173" respawnTime="60sec" /> <!-- Chef -->
         </group>
     </spawn>
 </list>

--- a/data/stats/chars/baseStats/AbyssWalker.xml
+++ b/data/stats/chars/baseStats/AbyssWalker.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>36</classId>
-    <staticData>
-        <baseINT>25</baseINT>
-        <baseSTR>41</baseSTR>
-        <baseCON>32</baseCON>
-        <baseMEN>26</baseMEN>
-        <baseDEX>34</baseDEX>
-        <baseWIT>12</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>15</magicAbnormalResist>
-        <creationPoints>
-            <node x="28295" y="11063" z="-4224"/>
-            <node x="28302" y="11008" z="-4224"/>
-            <node x="28377" y="10916" z="-4224"/>
-            <node x="28456" y="10997" z="-4224"/>
-            <node x="28461" y="11044" z="-4224"/>
-            <node x="28395" y="11127" z="-4224"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>85</walk>
-            <run>139</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>150</baseBreath>
-        <baseSafeFall>350</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>24</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.0</radius>
-            <height>23.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>94.0</hp>
-            <mp>30.0</mp>
-            <cp>51.7</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>107.65</hp>
-            <mp>35.46</mp>
-            <cp>59.2075</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>121.45</hp>
-            <mp>40.98</mp>
-            <cp>66.7975</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>135.4</hp>
-            <mp>46.56</mp>
-            <cp>74.47</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>149.5</hp>
-            <mp>52.2</mp>
-            <cp>82.225</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>163.75</hp>
-            <mp>57.9</mp>
-            <cp>90.0625</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>178.15</hp>
-            <mp>63.66</mp>
-            <cp>97.9825</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>192.7</hp>
-            <mp>69.48</mp>
-            <cp>105.985</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>207.4</hp>
-            <mp>75.36</mp>
-            <cp>114.07</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>222.25</hp>
-            <mp>81.3</mp>
-            <cp>122.2375</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>237.25</hp>
-            <mp>87.3</mp>
-            <cp>130.4875</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>252.4</hp>
-            <mp>93.36</mp>
-            <cp>138.82</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>267.7</hp>
-            <mp>99.48</mp>
-            <cp>147.235</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>283.15</hp>
-            <mp>105.66</mp>
-            <cp>155.7325</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>298.75</hp>
-            <mp>111.9</mp>
-            <cp>164.3125</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>314.5</hp>
-            <mp>118.2</mp>
-            <cp>172.975</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>330.4</hp>
-            <mp>124.56</mp>
-            <cp>181.72</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>346.45</hp>
-            <mp>130.98</mp>
-            <cp>190.5475</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>362.65</hp>
-            <mp>137.46</mp>
-            <cp>199.4575</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>379.0</hp>
-            <mp>144.0</mp>
-            <cp>208.45</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>412.0</hp>
-            <mp>153.9</mp>
-            <cp>226.6</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>445.3</hp>
-            <mp>163.89</mp>
-            <cp>244.915</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>478.9</hp>
-            <mp>173.97</mp>
-            <cp>263.395</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>512.8</hp>
-            <mp>184.14</mp>
-            <cp>282.04</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>547.0</hp>
-            <mp>194.4</mp>
-            <cp>300.85</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>581.5</hp>
-            <mp>204.75</mp>
-            <cp>319.825</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>616.3</hp>
-            <mp>215.19</mp>
-            <cp>338.965</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>651.4</hp>
-            <mp>225.72</mp>
-            <cp>358.27</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>686.8</hp>
-            <mp>236.34</mp>
-            <cp>377.74</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>722.5</hp>
-            <mp>247.05</mp>
-            <cp>397.375</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>758.5</hp>
-            <mp>257.85</mp>
-            <cp>417.175</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>794.8</hp>
-            <mp>268.74</mp>
-            <cp>437.14</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>831.4</hp>
-            <mp>279.72</mp>
-            <cp>457.27</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>868.3</hp>
-            <mp>290.79</mp>
-            <cp>477.565</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>905.5</hp>
-            <mp>301.95</mp>
-            <cp>498.025</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>943.0</hp>
-            <mp>313.2</mp>
-            <cp>518.65</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>980.8</hp>
-            <mp>324.54</mp>
-            <cp>539.44</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1018.9</hp>
-            <mp>335.97</mp>
-            <cp>560.395</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1057.3</hp>
-            <mp>347.49</mp>
-            <cp>581.515</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1096.0</hp>
-            <mp>359.1</mp>
-            <cp>602.8</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1145.4</hp>
-            <mp>378.6</mp>
-            <cp>629.97</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1195.18</hp>
-            <mp>398.25</mp>
-            <cp>657.349</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1245.34</hp>
-            <mp>418.05</mp>
-            <cp>684.937</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1295.88</hp>
-            <mp>438.0</mp>
-            <cp>712.734</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1346.8</hp>
-            <mp>458.1</mp>
-            <cp>740.74</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1398.1</hp>
-            <mp>478.35</mp>
-            <cp>768.955</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1449.78</hp>
-            <mp>498.75</mp>
-            <cp>797.379</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1501.84</hp>
-            <mp>519.3</mp>
-            <cp>826.012</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1554.28</hp>
-            <mp>540.0</mp>
-            <cp>854.854</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1607.1</hp>
-            <mp>560.85</mp>
-            <cp>883.905</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1660.3</hp>
-            <mp>581.85</mp>
-            <cp>913.165</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1713.88</hp>
-            <mp>603.0</mp>
-            <cp>942.634</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1767.84</hp>
-            <mp>624.3</mp>
-            <cp>972.312</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1822.18</hp>
-            <mp>645.75</mp>
-            <cp>1002.199</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1876.9</hp>
-            <mp>667.35</mp>
-            <cp>1032.295</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1932.0</hp>
-            <mp>689.1</mp>
-            <cp>1062.6</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1987.48</hp>
-            <mp>711.0</mp>
-            <cp>1093.114</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2043.34</hp>
-            <mp>733.05</mp>
-            <cp>1123.837</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2099.58</hp>
-            <mp>755.25</mp>
-            <cp>1154.769</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2156.2</hp>
-            <mp>777.6</mp>
-            <cp>1185.91</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2213.2</hp>
-            <mp>800.1</mp>
-            <cp>1217.26</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2270.58</hp>
-            <mp>822.75</mp>
-            <cp>1248.819</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2328.34</hp>
-            <mp>845.55</mp>
-            <cp>1280.587</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2386.48</hp>
-            <mp>868.5</mp>
-            <cp>1312.564</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2445.0</hp>
-            <mp>891.6</mp>
-            <cp>1344.75</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2503.9</hp>
-            <mp>914.85</mp>
-            <cp>1377.145</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2563.18</hp>
-            <mp>938.25</mp>
-            <cp>1409.749</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2622.84</hp>
-            <mp>961.8</mp>
-            <cp>1442.562</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2682.88</hp>
-            <mp>985.5</mp>
-            <cp>1475.584</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2743.3</hp>
-            <mp>1009.35</mp>
-            <cp>1508.815</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2804.1</hp>
-            <mp>1033.35</mp>
-            <cp>1542.255</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2865.28</hp>
-            <mp>1057.5</mp>
-            <cp>1575.904</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2926.84</hp>
-            <mp>1081.8</mp>
-            <cp>1609.762</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2988.78</hp>
-            <mp>1106.25</mp>
-            <cp>1643.829</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3051.1</hp>
-            <mp>1130.85</mp>
-            <cp>1678.105</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3113.8</hp>
-            <mp>1155.6</mp>
-            <cp>1712.59</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3176.88</hp>
-            <mp>1180.5</mp>
-            <cp>1747.284</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3240.34</hp>
-            <mp>1205.55</mp>
-            <cp>1782.187</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3304.18</hp>
-            <mp>1230.75</mp>
-            <cp>1817.299</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3368.4</hp>
-            <mp>1256.1</mp>
-            <cp>1852.62</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3433.0</hp>
-            <mp>1281.6</mp>
-            <cp>1888.15</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3497.98</hp>
-            <mp>1307.25</mp>
-            <cp>1923.889</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3563.34</hp>
-            <mp>1333.05</mp>
-            <cp>1959.837</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3629.08</hp>
-            <mp>1359.0</mp>
-            <cp>1995.994</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3695.2</hp>
-            <mp>1385.1</mp>
-            <cp>2032.36</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3761.7</hp>
-            <mp>1411.35</mp>
-            <cp>2068.935</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3828.58</hp>
-            <mp>1437.75</mp>
-            <cp>2105.719</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3895.84</hp>
-            <mp>1464.3</mp>
-            <cp>2142.712</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3963.48</hp>
-            <mp>1491.0</mp>
-            <cp>2179.914</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4031.5</hp>
-            <mp>1517.85</mp>
-            <cp>2217.325</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4099.9</hp>
-            <mp>1544.85</mp>
-            <cp>2254.945</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>36</classId>
+	<staticData>
+		<baseINT>25</baseINT>
+		<baseSTR>41</baseSTR>
+		<baseCON>32</baseCON>
+		<baseMEN>26</baseMEN>
+		<baseDEX>34</baseDEX>
+		<baseWIT>12</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="28295" y="11063" z="-4224" />
+			<node x="28302" y="11008" z="-4224" />
+			<node x="28377" y="10916" z="-4224" />
+			<node x="28456" y="10997" z="-4224" />
+			<node x="28461" y="11044" z="-4224" />
+			<node x="28395" y="11127" z="-4224" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>85</walk>
+			<run>139</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>350</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>94.0</hp>
+			<mp>30.0</mp>
+			<cp>51.7</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>107.65</hp>
+			<mp>35.46</mp>
+			<cp>59.2075</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>121.45</hp>
+			<mp>40.98</mp>
+			<cp>66.7975</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>135.4</hp>
+			<mp>46.56</mp>
+			<cp>74.47</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>149.5</hp>
+			<mp>52.2</mp>
+			<cp>82.225</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>163.75</hp>
+			<mp>57.9</mp>
+			<cp>90.0625</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>178.15</hp>
+			<mp>63.66</mp>
+			<cp>97.9825</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>192.7</hp>
+			<mp>69.48</mp>
+			<cp>105.985</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>207.4</hp>
+			<mp>75.36</mp>
+			<cp>114.07</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>222.25</hp>
+			<mp>81.3</mp>
+			<cp>122.2375</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>237.25</hp>
+			<mp>87.3</mp>
+			<cp>130.4875</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>252.4</hp>
+			<mp>93.36</mp>
+			<cp>138.82</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>267.7</hp>
+			<mp>99.48</mp>
+			<cp>147.235</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>283.15</hp>
+			<mp>105.66</mp>
+			<cp>155.7325</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>298.75</hp>
+			<mp>111.9</mp>
+			<cp>164.3125</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>314.5</hp>
+			<mp>118.2</mp>
+			<cp>172.975</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>330.4</hp>
+			<mp>124.56</mp>
+			<cp>181.72</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>346.45</hp>
+			<mp>130.98</mp>
+			<cp>190.5475</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>362.65</hp>
+			<mp>137.46</mp>
+			<cp>199.4575</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>379.0</hp>
+			<mp>144.0</mp>
+			<cp>208.45</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>412.0</hp>
+			<mp>153.9</mp>
+			<cp>226.6</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>445.3</hp>
+			<mp>163.89</mp>
+			<cp>244.915</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>478.9</hp>
+			<mp>173.97</mp>
+			<cp>263.395</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>512.8</hp>
+			<mp>184.14</mp>
+			<cp>282.04</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>547.0</hp>
+			<mp>194.4</mp>
+			<cp>300.85</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>581.5</hp>
+			<mp>204.75</mp>
+			<cp>319.825</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>616.3</hp>
+			<mp>215.19</mp>
+			<cp>338.965</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>651.4</hp>
+			<mp>225.72</mp>
+			<cp>358.27</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>686.8</hp>
+			<mp>236.34</mp>
+			<cp>377.74</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>722.5</hp>
+			<mp>247.05</mp>
+			<cp>397.375</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>758.5</hp>
+			<mp>257.85</mp>
+			<cp>417.175</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>794.8</hp>
+			<mp>268.74</mp>
+			<cp>437.14</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>831.4</hp>
+			<mp>279.72</mp>
+			<cp>457.27</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>868.3</hp>
+			<mp>290.79</mp>
+			<cp>477.565</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>905.5</hp>
+			<mp>301.95</mp>
+			<cp>498.025</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>943.0</hp>
+			<mp>313.2</mp>
+			<cp>518.65</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>980.8</hp>
+			<mp>324.54</mp>
+			<cp>539.44</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1018.9</hp>
+			<mp>335.97</mp>
+			<cp>560.395</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1057.3</hp>
+			<mp>347.49</mp>
+			<cp>581.515</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1096.0</hp>
+			<mp>359.1</mp>
+			<cp>602.8</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1145.4</hp>
+			<mp>378.6</mp>
+			<cp>629.97</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1195.18</hp>
+			<mp>398.25</mp>
+			<cp>657.349</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1245.34</hp>
+			<mp>418.05</mp>
+			<cp>684.937</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1295.88</hp>
+			<mp>438.0</mp>
+			<cp>712.734</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1346.8</hp>
+			<mp>458.1</mp>
+			<cp>740.74</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1398.1</hp>
+			<mp>478.35</mp>
+			<cp>768.955</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1449.78</hp>
+			<mp>498.75</mp>
+			<cp>797.379</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1501.84</hp>
+			<mp>519.3</mp>
+			<cp>826.012</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1554.28</hp>
+			<mp>540.0</mp>
+			<cp>854.854</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1607.1</hp>
+			<mp>560.85</mp>
+			<cp>883.905</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1660.3</hp>
+			<mp>581.85</mp>
+			<cp>913.165</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1713.88</hp>
+			<mp>603.0</mp>
+			<cp>942.634</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1767.84</hp>
+			<mp>624.3</mp>
+			<cp>972.312</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1822.18</hp>
+			<mp>645.75</mp>
+			<cp>1002.199</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1876.9</hp>
+			<mp>667.35</mp>
+			<cp>1032.295</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1932.0</hp>
+			<mp>689.1</mp>
+			<cp>1062.6</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1987.48</hp>
+			<mp>711.0</mp>
+			<cp>1093.114</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2043.34</hp>
+			<mp>733.05</mp>
+			<cp>1123.837</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2099.58</hp>
+			<mp>755.25</mp>
+			<cp>1154.769</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2156.2</hp>
+			<mp>777.6</mp>
+			<cp>1185.91</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2213.2</hp>
+			<mp>800.1</mp>
+			<cp>1217.26</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2270.58</hp>
+			<mp>822.75</mp>
+			<cp>1248.819</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2328.34</hp>
+			<mp>845.55</mp>
+			<cp>1280.587</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2386.48</hp>
+			<mp>868.5</mp>
+			<cp>1312.564</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2445.0</hp>
+			<mp>891.6</mp>
+			<cp>1344.75</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2503.9</hp>
+			<mp>914.85</mp>
+			<cp>1377.145</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2563.18</hp>
+			<mp>938.25</mp>
+			<cp>1409.749</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2622.84</hp>
+			<mp>961.8</mp>
+			<cp>1442.562</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2682.88</hp>
+			<mp>985.5</mp>
+			<cp>1475.584</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2743.3</hp>
+			<mp>1009.35</mp>
+			<cp>1508.815</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2804.1</hp>
+			<mp>1033.35</mp>
+			<cp>1542.255</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2865.28</hp>
+			<mp>1057.5</mp>
+			<cp>1575.904</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2926.84</hp>
+			<mp>1081.8</mp>
+			<cp>1609.762</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2988.78</hp>
+			<mp>1106.25</mp>
+			<cp>1643.829</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3051.1</hp>
+			<mp>1130.85</mp>
+			<cp>1678.105</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3113.8</hp>
+			<mp>1155.6</mp>
+			<cp>1712.59</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3176.88</hp>
+			<mp>1180.5</mp>
+			<cp>1747.284</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3240.34</hp>
+			<mp>1205.55</mp>
+			<cp>1782.187</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3304.18</hp>
+			<mp>1230.75</mp>
+			<cp>1817.299</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3368.4</hp>
+			<mp>1256.1</mp>
+			<cp>1852.62</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3433.0</hp>
+			<mp>1281.6</mp>
+			<cp>1888.15</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3497.98</hp>
+			<mp>1307.25</mp>
+			<cp>1923.889</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3563.34</hp>
+			<mp>1333.05</mp>
+			<cp>1959.837</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3629.08</hp>
+			<mp>1359.0</mp>
+			<cp>1995.994</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3695.2</hp>
+			<mp>1385.1</mp>
+			<cp>2032.36</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3761.7</hp>
+			<mp>1411.35</mp>
+			<cp>2068.935</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3828.58</hp>
+			<mp>1437.75</mp>
+			<cp>2105.719</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3895.84</hp>
+			<mp>1464.3</mp>
+			<cp>2142.712</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3963.48</hp>
+			<mp>1491.0</mp>
+			<cp>2179.914</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4031.5</hp>
+			<mp>1517.85</mp>
+			<cp>2217.325</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4099.9</hp>
+			<mp>1544.85</mp>
+			<cp>2254.945</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4168.68</hp>
+			<mp>1572.0</mp>
+			<cp>2292.774</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4237.84</hp>
+			<mp>1599.3</mp>
+			<cp>2330.812</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4307.38</hp>
+			<mp>1626.75</mp>
+			<cp>2369.059</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4377.3</hp>
+			<mp>1654.35</mp>
+			<cp>2407.515</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4447.6</hp>
+			<mp>1682.1</mp>
+			<cp>2446.18</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4518.28</hp>
+			<mp>1710.0</mp>
+			<cp>2485.054</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4589.34</hp>
+			<mp>1738.05</mp>
+			<cp>2524.137</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4660.78</hp>
+			<mp>1766.25</mp>
+			<cp>2563.429</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4732.6</hp>
+			<mp>1794.6</mp>
+			<cp>2602.93</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4804.8</hp>
+			<mp>1823.1</mp>
+			<cp>2642.64</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4877.38</hp>
+			<mp>1851.75</mp>
+			<cp>2682.57</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4950.34</hp>
+			<mp>1880.55</mp>
+			<cp>2722.7</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5023.68</hp>
+			<mp>1909.5</mp>
+			<cp>2763.04</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5097.4</hp>
+			<mp>1938.6</mp>
+			<cp>2803.59</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5171.5</hp>
+			<mp>1967.85</mp>
+			<cp>2844.35</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5245.98</hp>
+			<mp>1997.25</mp>
+			<cp>2885.289</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Adventurer.xml
+++ b/data/stats/chars/baseStats/Adventurer.xml
@@ -1,783 +1,783 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>93</classId>
-    <staticData>
-        <baseINT>21</baseINT>
-        <baseSTR>40</baseSTR>
-        <baseCON>43</baseCON>
-        <baseMEN>25</baseMEN>
-        <baseDEX>30</baseDEX>
-        <baseWIT>11</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-71338" y="258271" z="-3104"/>
-            <node x="-71417" y="258270" z="-3104"/>
-            <node x="-71453" y="258305" z="-3104"/>
-            <node x="-71467" y="258378" z="-3104"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>80</walk>
-            <run>132</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>100</baseBreath>
-        <baseSafeFall>250</baseSafeFall>
-        <collisionMale>
-            <radius>9.0</radius>
-            <height>23</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>8.0</radius>
-            <height>23.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>80.0</hp>
-            <mp>30.0</mp>
-            <cp>44.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>91.83</hp>
-            <mp>35.46</mp>
-            <cp>50.5065</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>103.79</hp>
-            <mp>40.98</mp>
-            <cp>57.0845</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>115.88</hp>
-            <mp>46.56</mp>
-            <cp>63.734</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>128.1</hp>
-            <mp>52.2</mp>
-            <cp>70.455</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>140.45</hp>
-            <mp>57.9</mp>
-            <cp>77.2475</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>152.93</hp>
-            <mp>63.66</mp>
-            <cp>84.1115</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>165.54</hp>
-            <mp>69.48</mp>
-            <cp>91.047</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>178.28</hp>
-            <mp>75.36</mp>
-            <cp>98.054</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>191.15</hp>
-            <mp>81.3</mp>
-            <cp>105.1325</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>204.15</hp>
-            <mp>87.3</mp>
-            <cp>112.2825</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>217.28</hp>
-            <mp>93.36</mp>
-            <cp>119.504</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>230.54</hp>
-            <mp>99.48</mp>
-            <cp>126.797</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>243.93</hp>
-            <mp>105.66</mp>
-            <cp>134.1615</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>257.45</hp>
-            <mp>111.9</mp>
-            <cp>141.5975</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>271.1</hp>
-            <mp>118.2</mp>
-            <cp>149.105</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>284.88</hp>
-            <mp>124.56</mp>
-            <cp>156.684</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>298.79</hp>
-            <mp>130.98</mp>
-            <cp>164.3345</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>312.83</hp>
-            <mp>137.46</mp>
-            <cp>172.0565</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>327.0</hp>
-            <mp>144.0</mp>
-            <cp>179.85</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>354.5</hp>
-            <mp>153.9</mp>
-            <cp>194.975</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>382.25</hp>
-            <mp>163.89</mp>
-            <cp>210.2375</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>410.25</hp>
-            <mp>173.97</mp>
-            <cp>225.6375</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>438.5</hp>
-            <mp>184.14</mp>
-            <cp>241.175</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>467.0</hp>
-            <mp>194.4</mp>
-            <cp>256.85</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>495.75</hp>
-            <mp>204.75</mp>
-            <cp>272.6625</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>524.75</hp>
-            <mp>215.19</mp>
-            <cp>288.6125</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>554.0</hp>
-            <mp>225.72</mp>
-            <cp>304.7</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>583.5</hp>
-            <mp>236.34</mp>
-            <cp>320.925</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>613.25</hp>
-            <mp>247.05</mp>
-            <cp>337.2875</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>643.25</hp>
-            <mp>257.85</mp>
-            <cp>353.7875</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>673.5</hp>
-            <mp>268.74</mp>
-            <cp>370.425</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>704.0</hp>
-            <mp>279.72</mp>
-            <cp>387.2</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>734.75</hp>
-            <mp>290.79</mp>
-            <cp>404.1125</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>765.75</hp>
-            <mp>301.95</mp>
-            <cp>421.1625</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>797.0</hp>
-            <mp>313.2</mp>
-            <cp>438.35</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>828.5</hp>
-            <mp>324.54</mp>
-            <cp>455.675</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>860.25</hp>
-            <mp>335.97</mp>
-            <cp>473.1375</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>892.25</hp>
-            <mp>347.49</mp>
-            <cp>490.7375</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>924.5</hp>
-            <mp>359.1</mp>
-            <cp>508.475</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>966.1</hp>
-            <mp>378.6</mp>
-            <cp>531.355</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1008.02</hp>
-            <mp>398.25</mp>
-            <cp>554.411</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1050.26</hp>
-            <mp>418.05</mp>
-            <cp>577.643</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1092.82</hp>
-            <mp>438.0</mp>
-            <cp>601.051</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1135.7</hp>
-            <mp>458.1</mp>
-            <cp>624.635</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1178.9</hp>
-            <mp>478.35</mp>
-            <cp>648.395</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1222.42</hp>
-            <mp>498.75</mp>
-            <cp>672.331</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1266.26</hp>
-            <mp>519.3</mp>
-            <cp>696.443</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1310.42</hp>
-            <mp>540.0</mp>
-            <cp>720.731</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1354.9</hp>
-            <mp>560.85</mp>
-            <cp>745.195</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1399.7</hp>
-            <mp>581.85</mp>
-            <cp>769.835</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1444.82</hp>
-            <mp>603.0</mp>
-            <cp>794.651</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1490.26</hp>
-            <mp>624.3</mp>
-            <cp>819.643</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1536.02</hp>
-            <mp>645.75</mp>
-            <cp>844.811</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1582.1</hp>
-            <mp>667.35</mp>
-            <cp>870.155</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1628.5</hp>
-            <mp>689.1</mp>
-            <cp>895.675</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1675.22</hp>
-            <mp>711.0</mp>
-            <cp>921.371</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1722.26</hp>
-            <mp>733.05</mp>
-            <cp>947.243</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>1769.62</hp>
-            <mp>755.25</mp>
-            <cp>973.291</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>1817.3</hp>
-            <mp>777.6</mp>
-            <cp>999.515</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>1865.3</hp>
-            <mp>800.1</mp>
-            <cp>1025.915</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>1913.62</hp>
-            <mp>822.75</mp>
-            <cp>1052.491</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>1962.26</hp>
-            <mp>845.55</mp>
-            <cp>1079.243</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2011.22</hp>
-            <mp>868.5</mp>
-            <cp>1106.171</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2060.5</hp>
-            <mp>891.6</mp>
-            <cp>1133.275</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2110.1</hp>
-            <mp>914.85</mp>
-            <cp>1160.555</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2160.02</hp>
-            <mp>938.25</mp>
-            <cp>1188.011</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2210.26</hp>
-            <mp>961.8</mp>
-            <cp>1215.643</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2260.82</hp>
-            <mp>985.5</mp>
-            <cp>1243.451</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2311.7</hp>
-            <mp>1009.35</mp>
-            <cp>1271.435</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2362.9</hp>
-            <mp>1033.35</mp>
-            <cp>1299.595</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2414.42</hp>
-            <mp>1057.5</mp>
-            <cp>1327.931</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2466.26</hp>
-            <mp>1081.8</mp>
-            <cp>1356.443</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2518.42</hp>
-            <mp>1106.25</mp>
-            <cp>1385.131</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2570.9</hp>
-            <mp>1130.85</mp>
-            <cp>1413.995</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>2623.7</hp>
-            <mp>1155.6</mp>
-            <cp>1443.035</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>2676.82</hp>
-            <mp>1180.5</mp>
-            <cp>1472.251</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>2730.26</hp>
-            <mp>1205.55</mp>
-            <cp>1501.643</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>2784.02</hp>
-            <mp>1230.75</mp>
-            <cp>1531.211</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>2838.1</hp>
-            <mp>1256.1</mp>
-            <cp>1560.955</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>2892.5</hp>
-            <mp>1281.6</mp>
-            <cp>1590.875</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>2947.22</hp>
-            <mp>1307.25</mp>
-            <cp>1620.971</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3002.26</hp>
-            <mp>1333.05</mp>
-            <cp>1651.243</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3057.62</hp>
-            <mp>1359.0</mp>
-            <cp>1681.691</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3113.3</hp>
-            <mp>1385.1</mp>
-            <cp>1712.315</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3169.3</hp>
-            <mp>1411.35</mp>
-            <cp>1743.115</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3225.62</hp>
-            <mp>1437.75</mp>
-            <cp>1774.091</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3282.26</hp>
-            <mp>1464.3</mp>
-            <cp>1805.243</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3339.22</hp>
-            <mp>1491.0</mp>
-            <cp>1836.571</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
+	<classId>93</classId>
+	<staticData>
+		<baseINT>21</baseINT>
+		<baseSTR>40</baseSTR>
+		<baseCON>43</baseCON>
+		<baseMEN>25</baseMEN>
+		<baseDEX>30</baseDEX>
+		<baseWIT>11</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-71338" y="258271" z="-3104" />
+			<node x="-71417" y="258270" z="-3104" />
+			<node x="-71453" y="258305" z="-3104" />
+			<node x="-71467" y="258378" z="-3104" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>80</walk>
+			<run>132</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>250</baseSafeFall>
+		<collisionMale>
+			<radius>9.0</radius>
+			<height>23</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>8.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>80.0</hp>
+			<mp>30.0</mp>
+			<cp>44.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>91.83</hp>
+			<mp>35.46</mp>
+			<cp>50.5065</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>103.79</hp>
+			<mp>40.98</mp>
+			<cp>57.0845</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>115.88</hp>
+			<mp>46.56</mp>
+			<cp>63.734</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>128.1</hp>
+			<mp>52.2</mp>
+			<cp>70.455</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>140.45</hp>
+			<mp>57.9</mp>
+			<cp>77.2475</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>152.93</hp>
+			<mp>63.66</mp>
+			<cp>84.1115</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>165.54</hp>
+			<mp>69.48</mp>
+			<cp>91.047</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>178.28</hp>
+			<mp>75.36</mp>
+			<cp>98.054</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>191.15</hp>
+			<mp>81.3</mp>
+			<cp>105.1325</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>204.15</hp>
+			<mp>87.3</mp>
+			<cp>112.2825</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>217.28</hp>
+			<mp>93.36</mp>
+			<cp>119.504</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>230.54</hp>
+			<mp>99.48</mp>
+			<cp>126.797</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>243.93</hp>
+			<mp>105.66</mp>
+			<cp>134.1615</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>257.45</hp>
+			<mp>111.9</mp>
+			<cp>141.5975</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>271.1</hp>
+			<mp>118.2</mp>
+			<cp>149.105</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>284.88</hp>
+			<mp>124.56</mp>
+			<cp>156.684</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>298.79</hp>
+			<mp>130.98</mp>
+			<cp>164.3345</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>312.83</hp>
+			<mp>137.46</mp>
+			<cp>172.0565</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>327.0</hp>
+			<mp>144.0</mp>
+			<cp>179.85</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>354.5</hp>
+			<mp>153.9</mp>
+			<cp>194.975</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>382.25</hp>
+			<mp>163.89</mp>
+			<cp>210.2375</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>410.25</hp>
+			<mp>173.97</mp>
+			<cp>225.6375</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>438.5</hp>
+			<mp>184.14</mp>
+			<cp>241.175</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>467.0</hp>
+			<mp>194.4</mp>
+			<cp>256.85</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>495.75</hp>
+			<mp>204.75</mp>
+			<cp>272.6625</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>524.75</hp>
+			<mp>215.19</mp>
+			<cp>288.6125</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>554.0</hp>
+			<mp>225.72</mp>
+			<cp>304.7</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>583.5</hp>
+			<mp>236.34</mp>
+			<cp>320.925</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>613.25</hp>
+			<mp>247.05</mp>
+			<cp>337.2875</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>643.25</hp>
+			<mp>257.85</mp>
+			<cp>353.7875</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>673.5</hp>
+			<mp>268.74</mp>
+			<cp>370.425</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>704.0</hp>
+			<mp>279.72</mp>
+			<cp>387.2</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>734.75</hp>
+			<mp>290.79</mp>
+			<cp>404.1125</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>765.75</hp>
+			<mp>301.95</mp>
+			<cp>421.1625</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>797.0</hp>
+			<mp>313.2</mp>
+			<cp>438.35</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>828.5</hp>
+			<mp>324.54</mp>
+			<cp>455.675</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>860.25</hp>
+			<mp>335.97</mp>
+			<cp>473.1375</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>892.25</hp>
+			<mp>347.49</mp>
+			<cp>490.7375</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>924.5</hp>
+			<mp>359.1</mp>
+			<cp>508.475</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>966.1</hp>
+			<mp>378.6</mp>
+			<cp>531.355</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1008.02</hp>
+			<mp>398.25</mp>
+			<cp>554.411</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1050.26</hp>
+			<mp>418.05</mp>
+			<cp>577.643</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1092.82</hp>
+			<mp>438.0</mp>
+			<cp>601.051</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1135.7</hp>
+			<mp>458.1</mp>
+			<cp>624.635</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1178.9</hp>
+			<mp>478.35</mp>
+			<cp>648.395</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1222.42</hp>
+			<mp>498.75</mp>
+			<cp>672.331</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1266.26</hp>
+			<mp>519.3</mp>
+			<cp>696.443</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1310.42</hp>
+			<mp>540.0</mp>
+			<cp>720.731</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1354.9</hp>
+			<mp>560.85</mp>
+			<cp>745.195</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1399.7</hp>
+			<mp>581.85</mp>
+			<cp>769.835</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1444.82</hp>
+			<mp>603.0</mp>
+			<cp>794.651</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1490.26</hp>
+			<mp>624.3</mp>
+			<cp>819.643</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1536.02</hp>
+			<mp>645.75</mp>
+			<cp>844.811</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1582.1</hp>
+			<mp>667.35</mp>
+			<cp>870.155</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1628.5</hp>
+			<mp>689.1</mp>
+			<cp>895.675</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1675.22</hp>
+			<mp>711.0</mp>
+			<cp>921.371</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1722.26</hp>
+			<mp>733.05</mp>
+			<cp>947.243</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1769.62</hp>
+			<mp>755.25</mp>
+			<cp>973.291</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1817.3</hp>
+			<mp>777.6</mp>
+			<cp>999.515</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>1865.3</hp>
+			<mp>800.1</mp>
+			<cp>1025.915</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>1913.62</hp>
+			<mp>822.75</mp>
+			<cp>1052.491</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>1962.26</hp>
+			<mp>845.55</mp>
+			<cp>1079.243</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2011.22</hp>
+			<mp>868.5</mp>
+			<cp>1106.171</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2060.5</hp>
+			<mp>891.6</mp>
+			<cp>1133.275</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2110.1</hp>
+			<mp>914.85</mp>
+			<cp>1160.555</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2160.02</hp>
+			<mp>938.25</mp>
+			<cp>1188.011</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2210.26</hp>
+			<mp>961.8</mp>
+			<cp>1215.643</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2260.82</hp>
+			<mp>985.5</mp>
+			<cp>1243.451</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2311.7</hp>
+			<mp>1009.35</mp>
+			<cp>1271.435</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2362.9</hp>
+			<mp>1033.35</mp>
+			<cp>1299.595</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2414.42</hp>
+			<mp>1057.5</mp>
+			<cp>1327.931</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2466.26</hp>
+			<mp>1081.8</mp>
+			<cp>1356.443</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2518.42</hp>
+			<mp>1106.25</mp>
+			<cp>1385.131</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2570.9</hp>
+			<mp>1130.85</mp>
+			<cp>1413.995</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>2623.7</hp>
+			<mp>1155.6</mp>
+			<cp>1443.035</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>2676.82</hp>
+			<mp>1180.5</mp>
+			<cp>1472.251</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>2730.26</hp>
+			<mp>1205.55</mp>
+			<cp>1501.643</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>2784.02</hp>
+			<mp>1230.75</mp>
+			<cp>1531.211</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>2838.1</hp>
+			<mp>1256.1</mp>
+			<cp>1560.955</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>2892.5</hp>
+			<mp>1281.6</mp>
+			<cp>1590.875</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>2947.22</hp>
+			<mp>1307.25</mp>
+			<cp>1620.971</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3002.26</hp>
+			<mp>1333.05</mp>
+			<cp>1651.243</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3057.62</hp>
+			<mp>1359.0</mp>
+			<cp>1681.691</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3113.3</hp>
+			<mp>1385.1</mp>
+			<cp>1712.315</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3169.3</hp>
+			<mp>1411.35</mp>
+			<cp>1743.115</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3225.62</hp>
+			<mp>1437.75</mp>
+			<cp>1774.091</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3282.26</hp>
+			<mp>1464.3</mp>
+			<cp>1805.243</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3339.22</hp>
+			<mp>1491.0</mp>
+			<cp>1836.571</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
 		<level val="90">
 			<hp>3396.5</hp>
 			<mp>1517.85</mp>
@@ -794,5 +794,133 @@
 			<mpRegen>3.0</mpRegen>
 			<cpRegen>8.5</cpRegen>
 		</level>
-    </lvlUpgainData>
+		<level val="92">
+			<hp>3512.02</hp>
+			<mp>1572.0</mp>
+			<cp>1931.611</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>3570.26</hp>
+			<mp>1599.3</mp>
+			<cp>1963.643</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>3628.82</hp>
+			<mp>1626.75</mp>
+			<cp>1995.851</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>3687.7</hp>
+			<mp>1654.35</mp>
+			<cp>2028.235</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>3746.9</hp>
+			<mp>1682.1</mp>
+			<cp>2060.795</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>3806.42</hp>
+			<mp>1710.0</mp>
+			<cp>2093.531</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>3866.26</hp>
+			<mp>1738.05</mp>
+			<cp>2126.443</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>3926.42</hp>
+			<mp>1766.25</mp>
+			<cp>2159.531</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>3986.9</hp>
+			<mp>1794.6</mp>
+			<cp>2192.8</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4047.7</hp>
+			<mp>1823.1</mp>
+			<cp>2226.25</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4108.82</hp>
+			<mp>1851.75</mp>
+			<cp>2259.88</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4170.26</hp>
+			<mp>1880.55</mp>
+			<cp>2293.68</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4232.02</hp>
+			<mp>1909.5</mp>
+			<cp>2327.67</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>4294.1</hp>
+			<mp>1938.6</mp>
+			<cp>2361.84</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>4356.5</hp>
+			<mp>1967.85</mp>
+			<cp>2396.19</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>4419.22</hp>
+			<mp>1997.25</mp>
+			<cp>2430.571</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Arbalester.xml
+++ b/data/stats/chars/baseStats/Arbalester.xml
@@ -1,0 +1,928 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
+    <classId>130</classId>
+    <staticData>
+        <baseINT>25</baseINT>
+        <baseSTR>41</baseSTR>
+        <baseCON>27</baseCON>
+        <baseMEN>22</baseMEN>
+        <baseDEX>35</baseDEX>
+        <baseWIT>20</baseWIT>
+        <physicalAbnormalResist>10</physicalAbnormalResist>
+        <magicAbnormalResist>10</magicAbnormalResist>
+        <creationPoints>
+            <node x="-125607" y="38452" z="1152" />
+            <node x="-125472" y="38450" z="1152" />
+            <node x="-125615" y="37771" z="1152" />
+            <node x="-125464" y="37776" z="1152" />
+            <node x="-125517" y="38267" z="1155" />
+            <node x="-125531" y="37944" z="1155" />
+        </creationPoints>
+        <basePAtk>4</basePAtk>
+        <baseCritRate>4</baseCritRate>
+        <baseMCritRate>5</baseMCritRate>
+        <baseAtkType>FIST</baseAtkType>
+        <basePAtkSpd>300</basePAtkSpd>
+        <baseMAtkSpd>333</baseMAtkSpd>
+        <basePDef>
+            <chest>31</chest>
+            <legs>18</legs>
+            <head>12</head>
+            <feet>7</feet>
+            <gloves>8</gloves>
+            <underwear>3</underwear>
+            <cloak>1</cloak>
+        </basePDef>
+        <baseMAtk>6</baseMAtk>
+        <baseMDef>
+            <rear>9</rear>
+            <lear>9</lear>
+            <rfinger>5</rfinger>
+            <lfinger>5</lfinger>
+            <neck>13</neck>
+        </baseMDef>
+        <baseCanPenetrate>0</baseCanPenetrate>
+        <baseAtkRange>20</baseAtkRange>
+        <baseDamRange>
+            <verticalDirection>0</verticalDirection>
+            <horizontalDirection>0</horizontalDirection>
+            <distance>26</distance>
+            <width>120</width>
+        </baseDamRange>
+        <baseRndDam>10</baseRndDam>
+        <baseMoveSpd>
+            <walk>87</walk>
+            <run>140</run>
+            <slowSwim>50</slowSwim>
+            <fastSwim>50</fastSwim>
+        </baseMoveSpd>
+        <baseBreath>100</baseBreath>
+        <baseSafeFall>500</baseSafeFall>
+        <collisionMale>
+            <radius>8.0</radius>
+            <height>25.2</height>
+        </collisionMale>
+        <collisionFemale>
+            <radius>7.0</radius>
+            <height>22.6</height>
+        </collisionFemale>
+    </staticData>
+    <lvlUpgainData>
+        <level val="1">
+            <hp>97.0</hp>
+            <mp>40.0</mp>
+            <cp>48.5</cp>
+            <hpRegen>2.0</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2.0</cpRegen>
+        </level>
+        <level val="2">
+            <hp>113.38</hp>
+            <mp>47.28</mp>
+            <cp>56.69</cp>
+            <hpRegen>2.05</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2.0</cpRegen>
+        </level>
+        <level val="3">
+            <hp>129.94</hp>
+            <mp>54.64</mp>
+            <cp>64.97</cp>
+            <hpRegen>2.1</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2.0</cpRegen>
+        </level>
+        <level val="4">
+            <hp>146.68</hp>
+            <mp>62.08</mp>
+            <cp>73.34</cp>
+            <hpRegen>2.15</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2.0</cpRegen>
+        </level>
+        <level val="5">
+            <hp>163.6</hp>
+            <mp>69.6</mp>
+            <cp>81.8</cp>
+            <hpRegen>2.2</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2.0</cpRegen>
+        </level>
+        <level val="6">
+            <hp>180.7</hp>
+            <mp>77.2</mp>
+            <cp>90.35</cp>
+            <hpRegen>2.25</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2.0</cpRegen>
+        </level>
+        <level val="7">
+            <hp>197.98</hp>
+            <mp>84.88</mp>
+            <cp>98.99</cp>
+            <hpRegen>2.3</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2.0</cpRegen>
+        </level>
+        <level val="8">
+            <hp>215.44</hp>
+            <mp>92.64</mp>
+            <cp>107.72</cp>
+            <hpRegen>2.35</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2.0</cpRegen>
+        </level>
+        <level val="9">
+            <hp>233.08</hp>
+            <mp>100.48</mp>
+            <cp>116.54</cp>
+            <hpRegen>2.4</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2.0</cpRegen>
+        </level>
+        <level val="10">
+            <hp>250.9</hp>
+            <mp>108.4</mp>
+            <cp>125.45</cp>
+            <hpRegen>2.45</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2.0</cpRegen>
+        </level>
+        <level val="11">
+            <hp>268.9</hp>
+            <mp>116.4</mp>
+            <cp>134.45</cp>
+            <hpRegen>2.5</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="12">
+            <hp>287.08</hp>
+            <mp>124.48</mp>
+            <cp>143.54</cp>
+            <hpRegen>2.6</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="13">
+            <hp>305.44</hp>
+            <mp>132.64</mp>
+            <cp>152.72</cp>
+            <hpRegen>2.7</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="14">
+            <hp>323.98</hp>
+            <mp>140.88</mp>
+            <cp>161.99</cp>
+            <hpRegen>2.8</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="15">
+            <hp>342.7</hp>
+            <mp>149.2</mp>
+            <cp>171.35</cp>
+            <hpRegen>2.9</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="16">
+            <hp>361.6</hp>
+            <mp>157.6</mp>
+            <cp>180.8</cp>
+            <hpRegen>3.0</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="17">
+            <hp>380.68</hp>
+            <mp>166.08</mp>
+            <cp>190.34</cp>
+            <hpRegen>3.1</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="18">
+            <hp>399.94</hp>
+            <mp>174.64</mp>
+            <cp>199.97</cp>
+            <hpRegen>3.2</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="19">
+            <hp>419.38</hp>
+            <mp>183.28</mp>
+            <cp>209.69</cp>
+            <hpRegen>3.3</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="20">
+            <hp>449.9</hp>
+            <mp>196.36</mp>
+            <cp>224.95</cp>
+            <hpRegen>3.4</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="21">
+            <hp>480.7</hp>
+            <mp>209.56</mp>
+            <cp>240.35</cp>
+            <hpRegen>3.5</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="22">
+            <hp>511.78</hp>
+            <mp>222.88</mp>
+            <cp>255.89</cp>
+            <hpRegen>3.6</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="23">
+            <hp>543.14</hp>
+            <mp>236.32</mp>
+            <cp>271.57</cp>
+            <hpRegen>3.7</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="24">
+            <hp>574.78</hp>
+            <mp>249.88</mp>
+            <cp>287.39</cp>
+            <hpRegen>3.8</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="25">
+            <hp>606.7</hp>
+            <mp>263.56</mp>
+            <cp>303.35</cp>
+            <hpRegen>3.9</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="26">
+            <hp>638.9</hp>
+            <mp>277.36</mp>
+            <cp>319.45</cp>
+            <hpRegen>4.0</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="27">
+            <hp>671.38</hp>
+            <mp>291.28</mp>
+            <cp>335.69</cp>
+            <hpRegen>4.1</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="28">
+            <hp>704.14</hp>
+            <mp>305.32</mp>
+            <cp>352.07</cp>
+            <hpRegen>4.2</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="29">
+            <hp>737.18</hp>
+            <mp>319.48</mp>
+            <cp>368.59</cp>
+            <hpRegen>4.3</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="30">
+            <hp>770.5</hp>
+            <mp>333.76</mp>
+            <cp>385.25</cp>
+            <hpRegen>4.4</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="31">
+            <hp>804.1</hp>
+            <mp>348.16</mp>
+            <cp>402.05</cp>
+            <hpRegen>4.5</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="32">
+            <hp>837.98</hp>
+            <mp>362.68</mp>
+            <cp>418.99</cp>
+            <hpRegen>4.6</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="33">
+            <hp>872.14</hp>
+            <mp>377.32</mp>
+            <cp>436.07</cp>
+            <hpRegen>4.7</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="34">
+            <hp>906.58</hp>
+            <mp>392.08</mp>
+            <cp>453.29</cp>
+            <hpRegen>4.8</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="35">
+            <hp>941.3</hp>
+            <mp>406.96</mp>
+            <cp>470.65</cp>
+            <hpRegen>4.9</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="36">
+            <hp>976.3</hp>
+            <mp>421.96</mp>
+            <cp>488.15</cp>
+            <hpRegen>5.0</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="37">
+            <hp>1011.58</hp>
+            <mp>437.08</mp>
+            <cp>505.79</cp>
+            <hpRegen>5.1</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="38">
+            <hp>1047.14</hp>
+            <mp>452.32</mp>
+            <cp>523.57</cp>
+            <hpRegen>5.2</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="39">
+            <hp>1082.98</hp>
+            <mp>467.68</mp>
+            <cp>541.49</cp>
+            <hpRegen>5.3</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="40">
+            <hp>1139.74</hp>
+            <mp>487.03</mp>
+            <cp>569.87</cp>
+            <hpRegen>5.4</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="41">
+            <hp>1196.94</hp>
+            <mp>506.53</mp>
+            <cp>598.47</cp>
+            <hpRegen>5.5</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="42">
+            <hp>1254.58</hp>
+            <mp>526.18</mp>
+            <cp>627.29</cp>
+            <hpRegen>5.6</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="43">
+            <hp>1312.66</hp>
+            <mp>545.98</mp>
+            <cp>656.33</cp>
+            <hpRegen>5.7</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="44">
+            <hp>1371.18</hp>
+            <mp>565.93</mp>
+            <cp>685.59</cp>
+            <hpRegen>5.8</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="45">
+            <hp>1430.14</hp>
+            <mp>586.03</mp>
+            <cp>715.07</cp>
+            <hpRegen>5.9</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="46">
+            <hp>1489.54</hp>
+            <mp>606.28</mp>
+            <cp>744.77</cp>
+            <hpRegen>6.0</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="47">
+            <hp>1549.38</hp>
+            <mp>626.68</mp>
+            <cp>774.69</cp>
+            <hpRegen>6.1</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="48">
+            <hp>1609.66</hp>
+            <mp>647.23</mp>
+            <cp>804.83</cp>
+            <hpRegen>6.2</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="49">
+            <hp>1670.38</hp>
+            <mp>667.93</mp>
+            <cp>835.19</cp>
+            <hpRegen>6.3</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="50">
+            <hp>1731.54</hp>
+            <mp>688.78</mp>
+            <cp>865.77</cp>
+            <hpRegen>6.4</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="51">
+            <hp>1793.14</hp>
+            <mp>709.78</mp>
+            <cp>896.57</cp>
+            <hpRegen>6.5</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="52">
+            <hp>1855.18</hp>
+            <mp>730.93</mp>
+            <cp>927.59</cp>
+            <hpRegen>6.6</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="53">
+            <hp>1917.66</hp>
+            <mp>752.23</mp>
+            <cp>958.83</cp>
+            <hpRegen>6.7</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="54">
+            <hp>1980.58</hp>
+            <mp>773.68</mp>
+            <cp>990.29</cp>
+            <hpRegen>6.8</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="55">
+            <hp>2043.94</hp>
+            <mp>795.28</mp>
+            <cp>1021.97</cp>
+            <hpRegen>6.9</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="56">
+            <hp>2107.74</hp>
+            <mp>817.03</mp>
+            <cp>1053.87</cp>
+            <hpRegen>7.0</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="57">
+            <hp>2171.98</hp>
+            <mp>838.93</mp>
+            <cp>1085.99</cp>
+            <hpRegen>7.1</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="58">
+            <hp>2236.66</hp>
+            <mp>860.98</mp>
+            <cp>1118.33</cp>
+            <hpRegen>7.2</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="59">
+            <hp>2301.78</hp>
+            <mp>883.18</mp>
+            <cp>1150.89</cp>
+            <hpRegen>7.3</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="60">
+            <hp>2367.34</hp>
+            <mp>905.53</mp>
+            <cp>1183.67</cp>
+            <hpRegen>7.4</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="61">
+            <hp>2433.34</hp>
+            <mp>928.03</mp>
+            <cp>1216.67</cp>
+            <hpRegen>7.5</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="62">
+            <hp>2499.78</hp>
+            <mp>950.68</mp>
+            <cp>1249.89</cp>
+            <hpRegen>7.6</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="63">
+            <hp>2566.66</hp>
+            <mp>973.48</mp>
+            <cp>1283.33</cp>
+            <hpRegen>7.7</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="64">
+            <hp>2633.98</hp>
+            <mp>996.43</mp>
+            <cp>1316.99</cp>
+            <hpRegen>7.8</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="65">
+            <hp>2701.74</hp>
+            <mp>1019.53</mp>
+            <cp>1350.87</cp>
+            <hpRegen>7.9</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="66">
+            <hp>2769.94</hp>
+            <mp>1042.78</mp>
+            <cp>1384.97</cp>
+            <hpRegen>8.0</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="67">
+            <hp>2838.58</hp>
+            <mp>1066.18</mp>
+            <cp>1419.29</cp>
+            <hpRegen>8.1</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="68">
+            <hp>2907.66</hp>
+            <mp>1089.73</mp>
+            <cp>1453.83</cp>
+            <hpRegen>8.2</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="69">
+            <hp>2977.18</hp>
+            <mp>1113.43</mp>
+            <cp>1488.59</cp>
+            <hpRegen>8.3</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="70">
+            <hp>3047.14</hp>
+            <mp>1137.28</mp>
+            <cp>1523.57</cp>
+            <hpRegen>8.4</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="71">
+            <hp>3117.54</hp>
+            <mp>1161.28</mp>
+            <cp>1558.77</cp>
+            <hpRegen>8.5</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="72">
+            <hp>3188.38</hp>
+            <mp>1185.43</mp>
+            <cp>1594.19</cp>
+            <hpRegen>8.6</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="73">
+            <hp>3259.66</hp>
+            <mp>1209.73</mp>
+            <cp>1629.83</cp>
+            <hpRegen>8.7</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="74">
+            <hp>3331.38</hp>
+            <mp>1234.18</mp>
+            <cp>1665.69</cp>
+            <hpRegen>8.8</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="75">
+            <hp>3403.54</hp>
+            <mp>1258.78</mp>
+            <cp>1701.77</cp>
+            <hpRegen>8.9</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="76">
+            <hp>3476.14</hp>
+            <mp>1283.53</mp>
+            <cp>1738.07</cp>
+            <hpRegen>9.0</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="77">
+            <hp>3549.18</hp>
+            <mp>1308.43</mp>
+            <cp>1774.59</cp>
+            <hpRegen>9.1</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="78">
+            <hp>3622.66</hp>
+            <mp>1333.48</mp>
+            <cp>1811.33</cp>
+            <hpRegen>9.2</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="79">
+            <hp>3696.58</hp>
+            <mp>1358.68</mp>
+            <cp>1848.29</cp>
+            <hpRegen>9.3</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="80">
+            <hp>3770.94</hp>
+            <mp>1384.03</mp>
+            <cp>1885.47</cp>
+            <hpRegen>9.4</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="81">
+            <hp>3845.74</hp>
+            <mp>1409.53</mp>
+            <cp>1922.87</cp>
+            <hpRegen>9.5</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="82">
+            <hp>3920.98</hp>
+            <mp>1435.18</mp>
+            <cp>1960.49</cp>
+            <hpRegen>9.6</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="83">
+            <hp>3996.66</hp>
+            <mp>1460.98</mp>
+            <cp>1998.33</cp>
+            <hpRegen>9.7</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="84">
+            <hp>4072.78</hp>
+            <mp>1486.93</mp>
+            <cp>2036.39</cp>
+            <hpRegen>9.8</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="85">
+            <hp>4149.34</hp>
+            <mp>1513.03</mp>
+            <cp>2074.67</cp>
+            <hpRegen>9.9</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="86">
+            <hp>4226.34</hp>
+            <mp>1539.28</mp>
+            <cp>2113.17</cp>
+            <hpRegen>10</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="87">
+            <hp>4303.78</hp>
+            <mp>1565.68</mp>
+            <cp>2151.89</cp>
+            <hpRegen>10.1</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="88">
+            <hp>4381.66</hp>
+            <mp>1592.23</mp>
+            <cp>2190.83</cp>
+            <hpRegen>10.2</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="89">
+            <hp>4459.98</hp>
+            <mp>1618.93</mp>
+            <cp>2229.99</cp>
+            <hpRegen>10.3</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="90">
+            <hp>4538.74</hp>
+            <mp>1645.78</mp>
+            <cp>2269.37</cp>
+            <hpRegen>10.4</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="91">
+            <hp>4617.94</hp>
+            <mp>1672.78</mp>
+            <cp>2308.97</cp>
+            <hpRegen>10.5</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="92">
+            <hp>4697.58</hp>
+            <mp>1699.93</mp>
+            <cp>2348.79</cp>
+            <hpRegen>10.6</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="93">
+            <hp>4777.66</hp>
+            <mp>1727.23</mp>
+            <cp>2388.83</cp>
+            <hpRegen>10.7</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="94">
+            <hp>4858.18</hp>
+            <mp>1754.68</mp>
+            <cp>2429.09</cp>
+            <hpRegen>10.8</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="95">
+            <hp>4939.14</hp>
+            <mp>1782.28</mp>
+            <cp>2469.57</cp>
+            <hpRegen>10.9</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="96">
+            <hp>5020.54</hp>
+            <mp>1810.03</mp>
+            <cp>2510.27</cp>
+            <hpRegen>11</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="97">
+            <hp>5102.38</hp>
+            <mp>1837.93</mp>
+            <cp>2551.19</cp>
+            <hpRegen>11.1</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="98">
+            <hp>5184.66</hp>
+            <mp>1865.98</mp>
+            <cp>2592.33</cp>
+            <hpRegen>11.2</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="99">
+            <hp>5267.38</hp>
+            <mp>1894.18</mp>
+            <cp>2633.69</cp>
+            <hpRegen>11.3</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="100">
+            <hp>5350.54</hp>
+            <mp>1922.53</mp>
+            <cp>2675.27</cp>
+            <hpRegen>11.4</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="101">
+            <hp>5434.14</hp>
+            <mp>1951.03</mp>
+            <cp>2717.07</cp>
+            <hpRegen>11.5</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="102">
+            <hp>5518.18</hp>
+            <mp>1979.68</mp>
+            <cp>2759.09</cp>
+            <hpRegen>11.6</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="103">
+            <hp>5602.66</hp>
+            <mp>2008.48</mp>
+            <cp>2801.33</cp>
+            <hpRegen>11.7</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="104">
+            <hp>5687.58</hp>
+            <mp>2037.43</mp>
+            <cp>2843.79</cp>
+            <hpRegen>11.8</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="105">
+            <hp>5772.94</hp>
+            <mp>2066.53</mp>
+            <cp>2886.47</cp>
+            <hpRegen>11.9</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="106">
+            <hp>5858.74</hp>
+            <mp>2095.78</mp>
+            <cp>2929.37</cp>
+            <hpRegen>12</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="107">
+            <hp>5944.98</hp>
+            <mp>2125.18</mp>
+            <cp>2972.49</cp>
+            <hpRegen>12.1</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+    </lvlUpgainData>
+</list>

--- a/data/stats/chars/baseStats/ArcanaLord.xml
+++ b/data/stats/chars/baseStats/ArcanaLord.xml
@@ -1,798 +1,926 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>96</classId>
-    <staticData>
-        <baseINT>41</baseINT>
-        <baseSTR>22</baseSTR>
-        <baseCON>27</baseCON>
-        <baseMEN>39</baseMEN>
-        <baseDEX>21</baseDEX>
-        <baseWIT>20</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-90875" y="248162" z="-3570"/>
-            <node x="-90954" y="248118" z="-3570"/>
-            <node x="-90918" y="248070" z="-3570"/>
-            <node x="-90890" y="248027" z="-3570"/>
-        </creationPoints>
-        <basePAtk>3</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>15</chest>
-            <legs>8</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>78</walk>
-            <run>124</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>100</baseBreath>
-        <baseSafeFall>200</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>22.8</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>6.5</radius>
-            <height>22.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>101.0</hp>
-            <mp>40.0</mp>
-            <cp>60.6</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>116.47</hp>
-            <mp>47.28</mp>
-            <cp>69.882</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>132.11</hp>
-            <mp>54.64</mp>
-            <cp>79.266</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>147.92</hp>
-            <mp>62.08</mp>
-            <cp>88.752</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>163.9</hp>
-            <mp>69.6</mp>
-            <cp>98.34</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>180.05</hp>
-            <mp>77.2</mp>
-            <cp>108.03</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>196.37</hp>
-            <mp>84.88</mp>
-            <cp>117.822</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>212.86</hp>
-            <mp>92.64</mp>
-            <cp>127.716</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>229.52</hp>
-            <mp>100.48</mp>
-            <cp>137.712</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>246.35</hp>
-            <mp>108.4</mp>
-            <cp>147.81</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>263.35</hp>
-            <mp>116.4</mp>
-            <cp>158.01</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>280.52</hp>
-            <mp>124.48</mp>
-            <cp>168.312</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>297.86</hp>
-            <mp>132.64</mp>
-            <cp>178.716</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>315.37</hp>
-            <mp>140.88</mp>
-            <cp>189.222</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>333.05</hp>
-            <mp>149.2</mp>
-            <cp>199.83</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>350.9</hp>
-            <mp>157.6</mp>
-            <cp>210.54</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>368.92</hp>
-            <mp>166.08</mp>
-            <cp>221.352</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>387.11</hp>
-            <mp>174.64</mp>
-            <cp>232.266</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>405.47</hp>
-            <mp>183.28</mp>
-            <cp>243.282</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>424.0</hp>
-            <mp>192.0</mp>
-            <cp>254.4</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>451.5</hp>
-            <mp>205.2</mp>
-            <cp>270.9</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>479.25</hp>
-            <mp>218.52</mp>
-            <cp>287.55</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>507.25</hp>
-            <mp>231.96</mp>
-            <cp>304.35</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>535.5</hp>
-            <mp>245.52</mp>
-            <cp>321.3</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>564.0</hp>
-            <mp>259.2</mp>
-            <cp>338.4</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>592.75</hp>
-            <mp>273.0</mp>
-            <cp>355.65</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>621.75</hp>
-            <mp>286.92</mp>
-            <cp>373.05</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>651.0</hp>
-            <mp>300.96</mp>
-            <cp>390.6</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>680.5</hp>
-            <mp>315.12</mp>
-            <cp>408.3</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>710.25</hp>
-            <mp>329.4</mp>
-            <cp>426.15</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>740.25</hp>
-            <mp>343.8</mp>
-            <cp>444.15</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>770.5</hp>
-            <mp>358.32</mp>
-            <cp>462.3</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>801.0</hp>
-            <mp>372.96</mp>
-            <cp>480.6</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>831.75</hp>
-            <mp>387.72</mp>
-            <cp>499.05</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>862.75</hp>
-            <mp>402.6</mp>
-            <cp>517.65</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>894.0</hp>
-            <mp>417.6</mp>
-            <cp>536.4</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>925.5</hp>
-            <mp>432.72</mp>
-            <cp>555.3</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>957.25</hp>
-            <mp>447.96</mp>
-            <cp>574.35</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>989.25</hp>
-            <mp>463.32</mp>
-            <cp>593.55</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1021.5</hp>
-            <mp>478.8</mp>
-            <cp>612.9</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1070.9</hp>
-            <mp>504.8</mp>
-            <cp>642.54</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1120.68</hp>
-            <mp>531.0</mp>
-            <cp>672.408</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1170.84</hp>
-            <mp>557.4</mp>
-            <cp>702.504</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1221.38</hp>
-            <mp>584.0</mp>
-            <cp>732.828</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1272.3</hp>
-            <mp>610.8</mp>
-            <cp>763.38</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1323.6</hp>
-            <mp>637.8</mp>
-            <cp>794.16</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1375.28</hp>
-            <mp>665.0</mp>
-            <cp>825.168</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1427.34</hp>
-            <mp>692.4</mp>
-            <cp>856.404</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1479.78</hp>
-            <mp>720.0</mp>
-            <cp>887.868</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1532.6</hp>
-            <mp>747.8</mp>
-            <cp>919.56</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1585.8</hp>
-            <mp>775.8</mp>
-            <cp>951.48</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1639.38</hp>
-            <mp>804.0</mp>
-            <cp>983.628</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1693.34</hp>
-            <mp>832.4</mp>
-            <cp>1016.004</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1747.68</hp>
-            <mp>861.0</mp>
-            <cp>1048.608</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1802.4</hp>
-            <mp>889.8</mp>
-            <cp>1081.44</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1857.5</hp>
-            <mp>918.8</mp>
-            <cp>1114.5</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1912.98</hp>
-            <mp>948.0</mp>
-            <cp>1147.788</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1968.84</hp>
-            <mp>977.4</mp>
-            <cp>1181.304</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2025.08</hp>
-            <mp>1007.0</mp>
-            <cp>1215.048</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2081.7</hp>
-            <mp>1036.8</mp>
-            <cp>1249.02</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2138.7</hp>
-            <mp>1066.8</mp>
-            <cp>1283.22</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2196.08</hp>
-            <mp>1097.0</mp>
-            <cp>1317.648</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2253.84</hp>
-            <mp>1127.4</mp>
-            <cp>1352.304</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2311.98</hp>
-            <mp>1158.0</mp>
-            <cp>1387.188</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2370.5</hp>
-            <mp>1188.8</mp>
-            <cp>1422.3</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2429.4</hp>
-            <mp>1219.8</mp>
-            <cp>1457.64</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2488.68</hp>
-            <mp>1251.0</mp>
-            <cp>1493.208</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2548.34</hp>
-            <mp>1282.4</mp>
-            <cp>1529.004</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2608.38</hp>
-            <mp>1314.0</mp>
-            <cp>1565.028</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2668.8</hp>
-            <mp>1345.8</mp>
-            <cp>1601.28</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2729.6</hp>
-            <mp>1377.8</mp>
-            <cp>1637.76</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2790.78</hp>
-            <mp>1410.0</mp>
-            <cp>1674.468</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2852.34</hp>
-            <mp>1442.4</mp>
-            <cp>1711.404</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2914.28</hp>
-            <mp>1475.0</mp>
-            <cp>1748.568</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2976.6</hp>
-            <mp>1507.8</mp>
-            <cp>1785.96</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3039.3</hp>
-            <mp>1540.8</mp>
-            <cp>1823.58</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3102.38</hp>
-            <mp>1574.0</mp>
-            <cp>1861.428</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3165.84</hp>
-            <mp>1607.4</mp>
-            <cp>1899.504</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3229.68</hp>
-            <mp>1641.0</mp>
-            <cp>1937.808</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3293.9</hp>
-            <mp>1674.8</mp>
-            <cp>1976.34</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3358.5</hp>
-            <mp>1708.8</mp>
-            <cp>2015.1</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3423.48</hp>
-            <mp>1743.0</mp>
-            <cp>2054.088</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3488.84</hp>
-            <mp>1777.4</mp>
-            <cp>2093.304</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3554.58</hp>
-            <mp>1812.0</mp>
-            <cp>2132.748</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3620.7</hp>
-            <mp>1846.8</mp>
-            <cp>2172.42</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3687.2</hp>
-            <mp>1881.8</mp>
-            <cp>2212.32</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3754.08</hp>
-            <mp>1917.0</mp>
-            <cp>2252.448</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3821.34</hp>
-            <mp>1952.4</mp>
-            <cp>2292.804</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3888.98</hp>
-            <mp>1988.0</mp>
-            <cp>2333.388</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3957.0</hp>
-            <mp>2023.8</mp>
-            <cp>2374.2</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4025.4</hp>
-            <mp>2059.8</mp>
-            <cp>2415.24</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>96</classId>
+	<staticData>
+		<baseINT>41</baseINT>
+		<baseSTR>22</baseSTR>
+		<baseCON>27</baseCON>
+		<baseMEN>39</baseMEN>
+		<baseDEX>21</baseDEX>
+		<baseWIT>20</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-90875" y="248162" z="-3570" />
+			<node x="-90954" y="248118" z="-3570" />
+			<node x="-90918" y="248070" z="-3570" />
+			<node x="-90890" y="248027" z="-3570" />
+		</creationPoints>
+		<basePAtk>3</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>15</chest>
+			<legs>8</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>78</walk>
+			<run>124</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>200</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>22.8</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>6.5</radius>
+			<height>22.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>101.0</hp>
+			<mp>40.0</mp>
+			<cp>60.6</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>116.47</hp>
+			<mp>47.28</mp>
+			<cp>69.882</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>132.11</hp>
+			<mp>54.64</mp>
+			<cp>79.266</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>147.92</hp>
+			<mp>62.08</mp>
+			<cp>88.752</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>163.9</hp>
+			<mp>69.6</mp>
+			<cp>98.34</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>180.05</hp>
+			<mp>77.2</mp>
+			<cp>108.03</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>196.37</hp>
+			<mp>84.88</mp>
+			<cp>117.822</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>212.86</hp>
+			<mp>92.64</mp>
+			<cp>127.716</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>229.52</hp>
+			<mp>100.48</mp>
+			<cp>137.712</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>246.35</hp>
+			<mp>108.4</mp>
+			<cp>147.81</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>263.35</hp>
+			<mp>116.4</mp>
+			<cp>158.01</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>280.52</hp>
+			<mp>124.48</mp>
+			<cp>168.312</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>297.86</hp>
+			<mp>132.64</mp>
+			<cp>178.716</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>315.37</hp>
+			<mp>140.88</mp>
+			<cp>189.222</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>333.05</hp>
+			<mp>149.2</mp>
+			<cp>199.83</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>350.9</hp>
+			<mp>157.6</mp>
+			<cp>210.54</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>368.92</hp>
+			<mp>166.08</mp>
+			<cp>221.352</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>387.11</hp>
+			<mp>174.64</mp>
+			<cp>232.266</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>405.47</hp>
+			<mp>183.28</mp>
+			<cp>243.282</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>424.0</hp>
+			<mp>192.0</mp>
+			<cp>254.4</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>451.5</hp>
+			<mp>205.2</mp>
+			<cp>270.9</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>479.25</hp>
+			<mp>218.52</mp>
+			<cp>287.55</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>507.25</hp>
+			<mp>231.96</mp>
+			<cp>304.35</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>535.5</hp>
+			<mp>245.52</mp>
+			<cp>321.3</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>564.0</hp>
+			<mp>259.2</mp>
+			<cp>338.4</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>592.75</hp>
+			<mp>273.0</mp>
+			<cp>355.65</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>621.75</hp>
+			<mp>286.92</mp>
+			<cp>373.05</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>651.0</hp>
+			<mp>300.96</mp>
+			<cp>390.6</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>680.5</hp>
+			<mp>315.12</mp>
+			<cp>408.3</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>710.25</hp>
+			<mp>329.4</mp>
+			<cp>426.15</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>740.25</hp>
+			<mp>343.8</mp>
+			<cp>444.15</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>770.5</hp>
+			<mp>358.32</mp>
+			<cp>462.3</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>801.0</hp>
+			<mp>372.96</mp>
+			<cp>480.6</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>831.75</hp>
+			<mp>387.72</mp>
+			<cp>499.05</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>862.75</hp>
+			<mp>402.6</mp>
+			<cp>517.65</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>894.0</hp>
+			<mp>417.6</mp>
+			<cp>536.4</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>925.5</hp>
+			<mp>432.72</mp>
+			<cp>555.3</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>957.25</hp>
+			<mp>447.96</mp>
+			<cp>574.35</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>989.25</hp>
+			<mp>463.32</mp>
+			<cp>593.55</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1021.5</hp>
+			<mp>478.8</mp>
+			<cp>612.9</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1070.9</hp>
+			<mp>504.8</mp>
+			<cp>642.54</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1120.68</hp>
+			<mp>531.0</mp>
+			<cp>672.408</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1170.84</hp>
+			<mp>557.4</mp>
+			<cp>702.504</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1221.38</hp>
+			<mp>584.0</mp>
+			<cp>732.828</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1272.3</hp>
+			<mp>610.8</mp>
+			<cp>763.38</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1323.6</hp>
+			<mp>637.8</mp>
+			<cp>794.16</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1375.28</hp>
+			<mp>665.0</mp>
+			<cp>825.168</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1427.34</hp>
+			<mp>692.4</mp>
+			<cp>856.404</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1479.78</hp>
+			<mp>720.0</mp>
+			<cp>887.868</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1532.6</hp>
+			<mp>747.8</mp>
+			<cp>919.56</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1585.8</hp>
+			<mp>775.8</mp>
+			<cp>951.48</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1639.38</hp>
+			<mp>804.0</mp>
+			<cp>983.628</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1693.34</hp>
+			<mp>832.4</mp>
+			<cp>1016.004</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1747.68</hp>
+			<mp>861.0</mp>
+			<cp>1048.608</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1802.4</hp>
+			<mp>889.8</mp>
+			<cp>1081.44</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1857.5</hp>
+			<mp>918.8</mp>
+			<cp>1114.5</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1912.98</hp>
+			<mp>948.0</mp>
+			<cp>1147.788</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1968.84</hp>
+			<mp>977.4</mp>
+			<cp>1181.304</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2025.08</hp>
+			<mp>1007.0</mp>
+			<cp>1215.048</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2081.7</hp>
+			<mp>1036.8</mp>
+			<cp>1249.02</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2138.7</hp>
+			<mp>1066.8</mp>
+			<cp>1283.22</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2196.08</hp>
+			<mp>1097.0</mp>
+			<cp>1317.648</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2253.84</hp>
+			<mp>1127.4</mp>
+			<cp>1352.304</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2311.98</hp>
+			<mp>1158.0</mp>
+			<cp>1387.188</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2370.5</hp>
+			<mp>1188.8</mp>
+			<cp>1422.3</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2429.4</hp>
+			<mp>1219.8</mp>
+			<cp>1457.64</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2488.68</hp>
+			<mp>1251.0</mp>
+			<cp>1493.208</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2548.34</hp>
+			<mp>1282.4</mp>
+			<cp>1529.004</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2608.38</hp>
+			<mp>1314.0</mp>
+			<cp>1565.028</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2668.8</hp>
+			<mp>1345.8</mp>
+			<cp>1601.28</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2729.6</hp>
+			<mp>1377.8</mp>
+			<cp>1637.76</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2790.78</hp>
+			<mp>1410.0</mp>
+			<cp>1674.468</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2852.34</hp>
+			<mp>1442.4</mp>
+			<cp>1711.404</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2914.28</hp>
+			<mp>1475.0</mp>
+			<cp>1748.568</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2976.6</hp>
+			<mp>1507.8</mp>
+			<cp>1785.96</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3039.3</hp>
+			<mp>1540.8</mp>
+			<cp>1823.58</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3102.38</hp>
+			<mp>1574.0</mp>
+			<cp>1861.428</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3165.84</hp>
+			<mp>1607.4</mp>
+			<cp>1899.504</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3229.68</hp>
+			<mp>1641.0</mp>
+			<cp>1937.808</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3293.9</hp>
+			<mp>1674.8</mp>
+			<cp>1976.34</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3358.5</hp>
+			<mp>1708.8</mp>
+			<cp>2015.1</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3423.48</hp>
+			<mp>1743.0</mp>
+			<cp>2054.088</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3488.84</hp>
+			<mp>1777.4</mp>
+			<cp>2093.304</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3554.58</hp>
+			<mp>1812.0</mp>
+			<cp>2132.748</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3620.7</hp>
+			<mp>1846.8</mp>
+			<cp>2172.42</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3687.2</hp>
+			<mp>1881.8</mp>
+			<cp>2212.32</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3754.08</hp>
+			<mp>1917.0</mp>
+			<cp>2252.448</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3821.34</hp>
+			<mp>1952.4</mp>
+			<cp>2292.804</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3888.98</hp>
+			<mp>1988.0</mp>
+			<cp>2333.388</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3957.0</hp>
+			<mp>2023.8</mp>
+			<cp>2374.2</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4025.4</hp>
+			<mp>2059.8</mp>
+			<cp>2415.24</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4094.18</hp>
+			<mp>2096.0</mp>
+			<cp>2456.508</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4163.34</hp>
+			<mp>2132.4</mp>
+			<cp>2498.004</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4232.88</hp>
+			<mp>2169.0</mp>
+			<cp>2539.728</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4302.8</hp>
+			<mp>2205.8</mp>
+			<cp>2581.68</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4373.1</hp>
+			<mp>2242.8</mp>
+			<cp>2623.86</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4443.78</hp>
+			<mp>2280.0</mp>
+			<cp>2666.268</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4514.84</hp>
+			<mp>2317.4</mp>
+			<cp>2708.904</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4586.28</hp>
+			<mp>2355.0</mp>
+			<cp>2751.768</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4658.1</hp>
+			<mp>2392.8</mp>
+			<cp>2794.86</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4730.3</hp>
+			<mp>2430.8</mp>
+			<cp>2838.19</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4802.88</hp>
+			<mp>2469</mp>
+			<cp>2881.74</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4875.84</hp>
+			<mp>2507.4</mp>
+			<cp>2925.52</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4949.18</hp>
+			<mp>2546</mp>
+			<cp>2969.54</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5022.9</hp>
+			<mp>2584.8</mp>
+			<cp>3013.78</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5097</hp>
+			<mp>2623.8</mp>
+			<cp>3058.26</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5171.48</hp>
+			<mp>2663</mp>
+			<cp>3102.888</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Archmage.xml
+++ b/data/stats/chars/baseStats/Archmage.xml
@@ -1,798 +1,926 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>94</classId>
-    <staticData>
-        <baseINT>41</baseINT>
-        <baseSTR>22</baseSTR>
-        <baseCON>27</baseCON>
-        <baseMEN>39</baseMEN>
-        <baseDEX>21</baseDEX>
-        <baseWIT>20</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-90875" y="248162" z="-3570"/>
-            <node x="-90954" y="248118" z="-3570"/>
-            <node x="-90918" y="248070" z="-3570"/>
-            <node x="-90890" y="248027" z="-3570"/>
-        </creationPoints>
-        <basePAtk>3</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>15</chest>
-            <legs>8</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>78</walk>
-            <run>124</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>100</baseBreath>
-        <baseSafeFall>200</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>22.8</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>6.5</radius>
-            <height>22.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>101.0</hp>
-            <mp>40.0</mp>
-            <cp>60.6</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>116.47</hp>
-            <mp>47.28</mp>
-            <cp>69.882</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>132.11</hp>
-            <mp>54.64</mp>
-            <cp>79.266</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>147.92</hp>
-            <mp>62.08</mp>
-            <cp>88.752</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>163.9</hp>
-            <mp>69.6</mp>
-            <cp>98.34</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>180.05</hp>
-            <mp>77.2</mp>
-            <cp>108.03</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>196.37</hp>
-            <mp>84.88</mp>
-            <cp>117.822</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>212.86</hp>
-            <mp>92.64</mp>
-            <cp>127.716</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>229.52</hp>
-            <mp>100.48</mp>
-            <cp>137.712</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>246.35</hp>
-            <mp>108.4</mp>
-            <cp>147.81</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>263.35</hp>
-            <mp>116.4</mp>
-            <cp>158.01</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>280.52</hp>
-            <mp>124.48</mp>
-            <cp>168.312</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>297.86</hp>
-            <mp>132.64</mp>
-            <cp>178.716</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>315.37</hp>
-            <mp>140.88</mp>
-            <cp>189.222</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>333.05</hp>
-            <mp>149.2</mp>
-            <cp>199.83</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>350.9</hp>
-            <mp>157.6</mp>
-            <cp>210.54</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>368.92</hp>
-            <mp>166.08</mp>
-            <cp>221.352</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>387.11</hp>
-            <mp>174.64</mp>
-            <cp>232.266</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>405.47</hp>
-            <mp>183.28</mp>
-            <cp>243.282</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>424.0</hp>
-            <mp>192.0</mp>
-            <cp>254.4</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>451.5</hp>
-            <mp>205.2</mp>
-            <cp>270.9</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>479.25</hp>
-            <mp>218.52</mp>
-            <cp>287.55</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>507.25</hp>
-            <mp>231.96</mp>
-            <cp>304.35</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>535.5</hp>
-            <mp>245.52</mp>
-            <cp>321.3</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>564.0</hp>
-            <mp>259.2</mp>
-            <cp>338.4</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>592.75</hp>
-            <mp>273.0</mp>
-            <cp>355.65</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>621.75</hp>
-            <mp>286.92</mp>
-            <cp>373.05</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>651.0</hp>
-            <mp>300.96</mp>
-            <cp>390.6</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>680.5</hp>
-            <mp>315.12</mp>
-            <cp>408.3</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>710.25</hp>
-            <mp>329.4</mp>
-            <cp>426.15</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>740.25</hp>
-            <mp>343.8</mp>
-            <cp>444.15</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>770.5</hp>
-            <mp>358.32</mp>
-            <cp>462.3</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>801.0</hp>
-            <mp>372.96</mp>
-            <cp>480.6</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>831.75</hp>
-            <mp>387.72</mp>
-            <cp>499.05</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>862.75</hp>
-            <mp>402.6</mp>
-            <cp>517.65</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>894.0</hp>
-            <mp>417.6</mp>
-            <cp>536.4</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>925.5</hp>
-            <mp>432.72</mp>
-            <cp>555.3</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>957.25</hp>
-            <mp>447.96</mp>
-            <cp>574.35</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>989.25</hp>
-            <mp>463.32</mp>
-            <cp>593.55</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1021.5</hp>
-            <mp>478.8</mp>
-            <cp>612.9</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1067.0</hp>
-            <mp>504.8</mp>
-            <cp>640.2</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1112.85</hp>
-            <mp>531.0</mp>
-            <cp>667.71</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1159.05</hp>
-            <mp>557.4</mp>
-            <cp>695.43</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1205.6</hp>
-            <mp>584.0</mp>
-            <cp>723.36</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1252.5</hp>
-            <mp>610.8</mp>
-            <cp>751.5</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1299.75</hp>
-            <mp>637.8</mp>
-            <cp>779.85</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1347.35</hp>
-            <mp>665.0</mp>
-            <cp>808.41</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1395.3</hp>
-            <mp>692.4</mp>
-            <cp>837.18</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1443.6</hp>
-            <mp>720.0</mp>
-            <cp>866.16</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1492.25</hp>
-            <mp>747.8</mp>
-            <cp>895.35</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1541.25</hp>
-            <mp>775.8</mp>
-            <cp>924.75</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1590.6</hp>
-            <mp>804.0</mp>
-            <cp>954.36</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1640.3</hp>
-            <mp>832.4</mp>
-            <cp>984.18</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1690.35</hp>
-            <mp>861.0</mp>
-            <cp>1014.21</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1740.75</hp>
-            <mp>889.8</mp>
-            <cp>1044.45</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1791.5</hp>
-            <mp>918.8</mp>
-            <cp>1074.9</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1842.6</hp>
-            <mp>948.0</mp>
-            <cp>1105.56</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1894.05</hp>
-            <mp>977.4</mp>
-            <cp>1136.43</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>1945.85</hp>
-            <mp>1007.0</mp>
-            <cp>1167.51</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>1998.0</hp>
-            <mp>1036.8</mp>
-            <cp>1198.8</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2050.5</hp>
-            <mp>1066.8</mp>
-            <cp>1230.3</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2103.35</hp>
-            <mp>1097.0</mp>
-            <cp>1262.01</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2156.55</hp>
-            <mp>1127.4</mp>
-            <cp>1293.93</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2210.1</hp>
-            <mp>1158.0</mp>
-            <cp>1326.06</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2264.0</hp>
-            <mp>1188.8</mp>
-            <cp>1358.4</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2318.25</hp>
-            <mp>1219.8</mp>
-            <cp>1390.95</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2372.85</hp>
-            <mp>1251.0</mp>
-            <cp>1423.71</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2427.8</hp>
-            <mp>1282.4</mp>
-            <cp>1456.68</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2483.1</hp>
-            <mp>1314.0</mp>
-            <cp>1489.86</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2538.75</hp>
-            <mp>1345.8</mp>
-            <cp>1523.25</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2594.75</hp>
-            <mp>1377.8</mp>
-            <cp>1556.85</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2651.1</hp>
-            <mp>1410.0</mp>
-            <cp>1590.66</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2707.8</hp>
-            <mp>1442.4</mp>
-            <cp>1624.68</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2764.85</hp>
-            <mp>1475.0</mp>
-            <cp>1658.91</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2822.25</hp>
-            <mp>1507.8</mp>
-            <cp>1693.35</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>2880.0</hp>
-            <mp>1540.8</mp>
-            <cp>1728.0</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>2938.1</hp>
-            <mp>1574.0</mp>
-            <cp>1762.86</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>2996.55</hp>
-            <mp>1607.4</mp>
-            <cp>1797.93</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3055.35</hp>
-            <mp>1641.0</mp>
-            <cp>1833.21</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3114.5</hp>
-            <mp>1674.8</mp>
-            <cp>1868.7</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3174.0</hp>
-            <mp>1708.8</mp>
-            <cp>1904.4</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3233.85</hp>
-            <mp>1743.0</mp>
-            <cp>1940.31</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3294.05</hp>
-            <mp>1777.4</mp>
-            <cp>1976.43</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3354.6</hp>
-            <mp>1812.0</mp>
-            <cp>2012.76</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3415.5</hp>
-            <mp>1846.8</mp>
-            <cp>2049.3</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3476.75</hp>
-            <mp>1881.8</mp>
-            <cp>2086.05</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3538.35</hp>
-            <mp>1917.0</mp>
-            <cp>2123.01</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3600.3</hp>
-            <mp>1952.4</mp>
-            <cp>2160.18</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3662.6</hp>
-            <mp>1988.0</mp>
-            <cp>2197.56</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3725.25</hp>
-            <mp>2023.8</mp>
-            <cp>2235.15</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>3788.25</hp>
-            <mp>2059.8</mp>
-            <cp>2272.95</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>94</classId>
+	<staticData>
+		<baseINT>41</baseINT>
+		<baseSTR>22</baseSTR>
+		<baseCON>27</baseCON>
+		<baseMEN>39</baseMEN>
+		<baseDEX>21</baseDEX>
+		<baseWIT>20</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-90875" y="248162" z="-3570" />
+			<node x="-90954" y="248118" z="-3570" />
+			<node x="-90918" y="248070" z="-3570" />
+			<node x="-90890" y="248027" z="-3570" />
+		</creationPoints>
+		<basePAtk>3</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>15</chest>
+			<legs>8</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>78</walk>
+			<run>124</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>200</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>22.8</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>6.5</radius>
+			<height>22.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>101.0</hp>
+			<mp>40.0</mp>
+			<cp>60.6</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>116.47</hp>
+			<mp>47.28</mp>
+			<cp>69.882</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>132.11</hp>
+			<mp>54.64</mp>
+			<cp>79.266</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>147.92</hp>
+			<mp>62.08</mp>
+			<cp>88.752</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>163.9</hp>
+			<mp>69.6</mp>
+			<cp>98.34</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>180.05</hp>
+			<mp>77.2</mp>
+			<cp>108.03</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>196.37</hp>
+			<mp>84.88</mp>
+			<cp>117.822</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>212.86</hp>
+			<mp>92.64</mp>
+			<cp>127.716</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>229.52</hp>
+			<mp>100.48</mp>
+			<cp>137.712</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>246.35</hp>
+			<mp>108.4</mp>
+			<cp>147.81</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>263.35</hp>
+			<mp>116.4</mp>
+			<cp>158.01</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>280.52</hp>
+			<mp>124.48</mp>
+			<cp>168.312</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>297.86</hp>
+			<mp>132.64</mp>
+			<cp>178.716</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>315.37</hp>
+			<mp>140.88</mp>
+			<cp>189.222</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>333.05</hp>
+			<mp>149.2</mp>
+			<cp>199.83</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>350.9</hp>
+			<mp>157.6</mp>
+			<cp>210.54</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>368.92</hp>
+			<mp>166.08</mp>
+			<cp>221.352</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>387.11</hp>
+			<mp>174.64</mp>
+			<cp>232.266</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>405.47</hp>
+			<mp>183.28</mp>
+			<cp>243.282</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>424.0</hp>
+			<mp>192.0</mp>
+			<cp>254.4</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>451.5</hp>
+			<mp>205.2</mp>
+			<cp>270.9</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>479.25</hp>
+			<mp>218.52</mp>
+			<cp>287.55</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>507.25</hp>
+			<mp>231.96</mp>
+			<cp>304.35</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>535.5</hp>
+			<mp>245.52</mp>
+			<cp>321.3</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>564.0</hp>
+			<mp>259.2</mp>
+			<cp>338.4</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>592.75</hp>
+			<mp>273.0</mp>
+			<cp>355.65</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>621.75</hp>
+			<mp>286.92</mp>
+			<cp>373.05</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>651.0</hp>
+			<mp>300.96</mp>
+			<cp>390.6</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>680.5</hp>
+			<mp>315.12</mp>
+			<cp>408.3</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>710.25</hp>
+			<mp>329.4</mp>
+			<cp>426.15</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>740.25</hp>
+			<mp>343.8</mp>
+			<cp>444.15</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>770.5</hp>
+			<mp>358.32</mp>
+			<cp>462.3</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>801.0</hp>
+			<mp>372.96</mp>
+			<cp>480.6</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>831.75</hp>
+			<mp>387.72</mp>
+			<cp>499.05</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>862.75</hp>
+			<mp>402.6</mp>
+			<cp>517.65</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>894.0</hp>
+			<mp>417.6</mp>
+			<cp>536.4</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>925.5</hp>
+			<mp>432.72</mp>
+			<cp>555.3</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>957.25</hp>
+			<mp>447.96</mp>
+			<cp>574.35</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>989.25</hp>
+			<mp>463.32</mp>
+			<cp>593.55</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1021.5</hp>
+			<mp>478.8</mp>
+			<cp>612.9</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1067.0</hp>
+			<mp>504.8</mp>
+			<cp>640.2</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1112.85</hp>
+			<mp>531.0</mp>
+			<cp>667.71</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1159.05</hp>
+			<mp>557.4</mp>
+			<cp>695.43</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1205.6</hp>
+			<mp>584.0</mp>
+			<cp>723.36</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1252.5</hp>
+			<mp>610.8</mp>
+			<cp>751.5</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1299.75</hp>
+			<mp>637.8</mp>
+			<cp>779.85</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1347.35</hp>
+			<mp>665.0</mp>
+			<cp>808.41</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1395.3</hp>
+			<mp>692.4</mp>
+			<cp>837.18</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1443.6</hp>
+			<mp>720.0</mp>
+			<cp>866.16</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1492.25</hp>
+			<mp>747.8</mp>
+			<cp>895.35</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1541.25</hp>
+			<mp>775.8</mp>
+			<cp>924.75</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1590.6</hp>
+			<mp>804.0</mp>
+			<cp>954.36</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1640.3</hp>
+			<mp>832.4</mp>
+			<cp>984.18</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1690.35</hp>
+			<mp>861.0</mp>
+			<cp>1014.21</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1740.75</hp>
+			<mp>889.8</mp>
+			<cp>1044.45</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1791.5</hp>
+			<mp>918.8</mp>
+			<cp>1074.9</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1842.6</hp>
+			<mp>948.0</mp>
+			<cp>1105.56</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1894.05</hp>
+			<mp>977.4</mp>
+			<cp>1136.43</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1945.85</hp>
+			<mp>1007.0</mp>
+			<cp>1167.51</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1998.0</hp>
+			<mp>1036.8</mp>
+			<cp>1198.8</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2050.5</hp>
+			<mp>1066.8</mp>
+			<cp>1230.3</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2103.35</hp>
+			<mp>1097.0</mp>
+			<cp>1262.01</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2156.55</hp>
+			<mp>1127.4</mp>
+			<cp>1293.93</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2210.1</hp>
+			<mp>1158.0</mp>
+			<cp>1326.06</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2264.0</hp>
+			<mp>1188.8</mp>
+			<cp>1358.4</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2318.25</hp>
+			<mp>1219.8</mp>
+			<cp>1390.95</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2372.85</hp>
+			<mp>1251.0</mp>
+			<cp>1423.71</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2427.8</hp>
+			<mp>1282.4</mp>
+			<cp>1456.68</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2483.1</hp>
+			<mp>1314.0</mp>
+			<cp>1489.86</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2538.75</hp>
+			<mp>1345.8</mp>
+			<cp>1523.25</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2594.75</hp>
+			<mp>1377.8</mp>
+			<cp>1556.85</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2651.1</hp>
+			<mp>1410.0</mp>
+			<cp>1590.66</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2707.8</hp>
+			<mp>1442.4</mp>
+			<cp>1624.68</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2764.85</hp>
+			<mp>1475.0</mp>
+			<cp>1658.91</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2822.25</hp>
+			<mp>1507.8</mp>
+			<cp>1693.35</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>2880.0</hp>
+			<mp>1540.8</mp>
+			<cp>1728.0</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>2938.1</hp>
+			<mp>1574.0</mp>
+			<cp>1762.86</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>2996.55</hp>
+			<mp>1607.4</mp>
+			<cp>1797.93</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3055.35</hp>
+			<mp>1641.0</mp>
+			<cp>1833.21</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3114.5</hp>
+			<mp>1674.8</mp>
+			<cp>1868.7</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3174.0</hp>
+			<mp>1708.8</mp>
+			<cp>1904.4</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3233.85</hp>
+			<mp>1743.0</mp>
+			<cp>1940.31</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3294.05</hp>
+			<mp>1777.4</mp>
+			<cp>1976.43</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3354.6</hp>
+			<mp>1812.0</mp>
+			<cp>2012.76</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3415.5</hp>
+			<mp>1846.8</mp>
+			<cp>2049.3</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3476.75</hp>
+			<mp>1881.8</mp>
+			<cp>2086.05</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3538.35</hp>
+			<mp>1917.0</mp>
+			<cp>2123.01</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3600.3</hp>
+			<mp>1952.4</mp>
+			<cp>2160.18</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3662.6</hp>
+			<mp>1988.0</mp>
+			<cp>2197.56</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3725.25</hp>
+			<mp>2023.8</mp>
+			<cp>2235.15</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3788.25</hp>
+			<mp>2059.8</mp>
+			<cp>2272.95</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>3851.6</hp>
+			<mp>2096.0</mp>
+			<cp>2310.96</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>3915.3</hp>
+			<mp>2132.4</mp>
+			<cp>2349.18</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>3979.35</hp>
+			<mp>2169.0</mp>
+			<cp>2387.61</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4043.75</hp>
+			<mp>2205.8</mp>
+			<cp>2426.25</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4108.5</hp>
+			<mp>2242.8</mp>
+			<cp>2465.1</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4173.6</hp>
+			<mp>2280.0</mp>
+			<cp>2504.16</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4239.05</hp>
+			<mp>2317.4</mp>
+			<cp>2543.43</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4304.85</hp>
+			<mp>2355.0</mp>
+			<cp>2582.91</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4371</hp>
+			<mp>2392.8</mp>
+			<cp>2622.6</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4437.5</hp>
+			<mp>2430.8</mp>
+			<cp>2662.5</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4504.35</hp>
+			<mp>2469</mp>
+			<cp>2702.61</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4571.55</hp>
+			<mp>2507.4</mp>
+			<cp>2742.93</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4639.1</hp>
+			<mp>2546</mp>
+			<cp>2783.46</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>4707</hp>
+			<mp>2584.8</mp>
+			<cp>2824.2</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>4775.25</hp>
+			<mp>2623.8</mp>
+			<cp>2865.15</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>4843.85</hp>
+			<mp>2663</mp>
+			<cp>2906.31</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Artisan.xml
+++ b/data/stats/chars/baseStats/Artisan.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>56</classId>
-    <staticData>
-        <baseINT>20</baseINT>
-        <baseSTR>39</baseSTR>
-        <baseCON>45</baseCON>
-        <baseMEN>27</baseMEN>
-        <baseDEX>29</baseDEX>
-        <baseWIT>10</baseWIT>
-        <physicalAbnormalResist>15</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="108644" y="-173947" z="-400"/>
-            <node x="108678" y="-174002" z="-400"/>
-            <node x="108505" y="-173964" z="-400"/>
-            <node x="108512" y="-174026" z="-400"/>
-            <node x="108549" y="-174075" z="-400"/>
-            <node x="108576" y="-174122" z="-400"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>80</walk>
-            <run>131</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>80</baseBreath>
-        <baseSafeFall>180</baseSafeFall>
-        <collisionMale>
-            <radius>9.0</radius>
-            <height>18.0</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>5.0</radius>
-            <height>19.0</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>80.0</hp>
-            <mp>30.0</mp>
-            <cp>64.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>92.74</hp>
-            <mp>35.46</mp>
-            <cp>74.192</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>105.62</hp>
-            <mp>40.98</mp>
-            <cp>84.496</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>118.64</hp>
-            <mp>46.56</mp>
-            <cp>94.912</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>131.8</hp>
-            <mp>52.2</mp>
-            <cp>105.44</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>145.1</hp>
-            <mp>57.9</mp>
-            <cp>116.08</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>158.54</hp>
-            <mp>63.66</mp>
-            <cp>126.832</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>172.12</hp>
-            <mp>69.48</mp>
-            <cp>137.696</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>185.84</hp>
-            <mp>75.36</mp>
-            <cp>148.672</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>199.7</hp>
-            <mp>81.3</mp>
-            <cp>159.76</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>213.7</hp>
-            <mp>87.3</mp>
-            <cp>170.96</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>227.84</hp>
-            <mp>93.36</mp>
-            <cp>182.272</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>242.12</hp>
-            <mp>99.48</mp>
-            <cp>193.696</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>256.54</hp>
-            <mp>105.66</mp>
-            <cp>205.232</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>271.1</hp>
-            <mp>111.9</mp>
-            <cp>216.88</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>285.8</hp>
-            <mp>118.2</mp>
-            <cp>228.64</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>300.64</hp>
-            <mp>124.56</mp>
-            <cp>240.512</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>315.62</hp>
-            <mp>130.98</mp>
-            <cp>252.496</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>330.74</hp>
-            <mp>137.46</mp>
-            <cp>264.592</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>346.0</hp>
-            <mp>144.0</mp>
-            <cp>276.8</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>379.0</hp>
-            <mp>153.9</mp>
-            <cp>303.2</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>412.3</hp>
-            <mp>163.89</mp>
-            <cp>329.84</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>445.9</hp>
-            <mp>173.97</mp>
-            <cp>356.72</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>479.8</hp>
-            <mp>184.14</mp>
-            <cp>383.84</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>514.0</hp>
-            <mp>194.4</mp>
-            <cp>411.2</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>548.5</hp>
-            <mp>204.75</mp>
-            <cp>438.8</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>583.3</hp>
-            <mp>215.19</mp>
-            <cp>466.64</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>618.4</hp>
-            <mp>225.72</mp>
-            <cp>494.72</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>653.8</hp>
-            <mp>236.34</mp>
-            <cp>523.04</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>689.5</hp>
-            <mp>247.05</mp>
-            <cp>551.6</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>725.5</hp>
-            <mp>257.85</mp>
-            <cp>580.4</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>761.8</hp>
-            <mp>268.74</mp>
-            <cp>609.44</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>798.4</hp>
-            <mp>279.72</mp>
-            <cp>638.72</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>835.3</hp>
-            <mp>290.79</mp>
-            <cp>668.24</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>872.5</hp>
-            <mp>301.95</mp>
-            <cp>698.0</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>910.0</hp>
-            <mp>313.2</mp>
-            <cp>728.0</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>947.8</hp>
-            <mp>324.54</mp>
-            <cp>758.24</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>985.9</hp>
-            <mp>335.97</mp>
-            <cp>788.72</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1024.3</hp>
-            <mp>347.49</mp>
-            <cp>819.44</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1063.0</hp>
-            <mp>359.1</mp>
-            <cp>850.4</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1102.0</hp>
-            <mp>370.8</mp>
-            <cp>881.6</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1141.3</hp>
-            <mp>382.59</mp>
-            <cp>913.04</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1180.9</hp>
-            <mp>394.47</mp>
-            <cp>944.72</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1220.8</hp>
-            <mp>406.44</mp>
-            <cp>976.64</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1261.0</hp>
-            <mp>418.5</mp>
-            <cp>1008.8</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1301.5</hp>
-            <mp>430.65</mp>
-            <cp>1041.2</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1342.3</hp>
-            <mp>442.89</mp>
-            <cp>1073.84</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1383.4</hp>
-            <mp>455.22</mp>
-            <cp>1106.72</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1424.8</hp>
-            <mp>467.64</mp>
-            <cp>1139.84</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1466.5</hp>
-            <mp>480.15</mp>
-            <cp>1173.2</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1508.5</hp>
-            <mp>492.75</mp>
-            <cp>1206.8</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1550.8</hp>
-            <mp>505.44</mp>
-            <cp>1240.64</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1593.4</hp>
-            <mp>518.22</mp>
-            <cp>1274.72</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1636.3</hp>
-            <mp>531.09</mp>
-            <cp>1309.04</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1679.5</hp>
-            <mp>544.05</mp>
-            <cp>1343.6</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1723.0</hp>
-            <mp>557.1</mp>
-            <cp>1378.4</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1766.8</hp>
-            <mp>570.24</mp>
-            <cp>1413.44</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1810.9</hp>
-            <mp>583.47</mp>
-            <cp>1448.72</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>1855.3</hp>
-            <mp>596.79</mp>
-            <cp>1484.24</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>1900.0</hp>
-            <mp>610.2</mp>
-            <cp>1520.0</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>1945.0</hp>
-            <mp>623.7</mp>
-            <cp>1556.0</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>1990.3</hp>
-            <mp>637.29</mp>
-            <cp>1592.24</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2035.9</hp>
-            <mp>650.97</mp>
-            <cp>1628.72</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2081.8</hp>
-            <mp>664.74</mp>
-            <cp>1665.44</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2128.0</hp>
-            <mp>678.6</mp>
-            <cp>1702.4</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2174.5</hp>
-            <mp>692.55</mp>
-            <cp>1739.6</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2221.3</hp>
-            <mp>706.59</mp>
-            <cp>1777.04</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2268.4</hp>
-            <mp>720.72</mp>
-            <cp>1814.72</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2315.8</hp>
-            <mp>734.94</mp>
-            <cp>1852.64</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2363.5</hp>
-            <mp>749.25</mp>
-            <cp>1890.8</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2411.5</hp>
-            <mp>763.65</mp>
-            <cp>1929.2</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2459.8</hp>
-            <mp>778.14</mp>
-            <cp>1967.84</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2508.4</hp>
-            <mp>792.72</mp>
-            <cp>2006.72</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2557.3</hp>
-            <mp>807.39</mp>
-            <cp>2045.84</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2606.5</hp>
-            <mp>822.15</mp>
-            <cp>2085.2</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>2656.0</hp>
-            <mp>837.0</mp>
-            <cp>2124.8</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>2705.8</hp>
-            <mp>851.94</mp>
-            <cp>2164.64</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>2755.9</hp>
-            <mp>866.97</mp>
-            <cp>2204.72</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>2806.3</hp>
-            <mp>882.09</mp>
-            <cp>2245.04</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>2857.0</hp>
-            <mp>897.3</mp>
-            <cp>2285.6</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>2908.0</hp>
-            <mp>912.6</mp>
-            <cp>2326.4</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>2959.3</hp>
-            <mp>927.99</mp>
-            <cp>2367.44</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3010.9</hp>
-            <mp>943.47</mp>
-            <cp>2408.72</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3062.8</hp>
-            <mp>959.04</mp>
-            <cp>2450.24</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3115.0</hp>
-            <mp>974.7</mp>
-            <cp>2492.0</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3167.5</hp>
-            <mp>990.45</mp>
-            <cp>2534.0</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3220.3</hp>
-            <mp>1006.29</mp>
-            <cp>2576.24</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3273.4</hp>
-            <mp>1022.22</mp>
-            <cp>2618.72</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3326.8</hp>
-            <mp>1038.24</mp>
-            <cp>2661.44</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3380.5</hp>
-            <mp>1054.35</mp>
-            <cp>2704.4</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>3434.5</hp>
-            <mp>1070.55</mp>
-            <cp>2747.6</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>56</classId>
+	<staticData>
+		<baseINT>20</baseINT>
+		<baseSTR>39</baseSTR>
+		<baseCON>45</baseCON>
+		<baseMEN>27</baseMEN>
+		<baseDEX>29</baseDEX>
+		<baseWIT>10</baseWIT>
+		<physicalAbnormalResist>15</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="108644" y="-173947" z="-400" />
+			<node x="108678" y="-174002" z="-400" />
+			<node x="108505" y="-173964" z="-400" />
+			<node x="108512" y="-174026" z="-400" />
+			<node x="108549" y="-174075" z="-400" />
+			<node x="108576" y="-174122" z="-400" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>80</walk>
+			<run>131</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>80</baseBreath>
+		<baseSafeFall>180</baseSafeFall>
+		<collisionMale>
+			<radius>9.0</radius>
+			<height>18.0</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>5.0</radius>
+			<height>19.0</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>80.0</hp>
+			<mp>30.0</mp>
+			<cp>64.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>92.74</hp>
+			<mp>35.46</mp>
+			<cp>74.192</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>105.62</hp>
+			<mp>40.98</mp>
+			<cp>84.496</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>118.64</hp>
+			<mp>46.56</mp>
+			<cp>94.912</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>131.8</hp>
+			<mp>52.2</mp>
+			<cp>105.44</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>145.1</hp>
+			<mp>57.9</mp>
+			<cp>116.08</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>158.54</hp>
+			<mp>63.66</mp>
+			<cp>126.832</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>172.12</hp>
+			<mp>69.48</mp>
+			<cp>137.696</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>185.84</hp>
+			<mp>75.36</mp>
+			<cp>148.672</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>199.7</hp>
+			<mp>81.3</mp>
+			<cp>159.76</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>213.7</hp>
+			<mp>87.3</mp>
+			<cp>170.96</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>227.84</hp>
+			<mp>93.36</mp>
+			<cp>182.272</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>242.12</hp>
+			<mp>99.48</mp>
+			<cp>193.696</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>256.54</hp>
+			<mp>105.66</mp>
+			<cp>205.232</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>271.1</hp>
+			<mp>111.9</mp>
+			<cp>216.88</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>285.8</hp>
+			<mp>118.2</mp>
+			<cp>228.64</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>300.64</hp>
+			<mp>124.56</mp>
+			<cp>240.512</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>315.62</hp>
+			<mp>130.98</mp>
+			<cp>252.496</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>330.74</hp>
+			<mp>137.46</mp>
+			<cp>264.592</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>346.0</hp>
+			<mp>144.0</mp>
+			<cp>276.8</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>379.0</hp>
+			<mp>153.9</mp>
+			<cp>303.2</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>412.3</hp>
+			<mp>163.89</mp>
+			<cp>329.84</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>445.9</hp>
+			<mp>173.97</mp>
+			<cp>356.72</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>479.8</hp>
+			<mp>184.14</mp>
+			<cp>383.84</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>514.0</hp>
+			<mp>194.4</mp>
+			<cp>411.2</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>548.5</hp>
+			<mp>204.75</mp>
+			<cp>438.8</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>583.3</hp>
+			<mp>215.19</mp>
+			<cp>466.64</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>618.4</hp>
+			<mp>225.72</mp>
+			<cp>494.72</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>653.8</hp>
+			<mp>236.34</mp>
+			<cp>523.04</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>689.5</hp>
+			<mp>247.05</mp>
+			<cp>551.6</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>725.5</hp>
+			<mp>257.85</mp>
+			<cp>580.4</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>761.8</hp>
+			<mp>268.74</mp>
+			<cp>609.44</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>798.4</hp>
+			<mp>279.72</mp>
+			<cp>638.72</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>835.3</hp>
+			<mp>290.79</mp>
+			<cp>668.24</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>872.5</hp>
+			<mp>301.95</mp>
+			<cp>698.0</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>910.0</hp>
+			<mp>313.2</mp>
+			<cp>728.0</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>947.8</hp>
+			<mp>324.54</mp>
+			<cp>758.24</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>985.9</hp>
+			<mp>335.97</mp>
+			<cp>788.72</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1024.3</hp>
+			<mp>347.49</mp>
+			<cp>819.44</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1063.0</hp>
+			<mp>359.1</mp>
+			<cp>850.4</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1102.0</hp>
+			<mp>370.8</mp>
+			<cp>881.6</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1141.3</hp>
+			<mp>382.59</mp>
+			<cp>913.04</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1180.9</hp>
+			<mp>394.47</mp>
+			<cp>944.72</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1220.8</hp>
+			<mp>406.44</mp>
+			<cp>976.64</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1261.0</hp>
+			<mp>418.5</mp>
+			<cp>1008.8</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1301.5</hp>
+			<mp>430.65</mp>
+			<cp>1041.2</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1342.3</hp>
+			<mp>442.89</mp>
+			<cp>1073.84</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1383.4</hp>
+			<mp>455.22</mp>
+			<cp>1106.72</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1424.8</hp>
+			<mp>467.64</mp>
+			<cp>1139.84</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1466.5</hp>
+			<mp>480.15</mp>
+			<cp>1173.2</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1508.5</hp>
+			<mp>492.75</mp>
+			<cp>1206.8</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1550.8</hp>
+			<mp>505.44</mp>
+			<cp>1240.64</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1593.4</hp>
+			<mp>518.22</mp>
+			<cp>1274.72</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1636.3</hp>
+			<mp>531.09</mp>
+			<cp>1309.04</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1679.5</hp>
+			<mp>544.05</mp>
+			<cp>1343.6</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1723.0</hp>
+			<mp>557.1</mp>
+			<cp>1378.4</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1766.8</hp>
+			<mp>570.24</mp>
+			<cp>1413.44</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1810.9</hp>
+			<mp>583.47</mp>
+			<cp>1448.72</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1855.3</hp>
+			<mp>596.79</mp>
+			<cp>1484.24</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1900.0</hp>
+			<mp>610.2</mp>
+			<cp>1520.0</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>1945.0</hp>
+			<mp>623.7</mp>
+			<cp>1556.0</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>1990.3</hp>
+			<mp>637.29</mp>
+			<cp>1592.24</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2035.9</hp>
+			<mp>650.97</mp>
+			<cp>1628.72</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2081.8</hp>
+			<mp>664.74</mp>
+			<cp>1665.44</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2128.0</hp>
+			<mp>678.6</mp>
+			<cp>1702.4</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2174.5</hp>
+			<mp>692.55</mp>
+			<cp>1739.6</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2221.3</hp>
+			<mp>706.59</mp>
+			<cp>1777.04</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2268.4</hp>
+			<mp>720.72</mp>
+			<cp>1814.72</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2315.8</hp>
+			<mp>734.94</mp>
+			<cp>1852.64</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2363.5</hp>
+			<mp>749.25</mp>
+			<cp>1890.8</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2411.5</hp>
+			<mp>763.65</mp>
+			<cp>1929.2</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2459.8</hp>
+			<mp>778.14</mp>
+			<cp>1967.84</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2508.4</hp>
+			<mp>792.72</mp>
+			<cp>2006.72</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2557.3</hp>
+			<mp>807.39</mp>
+			<cp>2045.84</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2606.5</hp>
+			<mp>822.15</mp>
+			<cp>2085.2</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>2656.0</hp>
+			<mp>837.0</mp>
+			<cp>2124.8</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>2705.8</hp>
+			<mp>851.94</mp>
+			<cp>2164.64</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>2755.9</hp>
+			<mp>866.97</mp>
+			<cp>2204.72</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>2806.3</hp>
+			<mp>882.09</mp>
+			<cp>2245.04</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>2857.0</hp>
+			<mp>897.3</mp>
+			<cp>2285.6</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>2908.0</hp>
+			<mp>912.6</mp>
+			<cp>2326.4</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>2959.3</hp>
+			<mp>927.99</mp>
+			<cp>2367.44</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3010.9</hp>
+			<mp>943.47</mp>
+			<cp>2408.72</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3062.8</hp>
+			<mp>959.04</mp>
+			<cp>2450.24</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3115.0</hp>
+			<mp>974.7</mp>
+			<cp>2492.0</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3167.5</hp>
+			<mp>990.45</mp>
+			<cp>2534.0</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3220.3</hp>
+			<mp>1006.29</mp>
+			<cp>2576.24</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3273.4</hp>
+			<mp>1022.22</mp>
+			<cp>2618.72</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3326.8</hp>
+			<mp>1038.24</mp>
+			<cp>2661.44</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3380.5</hp>
+			<mp>1054.35</mp>
+			<cp>2704.4</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3434.5</hp>
+			<mp>1070.55</mp>
+			<cp>2747.6</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>3488.8</hp>
+			<mp>1086.84</mp>
+			<cp>2791.04</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>3543.4</hp>
+			<mp>1103.22</mp>
+			<cp>2834.72</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>3598.3</hp>
+			<mp>1119.69</mp>
+			<cp>2878.64</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>3653.5</hp>
+			<mp>1136.25</mp>
+			<cp>2922.8</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>3709.0</hp>
+			<mp>1152.9</mp>
+			<cp>2967.2</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>3764.8</hp>
+			<mp>1169.64</mp>
+			<cp>3011.84</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>3820.9</hp>
+			<mp>1186.47</mp>
+			<cp>3056.72</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>3877.3</hp>
+			<mp>1203.39</mp>
+			<cp>3101.84</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>3934</hp>
+			<mp>1220.4</mp>
+			<cp>3147.2</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>3991</hp>
+			<mp>1237.5</mp>
+			<cp>3192.8</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4048.3</hp>
+			<mp>1254.69</mp>
+			<cp>3238.64</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4105.9</hp>
+			<mp>1271.97</mp>
+			<cp>3284.72</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4163.8</hp>
+			<mp>1289.34</mp>
+			<cp>3331.04</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>4222</hp>
+			<mp>1306.8</mp>
+			<cp>3377.6</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>4280.5</hp>
+			<mp>1324.35</mp>
+			<cp>3424.4</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>4339.3</hp>
+			<mp>1341.99</mp>
+			<cp>3471.44</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Assassin.xml
+++ b/data/stats/chars/baseStats/Assassin.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>35</classId>
-    <staticData>
-        <baseINT>25</baseINT>
-        <baseSTR>41</baseSTR>
-        <baseCON>32</baseCON>
-        <baseMEN>26</baseMEN>
-        <baseDEX>34</baseDEX>
-        <baseWIT>12</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>15</magicAbnormalResist>
-        <creationPoints>
-            <node x="28295" y="11063" z="-4224"/>
-            <node x="28302" y="11008" z="-4224"/>
-            <node x="28377" y="10916" z="-4224"/>
-            <node x="28456" y="10997" z="-4224"/>
-            <node x="28461" y="11044" z="-4224"/>
-            <node x="28395" y="11127" z="-4224"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>85</walk>
-            <run>139</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>150</baseBreath>
-        <baseSafeFall>350</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>24</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.0</radius>
-            <height>23.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>94.0</hp>
-            <mp>30.0</mp>
-            <cp>47.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>107.65</hp>
-            <mp>35.46</mp>
-            <cp>53.825</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>121.45</hp>
-            <mp>40.98</mp>
-            <cp>60.725</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>135.4</hp>
-            <mp>46.56</mp>
-            <cp>67.7</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>149.5</hp>
-            <mp>52.2</mp>
-            <cp>74.75</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>163.75</hp>
-            <mp>57.9</mp>
-            <cp>81.875</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>178.15</hp>
-            <mp>63.66</mp>
-            <cp>89.075</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>192.7</hp>
-            <mp>69.48</mp>
-            <cp>96.35</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>207.4</hp>
-            <mp>75.36</mp>
-            <cp>103.7</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>222.25</hp>
-            <mp>81.3</mp>
-            <cp>111.125</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>237.25</hp>
-            <mp>87.3</mp>
-            <cp>118.625</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>252.4</hp>
-            <mp>93.36</mp>
-            <cp>126.2</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>267.7</hp>
-            <mp>99.48</mp>
-            <cp>133.85</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>283.15</hp>
-            <mp>105.66</mp>
-            <cp>141.575</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>298.75</hp>
-            <mp>111.9</mp>
-            <cp>149.375</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>314.5</hp>
-            <mp>118.2</mp>
-            <cp>157.25</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>330.4</hp>
-            <mp>124.56</mp>
-            <cp>165.2</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>346.45</hp>
-            <mp>130.98</mp>
-            <cp>173.225</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>362.65</hp>
-            <mp>137.46</mp>
-            <cp>181.325</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>379.0</hp>
-            <mp>144.0</mp>
-            <cp>189.5</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>412.0</hp>
-            <mp>153.9</mp>
-            <cp>206.0</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>445.3</hp>
-            <mp>163.89</mp>
-            <cp>222.65</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>478.9</hp>
-            <mp>173.97</mp>
-            <cp>239.45</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>512.8</hp>
-            <mp>184.14</mp>
-            <cp>256.4</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>547.0</hp>
-            <mp>194.4</mp>
-            <cp>273.5</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>581.5</hp>
-            <mp>204.75</mp>
-            <cp>290.75</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>616.3</hp>
-            <mp>215.19</mp>
-            <cp>308.15</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>651.4</hp>
-            <mp>225.72</mp>
-            <cp>325.7</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>686.8</hp>
-            <mp>236.34</mp>
-            <cp>343.4</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>722.5</hp>
-            <mp>247.05</mp>
-            <cp>361.25</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>758.5</hp>
-            <mp>257.85</mp>
-            <cp>379.25</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>794.8</hp>
-            <mp>268.74</mp>
-            <cp>397.4</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>831.4</hp>
-            <mp>279.72</mp>
-            <cp>415.7</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>868.3</hp>
-            <mp>290.79</mp>
-            <cp>434.15</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>905.5</hp>
-            <mp>301.95</mp>
-            <cp>452.75</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>943.0</hp>
-            <mp>313.2</mp>
-            <cp>471.5</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>980.8</hp>
-            <mp>324.54</mp>
-            <cp>490.4</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1018.9</hp>
-            <mp>335.97</mp>
-            <cp>509.45</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1057.3</hp>
-            <mp>347.49</mp>
-            <cp>528.65</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1096.0</hp>
-            <mp>359.1</mp>
-            <cp>548.0</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1135.0</hp>
-            <mp>370.8</mp>
-            <cp>567.5</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1174.3</hp>
-            <mp>382.59</mp>
-            <cp>587.15</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1213.9</hp>
-            <mp>394.47</mp>
-            <cp>606.95</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1253.8</hp>
-            <mp>406.44</mp>
-            <cp>626.9</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1294.0</hp>
-            <mp>418.5</mp>
-            <cp>647.0</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1334.5</hp>
-            <mp>430.65</mp>
-            <cp>667.25</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1375.3</hp>
-            <mp>442.89</mp>
-            <cp>687.65</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1416.4</hp>
-            <mp>455.22</mp>
-            <cp>708.2</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1457.8</hp>
-            <mp>467.64</mp>
-            <cp>728.9</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1499.5</hp>
-            <mp>480.15</mp>
-            <cp>749.75</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1541.5</hp>
-            <mp>492.75</mp>
-            <cp>770.75</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1583.8</hp>
-            <mp>505.44</mp>
-            <cp>791.9</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1626.4</hp>
-            <mp>518.22</mp>
-            <cp>813.2</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1669.3</hp>
-            <mp>531.09</mp>
-            <cp>834.65</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1712.5</hp>
-            <mp>544.05</mp>
-            <cp>856.25</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1756.0</hp>
-            <mp>557.1</mp>
-            <cp>878.0</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1799.8</hp>
-            <mp>570.24</mp>
-            <cp>899.9</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1843.9</hp>
-            <mp>583.47</mp>
-            <cp>921.95</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>1888.3</hp>
-            <mp>596.79</mp>
-            <cp>944.15</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>1933.0</hp>
-            <mp>610.2</mp>
-            <cp>966.5</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>1978.0</hp>
-            <mp>623.7</mp>
-            <cp>989.0</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2023.3</hp>
-            <mp>637.29</mp>
-            <cp>1011.65</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2068.9</hp>
-            <mp>650.97</mp>
-            <cp>1034.45</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2114.8</hp>
-            <mp>664.74</mp>
-            <cp>1057.4</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2161.0</hp>
-            <mp>678.6</mp>
-            <cp>1080.5</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2207.5</hp>
-            <mp>692.55</mp>
-            <cp>1103.75</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2254.3</hp>
-            <mp>706.59</mp>
-            <cp>1127.15</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2301.4</hp>
-            <mp>720.72</mp>
-            <cp>1150.7</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2348.8</hp>
-            <mp>734.94</mp>
-            <cp>1174.4</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2396.5</hp>
-            <mp>749.25</mp>
-            <cp>1198.25</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2444.5</hp>
-            <mp>763.65</mp>
-            <cp>1222.25</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2492.8</hp>
-            <mp>778.14</mp>
-            <cp>1246.4</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2541.4</hp>
-            <mp>792.72</mp>
-            <cp>1270.7</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2590.3</hp>
-            <mp>807.39</mp>
-            <cp>1295.15</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2639.5</hp>
-            <mp>822.15</mp>
-            <cp>1319.75</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>2689.0</hp>
-            <mp>837.0</mp>
-            <cp>1344.5</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>2738.8</hp>
-            <mp>851.94</mp>
-            <cp>1369.4</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>2788.9</hp>
-            <mp>866.97</mp>
-            <cp>1394.45</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>2839.3</hp>
-            <mp>882.09</mp>
-            <cp>1419.65</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>2890.0</hp>
-            <mp>897.3</mp>
-            <cp>1445.0</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>2941.0</hp>
-            <mp>912.6</mp>
-            <cp>1470.5</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>2992.3</hp>
-            <mp>927.99</mp>
-            <cp>1496.15</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3043.9</hp>
-            <mp>943.47</mp>
-            <cp>1521.95</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3095.8</hp>
-            <mp>959.04</mp>
-            <cp>1547.9</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3148.0</hp>
-            <mp>974.7</mp>
-            <cp>1574.0</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3200.5</hp>
-            <mp>990.45</mp>
-            <cp>1600.25</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3253.3</hp>
-            <mp>1006.29</mp>
-            <cp>1626.65</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3306.4</hp>
-            <mp>1022.22</mp>
-            <cp>1653.2</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3359.8</hp>
-            <mp>1038.24</mp>
-            <cp>1679.9</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3413.5</hp>
-            <mp>1054.35</mp>
-            <cp>1706.75</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>3467.5</hp>
-            <mp>1070.55</mp>
-            <cp>1733.75</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>35</classId>
+	<staticData>
+		<baseINT>25</baseINT>
+		<baseSTR>41</baseSTR>
+		<baseCON>32</baseCON>
+		<baseMEN>26</baseMEN>
+		<baseDEX>34</baseDEX>
+		<baseWIT>12</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="28295" y="11063" z="-4224" />
+			<node x="28302" y="11008" z="-4224" />
+			<node x="28377" y="10916" z="-4224" />
+			<node x="28456" y="10997" z="-4224" />
+			<node x="28461" y="11044" z="-4224" />
+			<node x="28395" y="11127" z="-4224" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>85</walk>
+			<run>139</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>350</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>94.0</hp>
+			<mp>30.0</mp>
+			<cp>47.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>107.65</hp>
+			<mp>35.46</mp>
+			<cp>53.825</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>121.45</hp>
+			<mp>40.98</mp>
+			<cp>60.725</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>135.4</hp>
+			<mp>46.56</mp>
+			<cp>67.7</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>149.5</hp>
+			<mp>52.2</mp>
+			<cp>74.75</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>163.75</hp>
+			<mp>57.9</mp>
+			<cp>81.875</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>178.15</hp>
+			<mp>63.66</mp>
+			<cp>89.075</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>192.7</hp>
+			<mp>69.48</mp>
+			<cp>96.35</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>207.4</hp>
+			<mp>75.36</mp>
+			<cp>103.7</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>222.25</hp>
+			<mp>81.3</mp>
+			<cp>111.125</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>237.25</hp>
+			<mp>87.3</mp>
+			<cp>118.625</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>252.4</hp>
+			<mp>93.36</mp>
+			<cp>126.2</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>267.7</hp>
+			<mp>99.48</mp>
+			<cp>133.85</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>283.15</hp>
+			<mp>105.66</mp>
+			<cp>141.575</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>298.75</hp>
+			<mp>111.9</mp>
+			<cp>149.375</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>314.5</hp>
+			<mp>118.2</mp>
+			<cp>157.25</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>330.4</hp>
+			<mp>124.56</mp>
+			<cp>165.2</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>346.45</hp>
+			<mp>130.98</mp>
+			<cp>173.225</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>362.65</hp>
+			<mp>137.46</mp>
+			<cp>181.325</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>379.0</hp>
+			<mp>144.0</mp>
+			<cp>189.5</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>412.0</hp>
+			<mp>153.9</mp>
+			<cp>206.0</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>445.3</hp>
+			<mp>163.89</mp>
+			<cp>222.65</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>478.9</hp>
+			<mp>173.97</mp>
+			<cp>239.45</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>512.8</hp>
+			<mp>184.14</mp>
+			<cp>256.4</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>547.0</hp>
+			<mp>194.4</mp>
+			<cp>273.5</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>581.5</hp>
+			<mp>204.75</mp>
+			<cp>290.75</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>616.3</hp>
+			<mp>215.19</mp>
+			<cp>308.15</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>651.4</hp>
+			<mp>225.72</mp>
+			<cp>325.7</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>686.8</hp>
+			<mp>236.34</mp>
+			<cp>343.4</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>722.5</hp>
+			<mp>247.05</mp>
+			<cp>361.25</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>758.5</hp>
+			<mp>257.85</mp>
+			<cp>379.25</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>794.8</hp>
+			<mp>268.74</mp>
+			<cp>397.4</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>831.4</hp>
+			<mp>279.72</mp>
+			<cp>415.7</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>868.3</hp>
+			<mp>290.79</mp>
+			<cp>434.15</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>905.5</hp>
+			<mp>301.95</mp>
+			<cp>452.75</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>943.0</hp>
+			<mp>313.2</mp>
+			<cp>471.5</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>980.8</hp>
+			<mp>324.54</mp>
+			<cp>490.4</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1018.9</hp>
+			<mp>335.97</mp>
+			<cp>509.45</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1057.3</hp>
+			<mp>347.49</mp>
+			<cp>528.65</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1096.0</hp>
+			<mp>359.1</mp>
+			<cp>548.0</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1135.0</hp>
+			<mp>370.8</mp>
+			<cp>567.5</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1174.3</hp>
+			<mp>382.59</mp>
+			<cp>587.15</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1213.9</hp>
+			<mp>394.47</mp>
+			<cp>606.95</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1253.8</hp>
+			<mp>406.44</mp>
+			<cp>626.9</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1294.0</hp>
+			<mp>418.5</mp>
+			<cp>647.0</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1334.5</hp>
+			<mp>430.65</mp>
+			<cp>667.25</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1375.3</hp>
+			<mp>442.89</mp>
+			<cp>687.65</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1416.4</hp>
+			<mp>455.22</mp>
+			<cp>708.2</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1457.8</hp>
+			<mp>467.64</mp>
+			<cp>728.9</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1499.5</hp>
+			<mp>480.15</mp>
+			<cp>749.75</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1541.5</hp>
+			<mp>492.75</mp>
+			<cp>770.75</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1583.8</hp>
+			<mp>505.44</mp>
+			<cp>791.9</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1626.4</hp>
+			<mp>518.22</mp>
+			<cp>813.2</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1669.3</hp>
+			<mp>531.09</mp>
+			<cp>834.65</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1712.5</hp>
+			<mp>544.05</mp>
+			<cp>856.25</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1756.0</hp>
+			<mp>557.1</mp>
+			<cp>878.0</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1799.8</hp>
+			<mp>570.24</mp>
+			<cp>899.9</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1843.9</hp>
+			<mp>583.47</mp>
+			<cp>921.95</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1888.3</hp>
+			<mp>596.79</mp>
+			<cp>944.15</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1933.0</hp>
+			<mp>610.2</mp>
+			<cp>966.5</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>1978.0</hp>
+			<mp>623.7</mp>
+			<cp>989.0</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2023.3</hp>
+			<mp>637.29</mp>
+			<cp>1011.65</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2068.9</hp>
+			<mp>650.97</mp>
+			<cp>1034.45</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2114.8</hp>
+			<mp>664.74</mp>
+			<cp>1057.4</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2161.0</hp>
+			<mp>678.6</mp>
+			<cp>1080.5</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2207.5</hp>
+			<mp>692.55</mp>
+			<cp>1103.75</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2254.3</hp>
+			<mp>706.59</mp>
+			<cp>1127.15</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2301.4</hp>
+			<mp>720.72</mp>
+			<cp>1150.7</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2348.8</hp>
+			<mp>734.94</mp>
+			<cp>1174.4</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2396.5</hp>
+			<mp>749.25</mp>
+			<cp>1198.25</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2444.5</hp>
+			<mp>763.65</mp>
+			<cp>1222.25</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2492.8</hp>
+			<mp>778.14</mp>
+			<cp>1246.4</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2541.4</hp>
+			<mp>792.72</mp>
+			<cp>1270.7</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2590.3</hp>
+			<mp>807.39</mp>
+			<cp>1295.15</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2639.5</hp>
+			<mp>822.15</mp>
+			<cp>1319.75</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>2689.0</hp>
+			<mp>837.0</mp>
+			<cp>1344.5</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>2738.8</hp>
+			<mp>851.94</mp>
+			<cp>1369.4</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>2788.9</hp>
+			<mp>866.97</mp>
+			<cp>1394.45</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>2839.3</hp>
+			<mp>882.09</mp>
+			<cp>1419.65</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>2890.0</hp>
+			<mp>897.3</mp>
+			<cp>1445.0</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>2941.0</hp>
+			<mp>912.6</mp>
+			<cp>1470.5</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>2992.3</hp>
+			<mp>927.99</mp>
+			<cp>1496.15</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3043.9</hp>
+			<mp>943.47</mp>
+			<cp>1521.95</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3095.8</hp>
+			<mp>959.04</mp>
+			<cp>1547.9</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3148.0</hp>
+			<mp>974.7</mp>
+			<cp>1574.0</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3200.5</hp>
+			<mp>990.45</mp>
+			<cp>1600.25</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3253.3</hp>
+			<mp>1006.29</mp>
+			<cp>1626.65</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3306.4</hp>
+			<mp>1022.22</mp>
+			<cp>1653.2</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3359.8</hp>
+			<mp>1038.24</mp>
+			<cp>1679.9</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3413.5</hp>
+			<mp>1054.35</mp>
+			<cp>1706.75</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3467.5</hp>
+			<mp>1070.55</mp>
+			<cp>1733.75</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>3521.8</hp>
+			<mp>1086.84</mp>
+			<cp>1760.9</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>3576.4</hp>
+			<mp>1103.22</mp>
+			<cp>1788.2</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>3631.3</hp>
+			<mp>1119.69</mp>
+			<cp>1815.65</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>3686.5</hp>
+			<mp>1136.25</mp>
+			<cp>1843.25</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>3742.0</hp>
+			<mp>1152.9</mp>
+			<cp>1871.0</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>3797.8</hp>
+			<mp>1169.64</mp>
+			<cp>1898.9</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>3853.9</hp>
+			<mp>1186.47</mp>
+			<cp>1926.95</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>3910.3</hp>
+			<mp>1203.39</mp>
+			<cp>1955.15</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>3967</hp>
+			<mp>1220.4</mp>
+			<cp>1983.5</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4024</hp>
+			<mp>1237.5</mp>
+			<cp>2012</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4081.3</hp>
+			<mp>1254.69</mp>
+			<cp>2040.65</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4138.9</hp>
+			<mp>1271.97</mp>
+			<cp>2069.45</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4196.8</hp>
+			<mp>1289.34</mp>
+			<cp>2098.4</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>4255</hp>
+			<mp>1306.8</mp>
+			<cp>2127.5</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>4313.5</hp>
+			<mp>1324.35</mp>
+			<cp>2156.75</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>4372.3</hp>
+			<mp>1341.99</mp>
+			<cp>2186.15</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Berserker.xml
+++ b/data/stats/chars/baseStats/Berserker.xml
@@ -1,0 +1,928 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
+	<classId>127</classId>
+	<staticData>
+		<baseINT>25</baseINT>
+		<baseSTR>41</baseSTR>
+		<baseCON>27</baseCON>
+		<baseMEN>22</baseMEN>
+		<baseDEX>35</baseDEX>
+		<baseWIT>20</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-125607" y="38452" z="1152" />
+			<node x="-125472" y="38450" z="1152" />
+			<node x="-125615" y="37771" z="1152" />
+			<node x="-125464" y="37776" z="1152" />
+			<node x="-125517" y="38267" z="1155" />
+			<node x="-125531" y="37944" z="1155" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>87</walk>
+			<run>140</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>500</baseSafeFall>
+		<collisionMale>
+			<radius>8.0</radius>
+			<height>25.2</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.0</radius>
+			<height>22.6</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>95.0</hp>
+			<mp>30.0</mp>
+			<cp>47.5</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>108.65</hp>
+			<mp>35.46</mp>
+			<cp>54.325</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>122.45</hp>
+			<mp>40.98</mp>
+			<cp>61.225</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>136.4</hp>
+			<mp>46.56</mp>
+			<cp>68.2</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>150.5</hp>
+			<mp>52.2</mp>
+			<cp>75.25</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>164.75</hp>
+			<mp>57.9</mp>
+			<cp>82.375</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>179.15</hp>
+			<mp>63.66</mp>
+			<cp>89.575</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>193.7</hp>
+			<mp>69.48</mp>
+			<cp>96.85</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>208.4</hp>
+			<mp>75.36</mp>
+			<cp>104.2</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>223.25</hp>
+			<mp>81.3</mp>
+			<cp>111.625</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>238.25</hp>
+			<mp>87.3</mp>
+			<cp>119.125</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>253.4</hp>
+			<mp>93.36</mp>
+			<cp>126.7</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>268.7</hp>
+			<mp>99.48</mp>
+			<cp>134.35</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>284.15</hp>
+			<mp>105.66</mp>
+			<cp>142.075</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>299.75</hp>
+			<mp>111.9</mp>
+			<cp>149.875</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>315.5</hp>
+			<mp>118.2</mp>
+			<cp>157.75</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>331.4</hp>
+			<mp>124.56</mp>
+			<cp>165.7</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>347.45</hp>
+			<mp>130.98</mp>
+			<cp>173.725</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>363.65</hp>
+			<mp>137.46</mp>
+			<cp>181.825</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>398.53</hp>
+			<mp>147.27</mp>
+			<cp>199.265</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>433.73</hp>
+			<mp>157.17</mp>
+			<cp>216.865</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>469.25</hp>
+			<mp>167.16</mp>
+			<cp>234.625</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>505.09</hp>
+			<mp>177.24</mp>
+			<cp>252.545</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>541.25</hp>
+			<mp>187.41</mp>
+			<cp>270.625</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>577.73</hp>
+			<mp>197.67</mp>
+			<cp>288.865</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>614.53</hp>
+			<mp>208.02</mp>
+			<cp>307.265</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>651.65</hp>
+			<mp>218.46</mp>
+			<cp>325.825</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>689.09</hp>
+			<mp>228.99</mp>
+			<cp>344.545</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>726.85</hp>
+			<mp>239.61</mp>
+			<cp>363.425</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>764.93</hp>
+			<mp>250.32</mp>
+			<cp>382.465</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>803.33</hp>
+			<mp>261.12</mp>
+			<cp>401.665</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>842.05</hp>
+			<mp>272.01</mp>
+			<cp>421.025</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>881.09</hp>
+			<mp>282.99</mp>
+			<cp>440.545</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>920.45</hp>
+			<mp>294.06</mp>
+			<cp>460.225</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>960.13</hp>
+			<mp>305.22</mp>
+			<cp>480.065</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>1000.13</hp>
+			<mp>316.47</mp>
+			<cp>500.065</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>1040.45</hp>
+			<mp>327.81</mp>
+			<cp>520.225</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1081.09</hp>
+			<mp>339.24</mp>
+			<cp>540.545</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1122.05</hp>
+			<mp>350.76</mp>
+			<cp>561.025</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1178.81</hp>
+			<mp>370.11</mp>
+			<cp>589.405</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1236.01</hp>
+			<mp>389.61</mp>
+			<cp>618.005</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1293.65</hp>
+			<mp>409.26</mp>
+			<cp>646.825</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1351.73</hp>
+			<mp>429.06</mp>
+			<cp>675.865</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1410.25</hp>
+			<mp>449.01</mp>
+			<cp>705.125</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1469.21</hp>
+			<mp>469.11</mp>
+			<cp>734.605</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1528.61</hp>
+			<mp>489.36</mp>
+			<cp>764.305</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1588.45</hp>
+			<mp>509.76</mp>
+			<cp>794.225</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1648.73</hp>
+			<mp>530.31</mp>
+			<cp>824.365</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1709.45</hp>
+			<mp>551.01</mp>
+			<cp>854.725</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1770.61</hp>
+			<mp>571.86</mp>
+			<cp>885.305</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1832.21</hp>
+			<mp>592.86</mp>
+			<cp>916.105</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1894.25</hp>
+			<mp>614.01</mp>
+			<cp>947.125</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1956.73</hp>
+			<mp>635.31</mp>
+			<cp>978.365</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>2019.65</hp>
+			<mp>656.76</mp>
+			<cp>1009.825</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>2083.01</hp>
+			<mp>678.36</mp>
+			<cp>1041.505</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>2146.81</hp>
+			<mp>700.11</mp>
+			<cp>1073.405</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2211.05</hp>
+			<mp>722.01</mp>
+			<cp>1105.525</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2275.73</hp>
+			<mp>744.06</mp>
+			<cp>1137.865</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2340.85</hp>
+			<mp>766.26</mp>
+			<cp>1170.425</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2406.41</hp>
+			<mp>788.61</mp>
+			<cp>1203.205</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2472.41</hp>
+			<mp>811.11</mp>
+			<cp>1236.205</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2538.85</hp>
+			<mp>833.76</mp>
+			<cp>1269.425</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2605.73</hp>
+			<mp>856.56</mp>
+			<cp>1302.865</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2673.05</hp>
+			<mp>879.51</mp>
+			<cp>1336.525</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2740.81</hp>
+			<mp>902.61</mp>
+			<cp>1370.405</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2809.01</hp>
+			<mp>925.86</mp>
+			<cp>1404.505</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2877.65</hp>
+			<mp>949.26</mp>
+			<cp>1438.825</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2946.73</hp>
+			<mp>972.81</mp>
+			<cp>1473.365</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>3016.25</hp>
+			<mp>996.51</mp>
+			<cp>1508.125</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>3086.21</hp>
+			<mp>1020.36</mp>
+			<cp>1543.105</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>3156.61</hp>
+			<mp>1044.36</mp>
+			<cp>1578.305</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>3227.45</hp>
+			<mp>1068.51</mp>
+			<cp>1613.725</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>3298.73</hp>
+			<mp>1092.81</mp>
+			<cp>1649.365</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3370.45</hp>
+			<mp>1117.26</mp>
+			<cp>1685.225</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3442.61</hp>
+			<mp>1141.86</mp>
+			<cp>1721.305</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3515.21</hp>
+			<mp>1166.61</mp>
+			<cp>1757.605</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3588.25</hp>
+			<mp>1191.51</mp>
+			<cp>1794.125</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3661.73</hp>
+			<mp>1216.56</mp>
+			<cp>1830.865</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3735.65</hp>
+			<mp>1241.76</mp>
+			<cp>1867.825</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3810.01</hp>
+			<mp>1267.11</mp>
+			<cp>1905.005</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3884.81</hp>
+			<mp>1292.61</mp>
+			<cp>1942.405</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3960.05</hp>
+			<mp>1318.26</mp>
+			<cp>1980.025</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>4035.73</hp>
+			<mp>1344.06</mp>
+			<cp>2017.865</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>4111.85</hp>
+			<mp>1370.01</mp>
+			<cp>2055.925</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>4188.41</hp>
+			<mp>1396.11</mp>
+			<cp>2094.205</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>4265.41</hp>
+			<mp>1422.36</mp>
+			<cp>2132.705</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>4342.85</hp>
+			<mp>1448.76</mp>
+			<cp>2171.425</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4420.73</hp>
+			<mp>1475.31</mp>
+			<cp>2210.365</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4499.05</hp>
+			<mp>1502.01</mp>
+			<cp>2249.525</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4577.81</hp>
+			<mp>1528.86</mp>
+			<cp>2288.905</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4657.01</hp>
+			<mp>1555.86</mp>
+			<cp>2328.505</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4736.65</hp>
+			<mp>1583.01</mp>
+			<cp>2368.325</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4816.73</hp>
+			<mp>1610.31</mp>
+			<cp>2408.365</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4897.25</hp>
+			<mp>1637.76</mp>
+			<cp>2448.625</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4978.21</hp>
+			<mp>1665.36</mp>
+			<cp>2489.105</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>5059.61</hp>
+			<mp>1693.11</mp>
+			<cp>2529.805</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>5141.45</hp>
+			<mp>1721.01</mp>
+			<cp>2570.725</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>5223.73</hp>
+			<mp>1749.06</mp>
+			<cp>2611.865</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>5306.45</hp>
+			<mp>1777.26</mp>
+			<cp>2653.225</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>5389.61</hp>
+			<mp>1805.61</mp>
+			<cp>2694.81</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>5473.21</hp>
+			<mp>1834.11</mp>
+			<cp>2736.61</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5557.25</hp>
+			<mp>1862.76</mp>
+			<cp>2778.63</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5641.73</hp>
+			<mp>1891.56</mp>
+			<cp>2820.87</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5726.65</hp>
+			<mp>1920.51</mp>
+			<cp>2863.33</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5812.01</hp>
+			<mp>1949.61</mp>
+			<cp>2906.01</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5897.81</hp>
+			<mp>1978.86</mp>
+			<cp>2948.91</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5984.05</hp>
+			<mp>2008.26</mp>
+			<cp>2992.03</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
+</list>

--- a/data/stats/chars/baseStats/Bishop.xml
+++ b/data/stats/chars/baseStats/Bishop.xml
@@ -1,798 +1,926 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>16</classId>
-    <staticData>
-        <baseINT>41</baseINT>
-        <baseSTR>22</baseSTR>
-        <baseCON>27</baseCON>
-        <baseMEN>39</baseMEN>
-        <baseDEX>21</baseDEX>
-        <baseWIT>20</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-90875" y="248162" z="-3570"/>
-            <node x="-90954" y="248118" z="-3570"/>
-            <node x="-90918" y="248070" z="-3570"/>
-            <node x="-90890" y="248027" z="-3570"/>
-        </creationPoints>
-        <basePAtk>3</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>15</chest>
-            <legs>8</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>78</walk>
-            <run>124</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>100</baseBreath>
-        <baseSafeFall>200</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>22.8</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>6.5</radius>
-            <height>22.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>101.0</hp>
-            <mp>40.0</mp>
-            <cp>90.9</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>116.47</hp>
-            <mp>47.28</mp>
-            <cp>104.823</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>132.11</hp>
-            <mp>54.64</mp>
-            <cp>118.899</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>147.92</hp>
-            <mp>62.08</mp>
-            <cp>133.128</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>163.9</hp>
-            <mp>69.6</mp>
-            <cp>147.51</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>180.05</hp>
-            <mp>77.2</mp>
-            <cp>162.045</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>196.37</hp>
-            <mp>84.88</mp>
-            <cp>176.733</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>212.86</hp>
-            <mp>92.64</mp>
-            <cp>191.574</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>229.52</hp>
-            <mp>100.48</mp>
-            <cp>206.568</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>246.35</hp>
-            <mp>108.4</mp>
-            <cp>221.715</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>263.35</hp>
-            <mp>116.4</mp>
-            <cp>237.015</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>280.52</hp>
-            <mp>124.48</mp>
-            <cp>252.468</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>297.86</hp>
-            <mp>132.64</mp>
-            <cp>268.074</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>315.37</hp>
-            <mp>140.88</mp>
-            <cp>283.833</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>333.05</hp>
-            <mp>149.2</mp>
-            <cp>299.745</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>350.9</hp>
-            <mp>157.6</mp>
-            <cp>315.81</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>368.92</hp>
-            <mp>166.08</mp>
-            <cp>332.028</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>387.11</hp>
-            <mp>174.64</mp>
-            <cp>348.399</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>405.47</hp>
-            <mp>183.28</mp>
-            <cp>364.923</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>424.0</hp>
-            <mp>192.0</mp>
-            <cp>381.6</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>458.1</hp>
-            <mp>205.2</mp>
-            <cp>412.29</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>492.51</hp>
-            <mp>218.52</mp>
-            <cp>443.259</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>527.23</hp>
-            <mp>231.96</mp>
-            <cp>474.507</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>562.26</hp>
-            <mp>245.52</mp>
-            <cp>506.034</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>597.6</hp>
-            <mp>259.2</mp>
-            <cp>537.84</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>633.25</hp>
-            <mp>273.0</mp>
-            <cp>569.925</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>669.21</hp>
-            <mp>286.92</mp>
-            <cp>602.289</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>705.48</hp>
-            <mp>300.96</mp>
-            <cp>634.932</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>742.06</hp>
-            <mp>315.12</mp>
-            <cp>667.854</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>778.95</hp>
-            <mp>329.4</mp>
-            <cp>701.055</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>816.15</hp>
-            <mp>343.8</mp>
-            <cp>734.535</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>853.66</hp>
-            <mp>358.32</mp>
-            <cp>768.294</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>891.48</hp>
-            <mp>372.96</mp>
-            <cp>802.332</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>929.61</hp>
-            <mp>387.72</mp>
-            <cp>836.649</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>968.05</hp>
-            <mp>402.6</mp>
-            <cp>871.245</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>1006.8</hp>
-            <mp>417.6</mp>
-            <cp>906.12</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>1045.86</hp>
-            <mp>432.72</mp>
-            <cp>941.274</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1085.23</hp>
-            <mp>447.96</mp>
-            <cp>976.707</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1124.91</hp>
-            <mp>463.32</mp>
-            <cp>1012.419</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1164.9</hp>
-            <mp>478.8</mp>
-            <cp>1048.41</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1214.3</hp>
-            <mp>504.8</mp>
-            <cp>1092.87</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1264.08</hp>
-            <mp>531.0</mp>
-            <cp>1137.672</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1314.24</hp>
-            <mp>557.4</mp>
-            <cp>1182.816</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1364.78</hp>
-            <mp>584.0</mp>
-            <cp>1228.302</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1415.7</hp>
-            <mp>610.8</mp>
-            <cp>1274.13</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1467.0</hp>
-            <mp>637.8</mp>
-            <cp>1320.3</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1518.68</hp>
-            <mp>665.0</mp>
-            <cp>1366.812</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1570.74</hp>
-            <mp>692.4</mp>
-            <cp>1413.666</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1623.18</hp>
-            <mp>720.0</mp>
-            <cp>1460.862</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1676.0</hp>
-            <mp>747.8</mp>
-            <cp>1508.4</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1729.2</hp>
-            <mp>775.8</mp>
-            <cp>1556.28</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1782.78</hp>
-            <mp>804.0</mp>
-            <cp>1604.502</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1836.74</hp>
-            <mp>832.4</mp>
-            <cp>1653.066</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1891.08</hp>
-            <mp>861.0</mp>
-            <cp>1701.972</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1945.8</hp>
-            <mp>889.8</mp>
-            <cp>1751.22</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>2000.9</hp>
-            <mp>918.8</mp>
-            <cp>1800.81</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>2056.38</hp>
-            <mp>948.0</mp>
-            <cp>1850.742</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2112.24</hp>
-            <mp>977.4</mp>
-            <cp>1901.016</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2168.48</hp>
-            <mp>1007.0</mp>
-            <cp>1951.632</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2225.1</hp>
-            <mp>1036.8</mp>
-            <cp>2002.59</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2282.1</hp>
-            <mp>1066.8</mp>
-            <cp>2053.89</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2339.48</hp>
-            <mp>1097.0</mp>
-            <cp>2105.532</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2397.24</hp>
-            <mp>1127.4</mp>
-            <cp>2157.516</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2455.38</hp>
-            <mp>1158.0</mp>
-            <cp>2209.842</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2513.9</hp>
-            <mp>1188.8</mp>
-            <cp>2262.51</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2572.8</hp>
-            <mp>1219.8</mp>
-            <cp>2315.52</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2632.08</hp>
-            <mp>1251.0</mp>
-            <cp>2368.872</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2691.74</hp>
-            <mp>1282.4</mp>
-            <cp>2422.566</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2751.78</hp>
-            <mp>1314.0</mp>
-            <cp>2476.602</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2812.2</hp>
-            <mp>1345.8</mp>
-            <cp>2530.98</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2873.0</hp>
-            <mp>1377.8</mp>
-            <cp>2585.7</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2934.18</hp>
-            <mp>1410.0</mp>
-            <cp>2640.762</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2995.74</hp>
-            <mp>1442.4</mp>
-            <cp>2696.166</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>3057.68</hp>
-            <mp>1475.0</mp>
-            <cp>2751.912</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3120.0</hp>
-            <mp>1507.8</mp>
-            <cp>2808.0</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3182.7</hp>
-            <mp>1540.8</mp>
-            <cp>2864.43</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3245.78</hp>
-            <mp>1574.0</mp>
-            <cp>2921.202</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3309.24</hp>
-            <mp>1607.4</mp>
-            <cp>2978.316</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3373.08</hp>
-            <mp>1641.0</mp>
-            <cp>3035.772</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3437.3</hp>
-            <mp>1674.8</mp>
-            <cp>3093.57</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3501.9</hp>
-            <mp>1708.8</mp>
-            <cp>3151.71</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3566.88</hp>
-            <mp>1743.0</mp>
-            <cp>3210.192</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3632.24</hp>
-            <mp>1777.4</mp>
-            <cp>3269.016</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3697.98</hp>
-            <mp>1812.0</mp>
-            <cp>3328.182</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3764.1</hp>
-            <mp>1846.8</mp>
-            <cp>3387.69</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3830.6</hp>
-            <mp>1881.8</mp>
-            <cp>3447.54</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3897.48</hp>
-            <mp>1917.0</mp>
-            <cp>3507.732</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3964.74</hp>
-            <mp>1952.4</mp>
-            <cp>3568.266</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>4032.38</hp>
-            <mp>1988.0</mp>
-            <cp>3629.142</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4100.4</hp>
-            <mp>2023.8</mp>
-            <cp>3690.36</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4168.8</hp>
-            <mp>2059.8</mp>
-            <cp>3751.92</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>16</classId>
+	<staticData>
+		<baseINT>41</baseINT>
+		<baseSTR>22</baseSTR>
+		<baseCON>27</baseCON>
+		<baseMEN>39</baseMEN>
+		<baseDEX>21</baseDEX>
+		<baseWIT>20</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-90875" y="248162" z="-3570" />
+			<node x="-90954" y="248118" z="-3570" />
+			<node x="-90918" y="248070" z="-3570" />
+			<node x="-90890" y="248027" z="-3570" />
+		</creationPoints>
+		<basePAtk>3</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>15</chest>
+			<legs>8</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>78</walk>
+			<run>124</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>200</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>22.8</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>6.5</radius>
+			<height>22.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>101.0</hp>
+			<mp>40.0</mp>
+			<cp>90.9</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>116.47</hp>
+			<mp>47.28</mp>
+			<cp>104.823</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>132.11</hp>
+			<mp>54.64</mp>
+			<cp>118.899</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>147.92</hp>
+			<mp>62.08</mp>
+			<cp>133.128</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>163.9</hp>
+			<mp>69.6</mp>
+			<cp>147.51</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>180.05</hp>
+			<mp>77.2</mp>
+			<cp>162.045</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>196.37</hp>
+			<mp>84.88</mp>
+			<cp>176.733</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>212.86</hp>
+			<mp>92.64</mp>
+			<cp>191.574</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>229.52</hp>
+			<mp>100.48</mp>
+			<cp>206.568</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>246.35</hp>
+			<mp>108.4</mp>
+			<cp>221.715</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>263.35</hp>
+			<mp>116.4</mp>
+			<cp>237.015</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>280.52</hp>
+			<mp>124.48</mp>
+			<cp>252.468</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>297.86</hp>
+			<mp>132.64</mp>
+			<cp>268.074</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>315.37</hp>
+			<mp>140.88</mp>
+			<cp>283.833</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>333.05</hp>
+			<mp>149.2</mp>
+			<cp>299.745</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>350.9</hp>
+			<mp>157.6</mp>
+			<cp>315.81</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>368.92</hp>
+			<mp>166.08</mp>
+			<cp>332.028</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>387.11</hp>
+			<mp>174.64</mp>
+			<cp>348.399</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>405.47</hp>
+			<mp>183.28</mp>
+			<cp>364.923</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>424.0</hp>
+			<mp>192.0</mp>
+			<cp>381.6</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>458.1</hp>
+			<mp>205.2</mp>
+			<cp>412.29</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>492.51</hp>
+			<mp>218.52</mp>
+			<cp>443.259</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>527.23</hp>
+			<mp>231.96</mp>
+			<cp>474.507</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>562.26</hp>
+			<mp>245.52</mp>
+			<cp>506.034</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>597.6</hp>
+			<mp>259.2</mp>
+			<cp>537.84</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>633.25</hp>
+			<mp>273.0</mp>
+			<cp>569.925</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>669.21</hp>
+			<mp>286.92</mp>
+			<cp>602.289</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>705.48</hp>
+			<mp>300.96</mp>
+			<cp>634.932</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>742.06</hp>
+			<mp>315.12</mp>
+			<cp>667.854</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>778.95</hp>
+			<mp>329.4</mp>
+			<cp>701.055</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>816.15</hp>
+			<mp>343.8</mp>
+			<cp>734.535</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>853.66</hp>
+			<mp>358.32</mp>
+			<cp>768.294</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>891.48</hp>
+			<mp>372.96</mp>
+			<cp>802.332</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>929.61</hp>
+			<mp>387.72</mp>
+			<cp>836.649</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>968.05</hp>
+			<mp>402.6</mp>
+			<cp>871.245</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>1006.8</hp>
+			<mp>417.6</mp>
+			<cp>906.12</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>1045.86</hp>
+			<mp>432.72</mp>
+			<cp>941.274</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1085.23</hp>
+			<mp>447.96</mp>
+			<cp>976.707</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1124.91</hp>
+			<mp>463.32</mp>
+			<cp>1012.419</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1164.9</hp>
+			<mp>478.8</mp>
+			<cp>1048.41</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1214.3</hp>
+			<mp>504.8</mp>
+			<cp>1092.87</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1264.08</hp>
+			<mp>531.0</mp>
+			<cp>1137.672</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1314.24</hp>
+			<mp>557.4</mp>
+			<cp>1182.816</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1364.78</hp>
+			<mp>584.0</mp>
+			<cp>1228.302</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1415.7</hp>
+			<mp>610.8</mp>
+			<cp>1274.13</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1467.0</hp>
+			<mp>637.8</mp>
+			<cp>1320.3</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1518.68</hp>
+			<mp>665.0</mp>
+			<cp>1366.812</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1570.74</hp>
+			<mp>692.4</mp>
+			<cp>1413.666</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1623.18</hp>
+			<mp>720.0</mp>
+			<cp>1460.862</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1676.0</hp>
+			<mp>747.8</mp>
+			<cp>1508.4</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1729.2</hp>
+			<mp>775.8</mp>
+			<cp>1556.28</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1782.78</hp>
+			<mp>804.0</mp>
+			<cp>1604.502</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1836.74</hp>
+			<mp>832.4</mp>
+			<cp>1653.066</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1891.08</hp>
+			<mp>861.0</mp>
+			<cp>1701.972</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1945.8</hp>
+			<mp>889.8</mp>
+			<cp>1751.22</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>2000.9</hp>
+			<mp>918.8</mp>
+			<cp>1800.81</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2056.38</hp>
+			<mp>948.0</mp>
+			<cp>1850.742</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2112.24</hp>
+			<mp>977.4</mp>
+			<cp>1901.016</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2168.48</hp>
+			<mp>1007.0</mp>
+			<cp>1951.632</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2225.1</hp>
+			<mp>1036.8</mp>
+			<cp>2002.59</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2282.1</hp>
+			<mp>1066.8</mp>
+			<cp>2053.89</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2339.48</hp>
+			<mp>1097.0</mp>
+			<cp>2105.532</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2397.24</hp>
+			<mp>1127.4</mp>
+			<cp>2157.516</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2455.38</hp>
+			<mp>1158.0</mp>
+			<cp>2209.842</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2513.9</hp>
+			<mp>1188.8</mp>
+			<cp>2262.51</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2572.8</hp>
+			<mp>1219.8</mp>
+			<cp>2315.52</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2632.08</hp>
+			<mp>1251.0</mp>
+			<cp>2368.872</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2691.74</hp>
+			<mp>1282.4</mp>
+			<cp>2422.566</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2751.78</hp>
+			<mp>1314.0</mp>
+			<cp>2476.602</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2812.2</hp>
+			<mp>1345.8</mp>
+			<cp>2530.98</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2873.0</hp>
+			<mp>1377.8</mp>
+			<cp>2585.7</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2934.18</hp>
+			<mp>1410.0</mp>
+			<cp>2640.762</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2995.74</hp>
+			<mp>1442.4</mp>
+			<cp>2696.166</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3057.68</hp>
+			<mp>1475.0</mp>
+			<cp>2751.912</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3120.0</hp>
+			<mp>1507.8</mp>
+			<cp>2808.0</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3182.7</hp>
+			<mp>1540.8</mp>
+			<cp>2864.43</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3245.78</hp>
+			<mp>1574.0</mp>
+			<cp>2921.202</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3309.24</hp>
+			<mp>1607.4</mp>
+			<cp>2978.316</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3373.08</hp>
+			<mp>1641.0</mp>
+			<cp>3035.772</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3437.3</hp>
+			<mp>1674.8</mp>
+			<cp>3093.57</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3501.9</hp>
+			<mp>1708.8</mp>
+			<cp>3151.71</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3566.88</hp>
+			<mp>1743.0</mp>
+			<cp>3210.192</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3632.24</hp>
+			<mp>1777.4</mp>
+			<cp>3269.016</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3697.98</hp>
+			<mp>1812.0</mp>
+			<cp>3328.182</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3764.1</hp>
+			<mp>1846.8</mp>
+			<cp>3387.69</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3830.6</hp>
+			<mp>1881.8</mp>
+			<cp>3447.54</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3897.48</hp>
+			<mp>1917.0</mp>
+			<cp>3507.732</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3964.74</hp>
+			<mp>1952.4</mp>
+			<cp>3568.266</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4032.38</hp>
+			<mp>1988.0</mp>
+			<cp>3629.142</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4100.4</hp>
+			<mp>2023.8</mp>
+			<cp>3690.36</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4168.8</hp>
+			<mp>2059.8</mp>
+			<cp>3751.92</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4237.58</hp>
+			<mp>2096.0</mp>
+			<cp>3813.822</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4306.74</hp>
+			<mp>2132.4</mp>
+			<cp>3876.066</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4376.28</hp>
+			<mp>2169.0</mp>
+			<cp>3938.652</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4446.2</hp>
+			<mp>2205.8</mp>
+			<cp>4001.58</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4516.5</hp>
+			<mp>2242.8</mp>
+			<cp>4064.85</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4587.18</hp>
+			<mp>2280.0</mp>
+			<cp>4128.462</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4658.24</hp>
+			<mp>2317.4</mp>
+			<cp>4192.416</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4729.68</hp>
+			<mp>2355.0</mp>
+			<cp>4256.712</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4801.5</hp>
+			<mp>2392.8</mp>
+			<cp>4321.35</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4873.7</hp>
+			<mp>2430.8</mp>
+			<cp>4386.32</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4946.28</hp>
+			<mp>2469</mp>
+			<cp>4451.64</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5019.24</hp>
+			<mp>2507.4</mp>
+			<cp>4517.3</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5092.58</hp>
+			<mp>2546</mp>
+			<cp>4583.29</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5166.3</hp>
+			<mp>2584.8</mp>
+			<cp>4649.63</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5240.4</hp>
+			<mp>2623.8</mp>
+			<cp>4716.3</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5314.88</hp>
+			<mp>2663</mp>
+			<cp>4783.392</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Bladedancer.xml
+++ b/data/stats/chars/baseStats/Bladedancer.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>34</classId>
-    <staticData>
-        <baseINT>25</baseINT>
-        <baseSTR>41</baseSTR>
-        <baseCON>32</baseCON>
-        <baseMEN>26</baseMEN>
-        <baseDEX>34</baseDEX>
-        <baseWIT>12</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>15</magicAbnormalResist>
-        <creationPoints>
-            <node x="28295" y="11063" z="-4224"/>
-            <node x="28302" y="11008" z="-4224"/>
-            <node x="28377" y="10916" z="-4224"/>
-            <node x="28456" y="10997" z="-4224"/>
-            <node x="28461" y="11044" z="-4224"/>
-            <node x="28395" y="11127" z="-4224"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>85</walk>
-            <run>139</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>150</baseBreath>
-        <baseSafeFall>350</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>24</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.0</radius>
-            <height>23.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>94.0</hp>
-            <mp>30.0</mp>
-            <cp>47.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>107.65</hp>
-            <mp>35.46</mp>
-            <cp>53.825</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>121.45</hp>
-            <mp>40.98</mp>
-            <cp>60.725</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>135.4</hp>
-            <mp>46.56</mp>
-            <cp>67.7</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>149.5</hp>
-            <mp>52.2</mp>
-            <cp>74.75</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>163.75</hp>
-            <mp>57.9</mp>
-            <cp>81.875</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>178.15</hp>
-            <mp>63.66</mp>
-            <cp>89.075</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>192.7</hp>
-            <mp>69.48</mp>
-            <cp>96.35</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>207.4</hp>
-            <mp>75.36</mp>
-            <cp>103.7</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>222.25</hp>
-            <mp>81.3</mp>
-            <cp>111.125</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>237.25</hp>
-            <mp>87.3</mp>
-            <cp>118.625</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>252.4</hp>
-            <mp>93.36</mp>
-            <cp>126.2</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>267.7</hp>
-            <mp>99.48</mp>
-            <cp>133.85</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>283.15</hp>
-            <mp>105.66</mp>
-            <cp>141.575</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>298.75</hp>
-            <mp>111.9</mp>
-            <cp>149.375</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>314.5</hp>
-            <mp>118.2</mp>
-            <cp>157.25</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>330.4</hp>
-            <mp>124.56</mp>
-            <cp>165.2</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>346.45</hp>
-            <mp>130.98</mp>
-            <cp>173.225</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>362.65</hp>
-            <mp>137.46</mp>
-            <cp>181.325</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>379.0</hp>
-            <mp>144.0</mp>
-            <cp>189.5</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>414.2</hp>
-            <mp>153.9</mp>
-            <cp>207.1</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>449.72</hp>
-            <mp>163.89</mp>
-            <cp>224.86</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>485.56</hp>
-            <mp>173.97</mp>
-            <cp>242.78</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>521.72</hp>
-            <mp>184.14</mp>
-            <cp>260.86</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>558.2</hp>
-            <mp>194.4</mp>
-            <cp>279.1</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>595.0</hp>
-            <mp>204.75</mp>
-            <cp>297.5</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>632.12</hp>
-            <mp>215.19</mp>
-            <cp>316.06</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>669.56</hp>
-            <mp>225.72</mp>
-            <cp>334.78</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>707.32</hp>
-            <mp>236.34</mp>
-            <cp>353.66</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>745.4</hp>
-            <mp>247.05</mp>
-            <cp>372.7</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>783.8</hp>
-            <mp>257.85</mp>
-            <cp>391.9</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>822.52</hp>
-            <mp>268.74</mp>
-            <cp>411.26</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>861.56</hp>
-            <mp>279.72</mp>
-            <cp>430.78</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>900.92</hp>
-            <mp>290.79</mp>
-            <cp>450.46</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>940.6</hp>
-            <mp>301.95</mp>
-            <cp>470.3</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>980.6</hp>
-            <mp>313.2</mp>
-            <cp>490.3</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>1020.92</hp>
-            <mp>324.54</mp>
-            <cp>510.46</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1061.56</hp>
-            <mp>335.97</mp>
-            <cp>530.78</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1102.52</hp>
-            <mp>347.49</mp>
-            <cp>551.26</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1143.8</hp>
-            <mp>359.1</mp>
-            <cp>571.9</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1202.3</hp>
-            <mp>378.6</mp>
-            <cp>601.15</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1261.25</hp>
-            <mp>398.25</mp>
-            <cp>630.625</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1320.65</hp>
-            <mp>418.05</mp>
-            <cp>660.325</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1380.5</hp>
-            <mp>438.0</mp>
-            <cp>690.25</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1440.8</hp>
-            <mp>458.1</mp>
-            <cp>720.4</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1501.55</hp>
-            <mp>478.35</mp>
-            <cp>750.775</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1562.75</hp>
-            <mp>498.75</mp>
-            <cp>781.375</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1624.4</hp>
-            <mp>519.3</mp>
-            <cp>812.2</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1686.5</hp>
-            <mp>540.0</mp>
-            <cp>843.25</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1749.05</hp>
-            <mp>560.85</mp>
-            <cp>874.525</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1812.05</hp>
-            <mp>581.85</mp>
-            <cp>906.025</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1875.5</hp>
-            <mp>603.0</mp>
-            <cp>937.75</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1939.4</hp>
-            <mp>624.3</mp>
-            <cp>969.7</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>2003.75</hp>
-            <mp>645.75</mp>
-            <cp>1001.875</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>2068.55</hp>
-            <mp>667.35</mp>
-            <cp>1034.275</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>2133.8</hp>
-            <mp>689.1</mp>
-            <cp>1066.9</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>2199.5</hp>
-            <mp>711.0</mp>
-            <cp>1099.75</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2265.65</hp>
-            <mp>733.05</mp>
-            <cp>1132.825</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2332.25</hp>
-            <mp>755.25</mp>
-            <cp>1166.125</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2399.3</hp>
-            <mp>777.6</mp>
-            <cp>1199.65</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2466.8</hp>
-            <mp>800.1</mp>
-            <cp>1233.4</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2534.75</hp>
-            <mp>822.75</mp>
-            <cp>1267.375</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2603.15</hp>
-            <mp>845.55</mp>
-            <cp>1301.575</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2672.0</hp>
-            <mp>868.5</mp>
-            <cp>1336.0</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2741.3</hp>
-            <mp>891.6</mp>
-            <cp>1370.65</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2811.05</hp>
-            <mp>914.85</mp>
-            <cp>1405.525</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2881.25</hp>
-            <mp>938.25</mp>
-            <cp>1440.625</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2951.9</hp>
-            <mp>961.8</mp>
-            <cp>1475.95</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>3023.0</hp>
-            <mp>985.5</mp>
-            <cp>1511.5</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>3094.55</hp>
-            <mp>1009.35</mp>
-            <cp>1547.275</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>3166.55</hp>
-            <mp>1033.35</mp>
-            <cp>1583.275</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>3239.0</hp>
-            <mp>1057.5</mp>
-            <cp>1619.5</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>3311.9</hp>
-            <mp>1081.8</mp>
-            <cp>1655.95</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>3385.25</hp>
-            <mp>1106.25</mp>
-            <cp>1692.625</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3459.05</hp>
-            <mp>1130.85</mp>
-            <cp>1729.525</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3533.3</hp>
-            <mp>1155.6</mp>
-            <cp>1766.65</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3608.0</hp>
-            <mp>1180.5</mp>
-            <cp>1804.0</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3683.15</hp>
-            <mp>1205.55</mp>
-            <cp>1841.575</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3758.75</hp>
-            <mp>1230.75</mp>
-            <cp>1879.375</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3834.8</hp>
-            <mp>1256.1</mp>
-            <cp>1917.4</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3911.3</hp>
-            <mp>1281.6</mp>
-            <cp>1955.65</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3988.25</hp>
-            <mp>1307.25</mp>
-            <cp>1994.125</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>4065.65</hp>
-            <mp>1333.05</mp>
-            <cp>2032.825</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>4143.5</hp>
-            <mp>1359.0</mp>
-            <cp>2071.75</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>4221.8</hp>
-            <mp>1385.1</mp>
-            <cp>2110.9</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>4300.55</hp>
-            <mp>1411.35</mp>
-            <cp>2150.275</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>4379.75</hp>
-            <mp>1437.75</mp>
-            <cp>2189.875</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>4459.4</hp>
-            <mp>1464.3</mp>
-            <cp>2229.7</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>4539.5</hp>
-            <mp>1491.0</mp>
-            <cp>2269.75</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4620.05</hp>
-            <mp>1517.85</mp>
-            <cp>2310.025</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4701.05</hp>
-            <mp>1544.85</mp>
-            <cp>2350.525</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>34</classId>
+	<staticData>
+		<baseINT>25</baseINT>
+		<baseSTR>41</baseSTR>
+		<baseCON>32</baseCON>
+		<baseMEN>26</baseMEN>
+		<baseDEX>34</baseDEX>
+		<baseWIT>12</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="28295" y="11063" z="-4224" />
+			<node x="28302" y="11008" z="-4224" />
+			<node x="28377" y="10916" z="-4224" />
+			<node x="28456" y="10997" z="-4224" />
+			<node x="28461" y="11044" z="-4224" />
+			<node x="28395" y="11127" z="-4224" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>85</walk>
+			<run>139</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>350</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>94.0</hp>
+			<mp>30.0</mp>
+			<cp>47.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>107.65</hp>
+			<mp>35.46</mp>
+			<cp>53.825</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>121.45</hp>
+			<mp>40.98</mp>
+			<cp>60.725</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>135.4</hp>
+			<mp>46.56</mp>
+			<cp>67.7</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>149.5</hp>
+			<mp>52.2</mp>
+			<cp>74.75</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>163.75</hp>
+			<mp>57.9</mp>
+			<cp>81.875</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>178.15</hp>
+			<mp>63.66</mp>
+			<cp>89.075</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>192.7</hp>
+			<mp>69.48</mp>
+			<cp>96.35</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>207.4</hp>
+			<mp>75.36</mp>
+			<cp>103.7</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>222.25</hp>
+			<mp>81.3</mp>
+			<cp>111.125</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>237.25</hp>
+			<mp>87.3</mp>
+			<cp>118.625</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>252.4</hp>
+			<mp>93.36</mp>
+			<cp>126.2</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>267.7</hp>
+			<mp>99.48</mp>
+			<cp>133.85</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>283.15</hp>
+			<mp>105.66</mp>
+			<cp>141.575</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>298.75</hp>
+			<mp>111.9</mp>
+			<cp>149.375</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>314.5</hp>
+			<mp>118.2</mp>
+			<cp>157.25</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>330.4</hp>
+			<mp>124.56</mp>
+			<cp>165.2</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>346.45</hp>
+			<mp>130.98</mp>
+			<cp>173.225</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>362.65</hp>
+			<mp>137.46</mp>
+			<cp>181.325</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>379.0</hp>
+			<mp>144.0</mp>
+			<cp>189.5</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>414.2</hp>
+			<mp>153.9</mp>
+			<cp>207.1</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>449.72</hp>
+			<mp>163.89</mp>
+			<cp>224.86</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>485.56</hp>
+			<mp>173.97</mp>
+			<cp>242.78</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>521.72</hp>
+			<mp>184.14</mp>
+			<cp>260.86</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>558.2</hp>
+			<mp>194.4</mp>
+			<cp>279.1</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>595.0</hp>
+			<mp>204.75</mp>
+			<cp>297.5</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>632.12</hp>
+			<mp>215.19</mp>
+			<cp>316.06</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>669.56</hp>
+			<mp>225.72</mp>
+			<cp>334.78</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>707.32</hp>
+			<mp>236.34</mp>
+			<cp>353.66</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>745.4</hp>
+			<mp>247.05</mp>
+			<cp>372.7</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>783.8</hp>
+			<mp>257.85</mp>
+			<cp>391.9</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>822.52</hp>
+			<mp>268.74</mp>
+			<cp>411.26</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>861.56</hp>
+			<mp>279.72</mp>
+			<cp>430.78</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>900.92</hp>
+			<mp>290.79</mp>
+			<cp>450.46</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>940.6</hp>
+			<mp>301.95</mp>
+			<cp>470.3</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>980.6</hp>
+			<mp>313.2</mp>
+			<cp>490.3</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>1020.92</hp>
+			<mp>324.54</mp>
+			<cp>510.46</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1061.56</hp>
+			<mp>335.97</mp>
+			<cp>530.78</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1102.52</hp>
+			<mp>347.49</mp>
+			<cp>551.26</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1143.8</hp>
+			<mp>359.1</mp>
+			<cp>571.9</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1202.3</hp>
+			<mp>378.6</mp>
+			<cp>601.15</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1261.25</hp>
+			<mp>398.25</mp>
+			<cp>630.625</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1320.65</hp>
+			<mp>418.05</mp>
+			<cp>660.325</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1380.5</hp>
+			<mp>438.0</mp>
+			<cp>690.25</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1440.8</hp>
+			<mp>458.1</mp>
+			<cp>720.4</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1501.55</hp>
+			<mp>478.35</mp>
+			<cp>750.775</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1562.75</hp>
+			<mp>498.75</mp>
+			<cp>781.375</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1624.4</hp>
+			<mp>519.3</mp>
+			<cp>812.2</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1686.5</hp>
+			<mp>540.0</mp>
+			<cp>843.25</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1749.05</hp>
+			<mp>560.85</mp>
+			<cp>874.525</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1812.05</hp>
+			<mp>581.85</mp>
+			<cp>906.025</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1875.5</hp>
+			<mp>603.0</mp>
+			<cp>937.75</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1939.4</hp>
+			<mp>624.3</mp>
+			<cp>969.7</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>2003.75</hp>
+			<mp>645.75</mp>
+			<cp>1001.875</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>2068.55</hp>
+			<mp>667.35</mp>
+			<cp>1034.275</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>2133.8</hp>
+			<mp>689.1</mp>
+			<cp>1066.9</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2199.5</hp>
+			<mp>711.0</mp>
+			<cp>1099.75</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2265.65</hp>
+			<mp>733.05</mp>
+			<cp>1132.825</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2332.25</hp>
+			<mp>755.25</mp>
+			<cp>1166.125</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2399.3</hp>
+			<mp>777.6</mp>
+			<cp>1199.65</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2466.8</hp>
+			<mp>800.1</mp>
+			<cp>1233.4</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2534.75</hp>
+			<mp>822.75</mp>
+			<cp>1267.375</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2603.15</hp>
+			<mp>845.55</mp>
+			<cp>1301.575</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2672.0</hp>
+			<mp>868.5</mp>
+			<cp>1336.0</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2741.3</hp>
+			<mp>891.6</mp>
+			<cp>1370.65</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2811.05</hp>
+			<mp>914.85</mp>
+			<cp>1405.525</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2881.25</hp>
+			<mp>938.25</mp>
+			<cp>1440.625</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2951.9</hp>
+			<mp>961.8</mp>
+			<cp>1475.95</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>3023.0</hp>
+			<mp>985.5</mp>
+			<cp>1511.5</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>3094.55</hp>
+			<mp>1009.35</mp>
+			<cp>1547.275</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>3166.55</hp>
+			<mp>1033.35</mp>
+			<cp>1583.275</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>3239.0</hp>
+			<mp>1057.5</mp>
+			<cp>1619.5</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>3311.9</hp>
+			<mp>1081.8</mp>
+			<cp>1655.95</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3385.25</hp>
+			<mp>1106.25</mp>
+			<cp>1692.625</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3459.05</hp>
+			<mp>1130.85</mp>
+			<cp>1729.525</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3533.3</hp>
+			<mp>1155.6</mp>
+			<cp>1766.65</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3608.0</hp>
+			<mp>1180.5</mp>
+			<cp>1804.0</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3683.15</hp>
+			<mp>1205.55</mp>
+			<cp>1841.575</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3758.75</hp>
+			<mp>1230.75</mp>
+			<cp>1879.375</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3834.8</hp>
+			<mp>1256.1</mp>
+			<cp>1917.4</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3911.3</hp>
+			<mp>1281.6</mp>
+			<cp>1955.65</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3988.25</hp>
+			<mp>1307.25</mp>
+			<cp>1994.125</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>4065.65</hp>
+			<mp>1333.05</mp>
+			<cp>2032.825</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>4143.5</hp>
+			<mp>1359.0</mp>
+			<cp>2071.75</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>4221.8</hp>
+			<mp>1385.1</mp>
+			<cp>2110.9</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>4300.55</hp>
+			<mp>1411.35</mp>
+			<cp>2150.275</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>4379.75</hp>
+			<mp>1437.75</mp>
+			<cp>2189.875</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4459.4</hp>
+			<mp>1464.3</mp>
+			<cp>2229.7</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4539.5</hp>
+			<mp>1491.0</mp>
+			<cp>2269.75</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4620.05</hp>
+			<mp>1517.85</mp>
+			<cp>2310.025</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4701.05</hp>
+			<mp>1544.85</mp>
+			<cp>2350.525</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4782.5</hp>
+			<mp>1572.0</mp>
+			<cp>2391.25</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4864.4</hp>
+			<mp>1599.3</mp>
+			<cp>2432.2</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4946.75</hp>
+			<mp>1626.75</mp>
+			<cp>2473.375</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>5029.55</hp>
+			<mp>1654.35</mp>
+			<cp>2514.775</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>5112.8</hp>
+			<mp>1682.1</mp>
+			<cp>2556.4</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>5196.5</hp>
+			<mp>1710.0</mp>
+			<cp>2598.25</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>5280.65</hp>
+			<mp>1738.05</mp>
+			<cp>2640.325</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>5365.25</hp>
+			<mp>1766.25</mp>
+			<cp>2682.625</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>5450.3</hp>
+			<mp>1794.6</mp>
+			<cp>2725.16</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>5535.8</hp>
+			<mp>1823.1</mp>
+			<cp>2767.92</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5621.75</hp>
+			<mp>1851.75</mp>
+			<cp>2810.91</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5708.15</hp>
+			<mp>1880.55</mp>
+			<cp>2854.13</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5795</hp>
+			<mp>1909.5</mp>
+			<cp>2897.58</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5882.3</hp>
+			<mp>1938.6</mp>
+			<cp>2941.26</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5970.05</hp>
+			<mp>1967.85</mp>
+			<cp>2985.17</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>6058.25</hp>
+			<mp>1997.25</mp>
+			<cp>3029.125</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/BountyHunter.xml
+++ b/data/stats/chars/baseStats/BountyHunter.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>55</classId>
-    <staticData>
-        <baseINT>20</baseINT>
-        <baseSTR>39</baseSTR>
-        <baseCON>45</baseCON>
-        <baseMEN>27</baseMEN>
-        <baseDEX>29</baseDEX>
-        <baseWIT>10</baseWIT>
-        <physicalAbnormalResist>15</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="108644" y="-173947" z="-400"/>
-            <node x="108678" y="-174002" z="-400"/>
-            <node x="108505" y="-173964" z="-400"/>
-            <node x="108512" y="-174026" z="-400"/>
-            <node x="108549" y="-174075" z="-400"/>
-            <node x="108576" y="-174122" z="-400"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>80</walk>
-            <run>131</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>80</baseBreath>
-        <baseSafeFall>180</baseSafeFall>
-        <collisionMale>
-            <radius>9.0</radius>
-            <height>18.0</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>5.0</radius>
-            <height>19.0</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>80.0</hp>
-            <mp>30.0</mp>
-            <cp>56.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>92.74</hp>
-            <mp>35.46</mp>
-            <cp>64.918</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>105.62</hp>
-            <mp>40.98</mp>
-            <cp>73.934</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>118.64</hp>
-            <mp>46.56</mp>
-            <cp>83.048</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>131.8</hp>
-            <mp>52.2</mp>
-            <cp>92.26</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>145.1</hp>
-            <mp>57.9</mp>
-            <cp>101.57</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>158.54</hp>
-            <mp>63.66</mp>
-            <cp>110.978</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>172.12</hp>
-            <mp>69.48</mp>
-            <cp>120.484</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>185.84</hp>
-            <mp>75.36</mp>
-            <cp>130.088</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>199.7</hp>
-            <mp>81.3</mp>
-            <cp>139.79</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>213.7</hp>
-            <mp>87.3</mp>
-            <cp>149.59</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>227.84</hp>
-            <mp>93.36</mp>
-            <cp>159.488</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>242.12</hp>
-            <mp>99.48</mp>
-            <cp>169.484</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>256.54</hp>
-            <mp>105.66</mp>
-            <cp>179.578</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>271.1</hp>
-            <mp>111.9</mp>
-            <cp>189.77</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>285.8</hp>
-            <mp>118.2</mp>
-            <cp>200.06</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>300.64</hp>
-            <mp>124.56</mp>
-            <cp>210.448</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>315.62</hp>
-            <mp>130.98</mp>
-            <cp>220.934</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>330.74</hp>
-            <mp>137.46</mp>
-            <cp>231.518</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>346.0</hp>
-            <mp>144.0</mp>
-            <cp>242.2</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>381.2</hp>
-            <mp>153.9</mp>
-            <cp>266.84</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>416.72</hp>
-            <mp>163.89</mp>
-            <cp>291.704</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>452.56</hp>
-            <mp>173.97</mp>
-            <cp>316.792</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>488.72</hp>
-            <mp>184.14</mp>
-            <cp>342.104</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>525.2</hp>
-            <mp>194.4</mp>
-            <cp>367.64</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>562.0</hp>
-            <mp>204.75</mp>
-            <cp>393.4</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>599.12</hp>
-            <mp>215.19</mp>
-            <cp>419.384</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>636.56</hp>
-            <mp>225.72</mp>
-            <cp>445.592</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>674.32</hp>
-            <mp>236.34</mp>
-            <cp>472.024</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>712.4</hp>
-            <mp>247.05</mp>
-            <cp>498.68</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>750.8</hp>
-            <mp>257.85</mp>
-            <cp>525.56</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>789.52</hp>
-            <mp>268.74</mp>
-            <cp>552.664</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>828.56</hp>
-            <mp>279.72</mp>
-            <cp>579.992</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>867.92</hp>
-            <mp>290.79</mp>
-            <cp>607.544</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>907.6</hp>
-            <mp>301.95</mp>
-            <cp>635.32</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>947.6</hp>
-            <mp>313.2</mp>
-            <cp>663.32</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>987.92</hp>
-            <mp>324.54</mp>
-            <cp>691.544</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1028.56</hp>
-            <mp>335.97</mp>
-            <cp>719.992</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1069.52</hp>
-            <mp>347.49</mp>
-            <cp>748.664</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1110.8</hp>
-            <mp>359.1</mp>
-            <cp>777.56</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1168.0</hp>
-            <mp>378.6</mp>
-            <cp>817.6</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1225.64</hp>
-            <mp>398.25</mp>
-            <cp>857.948</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1283.72</hp>
-            <mp>418.05</mp>
-            <cp>898.604</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1342.24</hp>
-            <mp>438.0</mp>
-            <cp>939.568</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1401.2</hp>
-            <mp>458.1</mp>
-            <cp>980.84</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1460.6</hp>
-            <mp>478.35</mp>
-            <cp>1022.42</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1520.44</hp>
-            <mp>498.75</mp>
-            <cp>1064.308</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1580.72</hp>
-            <mp>519.3</mp>
-            <cp>1106.504</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1641.44</hp>
-            <mp>540.0</mp>
-            <cp>1149.008</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1702.6</hp>
-            <mp>560.85</mp>
-            <cp>1191.82</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1764.2</hp>
-            <mp>581.85</mp>
-            <cp>1234.94</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1826.24</hp>
-            <mp>603.0</mp>
-            <cp>1278.368</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1888.72</hp>
-            <mp>624.3</mp>
-            <cp>1322.104</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1951.64</hp>
-            <mp>645.75</mp>
-            <cp>1366.148</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>2015.0</hp>
-            <mp>667.35</mp>
-            <cp>1410.5</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>2078.8</hp>
-            <mp>689.1</mp>
-            <cp>1455.16</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>2143.04</hp>
-            <mp>711.0</mp>
-            <cp>1500.128</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2207.72</hp>
-            <mp>733.05</mp>
-            <cp>1545.404</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2272.84</hp>
-            <mp>755.25</mp>
-            <cp>1590.988</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2338.4</hp>
-            <mp>777.6</mp>
-            <cp>1636.88</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2404.4</hp>
-            <mp>800.1</mp>
-            <cp>1683.08</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2470.84</hp>
-            <mp>822.75</mp>
-            <cp>1729.588</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2537.72</hp>
-            <mp>845.55</mp>
-            <cp>1776.404</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2605.04</hp>
-            <mp>868.5</mp>
-            <cp>1823.528</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2672.8</hp>
-            <mp>891.6</mp>
-            <cp>1870.96</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2741.0</hp>
-            <mp>914.85</mp>
-            <cp>1918.7</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2809.64</hp>
-            <mp>938.25</mp>
-            <cp>1966.748</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2878.72</hp>
-            <mp>961.8</mp>
-            <cp>2015.104</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2948.24</hp>
-            <mp>985.5</mp>
-            <cp>2063.768</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>3018.2</hp>
-            <mp>1009.35</mp>
-            <cp>2112.74</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>3088.6</hp>
-            <mp>1033.35</mp>
-            <cp>2162.02</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>3159.44</hp>
-            <mp>1057.5</mp>
-            <cp>2211.608</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>3230.72</hp>
-            <mp>1081.8</mp>
-            <cp>2261.504</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>3302.44</hp>
-            <mp>1106.25</mp>
-            <cp>2311.708</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3374.6</hp>
-            <mp>1130.85</mp>
-            <cp>2362.22</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3447.2</hp>
-            <mp>1155.6</mp>
-            <cp>2413.04</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3520.24</hp>
-            <mp>1180.5</mp>
-            <cp>2464.168</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3593.72</hp>
-            <mp>1205.55</mp>
-            <cp>2515.604</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3667.64</hp>
-            <mp>1230.75</mp>
-            <cp>2567.348</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3742.0</hp>
-            <mp>1256.1</mp>
-            <cp>2619.4</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3816.8</hp>
-            <mp>1281.6</mp>
-            <cp>2671.76</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3892.04</hp>
-            <mp>1307.25</mp>
-            <cp>2724.428</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3967.72</hp>
-            <mp>1333.05</mp>
-            <cp>2777.404</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>4043.84</hp>
-            <mp>1359.0</mp>
-            <cp>2830.688</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>4120.4</hp>
-            <mp>1385.1</mp>
-            <cp>2884.28</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>4197.4</hp>
-            <mp>1411.35</mp>
-            <cp>2938.18</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>4274.84</hp>
-            <mp>1437.75</mp>
-            <cp>2992.388</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>4352.72</hp>
-            <mp>1464.3</mp>
-            <cp>3046.904</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>4431.04</hp>
-            <mp>1491.0</mp>
-            <cp>3101.728</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4509.8</hp>
-            <mp>1517.85</mp>
-            <cp>3156.86</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4589.0</hp>
-            <mp>1544.85</mp>
-            <cp>3212.3</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>55</classId>
+	<staticData>
+		<baseINT>20</baseINT>
+		<baseSTR>39</baseSTR>
+		<baseCON>45</baseCON>
+		<baseMEN>27</baseMEN>
+		<baseDEX>29</baseDEX>
+		<baseWIT>10</baseWIT>
+		<physicalAbnormalResist>15</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="108644" y="-173947" z="-400" />
+			<node x="108678" y="-174002" z="-400" />
+			<node x="108505" y="-173964" z="-400" />
+			<node x="108512" y="-174026" z="-400" />
+			<node x="108549" y="-174075" z="-400" />
+			<node x="108576" y="-174122" z="-400" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>80</walk>
+			<run>131</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>80</baseBreath>
+		<baseSafeFall>180</baseSafeFall>
+		<collisionMale>
+			<radius>9.0</radius>
+			<height>18.0</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>5.0</radius>
+			<height>19.0</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>80.0</hp>
+			<mp>30.0</mp>
+			<cp>56.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>92.74</hp>
+			<mp>35.46</mp>
+			<cp>64.918</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>105.62</hp>
+			<mp>40.98</mp>
+			<cp>73.934</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>118.64</hp>
+			<mp>46.56</mp>
+			<cp>83.048</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>131.8</hp>
+			<mp>52.2</mp>
+			<cp>92.26</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>145.1</hp>
+			<mp>57.9</mp>
+			<cp>101.57</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>158.54</hp>
+			<mp>63.66</mp>
+			<cp>110.978</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>172.12</hp>
+			<mp>69.48</mp>
+			<cp>120.484</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>185.84</hp>
+			<mp>75.36</mp>
+			<cp>130.088</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>199.7</hp>
+			<mp>81.3</mp>
+			<cp>139.79</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>213.7</hp>
+			<mp>87.3</mp>
+			<cp>149.59</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>227.84</hp>
+			<mp>93.36</mp>
+			<cp>159.488</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>242.12</hp>
+			<mp>99.48</mp>
+			<cp>169.484</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>256.54</hp>
+			<mp>105.66</mp>
+			<cp>179.578</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>271.1</hp>
+			<mp>111.9</mp>
+			<cp>189.77</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>285.8</hp>
+			<mp>118.2</mp>
+			<cp>200.06</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>300.64</hp>
+			<mp>124.56</mp>
+			<cp>210.448</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>315.62</hp>
+			<mp>130.98</mp>
+			<cp>220.934</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>330.74</hp>
+			<mp>137.46</mp>
+			<cp>231.518</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>346.0</hp>
+			<mp>144.0</mp>
+			<cp>242.2</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>381.2</hp>
+			<mp>153.9</mp>
+			<cp>266.84</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>416.72</hp>
+			<mp>163.89</mp>
+			<cp>291.704</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>452.56</hp>
+			<mp>173.97</mp>
+			<cp>316.792</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>488.72</hp>
+			<mp>184.14</mp>
+			<cp>342.104</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>525.2</hp>
+			<mp>194.4</mp>
+			<cp>367.64</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>562.0</hp>
+			<mp>204.75</mp>
+			<cp>393.4</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>599.12</hp>
+			<mp>215.19</mp>
+			<cp>419.384</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>636.56</hp>
+			<mp>225.72</mp>
+			<cp>445.592</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>674.32</hp>
+			<mp>236.34</mp>
+			<cp>472.024</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>712.4</hp>
+			<mp>247.05</mp>
+			<cp>498.68</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>750.8</hp>
+			<mp>257.85</mp>
+			<cp>525.56</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>789.52</hp>
+			<mp>268.74</mp>
+			<cp>552.664</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>828.56</hp>
+			<mp>279.72</mp>
+			<cp>579.992</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>867.92</hp>
+			<mp>290.79</mp>
+			<cp>607.544</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>907.6</hp>
+			<mp>301.95</mp>
+			<cp>635.32</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>947.6</hp>
+			<mp>313.2</mp>
+			<cp>663.32</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>987.92</hp>
+			<mp>324.54</mp>
+			<cp>691.544</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1028.56</hp>
+			<mp>335.97</mp>
+			<cp>719.992</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1069.52</hp>
+			<mp>347.49</mp>
+			<cp>748.664</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1110.8</hp>
+			<mp>359.1</mp>
+			<cp>777.56</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1168.0</hp>
+			<mp>378.6</mp>
+			<cp>817.6</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1225.64</hp>
+			<mp>398.25</mp>
+			<cp>857.948</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1283.72</hp>
+			<mp>418.05</mp>
+			<cp>898.604</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1342.24</hp>
+			<mp>438.0</mp>
+			<cp>939.568</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1401.2</hp>
+			<mp>458.1</mp>
+			<cp>980.84</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1460.6</hp>
+			<mp>478.35</mp>
+			<cp>1022.42</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1520.44</hp>
+			<mp>498.75</mp>
+			<cp>1064.308</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1580.72</hp>
+			<mp>519.3</mp>
+			<cp>1106.504</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1641.44</hp>
+			<mp>540.0</mp>
+			<cp>1149.008</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1702.6</hp>
+			<mp>560.85</mp>
+			<cp>1191.82</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1764.2</hp>
+			<mp>581.85</mp>
+			<cp>1234.94</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1826.24</hp>
+			<mp>603.0</mp>
+			<cp>1278.368</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1888.72</hp>
+			<mp>624.3</mp>
+			<cp>1322.104</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1951.64</hp>
+			<mp>645.75</mp>
+			<cp>1366.148</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>2015.0</hp>
+			<mp>667.35</mp>
+			<cp>1410.5</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>2078.8</hp>
+			<mp>689.1</mp>
+			<cp>1455.16</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2143.04</hp>
+			<mp>711.0</mp>
+			<cp>1500.128</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2207.72</hp>
+			<mp>733.05</mp>
+			<cp>1545.404</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2272.84</hp>
+			<mp>755.25</mp>
+			<cp>1590.988</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2338.4</hp>
+			<mp>777.6</mp>
+			<cp>1636.88</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2404.4</hp>
+			<mp>800.1</mp>
+			<cp>1683.08</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2470.84</hp>
+			<mp>822.75</mp>
+			<cp>1729.588</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2537.72</hp>
+			<mp>845.55</mp>
+			<cp>1776.404</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2605.04</hp>
+			<mp>868.5</mp>
+			<cp>1823.528</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2672.8</hp>
+			<mp>891.6</mp>
+			<cp>1870.96</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2741.0</hp>
+			<mp>914.85</mp>
+			<cp>1918.7</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2809.64</hp>
+			<mp>938.25</mp>
+			<cp>1966.748</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2878.72</hp>
+			<mp>961.8</mp>
+			<cp>2015.104</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2948.24</hp>
+			<mp>985.5</mp>
+			<cp>2063.768</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>3018.2</hp>
+			<mp>1009.35</mp>
+			<cp>2112.74</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>3088.6</hp>
+			<mp>1033.35</mp>
+			<cp>2162.02</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>3159.44</hp>
+			<mp>1057.5</mp>
+			<cp>2211.608</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>3230.72</hp>
+			<mp>1081.8</mp>
+			<cp>2261.504</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3302.44</hp>
+			<mp>1106.25</mp>
+			<cp>2311.708</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3374.6</hp>
+			<mp>1130.85</mp>
+			<cp>2362.22</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3447.2</hp>
+			<mp>1155.6</mp>
+			<cp>2413.04</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3520.24</hp>
+			<mp>1180.5</mp>
+			<cp>2464.168</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3593.72</hp>
+			<mp>1205.55</mp>
+			<cp>2515.604</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3667.64</hp>
+			<mp>1230.75</mp>
+			<cp>2567.348</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3742.0</hp>
+			<mp>1256.1</mp>
+			<cp>2619.4</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3816.8</hp>
+			<mp>1281.6</mp>
+			<cp>2671.76</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3892.04</hp>
+			<mp>1307.25</mp>
+			<cp>2724.428</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3967.72</hp>
+			<mp>1333.05</mp>
+			<cp>2777.404</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>4043.84</hp>
+			<mp>1359.0</mp>
+			<cp>2830.688</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>4120.4</hp>
+			<mp>1385.1</mp>
+			<cp>2884.28</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>4197.4</hp>
+			<mp>1411.35</mp>
+			<cp>2938.18</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>4274.84</hp>
+			<mp>1437.75</mp>
+			<cp>2992.388</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4352.72</hp>
+			<mp>1464.3</mp>
+			<cp>3046.904</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4431.04</hp>
+			<mp>1491.0</mp>
+			<cp>3101.728</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4509.8</hp>
+			<mp>1517.85</mp>
+			<cp>3156.86</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4589.0</hp>
+			<mp>1544.85</mp>
+			<cp>3212.3</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4668.64</hp>
+			<mp>1572.0</mp>
+			<cp>3268.048</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4748.72</hp>
+			<mp>1599.3</mp>
+			<cp>3324.104</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4829.24</hp>
+			<mp>1626.75</mp>
+			<cp>3380.468</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4910.2</hp>
+			<mp>1654.35</mp>
+			<cp>3437.14</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4991.6</hp>
+			<mp>1682.1</mp>
+			<cp>3494.12</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>5073.44</hp>
+			<mp>1710.0</mp>
+			<cp>3551.408</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>5155.72</hp>
+			<mp>1738.05</mp>
+			<cp>3609.004</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>5238.44</hp>
+			<mp>1766.25</mp>
+			<cp>3666.908</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>5321.6</hp>
+			<mp>1794.6</mp>
+			<cp>3725.12</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>5405.2</hp>
+			<mp>1823.1</mp>
+			<cp>3783.65</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5489.24</hp>
+			<mp>1851.75</mp>
+			<cp>3842.48</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5573.72</hp>
+			<mp>1880.55</mp>
+			<cp>3901.62</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5658.64</hp>
+			<mp>1909.5</mp>
+			<cp>3961.08</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5744</hp>
+			<mp>1938.6</mp>
+			<cp>4020.84</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5829.8</hp>
+			<mp>1967.85</mp>
+			<cp>4080.92</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5916.04</hp>
+			<mp>1997.25</mp>
+			<cp>4141.228</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Cardinal.xml
+++ b/data/stats/chars/baseStats/Cardinal.xml
@@ -1,798 +1,926 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>97</classId>
-    <staticData>
-        <baseINT>41</baseINT>
-        <baseSTR>22</baseSTR>
-        <baseCON>27</baseCON>
-        <baseMEN>39</baseMEN>
-        <baseDEX>21</baseDEX>
-        <baseWIT>20</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-90875" y="248162" z="-3570"/>
-            <node x="-90954" y="248118" z="-3570"/>
-            <node x="-90918" y="248070" z="-3570"/>
-            <node x="-90890" y="248027" z="-3570"/>
-        </creationPoints>
-        <basePAtk>3</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>15</chest>
-            <legs>8</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>78</walk>
-            <run>124</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>100</baseBreath>
-        <baseSafeFall>200</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>22.8</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>6.5</radius>
-            <height>22.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>101.0</hp>
-            <mp>40.0</mp>
-            <cp>90.9</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>116.47</hp>
-            <mp>47.28</mp>
-            <cp>104.823</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>132.11</hp>
-            <mp>54.64</mp>
-            <cp>118.899</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>147.92</hp>
-            <mp>62.08</mp>
-            <cp>133.128</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>163.9</hp>
-            <mp>69.6</mp>
-            <cp>147.51</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>180.05</hp>
-            <mp>77.2</mp>
-            <cp>162.045</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>196.37</hp>
-            <mp>84.88</mp>
-            <cp>176.733</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>212.86</hp>
-            <mp>92.64</mp>
-            <cp>191.574</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>229.52</hp>
-            <mp>100.48</mp>
-            <cp>206.568</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>246.35</hp>
-            <mp>108.4</mp>
-            <cp>221.715</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>263.35</hp>
-            <mp>116.4</mp>
-            <cp>237.015</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>280.52</hp>
-            <mp>124.48</mp>
-            <cp>252.468</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>297.86</hp>
-            <mp>132.64</mp>
-            <cp>268.074</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>315.37</hp>
-            <mp>140.88</mp>
-            <cp>283.833</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>333.05</hp>
-            <mp>149.2</mp>
-            <cp>299.745</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>350.9</hp>
-            <mp>157.6</mp>
-            <cp>315.81</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>368.92</hp>
-            <mp>166.08</mp>
-            <cp>332.028</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>387.11</hp>
-            <mp>174.64</mp>
-            <cp>348.399</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>405.47</hp>
-            <mp>183.28</mp>
-            <cp>364.923</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>424.0</hp>
-            <mp>192.0</mp>
-            <cp>381.6</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>458.1</hp>
-            <mp>205.2</mp>
-            <cp>412.29</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>492.51</hp>
-            <mp>218.52</mp>
-            <cp>443.259</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>527.23</hp>
-            <mp>231.96</mp>
-            <cp>474.507</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>562.26</hp>
-            <mp>245.52</mp>
-            <cp>506.034</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>597.6</hp>
-            <mp>259.2</mp>
-            <cp>537.84</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>633.25</hp>
-            <mp>273.0</mp>
-            <cp>569.925</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>669.21</hp>
-            <mp>286.92</mp>
-            <cp>602.289</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>705.48</hp>
-            <mp>300.96</mp>
-            <cp>634.932</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>742.06</hp>
-            <mp>315.12</mp>
-            <cp>667.854</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>778.95</hp>
-            <mp>329.4</mp>
-            <cp>701.055</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>816.15</hp>
-            <mp>343.8</mp>
-            <cp>734.535</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>853.66</hp>
-            <mp>358.32</mp>
-            <cp>768.294</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>891.48</hp>
-            <mp>372.96</mp>
-            <cp>802.332</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>929.61</hp>
-            <mp>387.72</mp>
-            <cp>836.649</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>968.05</hp>
-            <mp>402.6</mp>
-            <cp>871.245</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>1006.8</hp>
-            <mp>417.6</mp>
-            <cp>906.12</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>1045.86</hp>
-            <mp>432.72</mp>
-            <cp>941.274</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1085.23</hp>
-            <mp>447.96</mp>
-            <cp>976.707</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1124.91</hp>
-            <mp>463.32</mp>
-            <cp>1012.419</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1164.9</hp>
-            <mp>478.8</mp>
-            <cp>1048.41</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1214.3</hp>
-            <mp>504.8</mp>
-            <cp>1092.87</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1264.08</hp>
-            <mp>531.0</mp>
-            <cp>1137.672</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1314.24</hp>
-            <mp>557.4</mp>
-            <cp>1182.816</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1364.78</hp>
-            <mp>584.0</mp>
-            <cp>1228.302</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1415.7</hp>
-            <mp>610.8</mp>
-            <cp>1274.13</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1467.0</hp>
-            <mp>637.8</mp>
-            <cp>1320.3</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1518.68</hp>
-            <mp>665.0</mp>
-            <cp>1366.812</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1570.74</hp>
-            <mp>692.4</mp>
-            <cp>1413.666</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1623.18</hp>
-            <mp>720.0</mp>
-            <cp>1460.862</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1676.0</hp>
-            <mp>747.8</mp>
-            <cp>1508.4</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1729.2</hp>
-            <mp>775.8</mp>
-            <cp>1556.28</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1782.78</hp>
-            <mp>804.0</mp>
-            <cp>1604.502</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1836.74</hp>
-            <mp>832.4</mp>
-            <cp>1653.066</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1891.08</hp>
-            <mp>861.0</mp>
-            <cp>1701.972</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1945.8</hp>
-            <mp>889.8</mp>
-            <cp>1751.22</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>2000.9</hp>
-            <mp>918.8</mp>
-            <cp>1800.81</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>2056.38</hp>
-            <mp>948.0</mp>
-            <cp>1850.742</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2112.24</hp>
-            <mp>977.4</mp>
-            <cp>1901.016</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2168.48</hp>
-            <mp>1007.0</mp>
-            <cp>1951.632</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2225.1</hp>
-            <mp>1036.8</mp>
-            <cp>2002.59</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2282.1</hp>
-            <mp>1066.8</mp>
-            <cp>2053.89</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2339.48</hp>
-            <mp>1097.0</mp>
-            <cp>2105.532</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2397.24</hp>
-            <mp>1127.4</mp>
-            <cp>2157.516</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2455.38</hp>
-            <mp>1158.0</mp>
-            <cp>2209.842</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2513.9</hp>
-            <mp>1188.8</mp>
-            <cp>2262.51</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2572.8</hp>
-            <mp>1219.8</mp>
-            <cp>2315.52</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2632.08</hp>
-            <mp>1251.0</mp>
-            <cp>2368.872</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2691.74</hp>
-            <mp>1282.4</mp>
-            <cp>2422.566</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2751.78</hp>
-            <mp>1314.0</mp>
-            <cp>2476.602</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2812.2</hp>
-            <mp>1345.8</mp>
-            <cp>2530.98</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2873.0</hp>
-            <mp>1377.8</mp>
-            <cp>2585.7</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2934.18</hp>
-            <mp>1410.0</mp>
-            <cp>2640.762</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2995.74</hp>
-            <mp>1442.4</mp>
-            <cp>2696.166</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>3057.68</hp>
-            <mp>1475.0</mp>
-            <cp>2751.912</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3120.0</hp>
-            <mp>1507.8</mp>
-            <cp>2808.0</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3182.7</hp>
-            <mp>1540.8</mp>
-            <cp>2864.43</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3245.78</hp>
-            <mp>1574.0</mp>
-            <cp>2921.202</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3309.24</hp>
-            <mp>1607.4</mp>
-            <cp>2978.316</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3373.08</hp>
-            <mp>1641.0</mp>
-            <cp>3035.772</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3437.3</hp>
-            <mp>1674.8</mp>
-            <cp>3093.57</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3501.9</hp>
-            <mp>1708.8</mp>
-            <cp>3151.71</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3566.88</hp>
-            <mp>1743.0</mp>
-            <cp>3210.192</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3632.24</hp>
-            <mp>1777.4</mp>
-            <cp>3269.016</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3697.98</hp>
-            <mp>1812.0</mp>
-            <cp>3328.182</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3764.1</hp>
-            <mp>1846.8</mp>
-            <cp>3387.69</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3830.6</hp>
-            <mp>1881.8</mp>
-            <cp>3447.54</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3897.48</hp>
-            <mp>1917.0</mp>
-            <cp>3507.732</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3964.74</hp>
-            <mp>1952.4</mp>
-            <cp>3568.266</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>4032.38</hp>
-            <mp>1988.0</mp>
-            <cp>3629.142</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4100.4</hp>
-            <mp>2023.8</mp>
-            <cp>3690.36</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4168.8</hp>
-            <mp>2059.8</mp>
-            <cp>3751.92</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>97</classId>
+	<staticData>
+		<baseINT>41</baseINT>
+		<baseSTR>22</baseSTR>
+		<baseCON>27</baseCON>
+		<baseMEN>39</baseMEN>
+		<baseDEX>21</baseDEX>
+		<baseWIT>20</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-90875" y="248162" z="-3570" />
+			<node x="-90954" y="248118" z="-3570" />
+			<node x="-90918" y="248070" z="-3570" />
+			<node x="-90890" y="248027" z="-3570" />
+		</creationPoints>
+		<basePAtk>3</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>15</chest>
+			<legs>8</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>78</walk>
+			<run>124</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>200</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>22.8</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>6.5</radius>
+			<height>22.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>101.0</hp>
+			<mp>40.0</mp>
+			<cp>90.9</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>116.47</hp>
+			<mp>47.28</mp>
+			<cp>104.823</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>132.11</hp>
+			<mp>54.64</mp>
+			<cp>118.899</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>147.92</hp>
+			<mp>62.08</mp>
+			<cp>133.128</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>163.9</hp>
+			<mp>69.6</mp>
+			<cp>147.51</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>180.05</hp>
+			<mp>77.2</mp>
+			<cp>162.045</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>196.37</hp>
+			<mp>84.88</mp>
+			<cp>176.733</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>212.86</hp>
+			<mp>92.64</mp>
+			<cp>191.574</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>229.52</hp>
+			<mp>100.48</mp>
+			<cp>206.568</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>246.35</hp>
+			<mp>108.4</mp>
+			<cp>221.715</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>263.35</hp>
+			<mp>116.4</mp>
+			<cp>237.015</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>280.52</hp>
+			<mp>124.48</mp>
+			<cp>252.468</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>297.86</hp>
+			<mp>132.64</mp>
+			<cp>268.074</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>315.37</hp>
+			<mp>140.88</mp>
+			<cp>283.833</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>333.05</hp>
+			<mp>149.2</mp>
+			<cp>299.745</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>350.9</hp>
+			<mp>157.6</mp>
+			<cp>315.81</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>368.92</hp>
+			<mp>166.08</mp>
+			<cp>332.028</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>387.11</hp>
+			<mp>174.64</mp>
+			<cp>348.399</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>405.47</hp>
+			<mp>183.28</mp>
+			<cp>364.923</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>424.0</hp>
+			<mp>192.0</mp>
+			<cp>381.6</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>458.1</hp>
+			<mp>205.2</mp>
+			<cp>412.29</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>492.51</hp>
+			<mp>218.52</mp>
+			<cp>443.259</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>527.23</hp>
+			<mp>231.96</mp>
+			<cp>474.507</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>562.26</hp>
+			<mp>245.52</mp>
+			<cp>506.034</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>597.6</hp>
+			<mp>259.2</mp>
+			<cp>537.84</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>633.25</hp>
+			<mp>273.0</mp>
+			<cp>569.925</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>669.21</hp>
+			<mp>286.92</mp>
+			<cp>602.289</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>705.48</hp>
+			<mp>300.96</mp>
+			<cp>634.932</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>742.06</hp>
+			<mp>315.12</mp>
+			<cp>667.854</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>778.95</hp>
+			<mp>329.4</mp>
+			<cp>701.055</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>816.15</hp>
+			<mp>343.8</mp>
+			<cp>734.535</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>853.66</hp>
+			<mp>358.32</mp>
+			<cp>768.294</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>891.48</hp>
+			<mp>372.96</mp>
+			<cp>802.332</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>929.61</hp>
+			<mp>387.72</mp>
+			<cp>836.649</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>968.05</hp>
+			<mp>402.6</mp>
+			<cp>871.245</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>1006.8</hp>
+			<mp>417.6</mp>
+			<cp>906.12</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>1045.86</hp>
+			<mp>432.72</mp>
+			<cp>941.274</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1085.23</hp>
+			<mp>447.96</mp>
+			<cp>976.707</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1124.91</hp>
+			<mp>463.32</mp>
+			<cp>1012.419</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1164.9</hp>
+			<mp>478.8</mp>
+			<cp>1048.41</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1214.3</hp>
+			<mp>504.8</mp>
+			<cp>1092.87</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1264.08</hp>
+			<mp>531.0</mp>
+			<cp>1137.672</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1314.24</hp>
+			<mp>557.4</mp>
+			<cp>1182.816</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1364.78</hp>
+			<mp>584.0</mp>
+			<cp>1228.302</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1415.7</hp>
+			<mp>610.8</mp>
+			<cp>1274.13</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1467.0</hp>
+			<mp>637.8</mp>
+			<cp>1320.3</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1518.68</hp>
+			<mp>665.0</mp>
+			<cp>1366.812</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1570.74</hp>
+			<mp>692.4</mp>
+			<cp>1413.666</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1623.18</hp>
+			<mp>720.0</mp>
+			<cp>1460.862</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1676.0</hp>
+			<mp>747.8</mp>
+			<cp>1508.4</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1729.2</hp>
+			<mp>775.8</mp>
+			<cp>1556.28</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1782.78</hp>
+			<mp>804.0</mp>
+			<cp>1604.502</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1836.74</hp>
+			<mp>832.4</mp>
+			<cp>1653.066</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1891.08</hp>
+			<mp>861.0</mp>
+			<cp>1701.972</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1945.8</hp>
+			<mp>889.8</mp>
+			<cp>1751.22</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>2000.9</hp>
+			<mp>918.8</mp>
+			<cp>1800.81</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2056.38</hp>
+			<mp>948.0</mp>
+			<cp>1850.742</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2112.24</hp>
+			<mp>977.4</mp>
+			<cp>1901.016</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2168.48</hp>
+			<mp>1007.0</mp>
+			<cp>1951.632</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2225.1</hp>
+			<mp>1036.8</mp>
+			<cp>2002.59</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2282.1</hp>
+			<mp>1066.8</mp>
+			<cp>2053.89</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2339.48</hp>
+			<mp>1097.0</mp>
+			<cp>2105.532</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2397.24</hp>
+			<mp>1127.4</mp>
+			<cp>2157.516</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2455.38</hp>
+			<mp>1158.0</mp>
+			<cp>2209.842</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2513.9</hp>
+			<mp>1188.8</mp>
+			<cp>2262.51</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2572.8</hp>
+			<mp>1219.8</mp>
+			<cp>2315.52</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2632.08</hp>
+			<mp>1251.0</mp>
+			<cp>2368.872</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2691.74</hp>
+			<mp>1282.4</mp>
+			<cp>2422.566</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2751.78</hp>
+			<mp>1314.0</mp>
+			<cp>2476.602</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2812.2</hp>
+			<mp>1345.8</mp>
+			<cp>2530.98</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2873.0</hp>
+			<mp>1377.8</mp>
+			<cp>2585.7</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2934.18</hp>
+			<mp>1410.0</mp>
+			<cp>2640.762</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2995.74</hp>
+			<mp>1442.4</mp>
+			<cp>2696.166</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3057.68</hp>
+			<mp>1475.0</mp>
+			<cp>2751.912</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3120.0</hp>
+			<mp>1507.8</mp>
+			<cp>2808.0</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3182.7</hp>
+			<mp>1540.8</mp>
+			<cp>2864.43</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3245.78</hp>
+			<mp>1574.0</mp>
+			<cp>2921.202</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3309.24</hp>
+			<mp>1607.4</mp>
+			<cp>2978.316</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3373.08</hp>
+			<mp>1641.0</mp>
+			<cp>3035.772</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3437.3</hp>
+			<mp>1674.8</mp>
+			<cp>3093.57</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3501.9</hp>
+			<mp>1708.8</mp>
+			<cp>3151.71</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3566.88</hp>
+			<mp>1743.0</mp>
+			<cp>3210.192</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3632.24</hp>
+			<mp>1777.4</mp>
+			<cp>3269.016</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3697.98</hp>
+			<mp>1812.0</mp>
+			<cp>3328.182</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3764.1</hp>
+			<mp>1846.8</mp>
+			<cp>3387.69</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3830.6</hp>
+			<mp>1881.8</mp>
+			<cp>3447.54</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3897.48</hp>
+			<mp>1917.0</mp>
+			<cp>3507.732</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3964.74</hp>
+			<mp>1952.4</mp>
+			<cp>3568.266</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4032.38</hp>
+			<mp>1988.0</mp>
+			<cp>3629.142</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4100.4</hp>
+			<mp>2023.8</mp>
+			<cp>3690.36</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4168.8</hp>
+			<mp>2059.8</mp>
+			<cp>3751.92</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4237.58</hp>
+			<mp>2096.0</mp>
+			<cp>3813.822</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4306.74</hp>
+			<mp>2132.4</mp>
+			<cp>3876.066</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4376.28</hp>
+			<mp>2169.0</mp>
+			<cp>3938.652</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4446.2</hp>
+			<mp>2205.8</mp>
+			<cp>4001.58</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4516.5</hp>
+			<mp>2242.8</mp>
+			<cp>4064.85</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4587.18</hp>
+			<mp>2280.0</mp>
+			<cp>4128.462</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4658.24</hp>
+			<mp>2317.4</mp>
+			<cp>4192.416</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4729.68</hp>
+			<mp>2355.0</mp>
+			<cp>4256.712</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4801.5</hp>
+			<mp>2392.8</mp>
+			<cp>4321.35</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4873.7</hp>
+			<mp>2430.8</mp>
+			<cp>4386.32</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4946.28</hp>
+			<mp>2469</mp>
+			<cp>4451.64</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5019.24</hp>
+			<mp>2507.4</mp>
+			<cp>4517.3</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5092.58</hp>
+			<mp>2546</mp>
+			<cp>4583.29</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5166.3</hp>
+			<mp>2584.8</mp>
+			<cp>4649.63</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5240.4</hp>
+			<mp>2623.8</mp>
+			<cp>4716.3</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5314.88</hp>
+			<mp>2663</mp>
+			<cp>4783.392</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Cleric.xml
+++ b/data/stats/chars/baseStats/Cleric.xml
@@ -1,798 +1,926 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>15</classId>
-    <staticData>
-        <baseINT>41</baseINT>
-        <baseSTR>22</baseSTR>
-        <baseCON>27</baseCON>
-        <baseMEN>39</baseMEN>
-        <baseDEX>21</baseDEX>
-        <baseWIT>20</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-90875" y="248162" z="-3570"/>
-            <node x="-90954" y="248118" z="-3570"/>
-            <node x="-90918" y="248070" z="-3570"/>
-            <node x="-90890" y="248027" z="-3570"/>
-        </creationPoints>
-        <basePAtk>3</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>15</chest>
-            <legs>8</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>78</walk>
-            <run>124</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>100</baseBreath>
-        <baseSafeFall>200</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>22.8</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>6.5</radius>
-            <height>22.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>101.0</hp>
-            <mp>40.0</mp>
-            <cp>50.5</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>116.47</hp>
-            <mp>47.28</mp>
-            <cp>58.235</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>132.11</hp>
-            <mp>54.64</mp>
-            <cp>66.055</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>147.92</hp>
-            <mp>62.08</mp>
-            <cp>73.96</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>163.9</hp>
-            <mp>69.6</mp>
-            <cp>81.95</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>180.05</hp>
-            <mp>77.2</mp>
-            <cp>90.025</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>196.37</hp>
-            <mp>84.88</mp>
-            <cp>98.185</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>212.86</hp>
-            <mp>92.64</mp>
-            <cp>106.43</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>229.52</hp>
-            <mp>100.48</mp>
-            <cp>114.76</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>246.35</hp>
-            <mp>108.4</mp>
-            <cp>123.175</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>263.35</hp>
-            <mp>116.4</mp>
-            <cp>131.675</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>280.52</hp>
-            <mp>124.48</mp>
-            <cp>140.26</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>297.86</hp>
-            <mp>132.64</mp>
-            <cp>148.93</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>315.37</hp>
-            <mp>140.88</mp>
-            <cp>157.685</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>333.05</hp>
-            <mp>149.2</mp>
-            <cp>166.525</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>350.9</hp>
-            <mp>157.6</mp>
-            <cp>175.45</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>368.92</hp>
-            <mp>166.08</mp>
-            <cp>184.46</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>387.11</hp>
-            <mp>174.64</mp>
-            <cp>193.555</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>405.47</hp>
-            <mp>183.28</mp>
-            <cp>202.735</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>424.0</hp>
-            <mp>192.0</mp>
-            <cp>212.0</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>458.1</hp>
-            <mp>205.2</mp>
-            <cp>229.05</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>492.51</hp>
-            <mp>218.52</mp>
-            <cp>246.255</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>527.23</hp>
-            <mp>231.96</mp>
-            <cp>263.615</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>562.26</hp>
-            <mp>245.52</mp>
-            <cp>281.13</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>597.6</hp>
-            <mp>259.2</mp>
-            <cp>298.8</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>633.25</hp>
-            <mp>273.0</mp>
-            <cp>316.625</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>669.21</hp>
-            <mp>286.92</mp>
-            <cp>334.605</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>705.48</hp>
-            <mp>300.96</mp>
-            <cp>352.74</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>742.06</hp>
-            <mp>315.12</mp>
-            <cp>371.03</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>778.95</hp>
-            <mp>329.4</mp>
-            <cp>389.475</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>816.15</hp>
-            <mp>343.8</mp>
-            <cp>408.075</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>853.66</hp>
-            <mp>358.32</mp>
-            <cp>426.83</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>891.48</hp>
-            <mp>372.96</mp>
-            <cp>445.74</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>929.61</hp>
-            <mp>387.72</mp>
-            <cp>464.805</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>968.05</hp>
-            <mp>402.6</mp>
-            <cp>484.025</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>1006.8</hp>
-            <mp>417.6</mp>
-            <cp>503.4</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>1045.86</hp>
-            <mp>432.72</mp>
-            <cp>522.93</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1085.23</hp>
-            <mp>447.96</mp>
-            <cp>542.615</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1124.91</hp>
-            <mp>463.32</mp>
-            <cp>562.455</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1164.9</hp>
-            <mp>478.8</mp>
-            <cp>582.45</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1205.2</hp>
-            <mp>494.4</mp>
-            <cp>602.6</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1245.81</hp>
-            <mp>510.12</mp>
-            <cp>622.905</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1286.73</hp>
-            <mp>525.96</mp>
-            <cp>643.365</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1327.96</hp>
-            <mp>541.92</mp>
-            <cp>663.98</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1369.5</hp>
-            <mp>558.0</mp>
-            <cp>684.75</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1411.35</hp>
-            <mp>574.2</mp>
-            <cp>705.675</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1453.51</hp>
-            <mp>590.52</mp>
-            <cp>726.755</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1495.98</hp>
-            <mp>606.96</mp>
-            <cp>747.99</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1538.76</hp>
-            <mp>623.52</mp>
-            <cp>769.38</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1581.85</hp>
-            <mp>640.2</mp>
-            <cp>790.925</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1625.25</hp>
-            <mp>657.0</mp>
-            <cp>812.625</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1668.96</hp>
-            <mp>673.92</mp>
-            <cp>834.48</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1712.98</hp>
-            <mp>690.96</mp>
-            <cp>856.49</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1757.31</hp>
-            <mp>708.12</mp>
-            <cp>878.655</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1801.95</hp>
-            <mp>725.4</mp>
-            <cp>900.975</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1846.9</hp>
-            <mp>742.8</mp>
-            <cp>923.45</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1892.16</hp>
-            <mp>760.32</mp>
-            <cp>946.08</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1937.73</hp>
-            <mp>777.96</mp>
-            <cp>968.865</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>1983.61</hp>
-            <mp>795.72</mp>
-            <cp>991.805</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2029.8</hp>
-            <mp>813.6</mp>
-            <cp>1014.9</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2076.3</hp>
-            <mp>831.6</mp>
-            <cp>1038.15</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2123.11</hp>
-            <mp>849.72</mp>
-            <cp>1061.555</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2170.23</hp>
-            <mp>867.96</mp>
-            <cp>1085.115</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2217.66</hp>
-            <mp>886.32</mp>
-            <cp>1108.83</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2265.4</hp>
-            <mp>904.8</mp>
-            <cp>1132.7</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2313.45</hp>
-            <mp>923.4</mp>
-            <cp>1156.725</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2361.81</hp>
-            <mp>942.12</mp>
-            <cp>1180.905</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2410.48</hp>
-            <mp>960.96</mp>
-            <cp>1205.24</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2459.46</hp>
-            <mp>979.92</mp>
-            <cp>1229.73</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2508.75</hp>
-            <mp>999.0</mp>
-            <cp>1254.375</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2558.35</hp>
-            <mp>1018.2</mp>
-            <cp>1279.175</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2608.26</hp>
-            <mp>1037.52</mp>
-            <cp>1304.13</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2658.48</hp>
-            <mp>1056.96</mp>
-            <cp>1329.24</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2709.01</hp>
-            <mp>1076.52</mp>
-            <cp>1354.505</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2759.85</hp>
-            <mp>1096.2</mp>
-            <cp>1379.925</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>2811.0</hp>
-            <mp>1116.0</mp>
-            <cp>1405.5</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>2862.46</hp>
-            <mp>1135.92</mp>
-            <cp>1431.23</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>2914.23</hp>
-            <mp>1155.96</mp>
-            <cp>1457.115</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>2966.31</hp>
-            <mp>1176.12</mp>
-            <cp>1483.155</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3018.7</hp>
-            <mp>1196.4</mp>
-            <cp>1509.35</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3071.4</hp>
-            <mp>1216.8</mp>
-            <cp>1535.7</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3124.41</hp>
-            <mp>1237.32</mp>
-            <cp>1562.205</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3177.73</hp>
-            <mp>1257.96</mp>
-            <cp>1588.865</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3231.36</hp>
-            <mp>1278.72</mp>
-            <cp>1615.68</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3285.3</hp>
-            <mp>1299.6</mp>
-            <cp>1642.65</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3339.55</hp>
-            <mp>1320.6</mp>
-            <cp>1669.775</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3394.11</hp>
-            <mp>1341.72</mp>
-            <cp>1697.055</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3448.98</hp>
-            <mp>1362.96</mp>
-            <cp>1724.49</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3504.16</hp>
-            <mp>1384.32</mp>
-            <cp>1752.08</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3559.65</hp>
-            <mp>1405.8</mp>
-            <cp>1779.825</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>3615.45</hp>
-            <mp>1427.4</mp>
-            <cp>1807.725</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>15</classId>
+	<staticData>
+		<baseINT>41</baseINT>
+		<baseSTR>22</baseSTR>
+		<baseCON>27</baseCON>
+		<baseMEN>39</baseMEN>
+		<baseDEX>21</baseDEX>
+		<baseWIT>20</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-90875" y="248162" z="-3570" />
+			<node x="-90954" y="248118" z="-3570" />
+			<node x="-90918" y="248070" z="-3570" />
+			<node x="-90890" y="248027" z="-3570" />
+		</creationPoints>
+		<basePAtk>3</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>15</chest>
+			<legs>8</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>78</walk>
+			<run>124</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>200</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>22.8</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>6.5</radius>
+			<height>22.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>101.0</hp>
+			<mp>40.0</mp>
+			<cp>50.5</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>116.47</hp>
+			<mp>47.28</mp>
+			<cp>58.235</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>132.11</hp>
+			<mp>54.64</mp>
+			<cp>66.055</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>147.92</hp>
+			<mp>62.08</mp>
+			<cp>73.96</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>163.9</hp>
+			<mp>69.6</mp>
+			<cp>81.95</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>180.05</hp>
+			<mp>77.2</mp>
+			<cp>90.025</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>196.37</hp>
+			<mp>84.88</mp>
+			<cp>98.185</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>212.86</hp>
+			<mp>92.64</mp>
+			<cp>106.43</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>229.52</hp>
+			<mp>100.48</mp>
+			<cp>114.76</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>246.35</hp>
+			<mp>108.4</mp>
+			<cp>123.175</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>263.35</hp>
+			<mp>116.4</mp>
+			<cp>131.675</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>280.52</hp>
+			<mp>124.48</mp>
+			<cp>140.26</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>297.86</hp>
+			<mp>132.64</mp>
+			<cp>148.93</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>315.37</hp>
+			<mp>140.88</mp>
+			<cp>157.685</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>333.05</hp>
+			<mp>149.2</mp>
+			<cp>166.525</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>350.9</hp>
+			<mp>157.6</mp>
+			<cp>175.45</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>368.92</hp>
+			<mp>166.08</mp>
+			<cp>184.46</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>387.11</hp>
+			<mp>174.64</mp>
+			<cp>193.555</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>405.47</hp>
+			<mp>183.28</mp>
+			<cp>202.735</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>424.0</hp>
+			<mp>192.0</mp>
+			<cp>212.0</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>458.1</hp>
+			<mp>205.2</mp>
+			<cp>229.05</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>492.51</hp>
+			<mp>218.52</mp>
+			<cp>246.255</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>527.23</hp>
+			<mp>231.96</mp>
+			<cp>263.615</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>562.26</hp>
+			<mp>245.52</mp>
+			<cp>281.13</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>597.6</hp>
+			<mp>259.2</mp>
+			<cp>298.8</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>633.25</hp>
+			<mp>273.0</mp>
+			<cp>316.625</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>669.21</hp>
+			<mp>286.92</mp>
+			<cp>334.605</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>705.48</hp>
+			<mp>300.96</mp>
+			<cp>352.74</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>742.06</hp>
+			<mp>315.12</mp>
+			<cp>371.03</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>778.95</hp>
+			<mp>329.4</mp>
+			<cp>389.475</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>816.15</hp>
+			<mp>343.8</mp>
+			<cp>408.075</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>853.66</hp>
+			<mp>358.32</mp>
+			<cp>426.83</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>891.48</hp>
+			<mp>372.96</mp>
+			<cp>445.74</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>929.61</hp>
+			<mp>387.72</mp>
+			<cp>464.805</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>968.05</hp>
+			<mp>402.6</mp>
+			<cp>484.025</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>1006.8</hp>
+			<mp>417.6</mp>
+			<cp>503.4</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>1045.86</hp>
+			<mp>432.72</mp>
+			<cp>522.93</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1085.23</hp>
+			<mp>447.96</mp>
+			<cp>542.615</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1124.91</hp>
+			<mp>463.32</mp>
+			<cp>562.455</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1164.9</hp>
+			<mp>478.8</mp>
+			<cp>582.45</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1205.2</hp>
+			<mp>494.4</mp>
+			<cp>602.6</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1245.81</hp>
+			<mp>510.12</mp>
+			<cp>622.905</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1286.73</hp>
+			<mp>525.96</mp>
+			<cp>643.365</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1327.96</hp>
+			<mp>541.92</mp>
+			<cp>663.98</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1369.5</hp>
+			<mp>558.0</mp>
+			<cp>684.75</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1411.35</hp>
+			<mp>574.2</mp>
+			<cp>705.675</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1453.51</hp>
+			<mp>590.52</mp>
+			<cp>726.755</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1495.98</hp>
+			<mp>606.96</mp>
+			<cp>747.99</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1538.76</hp>
+			<mp>623.52</mp>
+			<cp>769.38</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1581.85</hp>
+			<mp>640.2</mp>
+			<cp>790.925</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1625.25</hp>
+			<mp>657.0</mp>
+			<cp>812.625</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1668.96</hp>
+			<mp>673.92</mp>
+			<cp>834.48</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1712.98</hp>
+			<mp>690.96</mp>
+			<cp>856.49</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1757.31</hp>
+			<mp>708.12</mp>
+			<cp>878.655</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1801.95</hp>
+			<mp>725.4</mp>
+			<cp>900.975</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1846.9</hp>
+			<mp>742.8</mp>
+			<cp>923.45</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1892.16</hp>
+			<mp>760.32</mp>
+			<cp>946.08</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1937.73</hp>
+			<mp>777.96</mp>
+			<cp>968.865</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1983.61</hp>
+			<mp>795.72</mp>
+			<cp>991.805</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2029.8</hp>
+			<mp>813.6</mp>
+			<cp>1014.9</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2076.3</hp>
+			<mp>831.6</mp>
+			<cp>1038.15</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2123.11</hp>
+			<mp>849.72</mp>
+			<cp>1061.555</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2170.23</hp>
+			<mp>867.96</mp>
+			<cp>1085.115</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2217.66</hp>
+			<mp>886.32</mp>
+			<cp>1108.83</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2265.4</hp>
+			<mp>904.8</mp>
+			<cp>1132.7</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2313.45</hp>
+			<mp>923.4</mp>
+			<cp>1156.725</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2361.81</hp>
+			<mp>942.12</mp>
+			<cp>1180.905</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2410.48</hp>
+			<mp>960.96</mp>
+			<cp>1205.24</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2459.46</hp>
+			<mp>979.92</mp>
+			<cp>1229.73</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2508.75</hp>
+			<mp>999.0</mp>
+			<cp>1254.375</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2558.35</hp>
+			<mp>1018.2</mp>
+			<cp>1279.175</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2608.26</hp>
+			<mp>1037.52</mp>
+			<cp>1304.13</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2658.48</hp>
+			<mp>1056.96</mp>
+			<cp>1329.24</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2709.01</hp>
+			<mp>1076.52</mp>
+			<cp>1354.505</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2759.85</hp>
+			<mp>1096.2</mp>
+			<cp>1379.925</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>2811.0</hp>
+			<mp>1116.0</mp>
+			<cp>1405.5</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>2862.46</hp>
+			<mp>1135.92</mp>
+			<cp>1431.23</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>2914.23</hp>
+			<mp>1155.96</mp>
+			<cp>1457.115</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>2966.31</hp>
+			<mp>1176.12</mp>
+			<cp>1483.155</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3018.7</hp>
+			<mp>1196.4</mp>
+			<cp>1509.35</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3071.4</hp>
+			<mp>1216.8</mp>
+			<cp>1535.7</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3124.41</hp>
+			<mp>1237.32</mp>
+			<cp>1562.205</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3177.73</hp>
+			<mp>1257.96</mp>
+			<cp>1588.865</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3231.36</hp>
+			<mp>1278.72</mp>
+			<cp>1615.68</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3285.3</hp>
+			<mp>1299.6</mp>
+			<cp>1642.65</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3339.55</hp>
+			<mp>1320.6</mp>
+			<cp>1669.775</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3394.11</hp>
+			<mp>1341.72</mp>
+			<cp>1697.055</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3448.98</hp>
+			<mp>1362.96</mp>
+			<cp>1724.49</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3504.16</hp>
+			<mp>1384.32</mp>
+			<cp>1752.08</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3559.65</hp>
+			<mp>1405.8</mp>
+			<cp>1779.825</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3615.45</hp>
+			<mp>1427.4</mp>
+			<cp>1807.725</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>3671.56</hp>
+			<mp>1449.12</mp>
+			<cp>1835.78</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>3727.98</hp>
+			<mp>1470.96</mp>
+			<cp>1863.99</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>3784.71</hp>
+			<mp>1492.92</mp>
+			<cp>1892.355</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>3841.75</hp>
+			<mp>1515.0</mp>
+			<cp>1920.875</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>3899.1</hp>
+			<mp>1537.2</mp>
+			<cp>1949.55</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>3956.76</hp>
+			<mp>1559.52</mp>
+			<cp>1978.38</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4014.73</hp>
+			<mp>1581.96</mp>
+			<cp>2007.365</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4073.01</hp>
+			<mp>1604.52</mp>
+			<cp>2036.505</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4131.6</hp>
+			<mp>1627.2</mp>
+			<cp>2065.81</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4190.5</hp>
+			<mp>1650</mp>
+			<cp>2095.27</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4249.71</hp>
+			<mp>1672.92</mp>
+			<cp>2124.89</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4309.23</hp>
+			<mp>1695.96</mp>
+			<cp>2154.67</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4369.06</hp>
+			<mp>1719.12</mp>
+			<cp>2184.61</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>4429.2</hp>
+			<mp>1742.4</mp>
+			<cp>2214.71</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>4489.65</hp>
+			<mp>1765.8</mp>
+			<cp>2244.97</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>4550.41</hp>
+			<mp>1789.32</mp>
+			<cp>2275.205</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/DarkAvenger.xml
+++ b/data/stats/chars/baseStats/DarkAvenger.xml
@@ -1,798 +1,926 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>6</classId>
-    <staticData>
-        <baseINT>21</baseINT>
-        <baseSTR>40</baseSTR>
-        <baseCON>43</baseCON>
-        <baseMEN>25</baseMEN>
-        <baseDEX>30</baseDEX>
-        <baseWIT>11</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-71338" y="258271" z="-3104"/>
-            <node x="-71417" y="258270" z="-3104"/>
-            <node x="-71453" y="258305" z="-3104"/>
-            <node x="-71467" y="258378" z="-3104"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>80</walk>
-            <run>132</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>100</baseBreath>
-        <baseSafeFall>250</baseSafeFall>
-        <collisionMale>
-            <radius>9.0</radius>
-            <height>23</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>8.0</radius>
-            <height>23.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>80.0</hp>
-            <mp>30.0</mp>
-            <cp>48.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>91.83</hp>
-            <mp>35.46</mp>
-            <cp>55.098</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>103.79</hp>
-            <mp>40.98</mp>
-            <cp>62.274</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>115.88</hp>
-            <mp>46.56</mp>
-            <cp>69.528</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>128.1</hp>
-            <mp>52.2</mp>
-            <cp>76.86</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>140.45</hp>
-            <mp>57.9</mp>
-            <cp>84.27</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>152.93</hp>
-            <mp>63.66</mp>
-            <cp>91.758</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>165.54</hp>
-            <mp>69.48</mp>
-            <cp>99.324</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>178.28</hp>
-            <mp>75.36</mp>
-            <cp>106.968</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>191.15</hp>
-            <mp>81.3</mp>
-            <cp>114.69</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>204.15</hp>
-            <mp>87.3</mp>
-            <cp>122.49</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>217.28</hp>
-            <mp>93.36</mp>
-            <cp>130.368</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>230.54</hp>
-            <mp>99.48</mp>
-            <cp>138.324</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>243.93</hp>
-            <mp>105.66</mp>
-            <cp>146.358</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>257.45</hp>
-            <mp>111.9</mp>
-            <cp>154.47</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>271.1</hp>
-            <mp>118.2</mp>
-            <cp>162.66</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>284.88</hp>
-            <mp>124.56</mp>
-            <cp>170.928</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>298.79</hp>
-            <mp>130.98</mp>
-            <cp>179.274</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>312.83</hp>
-            <mp>137.46</mp>
-            <cp>187.698</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>327.0</hp>
-            <mp>144.0</mp>
-            <cp>196.2</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>356.7</hp>
-            <mp>153.9</mp>
-            <cp>214.02</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>386.67</hp>
-            <mp>163.89</mp>
-            <cp>232.002</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>416.91</hp>
-            <mp>173.97</mp>
-            <cp>250.146</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>447.42</hp>
-            <mp>184.14</mp>
-            <cp>268.452</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>478.2</hp>
-            <mp>194.4</mp>
-            <cp>286.92</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>509.25</hp>
-            <mp>204.75</mp>
-            <cp>305.55</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>540.57</hp>
-            <mp>215.19</mp>
-            <cp>324.342</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>572.16</hp>
-            <mp>225.72</mp>
-            <cp>343.296</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>604.02</hp>
-            <mp>236.34</mp>
-            <cp>362.412</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>636.15</hp>
-            <mp>247.05</mp>
-            <cp>381.69</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>668.55</hp>
-            <mp>257.85</mp>
-            <cp>401.13</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>701.22</hp>
-            <mp>268.74</mp>
-            <cp>420.732</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>734.16</hp>
-            <mp>279.72</mp>
-            <cp>440.496</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>767.37</hp>
-            <mp>290.79</mp>
-            <cp>460.422</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>800.85</hp>
-            <mp>301.95</mp>
-            <cp>480.51</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>834.6</hp>
-            <mp>313.2</mp>
-            <cp>500.76</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>868.62</hp>
-            <mp>324.54</mp>
-            <cp>521.172</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>902.91</hp>
-            <mp>335.97</mp>
-            <cp>541.746</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>937.47</hp>
-            <mp>347.49</mp>
-            <cp>562.482</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>972.3</hp>
-            <mp>359.1</mp>
-            <cp>583.38</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1019.1</hp>
-            <mp>378.6</mp>
-            <cp>611.46</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1066.26</hp>
-            <mp>398.25</mp>
-            <cp>639.756</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1113.78</hp>
-            <mp>418.05</mp>
-            <cp>668.268</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1161.66</hp>
-            <mp>438.0</mp>
-            <cp>696.996</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1209.9</hp>
-            <mp>458.1</mp>
-            <cp>725.94</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1258.5</hp>
-            <mp>478.35</mp>
-            <cp>755.1</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1307.46</hp>
-            <mp>498.75</mp>
-            <cp>784.476</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1356.78</hp>
-            <mp>519.3</mp>
-            <cp>814.068</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1406.46</hp>
-            <mp>540.0</mp>
-            <cp>843.876</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1456.5</hp>
-            <mp>560.85</mp>
-            <cp>873.9</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1506.9</hp>
-            <mp>581.85</mp>
-            <cp>904.14</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1557.66</hp>
-            <mp>603.0</mp>
-            <cp>934.596</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1608.78</hp>
-            <mp>624.3</mp>
-            <cp>965.268</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1660.26</hp>
-            <mp>645.75</mp>
-            <cp>996.156</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1712.1</hp>
-            <mp>667.35</mp>
-            <cp>1027.26</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1764.3</hp>
-            <mp>689.1</mp>
-            <cp>1058.58</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1816.86</hp>
-            <mp>711.0</mp>
-            <cp>1090.116</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1869.78</hp>
-            <mp>733.05</mp>
-            <cp>1121.868</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>1923.06</hp>
-            <mp>755.25</mp>
-            <cp>1153.836</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>1976.7</hp>
-            <mp>777.6</mp>
-            <cp>1186.02</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2030.7</hp>
-            <mp>800.1</mp>
-            <cp>1218.42</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2085.06</hp>
-            <mp>822.75</mp>
-            <cp>1251.036</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2139.78</hp>
-            <mp>845.55</mp>
-            <cp>1283.868</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2194.86</hp>
-            <mp>868.5</mp>
-            <cp>1316.916</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2250.3</hp>
-            <mp>891.6</mp>
-            <cp>1350.18</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2306.1</hp>
-            <mp>914.85</mp>
-            <cp>1383.66</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2362.26</hp>
-            <mp>938.25</mp>
-            <cp>1417.356</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2418.78</hp>
-            <mp>961.8</mp>
-            <cp>1451.268</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2475.66</hp>
-            <mp>985.5</mp>
-            <cp>1485.396</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2532.9</hp>
-            <mp>1009.35</mp>
-            <cp>1519.74</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2590.5</hp>
-            <mp>1033.35</mp>
-            <cp>1554.3</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2648.46</hp>
-            <mp>1057.5</mp>
-            <cp>1589.076</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2706.78</hp>
-            <mp>1081.8</mp>
-            <cp>1624.068</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2765.46</hp>
-            <mp>1106.25</mp>
-            <cp>1659.276</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2824.5</hp>
-            <mp>1130.85</mp>
-            <cp>1694.7</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>2883.9</hp>
-            <mp>1155.6</mp>
-            <cp>1730.34</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>2943.66</hp>
-            <mp>1180.5</mp>
-            <cp>1766.196</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3003.78</hp>
-            <mp>1205.55</mp>
-            <cp>1802.268</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3064.26</hp>
-            <mp>1230.75</mp>
-            <cp>1838.556</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3125.1</hp>
-            <mp>1256.1</mp>
-            <cp>1875.06</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3186.3</hp>
-            <mp>1281.6</mp>
-            <cp>1911.78</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3247.86</hp>
-            <mp>1307.25</mp>
-            <cp>1948.716</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3309.78</hp>
-            <mp>1333.05</mp>
-            <cp>1985.868</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3372.06</hp>
-            <mp>1359.0</mp>
-            <cp>2023.236</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3434.7</hp>
-            <mp>1385.1</mp>
-            <cp>2060.82</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3497.7</hp>
-            <mp>1411.35</mp>
-            <cp>2098.62</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3561.06</hp>
-            <mp>1437.75</mp>
-            <cp>2136.636</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3624.78</hp>
-            <mp>1464.3</mp>
-            <cp>2174.868</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3688.86</hp>
-            <mp>1491.0</mp>
-            <cp>2213.316</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3753.3</hp>
-            <mp>1517.85</mp>
-            <cp>2251.98</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>3818.1</hp>
-            <mp>1544.85</mp>
-            <cp>2290.86</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>6</classId>
+	<staticData>
+		<baseINT>21</baseINT>
+		<baseSTR>40</baseSTR>
+		<baseCON>43</baseCON>
+		<baseMEN>25</baseMEN>
+		<baseDEX>30</baseDEX>
+		<baseWIT>11</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-71338" y="258271" z="-3104" />
+			<node x="-71417" y="258270" z="-3104" />
+			<node x="-71453" y="258305" z="-3104" />
+			<node x="-71467" y="258378" z="-3104" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>80</walk>
+			<run>132</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>250</baseSafeFall>
+		<collisionMale>
+			<radius>9.0</radius>
+			<height>23</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>8.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>80.0</hp>
+			<mp>30.0</mp>
+			<cp>48.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>91.83</hp>
+			<mp>35.46</mp>
+			<cp>55.098</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>103.79</hp>
+			<mp>40.98</mp>
+			<cp>62.274</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>115.88</hp>
+			<mp>46.56</mp>
+			<cp>69.528</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>128.1</hp>
+			<mp>52.2</mp>
+			<cp>76.86</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>140.45</hp>
+			<mp>57.9</mp>
+			<cp>84.27</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>152.93</hp>
+			<mp>63.66</mp>
+			<cp>91.758</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>165.54</hp>
+			<mp>69.48</mp>
+			<cp>99.324</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>178.28</hp>
+			<mp>75.36</mp>
+			<cp>106.968</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>191.15</hp>
+			<mp>81.3</mp>
+			<cp>114.69</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>204.15</hp>
+			<mp>87.3</mp>
+			<cp>122.49</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>217.28</hp>
+			<mp>93.36</mp>
+			<cp>130.368</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>230.54</hp>
+			<mp>99.48</mp>
+			<cp>138.324</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>243.93</hp>
+			<mp>105.66</mp>
+			<cp>146.358</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>257.45</hp>
+			<mp>111.9</mp>
+			<cp>154.47</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>271.1</hp>
+			<mp>118.2</mp>
+			<cp>162.66</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>284.88</hp>
+			<mp>124.56</mp>
+			<cp>170.928</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>298.79</hp>
+			<mp>130.98</mp>
+			<cp>179.274</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>312.83</hp>
+			<mp>137.46</mp>
+			<cp>187.698</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>327.0</hp>
+			<mp>144.0</mp>
+			<cp>196.2</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>356.7</hp>
+			<mp>153.9</mp>
+			<cp>214.02</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>386.67</hp>
+			<mp>163.89</mp>
+			<cp>232.002</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>416.91</hp>
+			<mp>173.97</mp>
+			<cp>250.146</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>447.42</hp>
+			<mp>184.14</mp>
+			<cp>268.452</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>478.2</hp>
+			<mp>194.4</mp>
+			<cp>286.92</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>509.25</hp>
+			<mp>204.75</mp>
+			<cp>305.55</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>540.57</hp>
+			<mp>215.19</mp>
+			<cp>324.342</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>572.16</hp>
+			<mp>225.72</mp>
+			<cp>343.296</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>604.02</hp>
+			<mp>236.34</mp>
+			<cp>362.412</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>636.15</hp>
+			<mp>247.05</mp>
+			<cp>381.69</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>668.55</hp>
+			<mp>257.85</mp>
+			<cp>401.13</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>701.22</hp>
+			<mp>268.74</mp>
+			<cp>420.732</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>734.16</hp>
+			<mp>279.72</mp>
+			<cp>440.496</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>767.37</hp>
+			<mp>290.79</mp>
+			<cp>460.422</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>800.85</hp>
+			<mp>301.95</mp>
+			<cp>480.51</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>834.6</hp>
+			<mp>313.2</mp>
+			<cp>500.76</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>868.62</hp>
+			<mp>324.54</mp>
+			<cp>521.172</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>902.91</hp>
+			<mp>335.97</mp>
+			<cp>541.746</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>937.47</hp>
+			<mp>347.49</mp>
+			<cp>562.482</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>972.3</hp>
+			<mp>359.1</mp>
+			<cp>583.38</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1019.1</hp>
+			<mp>378.6</mp>
+			<cp>611.46</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1066.26</hp>
+			<mp>398.25</mp>
+			<cp>639.756</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1113.78</hp>
+			<mp>418.05</mp>
+			<cp>668.268</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1161.66</hp>
+			<mp>438.0</mp>
+			<cp>696.996</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1209.9</hp>
+			<mp>458.1</mp>
+			<cp>725.94</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1258.5</hp>
+			<mp>478.35</mp>
+			<cp>755.1</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1307.46</hp>
+			<mp>498.75</mp>
+			<cp>784.476</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1356.78</hp>
+			<mp>519.3</mp>
+			<cp>814.068</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1406.46</hp>
+			<mp>540.0</mp>
+			<cp>843.876</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1456.5</hp>
+			<mp>560.85</mp>
+			<cp>873.9</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1506.9</hp>
+			<mp>581.85</mp>
+			<cp>904.14</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1557.66</hp>
+			<mp>603.0</mp>
+			<cp>934.596</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1608.78</hp>
+			<mp>624.3</mp>
+			<cp>965.268</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1660.26</hp>
+			<mp>645.75</mp>
+			<cp>996.156</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1712.1</hp>
+			<mp>667.35</mp>
+			<cp>1027.26</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1764.3</hp>
+			<mp>689.1</mp>
+			<cp>1058.58</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1816.86</hp>
+			<mp>711.0</mp>
+			<cp>1090.116</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1869.78</hp>
+			<mp>733.05</mp>
+			<cp>1121.868</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1923.06</hp>
+			<mp>755.25</mp>
+			<cp>1153.836</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1976.7</hp>
+			<mp>777.6</mp>
+			<cp>1186.02</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2030.7</hp>
+			<mp>800.1</mp>
+			<cp>1218.42</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2085.06</hp>
+			<mp>822.75</mp>
+			<cp>1251.036</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2139.78</hp>
+			<mp>845.55</mp>
+			<cp>1283.868</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2194.86</hp>
+			<mp>868.5</mp>
+			<cp>1316.916</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2250.3</hp>
+			<mp>891.6</mp>
+			<cp>1350.18</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2306.1</hp>
+			<mp>914.85</mp>
+			<cp>1383.66</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2362.26</hp>
+			<mp>938.25</mp>
+			<cp>1417.356</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2418.78</hp>
+			<mp>961.8</mp>
+			<cp>1451.268</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2475.66</hp>
+			<mp>985.5</mp>
+			<cp>1485.396</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2532.9</hp>
+			<mp>1009.35</mp>
+			<cp>1519.74</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2590.5</hp>
+			<mp>1033.35</mp>
+			<cp>1554.3</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2648.46</hp>
+			<mp>1057.5</mp>
+			<cp>1589.076</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2706.78</hp>
+			<mp>1081.8</mp>
+			<cp>1624.068</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2765.46</hp>
+			<mp>1106.25</mp>
+			<cp>1659.276</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2824.5</hp>
+			<mp>1130.85</mp>
+			<cp>1694.7</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>2883.9</hp>
+			<mp>1155.6</mp>
+			<cp>1730.34</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>2943.66</hp>
+			<mp>1180.5</mp>
+			<cp>1766.196</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3003.78</hp>
+			<mp>1205.55</mp>
+			<cp>1802.268</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3064.26</hp>
+			<mp>1230.75</mp>
+			<cp>1838.556</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3125.1</hp>
+			<mp>1256.1</mp>
+			<cp>1875.06</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3186.3</hp>
+			<mp>1281.6</mp>
+			<cp>1911.78</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3247.86</hp>
+			<mp>1307.25</mp>
+			<cp>1948.716</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3309.78</hp>
+			<mp>1333.05</mp>
+			<cp>1985.868</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3372.06</hp>
+			<mp>1359.0</mp>
+			<cp>2023.236</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3434.7</hp>
+			<mp>1385.1</mp>
+			<cp>2060.82</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3497.7</hp>
+			<mp>1411.35</mp>
+			<cp>2098.62</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3561.06</hp>
+			<mp>1437.75</mp>
+			<cp>2136.636</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3624.78</hp>
+			<mp>1464.3</mp>
+			<cp>2174.868</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3688.86</hp>
+			<mp>1491.0</mp>
+			<cp>2213.316</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3753.3</hp>
+			<mp>1517.85</mp>
+			<cp>2251.98</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3818.1</hp>
+			<mp>1544.85</mp>
+			<cp>2290.86</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>3883.26</hp>
+			<mp>1572.0</mp>
+			<cp>2329.956</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>3948.78</hp>
+			<mp>1599.3</mp>
+			<cp>2369.268</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4014.66</hp>
+			<mp>1626.75</mp>
+			<cp>2408.796</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4080.9</hp>
+			<mp>1654.35</mp>
+			<cp>2448.54</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4147.5</hp>
+			<mp>1682.1</mp>
+			<cp>2488.5</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4214.46</hp>
+			<mp>1710.0</mp>
+			<cp>2528.676</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4281.78</hp>
+			<mp>1738.05</mp>
+			<cp>2569.068</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4349.46</hp>
+			<mp>1766.25</mp>
+			<cp>2609.676</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4417.5</hp>
+			<mp>1794.6</mp>
+			<cp>2650.5</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4485.9</hp>
+			<mp>1823.1</mp>
+			<cp>2691.55</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4554.66</hp>
+			<mp>1851.75</mp>
+			<cp>2732.82</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4623.78</hp>
+			<mp>1880.55</mp>
+			<cp>2774.31</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4693.26</hp>
+			<mp>1909.5</mp>
+			<cp>2816.02</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>4763.1</hp>
+			<mp>1938.6</mp>
+			<cp>2857.94</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>4833.3</hp>
+			<mp>1967.85</mp>
+			<cp>2900.09</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>4903.86</hp>
+			<mp>1997.25</mp>
+			<cp>2942.316</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/DarkElfDeathBlader.xml
+++ b/data/stats/chars/baseStats/DarkElfDeathBlader.xml
@@ -1,0 +1,923 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
+	<classId>205</classId>
+	<staticData>
+		<baseINT>20</baseINT>
+		<baseSTR>41</baseSTR>
+		<baseCON>40</baseCON>
+		<baseMEN>25</baseMEN>
+		<baseDEX>34</baseDEX>
+		<baseWIT>10</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="47417" y="153541" z="-2728" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>85</walk>
+			<run>139</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>350</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>94.0</hp>
+			<mp>30.0</mp>
+			<cp>47.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>107.65</hp>
+			<mp>35.46</mp>
+			<cp>53.825</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>121.45</hp>
+			<mp>40.98</mp>
+			<cp>60.725</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>135.4</hp>
+			<mp>46.56</mp>
+			<cp>67.7</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>149.5</hp>
+			<mp>52.2</mp>
+			<cp>74.75</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>163.75</hp>
+			<mp>57.9</mp>
+			<cp>81.875</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>178.15</hp>
+			<mp>63.66</mp>
+			<cp>89.075</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>192.7</hp>
+			<mp>69.48</mp>
+			<cp>96.35</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>207.4</hp>
+			<mp>75.36</mp>
+			<cp>103.7</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>222.25</hp>
+			<mp>81.3</mp>
+			<cp>111.125</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>237.25</hp>
+			<mp>87.3</mp>
+			<cp>118.625</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>252.4</hp>
+			<mp>93.36</mp>
+			<cp>126.2</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>267.7</hp>
+			<mp>99.48</mp>
+			<cp>133.85</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>283.15</hp>
+			<mp>105.66</mp>
+			<cp>141.575</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>298.75</hp>
+			<mp>111.9</mp>
+			<cp>149.375</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>314.5</hp>
+			<mp>118.2</mp>
+			<cp>157.25</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>330.4</hp>
+			<mp>124.56</mp>
+			<cp>165.2</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>346.45</hp>
+			<mp>130.98</mp>
+			<cp>173.225</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>362.65</hp>
+			<mp>137.46</mp>
+			<cp>181.325</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>379.0</hp>
+			<mp>144.0</mp>
+			<cp>189.5</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>414.2</hp>
+			<mp>153.9</mp>
+			<cp>207.1</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>449.72</hp>
+			<mp>163.89</mp>
+			<cp>224.86</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>485.56</hp>
+			<mp>173.97</mp>
+			<cp>242.78</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>521.72</hp>
+			<mp>184.14</mp>
+			<cp>260.86</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>558.2</hp>
+			<mp>194.4</mp>
+			<cp>279.1</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>595.0</hp>
+			<mp>204.75</mp>
+			<cp>297.5</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>632.12</hp>
+			<mp>215.19</mp>
+			<cp>316.06</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>669.56</hp>
+			<mp>225.72</mp>
+			<cp>334.78</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>707.32</hp>
+			<mp>236.34</mp>
+			<cp>353.66</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>745.4</hp>
+			<mp>247.05</mp>
+			<cp>372.7</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>783.8</hp>
+			<mp>257.85</mp>
+			<cp>391.9</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>822.52</hp>
+			<mp>268.74</mp>
+			<cp>411.26</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>861.56</hp>
+			<mp>279.72</mp>
+			<cp>430.78</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>900.92</hp>
+			<mp>290.79</mp>
+			<cp>450.46</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>940.6</hp>
+			<mp>301.95</mp>
+			<cp>470.3</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>980.6</hp>
+			<mp>313.2</mp>
+			<cp>490.3</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>1020.92</hp>
+			<mp>324.54</mp>
+			<cp>510.46</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1061.56</hp>
+			<mp>335.97</mp>
+			<cp>530.78</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1102.52</hp>
+			<mp>347.49</mp>
+			<cp>551.26</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1143.8</hp>
+			<mp>359.1</mp>
+			<cp>571.9</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1185.4</hp>
+			<mp>370.8</mp>
+			<cp>592.7</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1227.32</hp>
+			<mp>382.59</mp>
+			<cp>613.66</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1269.56</hp>
+			<mp>394.47</mp>
+			<cp>634.78</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1312.12</hp>
+			<mp>406.44</mp>
+			<cp>656.06</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1355.0</hp>
+			<mp>418.5</mp>
+			<cp>677.5</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1398.2</hp>
+			<mp>430.65</mp>
+			<cp>699.1</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1441.72</hp>
+			<mp>442.89</mp>
+			<cp>720.86</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1485.56</hp>
+			<mp>455.22</mp>
+			<cp>742.78</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1529.72</hp>
+			<mp>467.64</mp>
+			<cp>764.86</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1574.2</hp>
+			<mp>480.15</mp>
+			<cp>787.1</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1619.0</hp>
+			<mp>492.75</mp>
+			<cp>809.5</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1664.12</hp>
+			<mp>505.44</mp>
+			<cp>832.06</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1709.56</hp>
+			<mp>518.22</mp>
+			<cp>854.78</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1755.32</hp>
+			<mp>531.09</mp>
+			<cp>877.66</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1801.4</hp>
+			<mp>544.05</mp>
+			<cp>900.7</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1847.8</hp>
+			<mp>557.1</mp>
+			<cp>923.9</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1894.52</hp>
+			<mp>570.24</mp>
+			<cp>947.26</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1941.56</hp>
+			<mp>583.47</mp>
+			<cp>970.78</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1988.92</hp>
+			<mp>596.79</mp>
+			<cp>994.46</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2036.6</hp>
+			<mp>610.2</mp>
+			<cp>1018.3</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2084.6</hp>
+			<mp>623.7</mp>
+			<cp>1042.3</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2132.92</hp>
+			<mp>637.29</mp>
+			<cp>1066.46</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2181.56</hp>
+			<mp>650.97</mp>
+			<cp>1090.78</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2230.52</hp>
+			<mp>664.74</mp>
+			<cp>1115.26</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2279.8</hp>
+			<mp>678.6</mp>
+			<cp>1139.9</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2329.4</hp>
+			<mp>692.55</mp>
+			<cp>1164.7</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2379.32</hp>
+			<mp>706.59</mp>
+			<cp>1189.66</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2429.56</hp>
+			<mp>720.72</mp>
+			<cp>1214.78</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2480.12</hp>
+			<mp>734.94</mp>
+			<cp>1240.06</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2531.0</hp>
+			<mp>749.25</mp>
+			<cp>1265.5</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2582.2</hp>
+			<mp>763.65</mp>
+			<cp>1291.1</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2633.72</hp>
+			<mp>778.14</mp>
+			<cp>1316.86</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2685.56</hp>
+			<mp>792.72</mp>
+			<cp>1342.78</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2737.72</hp>
+			<mp>807.39</mp>
+			<cp>1368.86</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2790.2</hp>
+			<mp>822.15</mp>
+			<cp>1395.1</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>2843.0</hp>
+			<mp>837.0</mp>
+			<cp>1421.5</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>2896.12</hp>
+			<mp>851.94</mp>
+			<cp>1448.06</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>2949.56</hp>
+			<mp>866.97</mp>
+			<cp>1474.78</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3003.32</hp>
+			<mp>882.09</mp>
+			<cp>1501.66</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3057.4</hp>
+			<mp>897.3</mp>
+			<cp>1528.7</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3111.8</hp>
+			<mp>912.6</mp>
+			<cp>1555.9</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3166.52</hp>
+			<mp>927.99</mp>
+			<cp>1583.26</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3221.56</hp>
+			<mp>943.47</mp>
+			<cp>1610.78</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3276.92</hp>
+			<mp>959.04</mp>
+			<cp>1638.46</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3332.6</hp>
+			<mp>974.7</mp>
+			<cp>1666.3</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3388.6</hp>
+			<mp>990.45</mp>
+			<cp>1694.3</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3444.92</hp>
+			<mp>1006.29</mp>
+			<cp>1722.46</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3501.56</hp>
+			<mp>1022.22</mp>
+			<cp>1750.78</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3558.52</hp>
+			<mp>1038.24</mp>
+			<cp>1779.26</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3615.8</hp>
+			<mp>1054.35</mp>
+			<cp>1807.9</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3673.4</hp>
+			<mp>1070.55</mp>
+			<cp>1836.7</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>3731.32</hp>
+			<mp>1086.84</mp>
+			<cp>1865.66</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>3789.56</hp>
+			<mp>1103.22</mp>
+			<cp>1894.78</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>3848.12</hp>
+			<mp>1119.69</mp>
+			<cp>1924.06</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>3907.0</hp>
+			<mp>1136.25</mp>
+			<cp>1953.5</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>3966.2</hp>
+			<mp>1152.9</mp>
+			<cp>1983.1</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4025.72</hp>
+			<mp>1169.64</mp>
+			<cp>2012.86</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4085.56</hp>
+			<mp>1186.47</mp>
+			<cp>2042.78</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4145.72</hp>
+			<mp>1203.39</mp>
+			<cp>2072.86</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4206.2</hp>
+			<mp>1220.4</mp>
+			<cp>2103.1</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4267</hp>
+			<mp>1237.5</mp>
+			<cp>2133.5</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4328.12</hp>
+			<mp>1254.69</mp>
+			<cp>2164.06</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4389.56</hp>
+			<mp>1271.97</mp>
+			<cp>2194.78</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4451.32</hp>
+			<mp>1289.34</mp>
+			<cp>2225.66</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>4513.4</hp>
+			<mp>1306.8</mp>
+			<cp>2256.7</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>4575.8</hp>
+			<mp>1324.35</mp>
+			<cp>2287.9</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>4638.52</hp>
+			<mp>1341.99</mp>
+			<cp>2319.26</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
+</list>

--- a/data/stats/chars/baseStats/DarkElfDeathKnight.xml
+++ b/data/stats/chars/baseStats/DarkElfDeathKnight.xml
@@ -1,0 +1,923 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
+	<classId>207</classId>
+	<staticData>
+		<baseINT>20</baseINT>
+		<baseSTR>41</baseSTR>
+		<baseCON>40</baseCON>
+		<baseMEN>25</baseMEN>
+		<baseDEX>34</baseDEX>
+		<baseWIT>10</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="47417" y="153541" z="-2728" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>85</walk>
+			<run>139</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>350</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>94.0</hp>
+			<mp>30.0</mp>
+			<cp>56.4</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>107.65</hp>
+			<mp>35.46</mp>
+			<cp>64.59</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>121.45</hp>
+			<mp>40.98</mp>
+			<cp>72.87</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>135.4</hp>
+			<mp>46.56</mp>
+			<cp>81.24</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>149.5</hp>
+			<mp>52.2</mp>
+			<cp>89.7</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>163.75</hp>
+			<mp>57.9</mp>
+			<cp>98.25</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>178.15</hp>
+			<mp>63.66</mp>
+			<cp>106.89</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>192.7</hp>
+			<mp>69.48</mp>
+			<cp>115.62</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>207.4</hp>
+			<mp>75.36</mp>
+			<cp>124.44</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>222.25</hp>
+			<mp>81.3</mp>
+			<cp>133.35</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>237.25</hp>
+			<mp>87.3</mp>
+			<cp>142.35</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>252.4</hp>
+			<mp>93.36</mp>
+			<cp>151.44</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>267.7</hp>
+			<mp>99.48</mp>
+			<cp>160.62</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>283.15</hp>
+			<mp>105.66</mp>
+			<cp>169.89</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>298.75</hp>
+			<mp>111.9</mp>
+			<cp>179.25</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>314.5</hp>
+			<mp>118.2</mp>
+			<cp>188.7</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>330.4</hp>
+			<mp>124.56</mp>
+			<cp>198.24</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>346.45</hp>
+			<mp>130.98</mp>
+			<cp>207.87</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>362.65</hp>
+			<mp>137.46</mp>
+			<cp>217.59</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>379.0</hp>
+			<mp>144.0</mp>
+			<cp>227.4</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>414.2</hp>
+			<mp>153.9</mp>
+			<cp>248.52</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>449.72</hp>
+			<mp>163.89</mp>
+			<cp>269.832</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>485.56</hp>
+			<mp>173.97</mp>
+			<cp>291.336</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>521.72</hp>
+			<mp>184.14</mp>
+			<cp>313.032</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>558.2</hp>
+			<mp>194.4</mp>
+			<cp>334.92</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>595.0</hp>
+			<mp>204.75</mp>
+			<cp>357.0</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>632.12</hp>
+			<mp>215.19</mp>
+			<cp>379.272</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>669.56</hp>
+			<mp>225.72</mp>
+			<cp>401.736</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>707.32</hp>
+			<mp>236.34</mp>
+			<cp>424.392</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>745.4</hp>
+			<mp>247.05</mp>
+			<cp>447.24</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>783.8</hp>
+			<mp>257.85</mp>
+			<cp>470.28</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>822.52</hp>
+			<mp>268.74</mp>
+			<cp>493.512</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>861.56</hp>
+			<mp>279.72</mp>
+			<cp>516.936</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>900.92</hp>
+			<mp>290.79</mp>
+			<cp>540.552</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>940.6</hp>
+			<mp>301.95</mp>
+			<cp>564.36</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>980.6</hp>
+			<mp>313.2</mp>
+			<cp>588.36</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>1020.92</hp>
+			<mp>324.54</mp>
+			<cp>612.552</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1061.56</hp>
+			<mp>335.97</mp>
+			<cp>636.936</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1102.52</hp>
+			<mp>347.49</mp>
+			<cp>661.512</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1143.8</hp>
+			<mp>359.1</mp>
+			<cp>686.28</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1198.4</hp>
+			<mp>378.6</mp>
+			<cp>719.04</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1253.42</hp>
+			<mp>398.25</mp>
+			<cp>752.052</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1308.86</hp>
+			<mp>418.05</mp>
+			<cp>785.316</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1364.72</hp>
+			<mp>438.0</mp>
+			<cp>818.832</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1421.0</hp>
+			<mp>458.1</mp>
+			<cp>852.6</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1477.7</hp>
+			<mp>478.35</mp>
+			<cp>886.62</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1534.82</hp>
+			<mp>498.75</mp>
+			<cp>920.892</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1592.36</hp>
+			<mp>519.3</mp>
+			<cp>955.416</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1650.32</hp>
+			<mp>540.0</mp>
+			<cp>990.192</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1708.7</hp>
+			<mp>560.85</mp>
+			<cp>1025.22</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1767.5</hp>
+			<mp>581.85</mp>
+			<cp>1060.5</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1826.72</hp>
+			<mp>603.0</mp>
+			<cp>1096.032</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1886.36</hp>
+			<mp>624.3</mp>
+			<cp>1131.816</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1946.42</hp>
+			<mp>645.75</mp>
+			<cp>1167.852</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>2006.9</hp>
+			<mp>667.35</mp>
+			<cp>1204.14</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>2067.8</hp>
+			<mp>689.1</mp>
+			<cp>1240.68</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2129.12</hp>
+			<mp>711.0</mp>
+			<cp>1277.472</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2190.86</hp>
+			<mp>733.05</mp>
+			<cp>1314.516</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2253.02</hp>
+			<mp>755.25</mp>
+			<cp>1351.812</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2315.6</hp>
+			<mp>777.6</mp>
+			<cp>1389.36</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2378.6</hp>
+			<mp>800.1</mp>
+			<cp>1427.16</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2442.02</hp>
+			<mp>822.75</mp>
+			<cp>1465.212</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2505.86</hp>
+			<mp>845.55</mp>
+			<cp>1503.516</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2570.12</hp>
+			<mp>868.5</mp>
+			<cp>1542.072</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2634.8</hp>
+			<mp>891.6</mp>
+			<cp>1580.88</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2699.9</hp>
+			<mp>914.85</mp>
+			<cp>1619.94</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2765.42</hp>
+			<mp>938.25</mp>
+			<cp>1659.252</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2831.36</hp>
+			<mp>961.8</mp>
+			<cp>1698.816</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2897.72</hp>
+			<mp>985.5</mp>
+			<cp>1738.632</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2964.5</hp>
+			<mp>1009.35</mp>
+			<cp>1778.7</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>3031.7</hp>
+			<mp>1033.35</mp>
+			<cp>1819.02</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>3099.32</hp>
+			<mp>1057.5</mp>
+			<cp>1859.592</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>3167.36</hp>
+			<mp>1081.8</mp>
+			<cp>1900.416</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3235.82</hp>
+			<mp>1106.25</mp>
+			<cp>1941.492</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3304.7</hp>
+			<mp>1130.85</mp>
+			<cp>1982.82</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3374.0</hp>
+			<mp>1155.6</mp>
+			<cp>2024.4</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3443.72</hp>
+			<mp>1180.5</mp>
+			<cp>2066.232</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3513.86</hp>
+			<mp>1205.55</mp>
+			<cp>2108.316</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3584.42</hp>
+			<mp>1230.75</mp>
+			<cp>2150.652</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3655.4</hp>
+			<mp>1256.1</mp>
+			<cp>2193.24</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3726.8</hp>
+			<mp>1281.6</mp>
+			<cp>2236.08</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3798.62</hp>
+			<mp>1307.25</mp>
+			<cp>2279.172</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3870.86</hp>
+			<mp>1333.05</mp>
+			<cp>2322.516</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3943.52</hp>
+			<mp>1359.0</mp>
+			<cp>2366.112</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>4016.6</hp>
+			<mp>1385.1</mp>
+			<cp>2409.96</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>4090.1</hp>
+			<mp>1411.35</mp>
+			<cp>2454.06</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>4164.02</hp>
+			<mp>1437.75</mp>
+			<cp>2498.412</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4238.36</hp>
+			<mp>1464.3</mp>
+			<cp>2543.016</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4313.12</hp>
+			<mp>1491.0</mp>
+			<cp>2587.872</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4388.3</hp>
+			<mp>1517.85</mp>
+			<cp>2632.98</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4463.9</hp>
+			<mp>1544.85</mp>
+			<cp>2678.34</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4539.92</hp>
+			<mp>1572.0</mp>
+			<cp>2723.952</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4616.36</hp>
+			<mp>1599.3</mp>
+			<cp>2769.816</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4693.22</hp>
+			<mp>1626.75</mp>
+			<cp>2815.932</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4770.5</hp>
+			<mp>1654.35</mp>
+			<cp>2862.3</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4848.2</hp>
+			<mp>1682.1</mp>
+			<cp>2908.92</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4926.32</hp>
+			<mp>1710.0</mp>
+			<cp>2955.792</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>5004.86</hp>
+			<mp>1738.05</mp>
+			<cp>3002.916</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>5083.82</hp>
+			<mp>1766.25</mp>
+			<cp>3050.292</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>5163.2</hp>
+			<mp>1794.6</mp>
+			<cp>3097.92</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>5243</hp>
+			<mp>1823.1</mp>
+			<cp>3145.79</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5323.22</hp>
+			<mp>1851.75</mp>
+			<cp>3193.92</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5403.86</hp>
+			<mp>1880.55</mp>
+			<cp>3242.3</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5484.92</hp>
+			<mp>1909.5</mp>
+			<cp>3290.92</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5566.4</hp>
+			<mp>1938.6</mp>
+			<cp>3339.8</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5648.3</hp>
+			<mp>1967.85</mp>
+			<cp>3388.92</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5730.62</hp>
+			<mp>1997.25</mp>
+			<cp>3438.372</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
+</list>

--- a/data/stats/chars/baseStats/DarkElfDeathWalker.xml
+++ b/data/stats/chars/baseStats/DarkElfDeathWalker.xml
@@ -1,0 +1,923 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
+	<classId>204</classId>
+	<staticData>
+		<baseINT>20</baseINT>
+		<baseSTR>41</baseSTR>
+		<baseCON>40</baseCON>
+		<baseMEN>25</baseMEN>
+		<baseDEX>34</baseDEX>
+		<baseWIT>10</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="47417" y="153541" z="-2728" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>85</walk>
+			<run>139</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>350</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>94.0</hp>
+			<mp>30.0</mp>
+			<cp>37.6</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>107.65</hp>
+			<mp>35.46</mp>
+			<cp>43.06</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>121.45</hp>
+			<mp>40.98</mp>
+			<cp>48.58</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>135.4</hp>
+			<mp>46.56</mp>
+			<cp>54.16</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>149.5</hp>
+			<mp>52.2</mp>
+			<cp>59.8</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>163.75</hp>
+			<mp>57.9</mp>
+			<cp>65.5</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>178.15</hp>
+			<mp>63.66</mp>
+			<cp>71.26</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>192.7</hp>
+			<mp>69.48</mp>
+			<cp>77.08</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>207.4</hp>
+			<mp>75.36</mp>
+			<cp>82.96</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>222.25</hp>
+			<mp>81.3</mp>
+			<cp>88.9</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>237.25</hp>
+			<mp>87.3</mp>
+			<cp>94.9</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>252.4</hp>
+			<mp>93.36</mp>
+			<cp>100.96</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>267.7</hp>
+			<mp>99.48</mp>
+			<cp>107.08</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>283.15</hp>
+			<mp>105.66</mp>
+			<cp>113.26</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>298.75</hp>
+			<mp>111.9</mp>
+			<cp>119.5</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>314.5</hp>
+			<mp>118.2</mp>
+			<cp>125.8</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>330.4</hp>
+			<mp>124.56</mp>
+			<cp>132.16</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>346.45</hp>
+			<mp>130.98</mp>
+			<cp>138.58</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>362.65</hp>
+			<mp>137.46</mp>
+			<cp>145.06</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>379.0</hp>
+			<mp>144.0</mp>
+			<cp>151.6</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>395.5</hp>
+			<mp>150.6</mp>
+			<cp>158.2</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>412.15</hp>
+			<mp>157.26</mp>
+			<cp>164.86</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>428.95</hp>
+			<mp>163.98</mp>
+			<cp>171.58</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>445.9</hp>
+			<mp>170.76</mp>
+			<cp>178.36</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>463.0</hp>
+			<mp>177.6</mp>
+			<cp>185.2</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>480.25</hp>
+			<mp>184.5</mp>
+			<cp>192.1</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>497.65</hp>
+			<mp>191.46</mp>
+			<cp>199.06</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>515.2</hp>
+			<mp>198.48</mp>
+			<cp>206.08</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>532.9</hp>
+			<mp>205.56</mp>
+			<cp>213.16</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>550.75</hp>
+			<mp>212.7</mp>
+			<cp>220.3</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>568.75</hp>
+			<mp>219.9</mp>
+			<cp>227.5</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>586.9</hp>
+			<mp>227.16</mp>
+			<cp>234.76</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>605.2</hp>
+			<mp>234.48</mp>
+			<cp>242.08</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>623.65</hp>
+			<mp>241.86</mp>
+			<cp>249.46</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>642.25</hp>
+			<mp>249.3</mp>
+			<cp>256.9</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>661.0</hp>
+			<mp>256.8</mp>
+			<cp>264.4</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>679.9</hp>
+			<mp>264.36</mp>
+			<cp>271.96</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>698.95</hp>
+			<mp>271.98</mp>
+			<cp>279.58</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>718.15</hp>
+			<mp>279.66</mp>
+			<cp>287.26</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>737.5</hp>
+			<mp>287.4</mp>
+			<cp>295.0</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>757.0</hp>
+			<mp>295.2</mp>
+			<cp>302.8</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>776.65</hp>
+			<mp>303.06</mp>
+			<cp>310.66</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>796.45</hp>
+			<mp>310.98</mp>
+			<cp>318.58</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>816.4</hp>
+			<mp>318.96</mp>
+			<cp>326.56</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>836.5</hp>
+			<mp>327.0</mp>
+			<cp>334.6</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>856.75</hp>
+			<mp>335.1</mp>
+			<cp>342.7</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>877.15</hp>
+			<mp>343.26</mp>
+			<cp>350.86</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>897.7</hp>
+			<mp>351.48</mp>
+			<cp>359.08</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>918.4</hp>
+			<mp>359.76</mp>
+			<cp>367.36</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>939.25</hp>
+			<mp>368.1</mp>
+			<cp>375.7</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>960.25</hp>
+			<mp>376.5</mp>
+			<cp>384.1</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>981.4</hp>
+			<mp>384.96</mp>
+			<cp>392.56</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1002.7</hp>
+			<mp>393.48</mp>
+			<cp>401.08</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1024.15</hp>
+			<mp>402.06</mp>
+			<cp>409.66</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1045.75</hp>
+			<mp>410.7</mp>
+			<cp>418.3</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1067.5</hp>
+			<mp>419.4</mp>
+			<cp>427.0</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1089.4</hp>
+			<mp>428.16</mp>
+			<cp>435.76</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1111.45</hp>
+			<mp>436.98</mp>
+			<cp>444.58</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1133.65</hp>
+			<mp>445.86</mp>
+			<cp>453.46</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1156.0</hp>
+			<mp>454.8</mp>
+			<cp>462.4</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>1178.5</hp>
+			<mp>463.8</mp>
+			<cp>471.4</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>1201.15</hp>
+			<mp>472.86</mp>
+			<cp>480.46</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>1223.95</hp>
+			<mp>481.98</mp>
+			<cp>489.58</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>1246.9</hp>
+			<mp>491.16</mp>
+			<cp>498.76</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>1270.0</hp>
+			<mp>500.4</mp>
+			<cp>508.0</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>1293.25</hp>
+			<mp>509.7</mp>
+			<cp>517.3</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>1316.65</hp>
+			<mp>519.06</mp>
+			<cp>526.66</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>1340.2</hp>
+			<mp>528.48</mp>
+			<cp>536.08</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>1363.9</hp>
+			<mp>537.96</mp>
+			<cp>545.56</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>1387.75</hp>
+			<mp>547.5</mp>
+			<cp>555.1</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>1411.75</hp>
+			<mp>557.1</mp>
+			<cp>564.7</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>1435.9</hp>
+			<mp>566.76</mp>
+			<cp>574.36</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>1460.2</hp>
+			<mp>576.48</mp>
+			<cp>584.08</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>1484.65</hp>
+			<mp>586.26</mp>
+			<cp>593.86</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>1509.25</hp>
+			<mp>596.1</mp>
+			<cp>603.7</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>1534.0</hp>
+			<mp>606.0</mp>
+			<cp>613.6</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>1558.9</hp>
+			<mp>615.96</mp>
+			<cp>623.56</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>1583.95</hp>
+			<mp>625.98</mp>
+			<cp>633.58</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>1609.15</hp>
+			<mp>636.06</mp>
+			<cp>643.66</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>1634.5</hp>
+			<mp>646.2</mp>
+			<cp>653.8</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>1660.0</hp>
+			<mp>656.4</mp>
+			<cp>664.0</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>1685.65</hp>
+			<mp>666.66</mp>
+			<cp>674.26</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>1711.45</hp>
+			<mp>676.98</mp>
+			<cp>684.58</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>1737.4</hp>
+			<mp>687.36</mp>
+			<cp>694.96</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>1763.5</hp>
+			<mp>697.8</mp>
+			<cp>705.4</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>1789.75</hp>
+			<mp>708.3</mp>
+			<cp>715.9</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>1816.15</hp>
+			<mp>718.86</mp>
+			<cp>726.46</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>1842.7</hp>
+			<mp>729.48</mp>
+			<cp>737.08</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>1869.4</hp>
+			<mp>740.16</mp>
+			<cp>747.76</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>1896.25</hp>
+			<mp>750.9</mp>
+			<cp>758.5</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>1923.25</hp>
+			<mp>761.7</mp>
+			<cp>769.3</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>1950.4</hp>
+			<mp>772.56</mp>
+			<cp>780.16</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>1977.7</hp>
+			<mp>783.48</mp>
+			<cp>791.08</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>2005.15</hp>
+			<mp>794.46</mp>
+			<cp>802.06</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>2032.75</hp>
+			<mp>805.5</mp>
+			<cp>813.1</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>2060.5</hp>
+			<mp>816.6</mp>
+			<cp>824.2</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>2088.4</hp>
+			<mp>827.76</mp>
+			<cp>835.36</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>2116.45</hp>
+			<mp>838.98</mp>
+			<cp>846.58</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>2144.65</hp>
+			<mp>850.26</mp>
+			<cp>857.86</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>2173</hp>
+			<mp>861.6</mp>
+			<cp>869.2</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>2201.5</hp>
+			<mp>873</mp>
+			<cp>880.6</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>2230.15</hp>
+			<mp>884.46</mp>
+			<cp>892.06</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>2258.95</hp>
+			<mp>895.98</mp>
+			<cp>903.58</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>2287.9</hp>
+			<mp>907.56</mp>
+			<cp>915.16</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>2317</hp>
+			<mp>919.2</mp>
+			<cp>926.8</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>2346.25</hp>
+			<mp>930.9</mp>
+			<cp>938.5</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>2375.65</hp>
+			<mp>942.66</mp>
+			<cp>950.26</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
+</list>

--- a/data/stats/chars/baseStats/DarkElfUndertaker.xml
+++ b/data/stats/chars/baseStats/DarkElfUndertaker.xml
@@ -1,0 +1,923 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
+	<classId>206</classId>
+	<staticData>
+		<baseINT>20</baseINT>
+		<baseSTR>41</baseSTR>
+		<baseCON>40</baseCON>
+		<baseMEN>25</baseMEN>
+		<baseDEX>34</baseDEX>
+		<baseWIT>10</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="47417" y="153541" z="-2728" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>85</walk>
+			<run>139</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>350</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>94.0</hp>
+			<mp>30.0</mp>
+			<cp>56.4</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>107.65</hp>
+			<mp>35.46</mp>
+			<cp>64.59</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>121.45</hp>
+			<mp>40.98</mp>
+			<cp>72.87</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>135.4</hp>
+			<mp>46.56</mp>
+			<cp>81.24</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>149.5</hp>
+			<mp>52.2</mp>
+			<cp>89.7</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>163.75</hp>
+			<mp>57.9</mp>
+			<cp>98.25</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>178.15</hp>
+			<mp>63.66</mp>
+			<cp>106.89</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>192.7</hp>
+			<mp>69.48</mp>
+			<cp>115.62</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>207.4</hp>
+			<mp>75.36</mp>
+			<cp>124.44</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>222.25</hp>
+			<mp>81.3</mp>
+			<cp>133.35</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>237.25</hp>
+			<mp>87.3</mp>
+			<cp>142.35</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>252.4</hp>
+			<mp>93.36</mp>
+			<cp>151.44</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>267.7</hp>
+			<mp>99.48</mp>
+			<cp>160.62</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>283.15</hp>
+			<mp>105.66</mp>
+			<cp>169.89</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>298.75</hp>
+			<mp>111.9</mp>
+			<cp>179.25</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>314.5</hp>
+			<mp>118.2</mp>
+			<cp>188.7</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>330.4</hp>
+			<mp>124.56</mp>
+			<cp>198.24</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>346.45</hp>
+			<mp>130.98</mp>
+			<cp>207.87</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>362.65</hp>
+			<mp>137.46</mp>
+			<cp>217.59</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>379.0</hp>
+			<mp>144.0</mp>
+			<cp>227.4</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>414.2</hp>
+			<mp>153.9</mp>
+			<cp>248.52</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>449.72</hp>
+			<mp>163.89</mp>
+			<cp>269.832</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>485.56</hp>
+			<mp>173.97</mp>
+			<cp>291.336</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>521.72</hp>
+			<mp>184.14</mp>
+			<cp>313.032</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>558.2</hp>
+			<mp>194.4</mp>
+			<cp>334.92</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>595.0</hp>
+			<mp>204.75</mp>
+			<cp>357.0</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>632.12</hp>
+			<mp>215.19</mp>
+			<cp>379.272</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>669.56</hp>
+			<mp>225.72</mp>
+			<cp>401.736</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>707.32</hp>
+			<mp>236.34</mp>
+			<cp>424.392</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>745.4</hp>
+			<mp>247.05</mp>
+			<cp>447.24</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>783.8</hp>
+			<mp>257.85</mp>
+			<cp>470.28</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>822.52</hp>
+			<mp>268.74</mp>
+			<cp>493.512</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>861.56</hp>
+			<mp>279.72</mp>
+			<cp>516.936</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>900.92</hp>
+			<mp>290.79</mp>
+			<cp>540.552</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>940.6</hp>
+			<mp>301.95</mp>
+			<cp>564.36</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>980.6</hp>
+			<mp>313.2</mp>
+			<cp>588.36</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>1020.92</hp>
+			<mp>324.54</mp>
+			<cp>612.552</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1061.56</hp>
+			<mp>335.97</mp>
+			<cp>636.936</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1102.52</hp>
+			<mp>347.49</mp>
+			<cp>661.512</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1143.8</hp>
+			<mp>359.1</mp>
+			<cp>686.28</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1198.4</hp>
+			<mp>378.6</mp>
+			<cp>719.04</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1253.42</hp>
+			<mp>398.25</mp>
+			<cp>752.052</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1308.86</hp>
+			<mp>418.05</mp>
+			<cp>785.316</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1364.72</hp>
+			<mp>438.0</mp>
+			<cp>818.832</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1421.0</hp>
+			<mp>458.1</mp>
+			<cp>852.6</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1477.7</hp>
+			<mp>478.35</mp>
+			<cp>886.62</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1534.82</hp>
+			<mp>498.75</mp>
+			<cp>920.892</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1592.36</hp>
+			<mp>519.3</mp>
+			<cp>955.416</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1650.32</hp>
+			<mp>540.0</mp>
+			<cp>990.192</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1708.7</hp>
+			<mp>560.85</mp>
+			<cp>1025.22</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1767.5</hp>
+			<mp>581.85</mp>
+			<cp>1060.5</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1826.72</hp>
+			<mp>603.0</mp>
+			<cp>1096.032</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1886.36</hp>
+			<mp>624.3</mp>
+			<cp>1131.816</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1946.42</hp>
+			<mp>645.75</mp>
+			<cp>1167.852</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>2006.9</hp>
+			<mp>667.35</mp>
+			<cp>1204.14</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>2067.8</hp>
+			<mp>689.1</mp>
+			<cp>1240.68</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2129.12</hp>
+			<mp>711.0</mp>
+			<cp>1277.472</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2190.86</hp>
+			<mp>733.05</mp>
+			<cp>1314.516</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2253.02</hp>
+			<mp>755.25</mp>
+			<cp>1351.812</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2315.6</hp>
+			<mp>777.6</mp>
+			<cp>1389.36</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2378.6</hp>
+			<mp>800.1</mp>
+			<cp>1427.16</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2442.02</hp>
+			<mp>822.75</mp>
+			<cp>1465.212</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2505.86</hp>
+			<mp>845.55</mp>
+			<cp>1503.516</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2570.12</hp>
+			<mp>868.5</mp>
+			<cp>1542.072</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2634.8</hp>
+			<mp>891.6</mp>
+			<cp>1580.88</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2699.9</hp>
+			<mp>914.85</mp>
+			<cp>1619.94</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2765.42</hp>
+			<mp>938.25</mp>
+			<cp>1659.252</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2831.36</hp>
+			<mp>961.8</mp>
+			<cp>1698.816</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2897.72</hp>
+			<mp>985.5</mp>
+			<cp>1738.632</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2964.5</hp>
+			<mp>1009.35</mp>
+			<cp>1778.7</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>3031.7</hp>
+			<mp>1033.35</mp>
+			<cp>1819.02</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>3099.32</hp>
+			<mp>1057.5</mp>
+			<cp>1859.592</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>3167.36</hp>
+			<mp>1081.8</mp>
+			<cp>1900.416</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3235.82</hp>
+			<mp>1106.25</mp>
+			<cp>1941.492</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3304.7</hp>
+			<mp>1130.85</mp>
+			<cp>1982.82</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3374.0</hp>
+			<mp>1155.6</mp>
+			<cp>2024.4</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3443.72</hp>
+			<mp>1180.5</mp>
+			<cp>2066.232</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3513.86</hp>
+			<mp>1205.55</mp>
+			<cp>2108.316</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3584.42</hp>
+			<mp>1230.75</mp>
+			<cp>2150.652</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3655.4</hp>
+			<mp>1256.1</mp>
+			<cp>2193.24</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3726.8</hp>
+			<mp>1281.6</mp>
+			<cp>2236.08</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3798.62</hp>
+			<mp>1307.25</mp>
+			<cp>2279.172</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3870.86</hp>
+			<mp>1333.05</mp>
+			<cp>2322.516</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3943.52</hp>
+			<mp>1359.0</mp>
+			<cp>2366.112</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>4016.6</hp>
+			<mp>1385.1</mp>
+			<cp>2409.96</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>4090.1</hp>
+			<mp>1411.35</mp>
+			<cp>2454.06</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>4164.02</hp>
+			<mp>1437.75</mp>
+			<cp>2498.412</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4238.36</hp>
+			<mp>1464.3</mp>
+			<cp>2543.016</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4313.12</hp>
+			<mp>1491.0</mp>
+			<cp>2587.872</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4388.3</hp>
+			<mp>1517.85</mp>
+			<cp>2632.98</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4463.9</hp>
+			<mp>1544.85</mp>
+			<cp>2678.34</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4539.92</hp>
+			<mp>1572.0</mp>
+			<cp>2723.952</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4616.36</hp>
+			<mp>1599.3</mp>
+			<cp>2769.816</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4693.22</hp>
+			<mp>1626.75</mp>
+			<cp>2815.932</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4770.5</hp>
+			<mp>1654.35</mp>
+			<cp>2862.3</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4848.2</hp>
+			<mp>1682.1</mp>
+			<cp>2908.92</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4926.32</hp>
+			<mp>1710.0</mp>
+			<cp>2955.792</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>5004.86</hp>
+			<mp>1738.05</mp>
+			<cp>3002.916</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>5083.82</hp>
+			<mp>1766.25</mp>
+			<cp>3050.292</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>5163.2</hp>
+			<mp>1794.6</mp>
+			<cp>3097.92</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>5243</hp>
+			<mp>1823.1</mp>
+			<cp>3145.79</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5323.22</hp>
+			<mp>1851.75</mp>
+			<cp>3193.92</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5403.86</hp>
+			<mp>1880.55</mp>
+			<cp>3242.3</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5484.92</hp>
+			<mp>1909.5</mp>
+			<cp>3290.92</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5566.4</hp>
+			<mp>1938.6</mp>
+			<cp>3339.8</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5648.3</hp>
+			<mp>1967.85</mp>
+			<cp>3388.92</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5730.62</hp>
+			<mp>1997.25</mp>
+			<cp>3438.372</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
+</list>

--- a/data/stats/chars/baseStats/DarkFighter.xml
+++ b/data/stats/chars/baseStats/DarkFighter.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>31</classId>
-    <staticData>
-        <baseINT>25</baseINT>
-        <baseSTR>41</baseSTR>
-        <baseCON>32</baseCON>
-        <baseMEN>26</baseMEN>
-        <baseDEX>34</baseDEX>
-        <baseWIT>12</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>15</magicAbnormalResist>
-        <creationPoints>
-            <node x="28295" y="11063" z="-4224"/>
-            <node x="28302" y="11008" z="-4224"/>
-            <node x="28377" y="10916" z="-4224"/>
-            <node x="28456" y="10997" z="-4224"/>
-            <node x="28461" y="11044" z="-4224"/>
-            <node x="28395" y="11127" z="-4224"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>85</walk>
-            <run>139</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>150</baseBreath>
-        <baseSafeFall>350</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>24</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.0</radius>
-            <height>23.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>94.0</hp>
-            <mp>30.0</mp>
-            <cp>37.6</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>107.65</hp>
-            <mp>35.46</mp>
-            <cp>43.06</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>121.45</hp>
-            <mp>40.98</mp>
-            <cp>48.58</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>135.4</hp>
-            <mp>46.56</mp>
-            <cp>54.16</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>149.5</hp>
-            <mp>52.2</mp>
-            <cp>59.8</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>163.75</hp>
-            <mp>57.9</mp>
-            <cp>65.5</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>178.15</hp>
-            <mp>63.66</mp>
-            <cp>71.26</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>192.7</hp>
-            <mp>69.48</mp>
-            <cp>77.08</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>207.4</hp>
-            <mp>75.36</mp>
-            <cp>82.96</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>222.25</hp>
-            <mp>81.3</mp>
-            <cp>88.9</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>237.25</hp>
-            <mp>87.3</mp>
-            <cp>94.9</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>252.4</hp>
-            <mp>93.36</mp>
-            <cp>100.96</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>267.7</hp>
-            <mp>99.48</mp>
-            <cp>107.08</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>283.15</hp>
-            <mp>105.66</mp>
-            <cp>113.26</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>298.75</hp>
-            <mp>111.9</mp>
-            <cp>119.5</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>314.5</hp>
-            <mp>118.2</mp>
-            <cp>125.8</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>330.4</hp>
-            <mp>124.56</mp>
-            <cp>132.16</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>346.45</hp>
-            <mp>130.98</mp>
-            <cp>138.58</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>362.65</hp>
-            <mp>137.46</mp>
-            <cp>145.06</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>379.0</hp>
-            <mp>144.0</mp>
-            <cp>151.6</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>395.5</hp>
-            <mp>150.6</mp>
-            <cp>158.2</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>412.15</hp>
-            <mp>157.26</mp>
-            <cp>164.86</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>428.95</hp>
-            <mp>163.98</mp>
-            <cp>171.58</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>445.9</hp>
-            <mp>170.76</mp>
-            <cp>178.36</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>463.0</hp>
-            <mp>177.6</mp>
-            <cp>185.2</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>480.25</hp>
-            <mp>184.5</mp>
-            <cp>192.1</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>497.65</hp>
-            <mp>191.46</mp>
-            <cp>199.06</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>515.2</hp>
-            <mp>198.48</mp>
-            <cp>206.08</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>532.9</hp>
-            <mp>205.56</mp>
-            <cp>213.16</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>550.75</hp>
-            <mp>212.7</mp>
-            <cp>220.3</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>568.75</hp>
-            <mp>219.9</mp>
-            <cp>227.5</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>586.9</hp>
-            <mp>227.16</mp>
-            <cp>234.76</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>605.2</hp>
-            <mp>234.48</mp>
-            <cp>242.08</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>623.65</hp>
-            <mp>241.86</mp>
-            <cp>249.46</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>642.25</hp>
-            <mp>249.3</mp>
-            <cp>256.9</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>661.0</hp>
-            <mp>256.8</mp>
-            <cp>264.4</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>679.9</hp>
-            <mp>264.36</mp>
-            <cp>271.96</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>698.95</hp>
-            <mp>271.98</mp>
-            <cp>279.58</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>718.15</hp>
-            <mp>279.66</mp>
-            <cp>287.26</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>737.5</hp>
-            <mp>287.4</mp>
-            <cp>295.0</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>757.0</hp>
-            <mp>295.2</mp>
-            <cp>302.8</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>776.65</hp>
-            <mp>303.06</mp>
-            <cp>310.66</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>796.45</hp>
-            <mp>310.98</mp>
-            <cp>318.58</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>816.4</hp>
-            <mp>318.96</mp>
-            <cp>326.56</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>836.5</hp>
-            <mp>327.0</mp>
-            <cp>334.6</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>856.75</hp>
-            <mp>335.1</mp>
-            <cp>342.7</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>877.15</hp>
-            <mp>343.26</mp>
-            <cp>350.86</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>897.7</hp>
-            <mp>351.48</mp>
-            <cp>359.08</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>918.4</hp>
-            <mp>359.76</mp>
-            <cp>367.36</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>939.25</hp>
-            <mp>368.1</mp>
-            <cp>375.7</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>960.25</hp>
-            <mp>376.5</mp>
-            <cp>384.1</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>981.4</hp>
-            <mp>384.96</mp>
-            <cp>392.56</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1002.7</hp>
-            <mp>393.48</mp>
-            <cp>401.08</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1024.15</hp>
-            <mp>402.06</mp>
-            <cp>409.66</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1045.75</hp>
-            <mp>410.7</mp>
-            <cp>418.3</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1067.5</hp>
-            <mp>419.4</mp>
-            <cp>427.0</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1089.4</hp>
-            <mp>428.16</mp>
-            <cp>435.76</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1111.45</hp>
-            <mp>436.98</mp>
-            <cp>444.58</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>1133.65</hp>
-            <mp>445.86</mp>
-            <cp>453.46</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>1156.0</hp>
-            <mp>454.8</mp>
-            <cp>462.4</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>1178.5</hp>
-            <mp>463.8</mp>
-            <cp>471.4</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>1201.15</hp>
-            <mp>472.86</mp>
-            <cp>480.46</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>1223.95</hp>
-            <mp>481.98</mp>
-            <cp>489.58</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>1246.9</hp>
-            <mp>491.16</mp>
-            <cp>498.76</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>1270.0</hp>
-            <mp>500.4</mp>
-            <cp>508.0</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>1293.25</hp>
-            <mp>509.7</mp>
-            <cp>517.3</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>1316.65</hp>
-            <mp>519.06</mp>
-            <cp>526.66</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>1340.2</hp>
-            <mp>528.48</mp>
-            <cp>536.08</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>1363.9</hp>
-            <mp>537.96</mp>
-            <cp>545.56</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>1387.75</hp>
-            <mp>547.5</mp>
-            <cp>555.1</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>1411.75</hp>
-            <mp>557.1</mp>
-            <cp>564.7</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>1435.9</hp>
-            <mp>566.76</mp>
-            <cp>574.36</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>1460.2</hp>
-            <mp>576.48</mp>
-            <cp>584.08</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>1484.65</hp>
-            <mp>586.26</mp>
-            <cp>593.86</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>1509.25</hp>
-            <mp>596.1</mp>
-            <cp>603.7</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>1534.0</hp>
-            <mp>606.0</mp>
-            <cp>613.6</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>1558.9</hp>
-            <mp>615.96</mp>
-            <cp>623.56</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>1583.95</hp>
-            <mp>625.98</mp>
-            <cp>633.58</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>1609.15</hp>
-            <mp>636.06</mp>
-            <cp>643.66</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>1634.5</hp>
-            <mp>646.2</mp>
-            <cp>653.8</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>1660.0</hp>
-            <mp>656.4</mp>
-            <cp>664.0</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>1685.65</hp>
-            <mp>666.66</mp>
-            <cp>674.26</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>1711.45</hp>
-            <mp>676.98</mp>
-            <cp>684.58</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>1737.4</hp>
-            <mp>687.36</mp>
-            <cp>694.96</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>1763.5</hp>
-            <mp>697.8</mp>
-            <cp>705.4</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>1789.75</hp>
-            <mp>708.3</mp>
-            <cp>715.9</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>1816.15</hp>
-            <mp>718.86</mp>
-            <cp>726.46</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>1842.7</hp>
-            <mp>729.48</mp>
-            <cp>737.08</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>1869.4</hp>
-            <mp>740.16</mp>
-            <cp>747.76</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>1896.25</hp>
-            <mp>750.9</mp>
-            <cp>758.5</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>1923.25</hp>
-            <mp>761.7</mp>
-            <cp>769.3</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>31</classId>
+	<staticData>
+		<baseINT>25</baseINT>
+		<baseSTR>41</baseSTR>
+		<baseCON>32</baseCON>
+		<baseMEN>26</baseMEN>
+		<baseDEX>34</baseDEX>
+		<baseWIT>12</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="28295" y="11063" z="-4224" />
+			<node x="28302" y="11008" z="-4224" />
+			<node x="28377" y="10916" z="-4224" />
+			<node x="28456" y="10997" z="-4224" />
+			<node x="28461" y="11044" z="-4224" />
+			<node x="28395" y="11127" z="-4224" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>85</walk>
+			<run>139</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>350</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>94.0</hp>
+			<mp>30.0</mp>
+			<cp>37.6</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>107.65</hp>
+			<mp>35.46</mp>
+			<cp>43.06</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>121.45</hp>
+			<mp>40.98</mp>
+			<cp>48.58</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>135.4</hp>
+			<mp>46.56</mp>
+			<cp>54.16</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>149.5</hp>
+			<mp>52.2</mp>
+			<cp>59.8</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>163.75</hp>
+			<mp>57.9</mp>
+			<cp>65.5</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>178.15</hp>
+			<mp>63.66</mp>
+			<cp>71.26</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>192.7</hp>
+			<mp>69.48</mp>
+			<cp>77.08</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>207.4</hp>
+			<mp>75.36</mp>
+			<cp>82.96</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>222.25</hp>
+			<mp>81.3</mp>
+			<cp>88.9</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>237.25</hp>
+			<mp>87.3</mp>
+			<cp>94.9</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>252.4</hp>
+			<mp>93.36</mp>
+			<cp>100.96</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>267.7</hp>
+			<mp>99.48</mp>
+			<cp>107.08</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>283.15</hp>
+			<mp>105.66</mp>
+			<cp>113.26</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>298.75</hp>
+			<mp>111.9</mp>
+			<cp>119.5</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>314.5</hp>
+			<mp>118.2</mp>
+			<cp>125.8</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>330.4</hp>
+			<mp>124.56</mp>
+			<cp>132.16</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>346.45</hp>
+			<mp>130.98</mp>
+			<cp>138.58</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>362.65</hp>
+			<mp>137.46</mp>
+			<cp>145.06</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>379.0</hp>
+			<mp>144.0</mp>
+			<cp>151.6</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>395.5</hp>
+			<mp>150.6</mp>
+			<cp>158.2</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>412.15</hp>
+			<mp>157.26</mp>
+			<cp>164.86</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>428.95</hp>
+			<mp>163.98</mp>
+			<cp>171.58</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>445.9</hp>
+			<mp>170.76</mp>
+			<cp>178.36</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>463.0</hp>
+			<mp>177.6</mp>
+			<cp>185.2</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>480.25</hp>
+			<mp>184.5</mp>
+			<cp>192.1</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>497.65</hp>
+			<mp>191.46</mp>
+			<cp>199.06</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>515.2</hp>
+			<mp>198.48</mp>
+			<cp>206.08</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>532.9</hp>
+			<mp>205.56</mp>
+			<cp>213.16</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>550.75</hp>
+			<mp>212.7</mp>
+			<cp>220.3</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>568.75</hp>
+			<mp>219.9</mp>
+			<cp>227.5</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>586.9</hp>
+			<mp>227.16</mp>
+			<cp>234.76</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>605.2</hp>
+			<mp>234.48</mp>
+			<cp>242.08</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>623.65</hp>
+			<mp>241.86</mp>
+			<cp>249.46</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>642.25</hp>
+			<mp>249.3</mp>
+			<cp>256.9</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>661.0</hp>
+			<mp>256.8</mp>
+			<cp>264.4</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>679.9</hp>
+			<mp>264.36</mp>
+			<cp>271.96</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>698.95</hp>
+			<mp>271.98</mp>
+			<cp>279.58</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>718.15</hp>
+			<mp>279.66</mp>
+			<cp>287.26</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>737.5</hp>
+			<mp>287.4</mp>
+			<cp>295.0</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>757.0</hp>
+			<mp>295.2</mp>
+			<cp>302.8</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>776.65</hp>
+			<mp>303.06</mp>
+			<cp>310.66</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>796.45</hp>
+			<mp>310.98</mp>
+			<cp>318.58</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>816.4</hp>
+			<mp>318.96</mp>
+			<cp>326.56</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>836.5</hp>
+			<mp>327.0</mp>
+			<cp>334.6</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>856.75</hp>
+			<mp>335.1</mp>
+			<cp>342.7</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>877.15</hp>
+			<mp>343.26</mp>
+			<cp>350.86</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>897.7</hp>
+			<mp>351.48</mp>
+			<cp>359.08</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>918.4</hp>
+			<mp>359.76</mp>
+			<cp>367.36</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>939.25</hp>
+			<mp>368.1</mp>
+			<cp>375.7</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>960.25</hp>
+			<mp>376.5</mp>
+			<cp>384.1</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>981.4</hp>
+			<mp>384.96</mp>
+			<cp>392.56</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1002.7</hp>
+			<mp>393.48</mp>
+			<cp>401.08</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1024.15</hp>
+			<mp>402.06</mp>
+			<cp>409.66</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1045.75</hp>
+			<mp>410.7</mp>
+			<cp>418.3</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1067.5</hp>
+			<mp>419.4</mp>
+			<cp>427.0</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1089.4</hp>
+			<mp>428.16</mp>
+			<cp>435.76</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1111.45</hp>
+			<mp>436.98</mp>
+			<cp>444.58</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1133.65</hp>
+			<mp>445.86</mp>
+			<cp>453.46</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1156.0</hp>
+			<mp>454.8</mp>
+			<cp>462.4</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>1178.5</hp>
+			<mp>463.8</mp>
+			<cp>471.4</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>1201.15</hp>
+			<mp>472.86</mp>
+			<cp>480.46</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>1223.95</hp>
+			<mp>481.98</mp>
+			<cp>489.58</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>1246.9</hp>
+			<mp>491.16</mp>
+			<cp>498.76</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>1270.0</hp>
+			<mp>500.4</mp>
+			<cp>508.0</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>1293.25</hp>
+			<mp>509.7</mp>
+			<cp>517.3</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>1316.65</hp>
+			<mp>519.06</mp>
+			<cp>526.66</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>1340.2</hp>
+			<mp>528.48</mp>
+			<cp>536.08</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>1363.9</hp>
+			<mp>537.96</mp>
+			<cp>545.56</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>1387.75</hp>
+			<mp>547.5</mp>
+			<cp>555.1</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>1411.75</hp>
+			<mp>557.1</mp>
+			<cp>564.7</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>1435.9</hp>
+			<mp>566.76</mp>
+			<cp>574.36</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>1460.2</hp>
+			<mp>576.48</mp>
+			<cp>584.08</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>1484.65</hp>
+			<mp>586.26</mp>
+			<cp>593.86</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>1509.25</hp>
+			<mp>596.1</mp>
+			<cp>603.7</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>1534.0</hp>
+			<mp>606.0</mp>
+			<cp>613.6</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>1558.9</hp>
+			<mp>615.96</mp>
+			<cp>623.56</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>1583.95</hp>
+			<mp>625.98</mp>
+			<cp>633.58</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>1609.15</hp>
+			<mp>636.06</mp>
+			<cp>643.66</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>1634.5</hp>
+			<mp>646.2</mp>
+			<cp>653.8</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>1660.0</hp>
+			<mp>656.4</mp>
+			<cp>664.0</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>1685.65</hp>
+			<mp>666.66</mp>
+			<cp>674.26</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>1711.45</hp>
+			<mp>676.98</mp>
+			<cp>684.58</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>1737.4</hp>
+			<mp>687.36</mp>
+			<cp>694.96</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>1763.5</hp>
+			<mp>697.8</mp>
+			<cp>705.4</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>1789.75</hp>
+			<mp>708.3</mp>
+			<cp>715.9</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>1816.15</hp>
+			<mp>718.86</mp>
+			<cp>726.46</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>1842.7</hp>
+			<mp>729.48</mp>
+			<cp>737.08</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>1869.4</hp>
+			<mp>740.16</mp>
+			<cp>747.76</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>1896.25</hp>
+			<mp>750.9</mp>
+			<cp>758.5</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>1923.25</hp>
+			<mp>761.7</mp>
+			<cp>769.3</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>1950.4</hp>
+			<mp>772.56</mp>
+			<cp>780.16</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>1977.7</hp>
+			<mp>783.48</mp>
+			<cp>791.08</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>2005.15</hp>
+			<mp>794.46</mp>
+			<cp>802.06</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>2032.75</hp>
+			<mp>805.5</mp>
+			<cp>813.1</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>2060.5</hp>
+			<mp>816.6</mp>
+			<cp>824.2</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>2088.4</hp>
+			<mp>827.76</mp>
+			<cp>835.36</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>2116.45</hp>
+			<mp>838.98</mp>
+			<cp>846.58</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>2144.65</hp>
+			<mp>850.26</mp>
+			<cp>857.86</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>2173</hp>
+			<mp>861.6</mp>
+			<cp>869.2</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>2201.5</hp>
+			<mp>873</mp>
+			<cp>880.6</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>2230.15</hp>
+			<mp>884.46</mp>
+			<cp>892.06</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>2258.95</hp>
+			<mp>895.98</mp>
+			<cp>903.58</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>2287.9</hp>
+			<mp>907.56</mp>
+			<cp>915.16</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>2317</hp>
+			<mp>919.2</mp>
+			<cp>926.8</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>2346.25</hp>
+			<mp>930.9</mp>
+			<cp>938.5</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>2375.65</hp>
+			<mp>942.66</mp>
+			<cp>950.26</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/DarkMystic.xml
+++ b/data/stats/chars/baseStats/DarkMystic.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>38</classId>
-    <staticData>
-        <baseINT>44</baseINT>
-        <baseSTR>23</baseSTR>
-        <baseCON>24</baseCON>
-        <baseMEN>37</baseMEN>
-        <baseDEX>23</baseDEX>
-        <baseWIT>19</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>15</magicAbnormalResist>
-        <creationPoints>
-            <node x="28295" y="11063" z="-4224"/>
-            <node x="28302" y="11008" z="-4224"/>
-            <node x="28377" y="10916" z="-4224"/>
-            <node x="28456" y="10997" z="-4224"/>
-            <node x="28461" y="11044" z="-4224"/>
-            <node x="28395" y="11127" z="-4224"/>
-        </creationPoints>
-        <basePAtk>3</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>15</chest>
-            <legs>8</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>85</walk>
-            <run>128</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>150</baseBreath>
-        <baseSafeFall>300</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>24</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.0</radius>
-            <height>23.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>106.0</hp>
-            <mp>40.0</mp>
-            <cp>53.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>121.47</hp>
-            <mp>47.28</mp>
-            <cp>60.735</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>137.11</hp>
-            <mp>54.64</mp>
-            <cp>68.555</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>152.92</hp>
-            <mp>62.08</mp>
-            <cp>76.46</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>168.9</hp>
-            <mp>69.6</mp>
-            <cp>84.45</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>185.05</hp>
-            <mp>77.2</mp>
-            <cp>92.525</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>201.37</hp>
-            <mp>84.88</mp>
-            <cp>100.685</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>217.86</hp>
-            <mp>92.64</mp>
-            <cp>108.93</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>234.52</hp>
-            <mp>100.48</mp>
-            <cp>117.26</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>251.35</hp>
-            <mp>108.4</mp>
-            <cp>125.675</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>268.35</hp>
-            <mp>116.4</mp>
-            <cp>134.175</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>285.52</hp>
-            <mp>124.48</mp>
-            <cp>142.76</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>302.86</hp>
-            <mp>132.64</mp>
-            <cp>151.43</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>320.37</hp>
-            <mp>140.88</mp>
-            <cp>160.185</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>338.05</hp>
-            <mp>149.2</mp>
-            <cp>169.025</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>355.9</hp>
-            <mp>157.6</mp>
-            <cp>177.95</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>373.92</hp>
-            <mp>166.08</mp>
-            <cp>186.96</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>392.11</hp>
-            <mp>174.64</mp>
-            <cp>196.055</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>410.47</hp>
-            <mp>183.28</mp>
-            <cp>205.235</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>429.0</hp>
-            <mp>192.0</mp>
-            <cp>214.5</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>447.7</hp>
-            <mp>200.8</mp>
-            <cp>223.85</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>466.57</hp>
-            <mp>209.68</mp>
-            <cp>233.285</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>485.61</hp>
-            <mp>218.64</mp>
-            <cp>242.805</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>504.82</hp>
-            <mp>227.68</mp>
-            <cp>252.41</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>524.2</hp>
-            <mp>236.8</mp>
-            <cp>262.1</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>543.75</hp>
-            <mp>246.0</mp>
-            <cp>271.875</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>563.47</hp>
-            <mp>255.28</mp>
-            <cp>281.735</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>583.36</hp>
-            <mp>264.64</mp>
-            <cp>291.68</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>603.42</hp>
-            <mp>274.08</mp>
-            <cp>301.71</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>623.65</hp>
-            <mp>283.6</mp>
-            <cp>311.825</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>644.05</hp>
-            <mp>293.2</mp>
-            <cp>322.025</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>664.62</hp>
-            <mp>302.88</mp>
-            <cp>332.31</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>685.36</hp>
-            <mp>312.64</mp>
-            <cp>342.68</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>706.27</hp>
-            <mp>322.48</mp>
-            <cp>353.135</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>727.35</hp>
-            <mp>332.4</mp>
-            <cp>363.675</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>748.6</hp>
-            <mp>342.4</mp>
-            <cp>374.3</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>770.02</hp>
-            <mp>352.48</mp>
-            <cp>385.01</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>791.61</hp>
-            <mp>362.64</mp>
-            <cp>395.805</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>813.37</hp>
-            <mp>372.88</mp>
-            <cp>406.685</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>835.3</hp>
-            <mp>383.2</mp>
-            <cp>417.65</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>857.4</hp>
-            <mp>393.6</mp>
-            <cp>428.7</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>879.67</hp>
-            <mp>404.08</mp>
-            <cp>439.835</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>902.11</hp>
-            <mp>414.64</mp>
-            <cp>451.055</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>924.72</hp>
-            <mp>425.28</mp>
-            <cp>462.36</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>947.5</hp>
-            <mp>436.0</mp>
-            <cp>473.75</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>970.45</hp>
-            <mp>446.8</mp>
-            <cp>485.225</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>993.57</hp>
-            <mp>457.68</mp>
-            <cp>496.785</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1016.86</hp>
-            <mp>468.64</mp>
-            <cp>508.43</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1040.32</hp>
-            <mp>479.68</mp>
-            <cp>520.16</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1063.95</hp>
-            <mp>490.8</mp>
-            <cp>531.975</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1087.75</hp>
-            <mp>502.0</mp>
-            <cp>543.875</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1111.72</hp>
-            <mp>513.28</mp>
-            <cp>555.86</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1135.86</hp>
-            <mp>524.64</mp>
-            <cp>567.93</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1160.17</hp>
-            <mp>536.08</mp>
-            <cp>580.085</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1184.65</hp>
-            <mp>547.6</mp>
-            <cp>592.325</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1209.3</hp>
-            <mp>559.2</mp>
-            <cp>604.65</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1234.12</hp>
-            <mp>570.88</mp>
-            <cp>617.06</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1259.11</hp>
-            <mp>582.64</mp>
-            <cp>629.555</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>1284.27</hp>
-            <mp>594.48</mp>
-            <cp>642.135</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>1309.6</hp>
-            <mp>606.4</mp>
-            <cp>654.8</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>1335.1</hp>
-            <mp>618.4</mp>
-            <cp>667.55</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>1360.77</hp>
-            <mp>630.48</mp>
-            <cp>680.385</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>1386.61</hp>
-            <mp>642.64</mp>
-            <cp>693.305</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>1412.62</hp>
-            <mp>654.88</mp>
-            <cp>706.31</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>1438.8</hp>
-            <mp>667.2</mp>
-            <cp>719.4</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>1465.15</hp>
-            <mp>679.6</mp>
-            <cp>732.575</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>1491.67</hp>
-            <mp>692.08</mp>
-            <cp>745.835</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>1518.36</hp>
-            <mp>704.64</mp>
-            <cp>759.18</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>1545.22</hp>
-            <mp>717.28</mp>
-            <cp>772.61</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>1572.25</hp>
-            <mp>730.0</mp>
-            <cp>786.125</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>1599.45</hp>
-            <mp>742.8</mp>
-            <cp>799.725</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>1626.82</hp>
-            <mp>755.68</mp>
-            <cp>813.41</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>1654.36</hp>
-            <mp>768.64</mp>
-            <cp>827.18</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>1682.07</hp>
-            <mp>781.68</mp>
-            <cp>841.035</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>1709.95</hp>
-            <mp>794.8</mp>
-            <cp>854.975</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>1738.0</hp>
-            <mp>808.0</mp>
-            <cp>869.0</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>1766.22</hp>
-            <mp>821.28</mp>
-            <cp>883.11</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>1794.61</hp>
-            <mp>834.64</mp>
-            <cp>897.305</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>1823.17</hp>
-            <mp>848.08</mp>
-            <cp>911.585</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>1851.9</hp>
-            <mp>861.6</mp>
-            <cp>925.95</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>1880.8</hp>
-            <mp>875.2</mp>
-            <cp>940.4</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>1909.87</hp>
-            <mp>888.88</mp>
-            <cp>954.935</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>1939.11</hp>
-            <mp>902.64</mp>
-            <cp>969.555</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>1968.52</hp>
-            <mp>916.48</mp>
-            <cp>984.26</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>1998.1</hp>
-            <mp>930.4</mp>
-            <cp>999.05</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>2027.85</hp>
-            <mp>944.4</mp>
-            <cp>1013.925</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>2057.77</hp>
-            <mp>958.48</mp>
-            <cp>1028.885</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>2087.86</hp>
-            <mp>972.64</mp>
-            <cp>1043.93</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>2118.12</hp>
-            <mp>986.88</mp>
-            <cp>1059.06</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>2148.55</hp>
-            <mp>1001.2</mp>
-            <cp>1074.275</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>2179.15</hp>
-            <mp>1015.6</mp>
-            <cp>1089.575</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>38</classId>
+	<staticData>
+		<baseINT>44</baseINT>
+		<baseSTR>23</baseSTR>
+		<baseCON>24</baseCON>
+		<baseMEN>37</baseMEN>
+		<baseDEX>23</baseDEX>
+		<baseWIT>19</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="28295" y="11063" z="-4224" />
+			<node x="28302" y="11008" z="-4224" />
+			<node x="28377" y="10916" z="-4224" />
+			<node x="28456" y="10997" z="-4224" />
+			<node x="28461" y="11044" z="-4224" />
+			<node x="28395" y="11127" z="-4224" />
+		</creationPoints>
+		<basePAtk>3</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>15</chest>
+			<legs>8</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>85</walk>
+			<run>128</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>300</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>106.0</hp>
+			<mp>40.0</mp>
+			<cp>53.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>121.47</hp>
+			<mp>47.28</mp>
+			<cp>60.735</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>137.11</hp>
+			<mp>54.64</mp>
+			<cp>68.555</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>152.92</hp>
+			<mp>62.08</mp>
+			<cp>76.46</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>168.9</hp>
+			<mp>69.6</mp>
+			<cp>84.45</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>185.05</hp>
+			<mp>77.2</mp>
+			<cp>92.525</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>201.37</hp>
+			<mp>84.88</mp>
+			<cp>100.685</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>217.86</hp>
+			<mp>92.64</mp>
+			<cp>108.93</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>234.52</hp>
+			<mp>100.48</mp>
+			<cp>117.26</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>251.35</hp>
+			<mp>108.4</mp>
+			<cp>125.675</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>268.35</hp>
+			<mp>116.4</mp>
+			<cp>134.175</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>285.52</hp>
+			<mp>124.48</mp>
+			<cp>142.76</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>302.86</hp>
+			<mp>132.64</mp>
+			<cp>151.43</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>320.37</hp>
+			<mp>140.88</mp>
+			<cp>160.185</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>338.05</hp>
+			<mp>149.2</mp>
+			<cp>169.025</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>355.9</hp>
+			<mp>157.6</mp>
+			<cp>177.95</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>373.92</hp>
+			<mp>166.08</mp>
+			<cp>186.96</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>392.11</hp>
+			<mp>174.64</mp>
+			<cp>196.055</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>410.47</hp>
+			<mp>183.28</mp>
+			<cp>205.235</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>429.0</hp>
+			<mp>192.0</mp>
+			<cp>214.5</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>447.7</hp>
+			<mp>200.8</mp>
+			<cp>223.85</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>466.57</hp>
+			<mp>209.68</mp>
+			<cp>233.285</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>485.61</hp>
+			<mp>218.64</mp>
+			<cp>242.805</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>504.82</hp>
+			<mp>227.68</mp>
+			<cp>252.41</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>524.2</hp>
+			<mp>236.8</mp>
+			<cp>262.1</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>543.75</hp>
+			<mp>246.0</mp>
+			<cp>271.875</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>563.47</hp>
+			<mp>255.28</mp>
+			<cp>281.735</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>583.36</hp>
+			<mp>264.64</mp>
+			<cp>291.68</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>603.42</hp>
+			<mp>274.08</mp>
+			<cp>301.71</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>623.65</hp>
+			<mp>283.6</mp>
+			<cp>311.825</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>644.05</hp>
+			<mp>293.2</mp>
+			<cp>322.025</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>664.62</hp>
+			<mp>302.88</mp>
+			<cp>332.31</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>685.36</hp>
+			<mp>312.64</mp>
+			<cp>342.68</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>706.27</hp>
+			<mp>322.48</mp>
+			<cp>353.135</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>727.35</hp>
+			<mp>332.4</mp>
+			<cp>363.675</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>748.6</hp>
+			<mp>342.4</mp>
+			<cp>374.3</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>770.02</hp>
+			<mp>352.48</mp>
+			<cp>385.01</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>791.61</hp>
+			<mp>362.64</mp>
+			<cp>395.805</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>813.37</hp>
+			<mp>372.88</mp>
+			<cp>406.685</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>835.3</hp>
+			<mp>383.2</mp>
+			<cp>417.65</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>857.4</hp>
+			<mp>393.6</mp>
+			<cp>428.7</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>879.67</hp>
+			<mp>404.08</mp>
+			<cp>439.835</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>902.11</hp>
+			<mp>414.64</mp>
+			<cp>451.055</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>924.72</hp>
+			<mp>425.28</mp>
+			<cp>462.36</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>947.5</hp>
+			<mp>436.0</mp>
+			<cp>473.75</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>970.45</hp>
+			<mp>446.8</mp>
+			<cp>485.225</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>993.57</hp>
+			<mp>457.68</mp>
+			<cp>496.785</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1016.86</hp>
+			<mp>468.64</mp>
+			<cp>508.43</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1040.32</hp>
+			<mp>479.68</mp>
+			<cp>520.16</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1063.95</hp>
+			<mp>490.8</mp>
+			<cp>531.975</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1087.75</hp>
+			<mp>502.0</mp>
+			<cp>543.875</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1111.72</hp>
+			<mp>513.28</mp>
+			<cp>555.86</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1135.86</hp>
+			<mp>524.64</mp>
+			<cp>567.93</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1160.17</hp>
+			<mp>536.08</mp>
+			<cp>580.085</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1184.65</hp>
+			<mp>547.6</mp>
+			<cp>592.325</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1209.3</hp>
+			<mp>559.2</mp>
+			<cp>604.65</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1234.12</hp>
+			<mp>570.88</mp>
+			<cp>617.06</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1259.11</hp>
+			<mp>582.64</mp>
+			<cp>629.555</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1284.27</hp>
+			<mp>594.48</mp>
+			<cp>642.135</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1309.6</hp>
+			<mp>606.4</mp>
+			<cp>654.8</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>1335.1</hp>
+			<mp>618.4</mp>
+			<cp>667.55</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>1360.77</hp>
+			<mp>630.48</mp>
+			<cp>680.385</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>1386.61</hp>
+			<mp>642.64</mp>
+			<cp>693.305</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>1412.62</hp>
+			<mp>654.88</mp>
+			<cp>706.31</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>1438.8</hp>
+			<mp>667.2</mp>
+			<cp>719.4</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>1465.15</hp>
+			<mp>679.6</mp>
+			<cp>732.575</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>1491.67</hp>
+			<mp>692.08</mp>
+			<cp>745.835</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>1518.36</hp>
+			<mp>704.64</mp>
+			<cp>759.18</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>1545.22</hp>
+			<mp>717.28</mp>
+			<cp>772.61</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>1572.25</hp>
+			<mp>730.0</mp>
+			<cp>786.125</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>1599.45</hp>
+			<mp>742.8</mp>
+			<cp>799.725</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>1626.82</hp>
+			<mp>755.68</mp>
+			<cp>813.41</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>1654.36</hp>
+			<mp>768.64</mp>
+			<cp>827.18</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>1682.07</hp>
+			<mp>781.68</mp>
+			<cp>841.035</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>1709.95</hp>
+			<mp>794.8</mp>
+			<cp>854.975</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>1738.0</hp>
+			<mp>808.0</mp>
+			<cp>869.0</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>1766.22</hp>
+			<mp>821.28</mp>
+			<cp>883.11</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>1794.61</hp>
+			<mp>834.64</mp>
+			<cp>897.305</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>1823.17</hp>
+			<mp>848.08</mp>
+			<cp>911.585</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>1851.9</hp>
+			<mp>861.6</mp>
+			<cp>925.95</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>1880.8</hp>
+			<mp>875.2</mp>
+			<cp>940.4</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>1909.87</hp>
+			<mp>888.88</mp>
+			<cp>954.935</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>1939.11</hp>
+			<mp>902.64</mp>
+			<cp>969.555</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>1968.52</hp>
+			<mp>916.48</mp>
+			<cp>984.26</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>1998.1</hp>
+			<mp>930.4</mp>
+			<cp>999.05</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>2027.85</hp>
+			<mp>944.4</mp>
+			<cp>1013.925</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>2057.77</hp>
+			<mp>958.48</mp>
+			<cp>1028.885</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>2087.86</hp>
+			<mp>972.64</mp>
+			<cp>1043.93</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>2118.12</hp>
+			<mp>986.88</mp>
+			<cp>1059.06</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>2148.55</hp>
+			<mp>1001.2</mp>
+			<cp>1074.275</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>2179.15</hp>
+			<mp>1015.6</mp>
+			<cp>1089.575</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>2209.92</hp>
+			<mp>1030.08</mp>
+			<cp>1104.96</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>2240.86</hp>
+			<mp>1044.64</mp>
+			<cp>1120.43</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>2271.97</hp>
+			<mp>1059.28</mp>
+			<cp>1135.985</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>2303.25</hp>
+			<mp>1074.0</mp>
+			<cp>1151.625</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>2334.7</hp>
+			<mp>1088.8</mp>
+			<cp>1167.35</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>2366.32</hp>
+			<mp>1103.68</mp>
+			<cp>1183.16</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>2398.11</hp>
+			<mp>1118.64</mp>
+			<cp>1199.055</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>2430.07</hp>
+			<mp>1133.68</mp>
+			<cp>1215.035</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>2462.2</hp>
+			<mp>1148.8</mp>
+			<cp>1231.11</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>2494.5</hp>
+			<mp>1164</mp>
+			<cp>1247.27</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>2526.97</hp>
+			<mp>1179.28</mp>
+			<cp>1263.52</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>2559.61</hp>
+			<mp>1194.64</mp>
+			<cp>1279.86</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>2592.42</hp>
+			<mp>1210.08</mp>
+			<cp>1296.29</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>2625.4</hp>
+			<mp>1225.6</mp>
+			<cp>1312.81</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>2658.55</hp>
+			<mp>1241.2</mp>
+			<cp>1329.42</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>2691.87</hp>
+			<mp>1256.88</mp>
+			<cp>1345.935</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/DarkWizard.xml
+++ b/data/stats/chars/baseStats/DarkWizard.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>39</classId>
-    <staticData>
-        <baseINT>44</baseINT>
-        <baseSTR>23</baseSTR>
-        <baseCON>24</baseCON>
-        <baseMEN>37</baseMEN>
-        <baseDEX>23</baseDEX>
-        <baseWIT>19</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>15</magicAbnormalResist>
-        <creationPoints>
-            <node x="28295" y="11063" z="-4224"/>
-            <node x="28302" y="11008" z="-4224"/>
-            <node x="28377" y="10916" z="-4224"/>
-            <node x="28456" y="10997" z="-4224"/>
-            <node x="28461" y="11044" z="-4224"/>
-            <node x="28395" y="11127" z="-4224"/>
-        </creationPoints>
-        <basePAtk>3</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>15</chest>
-            <legs>8</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>85</walk>
-            <run>128</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>150</baseBreath>
-        <baseSafeFall>300</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>24</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.0</radius>
-            <height>23.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>106.0</hp>
-            <mp>40.0</mp>
-            <cp>53.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>121.47</hp>
-            <mp>47.28</mp>
-            <cp>60.735</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>137.11</hp>
-            <mp>54.64</mp>
-            <cp>68.555</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>152.92</hp>
-            <mp>62.08</mp>
-            <cp>76.46</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>168.9</hp>
-            <mp>69.6</mp>
-            <cp>84.45</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>185.05</hp>
-            <mp>77.2</mp>
-            <cp>92.525</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>201.37</hp>
-            <mp>84.88</mp>
-            <cp>100.685</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>217.86</hp>
-            <mp>92.64</mp>
-            <cp>108.93</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>234.52</hp>
-            <mp>100.48</mp>
-            <cp>117.26</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>251.35</hp>
-            <mp>108.4</mp>
-            <cp>125.675</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>268.35</hp>
-            <mp>116.4</mp>
-            <cp>134.175</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>285.52</hp>
-            <mp>124.48</mp>
-            <cp>142.76</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>302.86</hp>
-            <mp>132.64</mp>
-            <cp>151.43</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>320.37</hp>
-            <mp>140.88</mp>
-            <cp>160.185</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>338.05</hp>
-            <mp>149.2</mp>
-            <cp>169.025</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>355.9</hp>
-            <mp>157.6</mp>
-            <cp>177.95</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>373.92</hp>
-            <mp>166.08</mp>
-            <cp>186.96</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>392.11</hp>
-            <mp>174.64</mp>
-            <cp>196.055</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>410.47</hp>
-            <mp>183.28</mp>
-            <cp>205.235</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>429.0</hp>
-            <mp>192.0</mp>
-            <cp>214.5</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>458.7</hp>
-            <mp>205.2</mp>
-            <cp>229.35</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>488.67</hp>
-            <mp>218.52</mp>
-            <cp>244.335</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>518.91</hp>
-            <mp>231.96</mp>
-            <cp>259.455</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>549.42</hp>
-            <mp>245.52</mp>
-            <cp>274.71</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>580.2</hp>
-            <mp>259.2</mp>
-            <cp>290.1</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>611.25</hp>
-            <mp>273.0</mp>
-            <cp>305.625</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>642.57</hp>
-            <mp>286.92</mp>
-            <cp>321.285</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>674.16</hp>
-            <mp>300.96</mp>
-            <cp>337.08</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>706.02</hp>
-            <mp>315.12</mp>
-            <cp>353.01</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>738.15</hp>
-            <mp>329.4</mp>
-            <cp>369.075</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>770.55</hp>
-            <mp>343.8</mp>
-            <cp>385.275</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>803.22</hp>
-            <mp>358.32</mp>
-            <cp>401.61</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>836.16</hp>
-            <mp>372.96</mp>
-            <cp>418.08</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>869.37</hp>
-            <mp>387.72</mp>
-            <cp>434.685</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>902.85</hp>
-            <mp>402.6</mp>
-            <cp>451.425</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>936.6</hp>
-            <mp>417.6</mp>
-            <cp>468.3</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>970.62</hp>
-            <mp>432.72</mp>
-            <cp>485.31</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1004.91</hp>
-            <mp>447.96</mp>
-            <cp>502.455</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1039.47</hp>
-            <mp>463.32</mp>
-            <cp>519.735</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1074.3</hp>
-            <mp>478.8</mp>
-            <cp>537.15</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1109.4</hp>
-            <mp>494.4</mp>
-            <cp>554.7</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1144.77</hp>
-            <mp>510.12</mp>
-            <cp>572.385</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1180.41</hp>
-            <mp>525.96</mp>
-            <cp>590.205</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1216.32</hp>
-            <mp>541.92</mp>
-            <cp>608.16</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1252.5</hp>
-            <mp>558.0</mp>
-            <cp>626.25</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1288.95</hp>
-            <mp>574.2</mp>
-            <cp>644.475</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1325.67</hp>
-            <mp>590.52</mp>
-            <cp>662.835</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1362.66</hp>
-            <mp>606.96</mp>
-            <cp>681.33</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1399.92</hp>
-            <mp>623.52</mp>
-            <cp>699.96</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1437.45</hp>
-            <mp>640.2</mp>
-            <cp>718.725</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1475.25</hp>
-            <mp>657.0</mp>
-            <cp>737.625</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1513.32</hp>
-            <mp>673.92</mp>
-            <cp>756.66</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1551.66</hp>
-            <mp>690.96</mp>
-            <cp>775.83</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1590.27</hp>
-            <mp>708.12</mp>
-            <cp>795.135</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1629.15</hp>
-            <mp>725.4</mp>
-            <cp>814.575</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1668.3</hp>
-            <mp>742.8</mp>
-            <cp>834.15</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1707.72</hp>
-            <mp>760.32</mp>
-            <cp>853.86</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1747.41</hp>
-            <mp>777.96</mp>
-            <cp>873.705</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>1787.37</hp>
-            <mp>795.72</mp>
-            <cp>893.685</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>1827.6</hp>
-            <mp>813.6</mp>
-            <cp>913.8</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>1868.1</hp>
-            <mp>831.6</mp>
-            <cp>934.05</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>1908.87</hp>
-            <mp>849.72</mp>
-            <cp>954.435</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>1949.91</hp>
-            <mp>867.96</mp>
-            <cp>974.955</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>1991.22</hp>
-            <mp>886.32</mp>
-            <cp>995.61</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2032.8</hp>
-            <mp>904.8</mp>
-            <cp>1016.4</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2074.65</hp>
-            <mp>923.4</mp>
-            <cp>1037.325</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2116.77</hp>
-            <mp>942.12</mp>
-            <cp>1058.385</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2159.16</hp>
-            <mp>960.96</mp>
-            <cp>1079.58</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2201.82</hp>
-            <mp>979.92</mp>
-            <cp>1100.91</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2244.75</hp>
-            <mp>999.0</mp>
-            <cp>1122.375</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2287.95</hp>
-            <mp>1018.2</mp>
-            <cp>1143.975</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2331.42</hp>
-            <mp>1037.52</mp>
-            <cp>1165.71</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2375.16</hp>
-            <mp>1056.96</mp>
-            <cp>1187.58</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2419.17</hp>
-            <mp>1076.52</mp>
-            <cp>1209.585</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2463.45</hp>
-            <mp>1096.2</mp>
-            <cp>1231.725</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>2508.0</hp>
-            <mp>1116.0</mp>
-            <cp>1254.0</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>2552.82</hp>
-            <mp>1135.92</mp>
-            <cp>1276.41</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>2597.91</hp>
-            <mp>1155.96</mp>
-            <cp>1298.955</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>2643.27</hp>
-            <mp>1176.12</mp>
-            <cp>1321.635</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>2688.9</hp>
-            <mp>1196.4</mp>
-            <cp>1344.45</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>2734.8</hp>
-            <mp>1216.8</mp>
-            <cp>1367.4</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>2780.97</hp>
-            <mp>1237.32</mp>
-            <cp>1390.485</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>2827.41</hp>
-            <mp>1257.96</mp>
-            <cp>1413.705</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>2874.12</hp>
-            <mp>1278.72</mp>
-            <cp>1437.06</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>2921.1</hp>
-            <mp>1299.6</mp>
-            <cp>1460.55</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>2968.35</hp>
-            <mp>1320.6</mp>
-            <cp>1484.175</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3015.87</hp>
-            <mp>1341.72</mp>
-            <cp>1507.935</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3063.66</hp>
-            <mp>1362.96</mp>
-            <cp>1531.83</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3111.72</hp>
-            <mp>1384.32</mp>
-            <cp>1555.86</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3160.05</hp>
-            <mp>1405.8</mp>
-            <cp>1580.025</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>3208.65</hp>
-            <mp>1427.4</mp>
-            <cp>1604.325</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>39</classId>
+	<staticData>
+		<baseINT>44</baseINT>
+		<baseSTR>23</baseSTR>
+		<baseCON>24</baseCON>
+		<baseMEN>37</baseMEN>
+		<baseDEX>23</baseDEX>
+		<baseWIT>19</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="28295" y="11063" z="-4224" />
+			<node x="28302" y="11008" z="-4224" />
+			<node x="28377" y="10916" z="-4224" />
+			<node x="28456" y="10997" z="-4224" />
+			<node x="28461" y="11044" z="-4224" />
+			<node x="28395" y="11127" z="-4224" />
+		</creationPoints>
+		<basePAtk>3</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>15</chest>
+			<legs>8</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>85</walk>
+			<run>128</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>300</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>106.0</hp>
+			<mp>40.0</mp>
+			<cp>53.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>121.47</hp>
+			<mp>47.28</mp>
+			<cp>60.735</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>137.11</hp>
+			<mp>54.64</mp>
+			<cp>68.555</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>152.92</hp>
+			<mp>62.08</mp>
+			<cp>76.46</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>168.9</hp>
+			<mp>69.6</mp>
+			<cp>84.45</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>185.05</hp>
+			<mp>77.2</mp>
+			<cp>92.525</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>201.37</hp>
+			<mp>84.88</mp>
+			<cp>100.685</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>217.86</hp>
+			<mp>92.64</mp>
+			<cp>108.93</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>234.52</hp>
+			<mp>100.48</mp>
+			<cp>117.26</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>251.35</hp>
+			<mp>108.4</mp>
+			<cp>125.675</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>268.35</hp>
+			<mp>116.4</mp>
+			<cp>134.175</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>285.52</hp>
+			<mp>124.48</mp>
+			<cp>142.76</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>302.86</hp>
+			<mp>132.64</mp>
+			<cp>151.43</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>320.37</hp>
+			<mp>140.88</mp>
+			<cp>160.185</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>338.05</hp>
+			<mp>149.2</mp>
+			<cp>169.025</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>355.9</hp>
+			<mp>157.6</mp>
+			<cp>177.95</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>373.92</hp>
+			<mp>166.08</mp>
+			<cp>186.96</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>392.11</hp>
+			<mp>174.64</mp>
+			<cp>196.055</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>410.47</hp>
+			<mp>183.28</mp>
+			<cp>205.235</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>429.0</hp>
+			<mp>192.0</mp>
+			<cp>214.5</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>458.7</hp>
+			<mp>205.2</mp>
+			<cp>229.35</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>488.67</hp>
+			<mp>218.52</mp>
+			<cp>244.335</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>518.91</hp>
+			<mp>231.96</mp>
+			<cp>259.455</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>549.42</hp>
+			<mp>245.52</mp>
+			<cp>274.71</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>580.2</hp>
+			<mp>259.2</mp>
+			<cp>290.1</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>611.25</hp>
+			<mp>273.0</mp>
+			<cp>305.625</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>642.57</hp>
+			<mp>286.92</mp>
+			<cp>321.285</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>674.16</hp>
+			<mp>300.96</mp>
+			<cp>337.08</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>706.02</hp>
+			<mp>315.12</mp>
+			<cp>353.01</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>738.15</hp>
+			<mp>329.4</mp>
+			<cp>369.075</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>770.55</hp>
+			<mp>343.8</mp>
+			<cp>385.275</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>803.22</hp>
+			<mp>358.32</mp>
+			<cp>401.61</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>836.16</hp>
+			<mp>372.96</mp>
+			<cp>418.08</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>869.37</hp>
+			<mp>387.72</mp>
+			<cp>434.685</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>902.85</hp>
+			<mp>402.6</mp>
+			<cp>451.425</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>936.6</hp>
+			<mp>417.6</mp>
+			<cp>468.3</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>970.62</hp>
+			<mp>432.72</mp>
+			<cp>485.31</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1004.91</hp>
+			<mp>447.96</mp>
+			<cp>502.455</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1039.47</hp>
+			<mp>463.32</mp>
+			<cp>519.735</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1074.3</hp>
+			<mp>478.8</mp>
+			<cp>537.15</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1109.4</hp>
+			<mp>494.4</mp>
+			<cp>554.7</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1144.77</hp>
+			<mp>510.12</mp>
+			<cp>572.385</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1180.41</hp>
+			<mp>525.96</mp>
+			<cp>590.205</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1216.32</hp>
+			<mp>541.92</mp>
+			<cp>608.16</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1252.5</hp>
+			<mp>558.0</mp>
+			<cp>626.25</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1288.95</hp>
+			<mp>574.2</mp>
+			<cp>644.475</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1325.67</hp>
+			<mp>590.52</mp>
+			<cp>662.835</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1362.66</hp>
+			<mp>606.96</mp>
+			<cp>681.33</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1399.92</hp>
+			<mp>623.52</mp>
+			<cp>699.96</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1437.45</hp>
+			<mp>640.2</mp>
+			<cp>718.725</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1475.25</hp>
+			<mp>657.0</mp>
+			<cp>737.625</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1513.32</hp>
+			<mp>673.92</mp>
+			<cp>756.66</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1551.66</hp>
+			<mp>690.96</mp>
+			<cp>775.83</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1590.27</hp>
+			<mp>708.12</mp>
+			<cp>795.135</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1629.15</hp>
+			<mp>725.4</mp>
+			<cp>814.575</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1668.3</hp>
+			<mp>742.8</mp>
+			<cp>834.15</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1707.72</hp>
+			<mp>760.32</mp>
+			<cp>853.86</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1747.41</hp>
+			<mp>777.96</mp>
+			<cp>873.705</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1787.37</hp>
+			<mp>795.72</mp>
+			<cp>893.685</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1827.6</hp>
+			<mp>813.6</mp>
+			<cp>913.8</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>1868.1</hp>
+			<mp>831.6</mp>
+			<cp>934.05</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>1908.87</hp>
+			<mp>849.72</mp>
+			<cp>954.435</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>1949.91</hp>
+			<mp>867.96</mp>
+			<cp>974.955</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>1991.22</hp>
+			<mp>886.32</mp>
+			<cp>995.61</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2032.8</hp>
+			<mp>904.8</mp>
+			<cp>1016.4</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2074.65</hp>
+			<mp>923.4</mp>
+			<cp>1037.325</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2116.77</hp>
+			<mp>942.12</mp>
+			<cp>1058.385</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2159.16</hp>
+			<mp>960.96</mp>
+			<cp>1079.58</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2201.82</hp>
+			<mp>979.92</mp>
+			<cp>1100.91</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2244.75</hp>
+			<mp>999.0</mp>
+			<cp>1122.375</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2287.95</hp>
+			<mp>1018.2</mp>
+			<cp>1143.975</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2331.42</hp>
+			<mp>1037.52</mp>
+			<cp>1165.71</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2375.16</hp>
+			<mp>1056.96</mp>
+			<cp>1187.58</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2419.17</hp>
+			<mp>1076.52</mp>
+			<cp>1209.585</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2463.45</hp>
+			<mp>1096.2</mp>
+			<cp>1231.725</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>2508.0</hp>
+			<mp>1116.0</mp>
+			<cp>1254.0</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>2552.82</hp>
+			<mp>1135.92</mp>
+			<cp>1276.41</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>2597.91</hp>
+			<mp>1155.96</mp>
+			<cp>1298.955</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>2643.27</hp>
+			<mp>1176.12</mp>
+			<cp>1321.635</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>2688.9</hp>
+			<mp>1196.4</mp>
+			<cp>1344.45</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>2734.8</hp>
+			<mp>1216.8</mp>
+			<cp>1367.4</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>2780.97</hp>
+			<mp>1237.32</mp>
+			<cp>1390.485</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>2827.41</hp>
+			<mp>1257.96</mp>
+			<cp>1413.705</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>2874.12</hp>
+			<mp>1278.72</mp>
+			<cp>1437.06</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>2921.1</hp>
+			<mp>1299.6</mp>
+			<cp>1460.55</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>2968.35</hp>
+			<mp>1320.6</mp>
+			<cp>1484.175</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3015.87</hp>
+			<mp>1341.72</mp>
+			<cp>1507.935</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3063.66</hp>
+			<mp>1362.96</mp>
+			<cp>1531.83</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3111.72</hp>
+			<mp>1384.32</mp>
+			<cp>1555.86</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3160.05</hp>
+			<mp>1405.8</mp>
+			<cp>1580.025</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3208.65</hp>
+			<mp>1427.4</mp>
+			<cp>1604.325</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>3257.52</hp>
+			<mp>1449.12</mp>
+			<cp>1628.76</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>3306.66</hp>
+			<mp>1470.96</mp>
+			<cp>1653.33</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>3356.07</hp>
+			<mp>1492.92</mp>
+			<cp>1678.035</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>3405.75</hp>
+			<mp>1515.0</mp>
+			<cp>1702.875</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>3455.7</hp>
+			<mp>1537.2</mp>
+			<cp>1727.85</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>3505.92</hp>
+			<mp>1559.52</mp>
+			<cp>1752.96</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>3556.41</hp>
+			<mp>1581.96</mp>
+			<cp>1778.205</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>3607.17</hp>
+			<mp>1604.52</mp>
+			<cp>1803.585</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>3658.2</hp>
+			<mp>1627.2</mp>
+			<cp>1829.11</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>3709.5</hp>
+			<mp>1650</mp>
+			<cp>1854.77</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>3761.07</hp>
+			<mp>1672.92</mp>
+			<cp>1880.57</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>3812.91</hp>
+			<mp>1695.96</mp>
+			<cp>1906.51</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>3865.02</hp>
+			<mp>1719.12</mp>
+			<cp>1932.59</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>3917.4</hp>
+			<mp>1742.4</mp>
+			<cp>1958.81</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>3970.05</hp>
+			<mp>1765.8</mp>
+			<cp>1985.17</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>4022.97</hp>
+			<mp>1789.32</mp>
+			<cp>2011.485</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Destroyer.xml
+++ b/data/stats/chars/baseStats/Destroyer.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>46</classId>
-    <staticData>
-        <baseINT>18</baseINT>
-        <baseSTR>40</baseSTR>
-        <baseCON>47</baseCON>
-        <baseMEN>27</baseMEN>
-        <baseDEX>26</baseDEX>
-        <baseWIT>12</baseWIT>
-        <physicalAbnormalResist>15</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-56733" y="-113459" z="-690"/>
-            <node x="-56686" y="-113470" z="-690"/>
-            <node x="-56728" y="-113610" z="-690"/>
-            <node x="-56693" y="-113610" z="-690"/>
-            <node x="-56743" y="-113757" z="-690"/>
-            <node x="-56682" y="-113730" z="-690"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>25</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>70</walk>
-            <run>130</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>90</baseBreath>
-        <baseSafeFall>200</baseSafeFall>
-        <collisionMale>
-            <radius>11</radius>
-            <height>28.0</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7</radius>
-            <height>27.0</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>80.0</hp>
-            <mp>30.0</mp>
-            <cp>56.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>92.74</hp>
-            <mp>35.46</mp>
-            <cp>64.918</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>105.62</hp>
-            <mp>40.98</mp>
-            <cp>73.934</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>118.64</hp>
-            <mp>46.56</mp>
-            <cp>83.048</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>131.8</hp>
-            <mp>52.2</mp>
-            <cp>92.26</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>145.1</hp>
-            <mp>57.9</mp>
-            <cp>101.57</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>158.54</hp>
-            <mp>63.66</mp>
-            <cp>110.978</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>172.12</hp>
-            <mp>69.48</mp>
-            <cp>120.484</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>185.84</hp>
-            <mp>75.36</mp>
-            <cp>130.088</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>199.7</hp>
-            <mp>81.3</mp>
-            <cp>139.79</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>213.7</hp>
-            <mp>87.3</mp>
-            <cp>149.59</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>227.84</hp>
-            <mp>93.36</mp>
-            <cp>159.488</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>242.12</hp>
-            <mp>99.48</mp>
-            <cp>169.484</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>256.54</hp>
-            <mp>105.66</mp>
-            <cp>179.578</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>271.1</hp>
-            <mp>111.9</mp>
-            <cp>189.77</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>285.8</hp>
-            <mp>118.2</mp>
-            <cp>200.06</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>300.64</hp>
-            <mp>124.56</mp>
-            <cp>210.448</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>315.62</hp>
-            <mp>130.98</mp>
-            <cp>220.934</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>330.74</hp>
-            <mp>137.46</mp>
-            <cp>231.518</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>346.0</hp>
-            <mp>144.0</mp>
-            <cp>242.2</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>381.2</hp>
-            <mp>153.9</mp>
-            <cp>266.84</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>416.72</hp>
-            <mp>163.89</mp>
-            <cp>291.704</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>452.56</hp>
-            <mp>173.97</mp>
-            <cp>316.792</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>488.72</hp>
-            <mp>184.14</mp>
-            <cp>342.104</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>525.2</hp>
-            <mp>194.4</mp>
-            <cp>367.64</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>562.0</hp>
-            <mp>204.75</mp>
-            <cp>393.4</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>599.12</hp>
-            <mp>215.19</mp>
-            <cp>419.384</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>636.56</hp>
-            <mp>225.72</mp>
-            <cp>445.592</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>674.32</hp>
-            <mp>236.34</mp>
-            <cp>472.024</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>712.4</hp>
-            <mp>247.05</mp>
-            <cp>498.68</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>750.8</hp>
-            <mp>257.85</mp>
-            <cp>525.56</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>789.52</hp>
-            <mp>268.74</mp>
-            <cp>552.664</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>828.56</hp>
-            <mp>279.72</mp>
-            <cp>579.992</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>867.92</hp>
-            <mp>290.79</mp>
-            <cp>607.544</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>907.6</hp>
-            <mp>301.95</mp>
-            <cp>635.32</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>947.6</hp>
-            <mp>313.2</mp>
-            <cp>663.32</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>987.92</hp>
-            <mp>324.54</mp>
-            <cp>691.544</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1028.56</hp>
-            <mp>335.97</mp>
-            <cp>719.992</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1069.52</hp>
-            <mp>347.49</mp>
-            <cp>748.664</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1110.8</hp>
-            <mp>359.1</mp>
-            <cp>777.56</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1168.0</hp>
-            <mp>378.6</mp>
-            <cp>817.6</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1225.64</hp>
-            <mp>398.25</mp>
-            <cp>857.948</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1283.72</hp>
-            <mp>418.05</mp>
-            <cp>898.604</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1342.24</hp>
-            <mp>438.0</mp>
-            <cp>939.568</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1401.2</hp>
-            <mp>458.1</mp>
-            <cp>980.84</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1460.6</hp>
-            <mp>478.35</mp>
-            <cp>1022.42</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1520.44</hp>
-            <mp>498.75</mp>
-            <cp>1064.308</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1580.72</hp>
-            <mp>519.3</mp>
-            <cp>1106.504</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1641.44</hp>
-            <mp>540.0</mp>
-            <cp>1149.008</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1702.6</hp>
-            <mp>560.85</mp>
-            <cp>1191.82</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1764.2</hp>
-            <mp>581.85</mp>
-            <cp>1234.94</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1826.24</hp>
-            <mp>603.0</mp>
-            <cp>1278.368</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1888.72</hp>
-            <mp>624.3</mp>
-            <cp>1322.104</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1951.64</hp>
-            <mp>645.75</mp>
-            <cp>1366.148</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>2015.0</hp>
-            <mp>667.35</mp>
-            <cp>1410.5</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>2078.8</hp>
-            <mp>689.1</mp>
-            <cp>1455.16</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>2143.04</hp>
-            <mp>711.0</mp>
-            <cp>1500.128</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2207.72</hp>
-            <mp>733.05</mp>
-            <cp>1545.404</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2272.84</hp>
-            <mp>755.25</mp>
-            <cp>1590.988</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2338.4</hp>
-            <mp>777.6</mp>
-            <cp>1636.88</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2404.4</hp>
-            <mp>800.1</mp>
-            <cp>1683.08</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2470.84</hp>
-            <mp>822.75</mp>
-            <cp>1729.588</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2537.72</hp>
-            <mp>845.55</mp>
-            <cp>1776.404</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2605.04</hp>
-            <mp>868.5</mp>
-            <cp>1823.528</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2672.8</hp>
-            <mp>891.6</mp>
-            <cp>1870.96</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2741.0</hp>
-            <mp>914.85</mp>
-            <cp>1918.7</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2809.64</hp>
-            <mp>938.25</mp>
-            <cp>1966.748</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2878.72</hp>
-            <mp>961.8</mp>
-            <cp>2015.104</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2948.24</hp>
-            <mp>985.5</mp>
-            <cp>2063.768</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>3018.2</hp>
-            <mp>1009.35</mp>
-            <cp>2112.74</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>3088.6</hp>
-            <mp>1033.35</mp>
-            <cp>2162.02</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>3159.44</hp>
-            <mp>1057.5</mp>
-            <cp>2211.608</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>3230.72</hp>
-            <mp>1081.8</mp>
-            <cp>2261.504</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>3302.44</hp>
-            <mp>1106.25</mp>
-            <cp>2311.708</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3374.6</hp>
-            <mp>1130.85</mp>
-            <cp>2362.22</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3447.2</hp>
-            <mp>1155.6</mp>
-            <cp>2413.04</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3520.24</hp>
-            <mp>1180.5</mp>
-            <cp>2464.168</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3593.72</hp>
-            <mp>1205.55</mp>
-            <cp>2515.604</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3667.64</hp>
-            <mp>1230.75</mp>
-            <cp>2567.348</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3742.0</hp>
-            <mp>1256.1</mp>
-            <cp>2619.4</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3816.8</hp>
-            <mp>1281.6</mp>
-            <cp>2671.76</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3892.04</hp>
-            <mp>1307.25</mp>
-            <cp>2724.428</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3967.72</hp>
-            <mp>1333.05</mp>
-            <cp>2777.404</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>4043.84</hp>
-            <mp>1359.0</mp>
-            <cp>2830.688</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>4120.4</hp>
-            <mp>1385.1</mp>
-            <cp>2884.28</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>4197.4</hp>
-            <mp>1411.35</mp>
-            <cp>2938.18</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>4274.84</hp>
-            <mp>1437.75</mp>
-            <cp>2992.388</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>4352.72</hp>
-            <mp>1464.3</mp>
-            <cp>3046.904</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>4431.04</hp>
-            <mp>1491.0</mp>
-            <cp>3101.728</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4509.8</hp>
-            <mp>1517.85</mp>
-            <cp>3156.86</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4589.0</hp>
-            <mp>1544.85</mp>
-            <cp>3212.3</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>46</classId>
+	<staticData>
+		<baseINT>18</baseINT>
+		<baseSTR>40</baseSTR>
+		<baseCON>47</baseCON>
+		<baseMEN>27</baseMEN>
+		<baseDEX>26</baseDEX>
+		<baseWIT>12</baseWIT>
+		<physicalAbnormalResist>15</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-56733" y="-113459" z="-690" />
+			<node x="-56686" y="-113470" z="-690" />
+			<node x="-56728" y="-113610" z="-690" />
+			<node x="-56693" y="-113610" z="-690" />
+			<node x="-56743" y="-113757" z="-690" />
+			<node x="-56682" y="-113730" z="-690" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>25</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>70</walk>
+			<run>130</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>90</baseBreath>
+		<baseSafeFall>200</baseSafeFall>
+		<collisionMale>
+			<radius>11</radius>
+			<height>28.0</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7</radius>
+			<height>27.0</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>80.0</hp>
+			<mp>30.0</mp>
+			<cp>56.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>92.74</hp>
+			<mp>35.46</mp>
+			<cp>64.918</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>105.62</hp>
+			<mp>40.98</mp>
+			<cp>73.934</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>118.64</hp>
+			<mp>46.56</mp>
+			<cp>83.048</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>131.8</hp>
+			<mp>52.2</mp>
+			<cp>92.26</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>145.1</hp>
+			<mp>57.9</mp>
+			<cp>101.57</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>158.54</hp>
+			<mp>63.66</mp>
+			<cp>110.978</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>172.12</hp>
+			<mp>69.48</mp>
+			<cp>120.484</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>185.84</hp>
+			<mp>75.36</mp>
+			<cp>130.088</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>199.7</hp>
+			<mp>81.3</mp>
+			<cp>139.79</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>213.7</hp>
+			<mp>87.3</mp>
+			<cp>149.59</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>227.84</hp>
+			<mp>93.36</mp>
+			<cp>159.488</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>242.12</hp>
+			<mp>99.48</mp>
+			<cp>169.484</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>256.54</hp>
+			<mp>105.66</mp>
+			<cp>179.578</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>271.1</hp>
+			<mp>111.9</mp>
+			<cp>189.77</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>285.8</hp>
+			<mp>118.2</mp>
+			<cp>200.06</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>300.64</hp>
+			<mp>124.56</mp>
+			<cp>210.448</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>315.62</hp>
+			<mp>130.98</mp>
+			<cp>220.934</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>330.74</hp>
+			<mp>137.46</mp>
+			<cp>231.518</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>346.0</hp>
+			<mp>144.0</mp>
+			<cp>242.2</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>381.2</hp>
+			<mp>153.9</mp>
+			<cp>266.84</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>416.72</hp>
+			<mp>163.89</mp>
+			<cp>291.704</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>452.56</hp>
+			<mp>173.97</mp>
+			<cp>316.792</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>488.72</hp>
+			<mp>184.14</mp>
+			<cp>342.104</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>525.2</hp>
+			<mp>194.4</mp>
+			<cp>367.64</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>562.0</hp>
+			<mp>204.75</mp>
+			<cp>393.4</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>599.12</hp>
+			<mp>215.19</mp>
+			<cp>419.384</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>636.56</hp>
+			<mp>225.72</mp>
+			<cp>445.592</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>674.32</hp>
+			<mp>236.34</mp>
+			<cp>472.024</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>712.4</hp>
+			<mp>247.05</mp>
+			<cp>498.68</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>750.8</hp>
+			<mp>257.85</mp>
+			<cp>525.56</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>789.52</hp>
+			<mp>268.74</mp>
+			<cp>552.664</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>828.56</hp>
+			<mp>279.72</mp>
+			<cp>579.992</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>867.92</hp>
+			<mp>290.79</mp>
+			<cp>607.544</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>907.6</hp>
+			<mp>301.95</mp>
+			<cp>635.32</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>947.6</hp>
+			<mp>313.2</mp>
+			<cp>663.32</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>987.92</hp>
+			<mp>324.54</mp>
+			<cp>691.544</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1028.56</hp>
+			<mp>335.97</mp>
+			<cp>719.992</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1069.52</hp>
+			<mp>347.49</mp>
+			<cp>748.664</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1110.8</hp>
+			<mp>359.1</mp>
+			<cp>777.56</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1168.0</hp>
+			<mp>378.6</mp>
+			<cp>817.6</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1225.64</hp>
+			<mp>398.25</mp>
+			<cp>857.948</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1283.72</hp>
+			<mp>418.05</mp>
+			<cp>898.604</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1342.24</hp>
+			<mp>438.0</mp>
+			<cp>939.568</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1401.2</hp>
+			<mp>458.1</mp>
+			<cp>980.84</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1460.6</hp>
+			<mp>478.35</mp>
+			<cp>1022.42</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1520.44</hp>
+			<mp>498.75</mp>
+			<cp>1064.308</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1580.72</hp>
+			<mp>519.3</mp>
+			<cp>1106.504</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1641.44</hp>
+			<mp>540.0</mp>
+			<cp>1149.008</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1702.6</hp>
+			<mp>560.85</mp>
+			<cp>1191.82</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1764.2</hp>
+			<mp>581.85</mp>
+			<cp>1234.94</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1826.24</hp>
+			<mp>603.0</mp>
+			<cp>1278.368</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1888.72</hp>
+			<mp>624.3</mp>
+			<cp>1322.104</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1951.64</hp>
+			<mp>645.75</mp>
+			<cp>1366.148</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>2015.0</hp>
+			<mp>667.35</mp>
+			<cp>1410.5</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>2078.8</hp>
+			<mp>689.1</mp>
+			<cp>1455.16</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2143.04</hp>
+			<mp>711.0</mp>
+			<cp>1500.128</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2207.72</hp>
+			<mp>733.05</mp>
+			<cp>1545.404</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2272.84</hp>
+			<mp>755.25</mp>
+			<cp>1590.988</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2338.4</hp>
+			<mp>777.6</mp>
+			<cp>1636.88</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2404.4</hp>
+			<mp>800.1</mp>
+			<cp>1683.08</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2470.84</hp>
+			<mp>822.75</mp>
+			<cp>1729.588</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2537.72</hp>
+			<mp>845.55</mp>
+			<cp>1776.404</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2605.04</hp>
+			<mp>868.5</mp>
+			<cp>1823.528</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2672.8</hp>
+			<mp>891.6</mp>
+			<cp>1870.96</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2741.0</hp>
+			<mp>914.85</mp>
+			<cp>1918.7</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2809.64</hp>
+			<mp>938.25</mp>
+			<cp>1966.748</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2878.72</hp>
+			<mp>961.8</mp>
+			<cp>2015.104</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2948.24</hp>
+			<mp>985.5</mp>
+			<cp>2063.768</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>3018.2</hp>
+			<mp>1009.35</mp>
+			<cp>2112.74</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>3088.6</hp>
+			<mp>1033.35</mp>
+			<cp>2162.02</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>3159.44</hp>
+			<mp>1057.5</mp>
+			<cp>2211.608</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>3230.72</hp>
+			<mp>1081.8</mp>
+			<cp>2261.504</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3302.44</hp>
+			<mp>1106.25</mp>
+			<cp>2311.708</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3374.6</hp>
+			<mp>1130.85</mp>
+			<cp>2362.22</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3447.2</hp>
+			<mp>1155.6</mp>
+			<cp>2413.04</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3520.24</hp>
+			<mp>1180.5</mp>
+			<cp>2464.168</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3593.72</hp>
+			<mp>1205.55</mp>
+			<cp>2515.604</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3667.64</hp>
+			<mp>1230.75</mp>
+			<cp>2567.348</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3742.0</hp>
+			<mp>1256.1</mp>
+			<cp>2619.4</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3816.8</hp>
+			<mp>1281.6</mp>
+			<cp>2671.76</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3892.04</hp>
+			<mp>1307.25</mp>
+			<cp>2724.428</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3967.72</hp>
+			<mp>1333.05</mp>
+			<cp>2777.404</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>4043.84</hp>
+			<mp>1359.0</mp>
+			<cp>2830.688</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>4120.4</hp>
+			<mp>1385.1</mp>
+			<cp>2884.28</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>4197.4</hp>
+			<mp>1411.35</mp>
+			<cp>2938.18</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>4274.84</hp>
+			<mp>1437.75</mp>
+			<cp>2992.388</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4352.72</hp>
+			<mp>1464.3</mp>
+			<cp>3046.904</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4431.04</hp>
+			<mp>1491.0</mp>
+			<cp>3101.728</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4509.8</hp>
+			<mp>1517.85</mp>
+			<cp>3156.86</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4589.0</hp>
+			<mp>1544.85</mp>
+			<cp>3212.3</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4668.64</hp>
+			<mp>1572.0</mp>
+			<cp>3268.048</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4748.72</hp>
+			<mp>1599.3</mp>
+			<cp>3324.104</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4829.24</hp>
+			<mp>1626.75</mp>
+			<cp>3380.468</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4910.2</hp>
+			<mp>1654.35</mp>
+			<cp>3437.14</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4991.6</hp>
+			<mp>1682.1</mp>
+			<cp>3494.12</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>5073.44</hp>
+			<mp>1710.0</mp>
+			<cp>3551.408</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>5155.72</hp>
+			<mp>1738.05</mp>
+			<cp>3609.004</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>5238.44</hp>
+			<mp>1766.25</mp>
+			<cp>3666.908</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>5321.6</hp>
+			<mp>1794.6</mp>
+			<cp>3725.12</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>5405.2</hp>
+			<mp>1823.1</mp>
+			<cp>3783.65</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5489.24</hp>
+			<mp>1851.75</mp>
+			<cp>3842.48</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5573.72</hp>
+			<mp>1880.55</mp>
+			<cp>3901.62</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5658.64</hp>
+			<mp>1909.5</mp>
+			<cp>3961.08</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5744</hp>
+			<mp>1938.6</mp>
+			<cp>4020.84</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5829.8</hp>
+			<mp>1967.85</mp>
+			<cp>4080.92</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5916.04</hp>
+			<mp>1997.25</mp>
+			<cp>4141.228</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Dominator.xml
+++ b/data/stats/chars/baseStats/Dominator.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>115</classId>
-    <staticData>
-        <baseINT>31</baseINT>
-        <baseSTR>27</baseSTR>
-        <baseCON>31</baseCON>
-        <baseMEN>42</baseMEN>
-        <baseDEX>24</baseDEX>
-        <baseWIT>15</baseWIT>
-        <physicalAbnormalResist>15</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-56733" y="-113459" z="-690"/>
-            <node x="-56686" y="-113470" z="-690"/>
-            <node x="-56728" y="-113610" z="-690"/>
-            <node x="-56693" y="-113610" z="-690"/>
-            <node x="-56743" y="-113757" z="-690"/>
-            <node x="-56682" y="-113730" z="-690"/>
-        </creationPoints>
-        <basePAtk>3</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>15</chest>
-            <legs>8</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>25</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>70</walk>
-            <run>128</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>90</baseBreath>
-        <baseSafeFall>250</baseSafeFall>
-        <collisionMale>
-            <radius>7.0</radius>
-            <height>27.5</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>8.0</radius>
-            <height>25.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>95.0</hp>
-            <mp>40.0</mp>
-            <cp>85.5</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>110.47</hp>
-            <mp>47.28</mp>
-            <cp>99.423</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>126.11</hp>
-            <mp>54.64</mp>
-            <cp>113.499</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>141.92</hp>
-            <mp>62.08</mp>
-            <cp>127.728</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>157.9</hp>
-            <mp>69.6</mp>
-            <cp>142.11</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>174.05</hp>
-            <mp>77.2</mp>
-            <cp>156.645</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>190.37</hp>
-            <mp>84.88</mp>
-            <cp>171.333</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>206.86</hp>
-            <mp>92.64</mp>
-            <cp>186.174</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>223.52</hp>
-            <mp>100.48</mp>
-            <cp>201.168</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>240.35</hp>
-            <mp>108.4</mp>
-            <cp>216.315</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>257.35</hp>
-            <mp>116.4</mp>
-            <cp>231.615</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>274.52</hp>
-            <mp>124.48</mp>
-            <cp>247.068</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>291.86</hp>
-            <mp>132.64</mp>
-            <cp>262.674</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>309.37</hp>
-            <mp>140.88</mp>
-            <cp>278.433</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>327.05</hp>
-            <mp>149.2</mp>
-            <cp>294.345</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>344.9</hp>
-            <mp>157.6</mp>
-            <cp>310.41</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>362.92</hp>
-            <mp>166.08</mp>
-            <cp>326.628</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>381.11</hp>
-            <mp>174.64</mp>
-            <cp>342.999</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>399.47</hp>
-            <mp>183.28</mp>
-            <cp>359.523</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>418.0</hp>
-            <mp>192.0</mp>
-            <cp>376.2</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>453.2</hp>
-            <mp>205.2</mp>
-            <cp>407.88</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>488.72</hp>
-            <mp>218.52</mp>
-            <cp>439.848</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>524.56</hp>
-            <mp>231.96</mp>
-            <cp>472.104</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>560.72</hp>
-            <mp>245.52</mp>
-            <cp>504.648</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>597.2</hp>
-            <mp>259.2</mp>
-            <cp>537.48</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>634.0</hp>
-            <mp>273.0</mp>
-            <cp>570.6</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>671.12</hp>
-            <mp>286.92</mp>
-            <cp>604.008</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>708.56</hp>
-            <mp>300.96</mp>
-            <cp>637.704</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>746.32</hp>
-            <mp>315.12</mp>
-            <cp>671.688</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>784.4</hp>
-            <mp>329.4</mp>
-            <cp>705.96</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>822.8</hp>
-            <mp>343.8</mp>
-            <cp>740.52</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>861.52</hp>
-            <mp>358.32</mp>
-            <cp>775.368</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>900.56</hp>
-            <mp>372.96</mp>
-            <cp>810.504</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>939.92</hp>
-            <mp>387.72</mp>
-            <cp>845.928</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>979.6</hp>
-            <mp>402.6</mp>
-            <cp>881.64</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>1019.6</hp>
-            <mp>417.6</mp>
-            <cp>917.64</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>1059.92</hp>
-            <mp>432.72</mp>
-            <cp>953.928</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1100.56</hp>
-            <mp>447.96</mp>
-            <cp>990.504</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1141.52</hp>
-            <mp>463.32</mp>
-            <cp>1027.368</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1182.8</hp>
-            <mp>478.8</mp>
-            <cp>1064.52</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1236.1</hp>
-            <mp>504.8</mp>
-            <cp>1112.49</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1289.81</hp>
-            <mp>531.0</mp>
-            <cp>1160.829</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1343.93</hp>
-            <mp>557.4</mp>
-            <cp>1209.537</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1398.46</hp>
-            <mp>584.0</mp>
-            <cp>1258.614</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1453.4</hp>
-            <mp>610.8</mp>
-            <cp>1308.06</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1508.75</hp>
-            <mp>637.8</mp>
-            <cp>1357.875</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1564.51</hp>
-            <mp>665.0</mp>
-            <cp>1408.059</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1620.68</hp>
-            <mp>692.4</mp>
-            <cp>1458.612</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1677.26</hp>
-            <mp>720.0</mp>
-            <cp>1509.534</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1734.25</hp>
-            <mp>747.8</mp>
-            <cp>1560.825</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1791.65</hp>
-            <mp>775.8</mp>
-            <cp>1612.485</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1849.46</hp>
-            <mp>804.0</mp>
-            <cp>1664.514</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1907.68</hp>
-            <mp>832.4</mp>
-            <cp>1716.912</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1966.31</hp>
-            <mp>861.0</mp>
-            <cp>1769.679</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>2025.35</hp>
-            <mp>889.8</mp>
-            <cp>1822.815</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>2084.8</hp>
-            <mp>918.8</mp>
-            <cp>1876.32</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>2144.66</hp>
-            <mp>948.0</mp>
-            <cp>1930.194</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2204.93</hp>
-            <mp>977.4</mp>
-            <cp>1984.437</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2265.61</hp>
-            <mp>1007.0</mp>
-            <cp>2039.049</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2326.7</hp>
-            <mp>1036.8</mp>
-            <cp>2094.03</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2388.2</hp>
-            <mp>1066.8</mp>
-            <cp>2149.38</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2450.11</hp>
-            <mp>1097.0</mp>
-            <cp>2205.099</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2512.43</hp>
-            <mp>1127.4</mp>
-            <cp>2261.187</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2575.16</hp>
-            <mp>1158.0</mp>
-            <cp>2317.644</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2638.3</hp>
-            <mp>1188.8</mp>
-            <cp>2374.47</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2701.85</hp>
-            <mp>1219.8</mp>
-            <cp>2431.665</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2765.81</hp>
-            <mp>1251.0</mp>
-            <cp>2489.229</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2830.18</hp>
-            <mp>1282.4</mp>
-            <cp>2547.162</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2894.96</hp>
-            <mp>1314.0</mp>
-            <cp>2605.464</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2960.15</hp>
-            <mp>1345.8</mp>
-            <cp>2664.135</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>3025.75</hp>
-            <mp>1377.8</mp>
-            <cp>2723.175</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>3091.76</hp>
-            <mp>1410.0</mp>
-            <cp>2782.584</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>3158.18</hp>
-            <mp>1442.4</mp>
-            <cp>2842.362</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>3225.01</hp>
-            <mp>1475.0</mp>
-            <cp>2902.509</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3292.25</hp>
-            <mp>1507.8</mp>
-            <cp>2963.025</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3359.9</hp>
-            <mp>1540.8</mp>
-            <cp>3023.91</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3427.96</hp>
-            <mp>1574.0</mp>
-            <cp>3085.164</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3496.43</hp>
-            <mp>1607.4</mp>
-            <cp>3146.787</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3565.31</hp>
-            <mp>1641.0</mp>
-            <cp>3208.779</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3634.6</hp>
-            <mp>1674.8</mp>
-            <cp>3271.14</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3704.3</hp>
-            <mp>1708.8</mp>
-            <cp>3333.87</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3774.41</hp>
-            <mp>1743.0</mp>
-            <cp>3396.969</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3844.93</hp>
-            <mp>1777.4</mp>
-            <cp>3460.437</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3915.86</hp>
-            <mp>1812.0</mp>
-            <cp>3524.274</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3987.2</hp>
-            <mp>1846.8</mp>
-            <cp>3588.48</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>4058.95</hp>
-            <mp>1881.8</mp>
-            <cp>3653.055</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>4131.11</hp>
-            <mp>1917.0</mp>
-            <cp>3717.999</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>4203.68</hp>
-            <mp>1952.4</mp>
-            <cp>3783.312</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>4276.66</hp>
-            <mp>1988.0</mp>
-            <cp>3848.994</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4350.05</hp>
-            <mp>2023.8</mp>
-            <cp>3915.045</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4423.85</hp>
-            <mp>2059.8</mp>
-            <cp>3981.465</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>115</classId>
+	<staticData>
+		<baseINT>31</baseINT>
+		<baseSTR>27</baseSTR>
+		<baseCON>31</baseCON>
+		<baseMEN>42</baseMEN>
+		<baseDEX>24</baseDEX>
+		<baseWIT>15</baseWIT>
+		<physicalAbnormalResist>15</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-56733" y="-113459" z="-690" />
+			<node x="-56686" y="-113470" z="-690" />
+			<node x="-56728" y="-113610" z="-690" />
+			<node x="-56693" y="-113610" z="-690" />
+			<node x="-56743" y="-113757" z="-690" />
+			<node x="-56682" y="-113730" z="-690" />
+		</creationPoints>
+		<basePAtk>3</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>15</chest>
+			<legs>8</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>25</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>70</walk>
+			<run>128</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>90</baseBreath>
+		<baseSafeFall>250</baseSafeFall>
+		<collisionMale>
+			<radius>7.0</radius>
+			<height>27.5</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>8.0</radius>
+			<height>25.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>95.0</hp>
+			<mp>40.0</mp>
+			<cp>85.5</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>110.47</hp>
+			<mp>47.28</mp>
+			<cp>99.423</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>126.11</hp>
+			<mp>54.64</mp>
+			<cp>113.499</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>141.92</hp>
+			<mp>62.08</mp>
+			<cp>127.728</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>157.9</hp>
+			<mp>69.6</mp>
+			<cp>142.11</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>174.05</hp>
+			<mp>77.2</mp>
+			<cp>156.645</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>190.37</hp>
+			<mp>84.88</mp>
+			<cp>171.333</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>206.86</hp>
+			<mp>92.64</mp>
+			<cp>186.174</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>223.52</hp>
+			<mp>100.48</mp>
+			<cp>201.168</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>240.35</hp>
+			<mp>108.4</mp>
+			<cp>216.315</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>257.35</hp>
+			<mp>116.4</mp>
+			<cp>231.615</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>274.52</hp>
+			<mp>124.48</mp>
+			<cp>247.068</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>291.86</hp>
+			<mp>132.64</mp>
+			<cp>262.674</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>309.37</hp>
+			<mp>140.88</mp>
+			<cp>278.433</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>327.05</hp>
+			<mp>149.2</mp>
+			<cp>294.345</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>344.9</hp>
+			<mp>157.6</mp>
+			<cp>310.41</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>362.92</hp>
+			<mp>166.08</mp>
+			<cp>326.628</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>381.11</hp>
+			<mp>174.64</mp>
+			<cp>342.999</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>399.47</hp>
+			<mp>183.28</mp>
+			<cp>359.523</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>418.0</hp>
+			<mp>192.0</mp>
+			<cp>376.2</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>453.2</hp>
+			<mp>205.2</mp>
+			<cp>407.88</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>488.72</hp>
+			<mp>218.52</mp>
+			<cp>439.848</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>524.56</hp>
+			<mp>231.96</mp>
+			<cp>472.104</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>560.72</hp>
+			<mp>245.52</mp>
+			<cp>504.648</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>597.2</hp>
+			<mp>259.2</mp>
+			<cp>537.48</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>634.0</hp>
+			<mp>273.0</mp>
+			<cp>570.6</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>671.12</hp>
+			<mp>286.92</mp>
+			<cp>604.008</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>708.56</hp>
+			<mp>300.96</mp>
+			<cp>637.704</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>746.32</hp>
+			<mp>315.12</mp>
+			<cp>671.688</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>784.4</hp>
+			<mp>329.4</mp>
+			<cp>705.96</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>822.8</hp>
+			<mp>343.8</mp>
+			<cp>740.52</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>861.52</hp>
+			<mp>358.32</mp>
+			<cp>775.368</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>900.56</hp>
+			<mp>372.96</mp>
+			<cp>810.504</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>939.92</hp>
+			<mp>387.72</mp>
+			<cp>845.928</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>979.6</hp>
+			<mp>402.6</mp>
+			<cp>881.64</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>1019.6</hp>
+			<mp>417.6</mp>
+			<cp>917.64</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>1059.92</hp>
+			<mp>432.72</mp>
+			<cp>953.928</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1100.56</hp>
+			<mp>447.96</mp>
+			<cp>990.504</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1141.52</hp>
+			<mp>463.32</mp>
+			<cp>1027.368</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1182.8</hp>
+			<mp>478.8</mp>
+			<cp>1064.52</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1236.1</hp>
+			<mp>504.8</mp>
+			<cp>1112.49</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1289.81</hp>
+			<mp>531.0</mp>
+			<cp>1160.829</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1343.93</hp>
+			<mp>557.4</mp>
+			<cp>1209.537</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1398.46</hp>
+			<mp>584.0</mp>
+			<cp>1258.614</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1453.4</hp>
+			<mp>610.8</mp>
+			<cp>1308.06</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1508.75</hp>
+			<mp>637.8</mp>
+			<cp>1357.875</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1564.51</hp>
+			<mp>665.0</mp>
+			<cp>1408.059</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1620.68</hp>
+			<mp>692.4</mp>
+			<cp>1458.612</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1677.26</hp>
+			<mp>720.0</mp>
+			<cp>1509.534</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1734.25</hp>
+			<mp>747.8</mp>
+			<cp>1560.825</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1791.65</hp>
+			<mp>775.8</mp>
+			<cp>1612.485</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1849.46</hp>
+			<mp>804.0</mp>
+			<cp>1664.514</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1907.68</hp>
+			<mp>832.4</mp>
+			<cp>1716.912</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1966.31</hp>
+			<mp>861.0</mp>
+			<cp>1769.679</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>2025.35</hp>
+			<mp>889.8</mp>
+			<cp>1822.815</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>2084.8</hp>
+			<mp>918.8</mp>
+			<cp>1876.32</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2144.66</hp>
+			<mp>948.0</mp>
+			<cp>1930.194</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2204.93</hp>
+			<mp>977.4</mp>
+			<cp>1984.437</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2265.61</hp>
+			<mp>1007.0</mp>
+			<cp>2039.049</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2326.7</hp>
+			<mp>1036.8</mp>
+			<cp>2094.03</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2388.2</hp>
+			<mp>1066.8</mp>
+			<cp>2149.38</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2450.11</hp>
+			<mp>1097.0</mp>
+			<cp>2205.099</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2512.43</hp>
+			<mp>1127.4</mp>
+			<cp>2261.187</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2575.16</hp>
+			<mp>1158.0</mp>
+			<cp>2317.644</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2638.3</hp>
+			<mp>1188.8</mp>
+			<cp>2374.47</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2701.85</hp>
+			<mp>1219.8</mp>
+			<cp>2431.665</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2765.81</hp>
+			<mp>1251.0</mp>
+			<cp>2489.229</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2830.18</hp>
+			<mp>1282.4</mp>
+			<cp>2547.162</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2894.96</hp>
+			<mp>1314.0</mp>
+			<cp>2605.464</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2960.15</hp>
+			<mp>1345.8</mp>
+			<cp>2664.135</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>3025.75</hp>
+			<mp>1377.8</mp>
+			<cp>2723.175</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>3091.76</hp>
+			<mp>1410.0</mp>
+			<cp>2782.584</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>3158.18</hp>
+			<mp>1442.4</mp>
+			<cp>2842.362</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3225.01</hp>
+			<mp>1475.0</mp>
+			<cp>2902.509</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3292.25</hp>
+			<mp>1507.8</mp>
+			<cp>2963.025</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3359.9</hp>
+			<mp>1540.8</mp>
+			<cp>3023.91</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3427.96</hp>
+			<mp>1574.0</mp>
+			<cp>3085.164</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3496.43</hp>
+			<mp>1607.4</mp>
+			<cp>3146.787</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3565.31</hp>
+			<mp>1641.0</mp>
+			<cp>3208.779</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3634.6</hp>
+			<mp>1674.8</mp>
+			<cp>3271.14</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3704.3</hp>
+			<mp>1708.8</mp>
+			<cp>3333.87</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3774.41</hp>
+			<mp>1743.0</mp>
+			<cp>3396.969</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3844.93</hp>
+			<mp>1777.4</mp>
+			<cp>3460.437</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3915.86</hp>
+			<mp>1812.0</mp>
+			<cp>3524.274</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3987.2</hp>
+			<mp>1846.8</mp>
+			<cp>3588.48</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>4058.95</hp>
+			<mp>1881.8</mp>
+			<cp>3653.055</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>4131.11</hp>
+			<mp>1917.0</mp>
+			<cp>3717.999</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4203.68</hp>
+			<mp>1952.4</mp>
+			<cp>3783.312</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4276.66</hp>
+			<mp>1988.0</mp>
+			<cp>3848.994</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4350.05</hp>
+			<mp>2023.8</mp>
+			<cp>3915.045</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4423.85</hp>
+			<mp>2059.8</mp>
+			<cp>3981.465</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4498.06</hp>
+			<mp>2096.0</mp>
+			<cp>4048.254</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4572.68</hp>
+			<mp>2132.4</mp>
+			<cp>4115.412</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4647.71</hp>
+			<mp>2169.0</mp>
+			<cp>4182.939</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4723.15</hp>
+			<mp>2205.8</mp>
+			<cp>4250.835</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4799.0</hp>
+			<mp>2242.8</mp>
+			<cp>4319.1</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4875.26</hp>
+			<mp>2280.0</mp>
+			<cp>4387.734</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4951.93</hp>
+			<mp>2317.4</mp>
+			<cp>4456.737</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>5029.01</hp>
+			<mp>2355.0</mp>
+			<cp>4526.109</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>5106.5</hp>
+			<mp>2392.8</mp>
+			<cp>4595.85</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>5184.4</hp>
+			<mp>2430.8</mp>
+			<cp>4665.96</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5262.71</hp>
+			<mp>2469</mp>
+			<cp>4736.45</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5341.43</hp>
+			<mp>2507.4</mp>
+			<cp>4807.3</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5420.56</hp>
+			<mp>2546</mp>
+			<cp>4878.52</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5500.1</hp>
+			<mp>2584.8</mp>
+			<cp>4950.11</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5580.05</hp>
+			<mp>2623.8</mp>
+			<cp>5022.07</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5660.41</hp>
+			<mp>2663</mp>
+			<cp>5094.369</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Doombringer.xml
+++ b/data/stats/chars/baseStats/Doombringer.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>131</classId> <!-- TODO update data -->
-    <staticData>
-        <baseINT>25</baseINT>
-        <baseSTR>41</baseSTR>
-        <baseCON>27</baseCON>
-        <baseMEN>22</baseMEN>
-        <baseDEX>35</baseDEX>
-        <baseWIT>20</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-125607" y="38452" z="1152"/>
-            <node x="-125472" y="38450" z="1152"/>
-            <node x="-125615" y="37771" z="1152"/>
-            <node x="-125464" y="37776" z="1152"/>
-            <node x="-125517" y="38267" z="1155"/>
-            <node x="-125531" y="37944" z="1155"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>87</walk>
-            <run>140</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>100</baseBreath>
-        <baseSafeFall>500</baseSafeFall>
-        <collisionMale>
-            <radius>8.0</radius>
-            <height>25.2</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.0</radius>
-            <height>22.6</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>95.0</hp>
-            <mp>30.0</mp>
-            <cp>47.5</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>108.65</hp>
-            <mp>35.46</mp>
-            <cp>54.325</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>122.45</hp>
-            <mp>40.98</mp>
-            <cp>61.225</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>136.4</hp>
-            <mp>46.56</mp>
-            <cp>68.2</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>150.5</hp>
-            <mp>52.2</mp>
-            <cp>75.25</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>164.75</hp>
-            <mp>57.9</mp>
-            <cp>82.375</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>179.15</hp>
-            <mp>63.66</mp>
-            <cp>89.575</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>193.7</hp>
-            <mp>69.48</mp>
-            <cp>96.85</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>208.4</hp>
-            <mp>75.36</mp>
-            <cp>104.2</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>223.25</hp>
-            <mp>81.3</mp>
-            <cp>111.625</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>238.25</hp>
-            <mp>87.3</mp>
-            <cp>119.125</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>253.4</hp>
-            <mp>93.36</mp>
-            <cp>126.7</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>268.7</hp>
-            <mp>99.48</mp>
-            <cp>134.35</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>284.15</hp>
-            <mp>105.66</mp>
-            <cp>142.075</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>299.75</hp>
-            <mp>111.9</mp>
-            <cp>149.875</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>315.5</hp>
-            <mp>118.2</mp>
-            <cp>157.75</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>331.4</hp>
-            <mp>124.56</mp>
-            <cp>165.7</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>347.45</hp>
-            <mp>130.98</mp>
-            <cp>173.725</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>363.65</hp>
-            <mp>137.46</mp>
-            <cp>181.825</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>398.53</hp>
-            <mp>147.27</mp>
-            <cp>199.265</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>433.73</hp>
-            <mp>157.17</mp>
-            <cp>216.865</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>469.25</hp>
-            <mp>167.16</mp>
-            <cp>234.625</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>505.09</hp>
-            <mp>177.24</mp>
-            <cp>252.545</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>541.25</hp>
-            <mp>187.41</mp>
-            <cp>270.625</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>577.73</hp>
-            <mp>197.67</mp>
-            <cp>288.865</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>614.53</hp>
-            <mp>208.02</mp>
-            <cp>307.265</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>651.65</hp>
-            <mp>218.46</mp>
-            <cp>325.825</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>689.09</hp>
-            <mp>228.99</mp>
-            <cp>344.545</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>726.85</hp>
-            <mp>239.61</mp>
-            <cp>363.425</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>764.93</hp>
-            <mp>250.32</mp>
-            <cp>382.465</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>803.33</hp>
-            <mp>261.12</mp>
-            <cp>401.665</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>842.05</hp>
-            <mp>272.01</mp>
-            <cp>421.025</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>881.09</hp>
-            <mp>282.99</mp>
-            <cp>440.545</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>920.45</hp>
-            <mp>294.06</mp>
-            <cp>460.225</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>960.13</hp>
-            <mp>305.22</mp>
-            <cp>480.065</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>1000.13</hp>
-            <mp>316.47</mp>
-            <cp>500.065</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>1040.45</hp>
-            <mp>327.81</mp>
-            <cp>520.225</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1081.09</hp>
-            <mp>339.24</mp>
-            <cp>540.545</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1122.05</hp>
-            <mp>350.76</mp>
-            <cp>561.025</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1178.81</hp>
-            <mp>370.11</mp>
-            <cp>589.405</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1236.01</hp>
-            <mp>389.61</mp>
-            <cp>618.005</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1293.65</hp>
-            <mp>409.26</mp>
-            <cp>646.825</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1351.73</hp>
-            <mp>429.06</mp>
-            <cp>675.865</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1410.25</hp>
-            <mp>449.01</mp>
-            <cp>705.125</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1469.21</hp>
-            <mp>469.11</mp>
-            <cp>734.605</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1528.61</hp>
-            <mp>489.36</mp>
-            <cp>764.305</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1588.45</hp>
-            <mp>509.76</mp>
-            <cp>794.225</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1648.73</hp>
-            <mp>530.31</mp>
-            <cp>824.365</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1709.45</hp>
-            <mp>551.01</mp>
-            <cp>854.725</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1770.61</hp>
-            <mp>571.86</mp>
-            <cp>885.305</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1832.21</hp>
-            <mp>592.86</mp>
-            <cp>916.105</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1894.25</hp>
-            <mp>614.01</mp>
-            <cp>947.125</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1956.73</hp>
-            <mp>635.31</mp>
-            <cp>978.365</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>2019.65</hp>
-            <mp>656.76</mp>
-            <cp>1009.825</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>2083.01</hp>
-            <mp>678.36</mp>
-            <cp>1041.505</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>2146.81</hp>
-            <mp>700.11</mp>
-            <cp>1073.405</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>2211.05</hp>
-            <mp>722.01</mp>
-            <cp>1105.525</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2275.73</hp>
-            <mp>744.06</mp>
-            <cp>1137.865</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2340.85</hp>
-            <mp>766.26</mp>
-            <cp>1170.425</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2406.41</hp>
-            <mp>788.61</mp>
-            <cp>1203.205</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2472.41</hp>
-            <mp>811.11</mp>
-            <cp>1236.205</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2538.85</hp>
-            <mp>833.76</mp>
-            <cp>1269.425</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2605.73</hp>
-            <mp>856.56</mp>
-            <cp>1302.865</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2673.05</hp>
-            <mp>879.51</mp>
-            <cp>1336.525</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2740.81</hp>
-            <mp>902.61</mp>
-            <cp>1370.405</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2809.01</hp>
-            <mp>925.86</mp>
-            <cp>1404.505</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2877.65</hp>
-            <mp>949.26</mp>
-            <cp>1438.825</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2946.73</hp>
-            <mp>972.81</mp>
-            <cp>1473.365</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>3016.25</hp>
-            <mp>996.51</mp>
-            <cp>1508.125</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>3086.21</hp>
-            <mp>1020.36</mp>
-            <cp>1543.105</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>3156.61</hp>
-            <mp>1044.36</mp>
-            <cp>1578.305</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>3227.45</hp>
-            <mp>1068.51</mp>
-            <cp>1613.725</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>3298.73</hp>
-            <mp>1092.81</mp>
-            <cp>1649.365</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>3370.45</hp>
-            <mp>1117.26</mp>
-            <cp>1685.225</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3442.61</hp>
-            <mp>1141.86</mp>
-            <cp>1721.305</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3515.21</hp>
-            <mp>1166.61</mp>
-            <cp>1757.605</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3588.25</hp>
-            <mp>1191.51</mp>
-            <cp>1794.125</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3661.73</hp>
-            <mp>1216.56</mp>
-            <cp>1830.865</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3735.65</hp>
-            <mp>1241.76</mp>
-            <cp>1867.825</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3810.01</hp>
-            <mp>1267.11</mp>
-            <cp>1905.005</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3884.81</hp>
-            <mp>1292.61</mp>
-            <cp>1942.405</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3960.05</hp>
-            <mp>1318.26</mp>
-            <cp>1980.025</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>4035.73</hp>
-            <mp>1344.06</mp>
-            <cp>2017.865</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>4111.85</hp>
-            <mp>1370.01</mp>
-            <cp>2055.925</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>4188.41</hp>
-            <mp>1396.11</mp>
-            <cp>2094.205</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>4265.41</hp>
-            <mp>1422.36</mp>
-            <cp>2132.705</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>4342.85</hp>
-            <mp>1448.76</mp>
-            <cp>2171.425</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>4420.73</hp>
-            <mp>1475.31</mp>
-            <cp>2210.365</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>4499.05</hp>
-            <mp>1502.01</mp>
-            <cp>2249.525</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4577.81</hp>
-            <mp>1528.86</mp>
-            <cp>2288.905</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4657.01</hp>
-            <mp>1555.86</mp>
-            <cp>2328.505</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>131</classId>
+	<staticData>
+		<baseINT>25</baseINT>
+		<baseSTR>41</baseSTR>
+		<baseCON>27</baseCON>
+		<baseMEN>22</baseMEN>
+		<baseDEX>35</baseDEX>
+		<baseWIT>20</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-125607" y="38452" z="1152" />
+			<node x="-125472" y="38450" z="1152" />
+			<node x="-125615" y="37771" z="1152" />
+			<node x="-125464" y="37776" z="1152" />
+			<node x="-125517" y="38267" z="1155" />
+			<node x="-125531" y="37944" z="1155" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>87</walk>
+			<run>140</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>500</baseSafeFall>
+		<collisionMale>
+			<radius>8.0</radius>
+			<height>25.2</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.0</radius>
+			<height>22.6</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>95.0</hp>
+			<mp>30.0</mp>
+			<cp>47.5</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>108.65</hp>
+			<mp>35.46</mp>
+			<cp>54.325</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>122.45</hp>
+			<mp>40.98</mp>
+			<cp>61.225</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>136.4</hp>
+			<mp>46.56</mp>
+			<cp>68.2</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>150.5</hp>
+			<mp>52.2</mp>
+			<cp>75.25</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>164.75</hp>
+			<mp>57.9</mp>
+			<cp>82.375</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>179.15</hp>
+			<mp>63.66</mp>
+			<cp>89.575</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>193.7</hp>
+			<mp>69.48</mp>
+			<cp>96.85</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>208.4</hp>
+			<mp>75.36</mp>
+			<cp>104.2</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>223.25</hp>
+			<mp>81.3</mp>
+			<cp>111.625</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>238.25</hp>
+			<mp>87.3</mp>
+			<cp>119.125</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>253.4</hp>
+			<mp>93.36</mp>
+			<cp>126.7</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>268.7</hp>
+			<mp>99.48</mp>
+			<cp>134.35</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>284.15</hp>
+			<mp>105.66</mp>
+			<cp>142.075</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>299.75</hp>
+			<mp>111.9</mp>
+			<cp>149.875</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>315.5</hp>
+			<mp>118.2</mp>
+			<cp>157.75</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>331.4</hp>
+			<mp>124.56</mp>
+			<cp>165.7</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>347.45</hp>
+			<mp>130.98</mp>
+			<cp>173.725</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>363.65</hp>
+			<mp>137.46</mp>
+			<cp>181.825</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>398.53</hp>
+			<mp>147.27</mp>
+			<cp>199.265</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>433.73</hp>
+			<mp>157.17</mp>
+			<cp>216.865</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>469.25</hp>
+			<mp>167.16</mp>
+			<cp>234.625</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>505.09</hp>
+			<mp>177.24</mp>
+			<cp>252.545</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>541.25</hp>
+			<mp>187.41</mp>
+			<cp>270.625</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>577.73</hp>
+			<mp>197.67</mp>
+			<cp>288.865</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>614.53</hp>
+			<mp>208.02</mp>
+			<cp>307.265</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>651.65</hp>
+			<mp>218.46</mp>
+			<cp>325.825</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>689.09</hp>
+			<mp>228.99</mp>
+			<cp>344.545</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>726.85</hp>
+			<mp>239.61</mp>
+			<cp>363.425</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>764.93</hp>
+			<mp>250.32</mp>
+			<cp>382.465</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>803.33</hp>
+			<mp>261.12</mp>
+			<cp>401.665</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>842.05</hp>
+			<mp>272.01</mp>
+			<cp>421.025</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>881.09</hp>
+			<mp>282.99</mp>
+			<cp>440.545</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>920.45</hp>
+			<mp>294.06</mp>
+			<cp>460.225</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>960.13</hp>
+			<mp>305.22</mp>
+			<cp>480.065</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>1000.13</hp>
+			<mp>316.47</mp>
+			<cp>500.065</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>1040.45</hp>
+			<mp>327.81</mp>
+			<cp>520.225</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1081.09</hp>
+			<mp>339.24</mp>
+			<cp>540.545</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1122.05</hp>
+			<mp>350.76</mp>
+			<cp>561.025</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1178.81</hp>
+			<mp>370.11</mp>
+			<cp>589.405</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1236.01</hp>
+			<mp>389.61</mp>
+			<cp>618.005</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1293.65</hp>
+			<mp>409.26</mp>
+			<cp>646.825</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1351.73</hp>
+			<mp>429.06</mp>
+			<cp>675.865</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1410.25</hp>
+			<mp>449.01</mp>
+			<cp>705.125</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1469.21</hp>
+			<mp>469.11</mp>
+			<cp>734.605</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1528.61</hp>
+			<mp>489.36</mp>
+			<cp>764.305</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1588.45</hp>
+			<mp>509.76</mp>
+			<cp>794.225</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1648.73</hp>
+			<mp>530.31</mp>
+			<cp>824.365</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1709.45</hp>
+			<mp>551.01</mp>
+			<cp>854.725</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1770.61</hp>
+			<mp>571.86</mp>
+			<cp>885.305</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1832.21</hp>
+			<mp>592.86</mp>
+			<cp>916.105</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1894.25</hp>
+			<mp>614.01</mp>
+			<cp>947.125</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1956.73</hp>
+			<mp>635.31</mp>
+			<cp>978.365</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>2019.65</hp>
+			<mp>656.76</mp>
+			<cp>1009.825</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>2083.01</hp>
+			<mp>678.36</mp>
+			<cp>1041.505</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>2146.81</hp>
+			<mp>700.11</mp>
+			<cp>1073.405</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2211.05</hp>
+			<mp>722.01</mp>
+			<cp>1105.525</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2275.73</hp>
+			<mp>744.06</mp>
+			<cp>1137.865</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2340.85</hp>
+			<mp>766.26</mp>
+			<cp>1170.425</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2406.41</hp>
+			<mp>788.61</mp>
+			<cp>1203.205</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2472.41</hp>
+			<mp>811.11</mp>
+			<cp>1236.205</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2538.85</hp>
+			<mp>833.76</mp>
+			<cp>1269.425</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2605.73</hp>
+			<mp>856.56</mp>
+			<cp>1302.865</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2673.05</hp>
+			<mp>879.51</mp>
+			<cp>1336.525</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2740.81</hp>
+			<mp>902.61</mp>
+			<cp>1370.405</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2809.01</hp>
+			<mp>925.86</mp>
+			<cp>1404.505</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2877.65</hp>
+			<mp>949.26</mp>
+			<cp>1438.825</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2946.73</hp>
+			<mp>972.81</mp>
+			<cp>1473.365</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>3016.25</hp>
+			<mp>996.51</mp>
+			<cp>1508.125</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>3086.21</hp>
+			<mp>1020.36</mp>
+			<cp>1543.105</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>3156.61</hp>
+			<mp>1044.36</mp>
+			<cp>1578.305</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>3227.45</hp>
+			<mp>1068.51</mp>
+			<cp>1613.725</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>3298.73</hp>
+			<mp>1092.81</mp>
+			<cp>1649.365</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3370.45</hp>
+			<mp>1117.26</mp>
+			<cp>1685.225</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3442.61</hp>
+			<mp>1141.86</mp>
+			<cp>1721.305</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3515.21</hp>
+			<mp>1166.61</mp>
+			<cp>1757.605</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3588.25</hp>
+			<mp>1191.51</mp>
+			<cp>1794.125</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3661.73</hp>
+			<mp>1216.56</mp>
+			<cp>1830.865</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3735.65</hp>
+			<mp>1241.76</mp>
+			<cp>1867.825</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3810.01</hp>
+			<mp>1267.11</mp>
+			<cp>1905.005</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3884.81</hp>
+			<mp>1292.61</mp>
+			<cp>1942.405</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3960.05</hp>
+			<mp>1318.26</mp>
+			<cp>1980.025</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>4035.73</hp>
+			<mp>1344.06</mp>
+			<cp>2017.865</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>4111.85</hp>
+			<mp>1370.01</mp>
+			<cp>2055.925</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>4188.41</hp>
+			<mp>1396.11</mp>
+			<cp>2094.205</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>4265.41</hp>
+			<mp>1422.36</mp>
+			<cp>2132.705</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>4342.85</hp>
+			<mp>1448.76</mp>
+			<cp>2171.425</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4420.73</hp>
+			<mp>1475.31</mp>
+			<cp>2210.365</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4499.05</hp>
+			<mp>1502.01</mp>
+			<cp>2249.525</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4577.81</hp>
+			<mp>1528.86</mp>
+			<cp>2288.905</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4657.01</hp>
+			<mp>1555.86</mp>
+			<cp>2328.505</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4736.65</hp>
+			<mp>1583.01</mp>
+			<cp>2368.325</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4816.73</hp>
+			<mp>1610.31</mp>
+			<cp>2408.365</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4897.25</hp>
+			<mp>1637.76</mp>
+			<cp>2448.625</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4978.21</hp>
+			<mp>1665.36</mp>
+			<cp>2489.105</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>5059.61</hp>
+			<mp>1693.11</mp>
+			<cp>2529.805</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>5141.45</hp>
+			<mp>1721.01</mp>
+			<cp>2570.725</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>5223.73</hp>
+			<mp>1749.06</mp>
+			<cp>2611.865</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>5306.45</hp>
+			<mp>1777.26</mp>
+			<cp>2653.225</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>5389.61</hp>
+			<mp>1805.61</mp>
+			<cp>2694.81</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>5473.21</hp>
+			<mp>1834.11</mp>
+			<cp>2736.61</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5557.25</hp>
+			<mp>1862.76</mp>
+			<cp>2778.63</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5641.73</hp>
+			<mp>1891.56</mp>
+			<cp>2820.87</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5726.65</hp>
+			<mp>1920.51</mp>
+			<cp>2863.33</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5812.01</hp>
+			<mp>1949.61</mp>
+			<cp>2906.01</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5897.81</hp>
+			<mp>1978.86</mp>
+			<cp>2948.91</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5984.05</hp>
+			<mp>2008.26</mp>
+			<cp>2992.025</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Doomcryer.xml
+++ b/data/stats/chars/baseStats/Doomcryer.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>116</classId>
-    <staticData>
-        <baseINT>31</baseINT>
-        <baseSTR>27</baseSTR>
-        <baseCON>31</baseCON>
-        <baseMEN>42</baseMEN>
-        <baseDEX>24</baseDEX>
-        <baseWIT>15</baseWIT>
-        <physicalAbnormalResist>15</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-56733" y="-113459" z="-690"/>
-            <node x="-56686" y="-113470" z="-690"/>
-            <node x="-56728" y="-113610" z="-690"/>
-            <node x="-56693" y="-113610" z="-690"/>
-            <node x="-56743" y="-113757" z="-690"/>
-            <node x="-56682" y="-113730" z="-690"/>
-        </creationPoints>
-        <basePAtk>3</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>15</chest>
-            <legs>8</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>25</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>70</walk>
-            <run>128</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>90</baseBreath>
-        <baseSafeFall>250</baseSafeFall>
-        <collisionMale>
-            <radius>7.0</radius>
-            <height>27.5</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>8.0</radius>
-            <height>25.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>95.0</hp>
-            <mp>40.0</mp>
-            <cp>47.5</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>110.47</hp>
-            <mp>47.28</mp>
-            <cp>55.235</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>126.11</hp>
-            <mp>54.64</mp>
-            <cp>63.055</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>141.92</hp>
-            <mp>62.08</mp>
-            <cp>70.96</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>157.9</hp>
-            <mp>69.6</mp>
-            <cp>78.95</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>174.05</hp>
-            <mp>77.2</mp>
-            <cp>87.025</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>190.37</hp>
-            <mp>84.88</mp>
-            <cp>95.185</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>206.86</hp>
-            <mp>92.64</mp>
-            <cp>103.43</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>223.52</hp>
-            <mp>100.48</mp>
-            <cp>111.76</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>240.35</hp>
-            <mp>108.4</mp>
-            <cp>120.175</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>257.35</hp>
-            <mp>116.4</mp>
-            <cp>128.675</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>274.52</hp>
-            <mp>124.48</mp>
-            <cp>137.26</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>291.86</hp>
-            <mp>132.64</mp>
-            <cp>145.93</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>309.37</hp>
-            <mp>140.88</mp>
-            <cp>154.685</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>327.05</hp>
-            <mp>149.2</mp>
-            <cp>163.525</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>344.9</hp>
-            <mp>157.6</mp>
-            <cp>172.45</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>362.92</hp>
-            <mp>166.08</mp>
-            <cp>181.46</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>381.11</hp>
-            <mp>174.64</mp>
-            <cp>190.555</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>399.47</hp>
-            <mp>183.28</mp>
-            <cp>199.735</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>418.0</hp>
-            <mp>192.0</mp>
-            <cp>209.0</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>453.2</hp>
-            <mp>205.2</mp>
-            <cp>226.6</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>488.72</hp>
-            <mp>218.52</mp>
-            <cp>244.36</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>524.56</hp>
-            <mp>231.96</mp>
-            <cp>262.28</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>560.72</hp>
-            <mp>245.52</mp>
-            <cp>280.36</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>597.2</hp>
-            <mp>259.2</mp>
-            <cp>298.6</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>634.0</hp>
-            <mp>273.0</mp>
-            <cp>317.0</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>671.12</hp>
-            <mp>286.92</mp>
-            <cp>335.56</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>708.56</hp>
-            <mp>300.96</mp>
-            <cp>354.28</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>746.32</hp>
-            <mp>315.12</mp>
-            <cp>373.16</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>784.4</hp>
-            <mp>329.4</mp>
-            <cp>392.2</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>822.8</hp>
-            <mp>343.8</mp>
-            <cp>411.4</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>861.52</hp>
-            <mp>358.32</mp>
-            <cp>430.76</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>900.56</hp>
-            <mp>372.96</mp>
-            <cp>450.28</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>939.92</hp>
-            <mp>387.72</mp>
-            <cp>469.96</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>979.6</hp>
-            <mp>402.6</mp>
-            <cp>489.8</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>1019.6</hp>
-            <mp>417.6</mp>
-            <cp>509.8</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>1059.92</hp>
-            <mp>432.72</mp>
-            <cp>529.96</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1100.56</hp>
-            <mp>447.96</mp>
-            <cp>550.28</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1141.52</hp>
-            <mp>463.32</mp>
-            <cp>570.76</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1182.8</hp>
-            <mp>478.8</mp>
-            <cp>591.4</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1236.1</hp>
-            <mp>504.8</mp>
-            <cp>618.05</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1289.81</hp>
-            <mp>531.0</mp>
-            <cp>644.905</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1343.93</hp>
-            <mp>557.4</mp>
-            <cp>671.965</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1398.46</hp>
-            <mp>584.0</mp>
-            <cp>699.23</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1453.4</hp>
-            <mp>610.8</mp>
-            <cp>726.7</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1508.75</hp>
-            <mp>637.8</mp>
-            <cp>754.375</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1564.51</hp>
-            <mp>665.0</mp>
-            <cp>782.255</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1620.68</hp>
-            <mp>692.4</mp>
-            <cp>810.34</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1677.26</hp>
-            <mp>720.0</mp>
-            <cp>838.63</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1734.25</hp>
-            <mp>747.8</mp>
-            <cp>867.125</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1791.65</hp>
-            <mp>775.8</mp>
-            <cp>895.825</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1849.46</hp>
-            <mp>804.0</mp>
-            <cp>924.73</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1907.68</hp>
-            <mp>832.4</mp>
-            <cp>953.84</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1966.31</hp>
-            <mp>861.0</mp>
-            <cp>983.155</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>2025.35</hp>
-            <mp>889.8</mp>
-            <cp>1012.675</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>2084.8</hp>
-            <mp>918.8</mp>
-            <cp>1042.4</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>2144.66</hp>
-            <mp>948.0</mp>
-            <cp>1072.33</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2204.93</hp>
-            <mp>977.4</mp>
-            <cp>1102.465</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2265.61</hp>
-            <mp>1007.0</mp>
-            <cp>1132.805</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2326.7</hp>
-            <mp>1036.8</mp>
-            <cp>1163.35</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2388.2</hp>
-            <mp>1066.8</mp>
-            <cp>1194.1</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2450.11</hp>
-            <mp>1097.0</mp>
-            <cp>1225.055</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2512.43</hp>
-            <mp>1127.4</mp>
-            <cp>1256.215</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2575.16</hp>
-            <mp>1158.0</mp>
-            <cp>1287.58</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2638.3</hp>
-            <mp>1188.8</mp>
-            <cp>1319.15</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2701.85</hp>
-            <mp>1219.8</mp>
-            <cp>1350.925</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2765.81</hp>
-            <mp>1251.0</mp>
-            <cp>1382.905</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2830.18</hp>
-            <mp>1282.4</mp>
-            <cp>1415.09</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2894.96</hp>
-            <mp>1314.0</mp>
-            <cp>1447.48</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2960.15</hp>
-            <mp>1345.8</mp>
-            <cp>1480.075</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>3025.75</hp>
-            <mp>1377.8</mp>
-            <cp>1512.875</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>3091.76</hp>
-            <mp>1410.0</mp>
-            <cp>1545.88</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>3158.18</hp>
-            <mp>1442.4</mp>
-            <cp>1579.09</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>3225.01</hp>
-            <mp>1475.0</mp>
-            <cp>1612.505</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3292.25</hp>
-            <mp>1507.8</mp>
-            <cp>1646.125</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3359.9</hp>
-            <mp>1540.8</mp>
-            <cp>1679.95</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3427.96</hp>
-            <mp>1574.0</mp>
-            <cp>1713.98</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3496.43</hp>
-            <mp>1607.4</mp>
-            <cp>1748.215</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3565.31</hp>
-            <mp>1641.0</mp>
-            <cp>1782.655</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3634.6</hp>
-            <mp>1674.8</mp>
-            <cp>1817.3</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3704.3</hp>
-            <mp>1708.8</mp>
-            <cp>1852.15</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3774.41</hp>
-            <mp>1743.0</mp>
-            <cp>1887.205</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3844.93</hp>
-            <mp>1777.4</mp>
-            <cp>1922.465</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3915.86</hp>
-            <mp>1812.0</mp>
-            <cp>1957.93</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3987.2</hp>
-            <mp>1846.8</mp>
-            <cp>1993.6</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>4058.95</hp>
-            <mp>1881.8</mp>
-            <cp>2029.475</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>4131.11</hp>
-            <mp>1917.0</mp>
-            <cp>2065.555</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>4203.68</hp>
-            <mp>1952.4</mp>
-            <cp>2101.84</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>4276.66</hp>
-            <mp>1988.0</mp>
-            <cp>2138.33</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4350.05</hp>
-            <mp>2023.8</mp>
-            <cp>2175.025</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4423.85</hp>
-            <mp>2059.8</mp>
-            <cp>2211.925</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>116</classId>
+	<staticData>
+		<baseINT>31</baseINT>
+		<baseSTR>27</baseSTR>
+		<baseCON>31</baseCON>
+		<baseMEN>42</baseMEN>
+		<baseDEX>24</baseDEX>
+		<baseWIT>15</baseWIT>
+		<physicalAbnormalResist>15</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-56733" y="-113459" z="-690" />
+			<node x="-56686" y="-113470" z="-690" />
+			<node x="-56728" y="-113610" z="-690" />
+			<node x="-56693" y="-113610" z="-690" />
+			<node x="-56743" y="-113757" z="-690" />
+			<node x="-56682" y="-113730" z="-690" />
+		</creationPoints>
+		<basePAtk>3</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>15</chest>
+			<legs>8</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>25</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>70</walk>
+			<run>128</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>90</baseBreath>
+		<baseSafeFall>250</baseSafeFall>
+		<collisionMale>
+			<radius>7.0</radius>
+			<height>27.5</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>8.0</radius>
+			<height>25.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>95.0</hp>
+			<mp>40.0</mp>
+			<cp>47.5</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>110.47</hp>
+			<mp>47.28</mp>
+			<cp>55.235</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>126.11</hp>
+			<mp>54.64</mp>
+			<cp>63.055</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>141.92</hp>
+			<mp>62.08</mp>
+			<cp>70.96</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>157.9</hp>
+			<mp>69.6</mp>
+			<cp>78.95</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>174.05</hp>
+			<mp>77.2</mp>
+			<cp>87.025</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>190.37</hp>
+			<mp>84.88</mp>
+			<cp>95.185</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>206.86</hp>
+			<mp>92.64</mp>
+			<cp>103.43</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>223.52</hp>
+			<mp>100.48</mp>
+			<cp>111.76</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>240.35</hp>
+			<mp>108.4</mp>
+			<cp>120.175</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>257.35</hp>
+			<mp>116.4</mp>
+			<cp>128.675</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>274.52</hp>
+			<mp>124.48</mp>
+			<cp>137.26</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>291.86</hp>
+			<mp>132.64</mp>
+			<cp>145.93</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>309.37</hp>
+			<mp>140.88</mp>
+			<cp>154.685</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>327.05</hp>
+			<mp>149.2</mp>
+			<cp>163.525</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>344.9</hp>
+			<mp>157.6</mp>
+			<cp>172.45</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>362.92</hp>
+			<mp>166.08</mp>
+			<cp>181.46</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>381.11</hp>
+			<mp>174.64</mp>
+			<cp>190.555</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>399.47</hp>
+			<mp>183.28</mp>
+			<cp>199.735</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>418.0</hp>
+			<mp>192.0</mp>
+			<cp>209.0</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>453.2</hp>
+			<mp>205.2</mp>
+			<cp>226.6</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>488.72</hp>
+			<mp>218.52</mp>
+			<cp>244.36</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>524.56</hp>
+			<mp>231.96</mp>
+			<cp>262.28</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>560.72</hp>
+			<mp>245.52</mp>
+			<cp>280.36</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>597.2</hp>
+			<mp>259.2</mp>
+			<cp>298.6</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>634.0</hp>
+			<mp>273.0</mp>
+			<cp>317.0</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>671.12</hp>
+			<mp>286.92</mp>
+			<cp>335.56</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>708.56</hp>
+			<mp>300.96</mp>
+			<cp>354.28</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>746.32</hp>
+			<mp>315.12</mp>
+			<cp>373.16</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>784.4</hp>
+			<mp>329.4</mp>
+			<cp>392.2</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>822.8</hp>
+			<mp>343.8</mp>
+			<cp>411.4</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>861.52</hp>
+			<mp>358.32</mp>
+			<cp>430.76</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>900.56</hp>
+			<mp>372.96</mp>
+			<cp>450.28</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>939.92</hp>
+			<mp>387.72</mp>
+			<cp>469.96</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>979.6</hp>
+			<mp>402.6</mp>
+			<cp>489.8</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>1019.6</hp>
+			<mp>417.6</mp>
+			<cp>509.8</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>1059.92</hp>
+			<mp>432.72</mp>
+			<cp>529.96</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1100.56</hp>
+			<mp>447.96</mp>
+			<cp>550.28</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1141.52</hp>
+			<mp>463.32</mp>
+			<cp>570.76</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1182.8</hp>
+			<mp>478.8</mp>
+			<cp>591.4</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1236.1</hp>
+			<mp>504.8</mp>
+			<cp>618.05</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1289.81</hp>
+			<mp>531.0</mp>
+			<cp>644.905</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1343.93</hp>
+			<mp>557.4</mp>
+			<cp>671.965</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1398.46</hp>
+			<mp>584.0</mp>
+			<cp>699.23</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1453.4</hp>
+			<mp>610.8</mp>
+			<cp>726.7</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1508.75</hp>
+			<mp>637.8</mp>
+			<cp>754.375</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1564.51</hp>
+			<mp>665.0</mp>
+			<cp>782.255</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1620.68</hp>
+			<mp>692.4</mp>
+			<cp>810.34</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1677.26</hp>
+			<mp>720.0</mp>
+			<cp>838.63</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1734.25</hp>
+			<mp>747.8</mp>
+			<cp>867.125</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1791.65</hp>
+			<mp>775.8</mp>
+			<cp>895.825</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1849.46</hp>
+			<mp>804.0</mp>
+			<cp>924.73</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1907.68</hp>
+			<mp>832.4</mp>
+			<cp>953.84</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1966.31</hp>
+			<mp>861.0</mp>
+			<cp>983.155</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>2025.35</hp>
+			<mp>889.8</mp>
+			<cp>1012.675</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>2084.8</hp>
+			<mp>918.8</mp>
+			<cp>1042.4</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2144.66</hp>
+			<mp>948.0</mp>
+			<cp>1072.33</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2204.93</hp>
+			<mp>977.4</mp>
+			<cp>1102.465</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2265.61</hp>
+			<mp>1007.0</mp>
+			<cp>1132.805</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2326.7</hp>
+			<mp>1036.8</mp>
+			<cp>1163.35</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2388.2</hp>
+			<mp>1066.8</mp>
+			<cp>1194.1</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2450.11</hp>
+			<mp>1097.0</mp>
+			<cp>1225.055</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2512.43</hp>
+			<mp>1127.4</mp>
+			<cp>1256.215</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2575.16</hp>
+			<mp>1158.0</mp>
+			<cp>1287.58</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2638.3</hp>
+			<mp>1188.8</mp>
+			<cp>1319.15</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2701.85</hp>
+			<mp>1219.8</mp>
+			<cp>1350.925</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2765.81</hp>
+			<mp>1251.0</mp>
+			<cp>1382.905</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2830.18</hp>
+			<mp>1282.4</mp>
+			<cp>1415.09</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2894.96</hp>
+			<mp>1314.0</mp>
+			<cp>1447.48</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2960.15</hp>
+			<mp>1345.8</mp>
+			<cp>1480.075</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>3025.75</hp>
+			<mp>1377.8</mp>
+			<cp>1512.875</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>3091.76</hp>
+			<mp>1410.0</mp>
+			<cp>1545.88</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>3158.18</hp>
+			<mp>1442.4</mp>
+			<cp>1579.09</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3225.01</hp>
+			<mp>1475.0</mp>
+			<cp>1612.505</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3292.25</hp>
+			<mp>1507.8</mp>
+			<cp>1646.125</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3359.9</hp>
+			<mp>1540.8</mp>
+			<cp>1679.95</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3427.96</hp>
+			<mp>1574.0</mp>
+			<cp>1713.98</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3496.43</hp>
+			<mp>1607.4</mp>
+			<cp>1748.215</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3565.31</hp>
+			<mp>1641.0</mp>
+			<cp>1782.655</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3634.6</hp>
+			<mp>1674.8</mp>
+			<cp>1817.3</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3704.3</hp>
+			<mp>1708.8</mp>
+			<cp>1852.15</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3774.41</hp>
+			<mp>1743.0</mp>
+			<cp>1887.205</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3844.93</hp>
+			<mp>1777.4</mp>
+			<cp>1922.465</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3915.86</hp>
+			<mp>1812.0</mp>
+			<cp>1957.93</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3987.2</hp>
+			<mp>1846.8</mp>
+			<cp>1993.6</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>4058.95</hp>
+			<mp>1881.8</mp>
+			<cp>2029.475</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>4131.11</hp>
+			<mp>1917.0</mp>
+			<cp>2065.555</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4203.68</hp>
+			<mp>1952.4</mp>
+			<cp>2101.84</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4276.66</hp>
+			<mp>1988.0</mp>
+			<cp>2138.33</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4350.05</hp>
+			<mp>2023.8</mp>
+			<cp>2175.025</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4423.85</hp>
+			<mp>2059.8</mp>
+			<cp>2211.925</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4498.06</hp>
+			<mp>2096.0</mp>
+			<cp>2249.03</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4572.68</hp>
+			<mp>2132.4</mp>
+			<cp>2286.34</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4647.71</hp>
+			<mp>2169.0</mp>
+			<cp>2323.855</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4723.15</hp>
+			<mp>2205.8</mp>
+			<cp>2361.575</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4799.0</hp>
+			<mp>2242.8</mp>
+			<cp>2399.5</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4875.26</hp>
+			<mp>2280.0</mp>
+			<cp>2437.63</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4951.93</hp>
+			<mp>2317.4</mp>
+			<cp>2475.965</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>5029.01</hp>
+			<mp>2355.0</mp>
+			<cp>2514.505</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>5106.5</hp>
+			<mp>2392.8</mp>
+			<cp>2553.25</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>5184.4</hp>
+			<mp>2430.8</mp>
+			<cp>2592.19</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5262.71</hp>
+			<mp>2469</mp>
+			<cp>2631.33</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5341.43</hp>
+			<mp>2507.4</mp>
+			<cp>2670.67</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5420.56</hp>
+			<mp>2546</mp>
+			<cp>2710.21</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5500.1</hp>
+			<mp>2584.8</mp>
+			<cp>2749.95</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5580.05</hp>
+			<mp>2623.8</mp>
+			<cp>2789.89</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5660.41</hp>
+			<mp>2663</mp>
+			<cp>2830.205</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Dreadnought.xml
+++ b/data/stats/chars/baseStats/Dreadnought.xml
@@ -1,798 +1,926 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>89</classId>
-    <staticData>
-        <baseINT>21</baseINT>
-        <baseSTR>40</baseSTR>
-        <baseCON>43</baseCON>
-        <baseMEN>25</baseMEN>
-        <baseDEX>30</baseDEX>
-        <baseWIT>11</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-71338" y="258271" z="-3104"/>
-            <node x="-71417" y="258270" z="-3104"/>
-            <node x="-71453" y="258305" z="-3104"/>
-            <node x="-71467" y="258378" z="-3104"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>80</walk>
-            <run>132</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>100</baseBreath>
-        <baseSafeFall>250</baseSafeFall>
-        <collisionMale>
-            <radius>9.0</radius>
-            <height>23</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>8.0</radius>
-            <height>23.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>80.0</hp>
-            <mp>30.0</mp>
-            <cp>64.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>91.83</hp>
-            <mp>35.46</mp>
-            <cp>73.464</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>103.79</hp>
-            <mp>40.98</mp>
-            <cp>83.032</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>115.88</hp>
-            <mp>46.56</mp>
-            <cp>92.704</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>128.1</hp>
-            <mp>52.2</mp>
-            <cp>102.48</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>140.45</hp>
-            <mp>57.9</mp>
-            <cp>112.36</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>152.93</hp>
-            <mp>63.66</mp>
-            <cp>122.344</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>165.54</hp>
-            <mp>69.48</mp>
-            <cp>132.432</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>178.28</hp>
-            <mp>75.36</mp>
-            <cp>142.624</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>191.15</hp>
-            <mp>81.3</mp>
-            <cp>152.92</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>204.15</hp>
-            <mp>87.3</mp>
-            <cp>163.32</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>217.28</hp>
-            <mp>93.36</mp>
-            <cp>173.824</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>230.54</hp>
-            <mp>99.48</mp>
-            <cp>184.432</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>243.93</hp>
-            <mp>105.66</mp>
-            <cp>195.144</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>257.45</hp>
-            <mp>111.9</mp>
-            <cp>205.96</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>271.1</hp>
-            <mp>118.2</mp>
-            <cp>216.88</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>284.88</hp>
-            <mp>124.56</mp>
-            <cp>227.904</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>298.79</hp>
-            <mp>130.98</mp>
-            <cp>239.032</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>312.83</hp>
-            <mp>137.46</mp>
-            <cp>250.264</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>327.0</hp>
-            <mp>144.0</mp>
-            <cp>261.6</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>360.0</hp>
-            <mp>153.9</mp>
-            <cp>288.0</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>393.3</hp>
-            <mp>163.89</mp>
-            <cp>314.64</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>426.9</hp>
-            <mp>173.97</mp>
-            <cp>341.52</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>460.8</hp>
-            <mp>184.14</mp>
-            <cp>368.64</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>495.0</hp>
-            <mp>194.4</mp>
-            <cp>396.0</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>529.5</hp>
-            <mp>204.75</mp>
-            <cp>423.6</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>564.3</hp>
-            <mp>215.19</mp>
-            <cp>451.44</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>599.4</hp>
-            <mp>225.72</mp>
-            <cp>479.52</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>634.8</hp>
-            <mp>236.34</mp>
-            <cp>507.84</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>670.5</hp>
-            <mp>247.05</mp>
-            <cp>536.4</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>706.5</hp>
-            <mp>257.85</mp>
-            <cp>565.2</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>742.8</hp>
-            <mp>268.74</mp>
-            <cp>594.24</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>779.4</hp>
-            <mp>279.72</mp>
-            <cp>623.52</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>816.3</hp>
-            <mp>290.79</mp>
-            <cp>653.04</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>853.5</hp>
-            <mp>301.95</mp>
-            <cp>682.8</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>891.0</hp>
-            <mp>313.2</mp>
-            <cp>712.8</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>928.8</hp>
-            <mp>324.54</mp>
-            <cp>743.04</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>966.9</hp>
-            <mp>335.97</mp>
-            <cp>773.52</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1005.3</hp>
-            <mp>347.49</mp>
-            <cp>804.24</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1044.0</hp>
-            <mp>359.1</mp>
-            <cp>835.2</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1098.6</hp>
-            <mp>378.6</mp>
-            <cp>878.88</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1153.62</hp>
-            <mp>398.25</mp>
-            <cp>922.896</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1209.06</hp>
-            <mp>418.05</mp>
-            <cp>967.248</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1264.92</hp>
-            <mp>438.0</mp>
-            <cp>1011.936</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1321.2</hp>
-            <mp>458.1</mp>
-            <cp>1056.96</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1377.9</hp>
-            <mp>478.35</mp>
-            <cp>1102.32</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1435.02</hp>
-            <mp>498.75</mp>
-            <cp>1148.016</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1492.56</hp>
-            <mp>519.3</mp>
-            <cp>1194.048</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1550.52</hp>
-            <mp>540.0</mp>
-            <cp>1240.416</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1608.9</hp>
-            <mp>560.85</mp>
-            <cp>1287.12</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1667.7</hp>
-            <mp>581.85</mp>
-            <cp>1334.16</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1726.92</hp>
-            <mp>603.0</mp>
-            <cp>1381.536</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1786.56</hp>
-            <mp>624.3</mp>
-            <cp>1429.248</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1846.62</hp>
-            <mp>645.75</mp>
-            <cp>1477.296</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1907.1</hp>
-            <mp>667.35</mp>
-            <cp>1525.68</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1968.0</hp>
-            <mp>689.1</mp>
-            <cp>1574.4</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>2029.32</hp>
-            <mp>711.0</mp>
-            <cp>1623.456</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2091.06</hp>
-            <mp>733.05</mp>
-            <cp>1672.848</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2153.22</hp>
-            <mp>755.25</mp>
-            <cp>1722.576</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2215.8</hp>
-            <mp>777.6</mp>
-            <cp>1772.64</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2278.8</hp>
-            <mp>800.1</mp>
-            <cp>1823.04</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2342.22</hp>
-            <mp>822.75</mp>
-            <cp>1873.776</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2406.06</hp>
-            <mp>845.55</mp>
-            <cp>1924.848</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2470.32</hp>
-            <mp>868.5</mp>
-            <cp>1976.256</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2535.0</hp>
-            <mp>891.6</mp>
-            <cp>2028.0</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2600.1</hp>
-            <mp>914.85</mp>
-            <cp>2080.08</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2665.62</hp>
-            <mp>938.25</mp>
-            <cp>2132.496</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2731.56</hp>
-            <mp>961.8</mp>
-            <cp>2185.248</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2797.92</hp>
-            <mp>985.5</mp>
-            <cp>2238.336</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2864.7</hp>
-            <mp>1009.35</mp>
-            <cp>2291.76</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2931.9</hp>
-            <mp>1033.35</mp>
-            <cp>2345.52</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2999.52</hp>
-            <mp>1057.5</mp>
-            <cp>2399.616</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>3067.56</hp>
-            <mp>1081.8</mp>
-            <cp>2454.048</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>3136.02</hp>
-            <mp>1106.25</mp>
-            <cp>2508.816</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3204.9</hp>
-            <mp>1130.85</mp>
-            <cp>2563.92</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3274.2</hp>
-            <mp>1155.6</mp>
-            <cp>2619.36</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3343.92</hp>
-            <mp>1180.5</mp>
-            <cp>2675.136</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3414.06</hp>
-            <mp>1205.55</mp>
-            <cp>2731.248</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3484.62</hp>
-            <mp>1230.75</mp>
-            <cp>2787.696</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3555.6</hp>
-            <mp>1256.1</mp>
-            <cp>2844.48</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3627.0</hp>
-            <mp>1281.6</mp>
-            <cp>2901.6</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3698.82</hp>
-            <mp>1307.25</mp>
-            <cp>2959.056</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3771.06</hp>
-            <mp>1333.05</mp>
-            <cp>3016.848</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3843.72</hp>
-            <mp>1359.0</mp>
-            <cp>3074.976</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3916.8</hp>
-            <mp>1385.1</mp>
-            <cp>3133.44</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3990.3</hp>
-            <mp>1411.35</mp>
-            <cp>3192.24</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>4064.22</hp>
-            <mp>1437.75</mp>
-            <cp>3251.376</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>4138.56</hp>
-            <mp>1464.3</mp>
-            <cp>3310.848</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>4213.32</hp>
-            <mp>1491.0</mp>
-            <cp>3370.656</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4288.5</hp>
-            <mp>1517.85</mp>
-            <cp>3430.8</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4364.1</hp>
-            <mp>1544.85</mp>
-            <cp>3491.28</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>89</classId>
+	<staticData>
+		<baseINT>21</baseINT>
+		<baseSTR>40</baseSTR>
+		<baseCON>43</baseCON>
+		<baseMEN>25</baseMEN>
+		<baseDEX>30</baseDEX>
+		<baseWIT>11</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-71338" y="258271" z="-3104" />
+			<node x="-71417" y="258270" z="-3104" />
+			<node x="-71453" y="258305" z="-3104" />
+			<node x="-71467" y="258378" z="-3104" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>80</walk>
+			<run>132</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>250</baseSafeFall>
+		<collisionMale>
+			<radius>9.0</radius>
+			<height>23</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>8.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>80.0</hp>
+			<mp>30.0</mp>
+			<cp>64.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>91.83</hp>
+			<mp>35.46</mp>
+			<cp>73.464</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>103.79</hp>
+			<mp>40.98</mp>
+			<cp>83.032</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>115.88</hp>
+			<mp>46.56</mp>
+			<cp>92.704</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>128.1</hp>
+			<mp>52.2</mp>
+			<cp>102.48</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>140.45</hp>
+			<mp>57.9</mp>
+			<cp>112.36</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>152.93</hp>
+			<mp>63.66</mp>
+			<cp>122.344</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>165.54</hp>
+			<mp>69.48</mp>
+			<cp>132.432</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>178.28</hp>
+			<mp>75.36</mp>
+			<cp>142.624</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>191.15</hp>
+			<mp>81.3</mp>
+			<cp>152.92</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>204.15</hp>
+			<mp>87.3</mp>
+			<cp>163.32</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>217.28</hp>
+			<mp>93.36</mp>
+			<cp>173.824</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>230.54</hp>
+			<mp>99.48</mp>
+			<cp>184.432</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>243.93</hp>
+			<mp>105.66</mp>
+			<cp>195.144</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>257.45</hp>
+			<mp>111.9</mp>
+			<cp>205.96</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>271.1</hp>
+			<mp>118.2</mp>
+			<cp>216.88</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>284.88</hp>
+			<mp>124.56</mp>
+			<cp>227.904</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>298.79</hp>
+			<mp>130.98</mp>
+			<cp>239.032</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>312.83</hp>
+			<mp>137.46</mp>
+			<cp>250.264</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>327.0</hp>
+			<mp>144.0</mp>
+			<cp>261.6</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>360.0</hp>
+			<mp>153.9</mp>
+			<cp>288.0</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>393.3</hp>
+			<mp>163.89</mp>
+			<cp>314.64</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>426.9</hp>
+			<mp>173.97</mp>
+			<cp>341.52</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>460.8</hp>
+			<mp>184.14</mp>
+			<cp>368.64</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>495.0</hp>
+			<mp>194.4</mp>
+			<cp>396.0</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>529.5</hp>
+			<mp>204.75</mp>
+			<cp>423.6</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>564.3</hp>
+			<mp>215.19</mp>
+			<cp>451.44</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>599.4</hp>
+			<mp>225.72</mp>
+			<cp>479.52</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>634.8</hp>
+			<mp>236.34</mp>
+			<cp>507.84</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>670.5</hp>
+			<mp>247.05</mp>
+			<cp>536.4</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>706.5</hp>
+			<mp>257.85</mp>
+			<cp>565.2</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>742.8</hp>
+			<mp>268.74</mp>
+			<cp>594.24</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>779.4</hp>
+			<mp>279.72</mp>
+			<cp>623.52</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>816.3</hp>
+			<mp>290.79</mp>
+			<cp>653.04</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>853.5</hp>
+			<mp>301.95</mp>
+			<cp>682.8</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>891.0</hp>
+			<mp>313.2</mp>
+			<cp>712.8</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>928.8</hp>
+			<mp>324.54</mp>
+			<cp>743.04</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>966.9</hp>
+			<mp>335.97</mp>
+			<cp>773.52</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1005.3</hp>
+			<mp>347.49</mp>
+			<cp>804.24</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1044.0</hp>
+			<mp>359.1</mp>
+			<cp>835.2</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1098.6</hp>
+			<mp>378.6</mp>
+			<cp>878.88</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1153.62</hp>
+			<mp>398.25</mp>
+			<cp>922.896</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1209.06</hp>
+			<mp>418.05</mp>
+			<cp>967.248</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1264.92</hp>
+			<mp>438.0</mp>
+			<cp>1011.936</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1321.2</hp>
+			<mp>458.1</mp>
+			<cp>1056.96</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1377.9</hp>
+			<mp>478.35</mp>
+			<cp>1102.32</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1435.02</hp>
+			<mp>498.75</mp>
+			<cp>1148.016</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1492.56</hp>
+			<mp>519.3</mp>
+			<cp>1194.048</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1550.52</hp>
+			<mp>540.0</mp>
+			<cp>1240.416</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1608.9</hp>
+			<mp>560.85</mp>
+			<cp>1287.12</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1667.7</hp>
+			<mp>581.85</mp>
+			<cp>1334.16</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1726.92</hp>
+			<mp>603.0</mp>
+			<cp>1381.536</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1786.56</hp>
+			<mp>624.3</mp>
+			<cp>1429.248</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1846.62</hp>
+			<mp>645.75</mp>
+			<cp>1477.296</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1907.1</hp>
+			<mp>667.35</mp>
+			<cp>1525.68</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1968.0</hp>
+			<mp>689.1</mp>
+			<cp>1574.4</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2029.32</hp>
+			<mp>711.0</mp>
+			<cp>1623.456</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2091.06</hp>
+			<mp>733.05</mp>
+			<cp>1672.848</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2153.22</hp>
+			<mp>755.25</mp>
+			<cp>1722.576</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2215.8</hp>
+			<mp>777.6</mp>
+			<cp>1772.64</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2278.8</hp>
+			<mp>800.1</mp>
+			<cp>1823.04</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2342.22</hp>
+			<mp>822.75</mp>
+			<cp>1873.776</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2406.06</hp>
+			<mp>845.55</mp>
+			<cp>1924.848</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2470.32</hp>
+			<mp>868.5</mp>
+			<cp>1976.256</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2535.0</hp>
+			<mp>891.6</mp>
+			<cp>2028.0</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2600.1</hp>
+			<mp>914.85</mp>
+			<cp>2080.08</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2665.62</hp>
+			<mp>938.25</mp>
+			<cp>2132.496</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2731.56</hp>
+			<mp>961.8</mp>
+			<cp>2185.248</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2797.92</hp>
+			<mp>985.5</mp>
+			<cp>2238.336</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2864.7</hp>
+			<mp>1009.35</mp>
+			<cp>2291.76</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2931.9</hp>
+			<mp>1033.35</mp>
+			<cp>2345.52</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2999.52</hp>
+			<mp>1057.5</mp>
+			<cp>2399.616</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>3067.56</hp>
+			<mp>1081.8</mp>
+			<cp>2454.048</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3136.02</hp>
+			<mp>1106.25</mp>
+			<cp>2508.816</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3204.9</hp>
+			<mp>1130.85</mp>
+			<cp>2563.92</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3274.2</hp>
+			<mp>1155.6</mp>
+			<cp>2619.36</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3343.92</hp>
+			<mp>1180.5</mp>
+			<cp>2675.136</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3414.06</hp>
+			<mp>1205.55</mp>
+			<cp>2731.248</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3484.62</hp>
+			<mp>1230.75</mp>
+			<cp>2787.696</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3555.6</hp>
+			<mp>1256.1</mp>
+			<cp>2844.48</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3627.0</hp>
+			<mp>1281.6</mp>
+			<cp>2901.6</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3698.82</hp>
+			<mp>1307.25</mp>
+			<cp>2959.056</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3771.06</hp>
+			<mp>1333.05</mp>
+			<cp>3016.848</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3843.72</hp>
+			<mp>1359.0</mp>
+			<cp>3074.976</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3916.8</hp>
+			<mp>1385.1</mp>
+			<cp>3133.44</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3990.3</hp>
+			<mp>1411.35</mp>
+			<cp>3192.24</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>4064.22</hp>
+			<mp>1437.75</mp>
+			<cp>3251.376</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4138.56</hp>
+			<mp>1464.3</mp>
+			<cp>3310.848</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4213.32</hp>
+			<mp>1491.0</mp>
+			<cp>3370.656</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4288.5</hp>
+			<mp>1517.85</mp>
+			<cp>3430.8</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4364.1</hp>
+			<mp>1544.85</mp>
+			<cp>3491.28</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4440.12</hp>
+			<mp>1572.0</mp>
+			<cp>3552.096</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4516.56</hp>
+			<mp>1599.3</mp>
+			<cp>3613.248</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4593.42</hp>
+			<mp>1626.75</mp>
+			<cp>3674.736</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4670.7</hp>
+			<mp>1654.35</mp>
+			<cp>3736.56</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4748.4</hp>
+			<mp>1682.1</mp>
+			<cp>3798.72</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4826.52</hp>
+			<mp>1710.0</mp>
+			<cp>3861.216</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4905.06</hp>
+			<mp>1738.05</mp>
+			<cp>3924.048</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4984.02</hp>
+			<mp>1766.25</mp>
+			<cp>3987.216</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>5063.4</hp>
+			<mp>1794.6</mp>
+			<cp>4050.72</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>5143.2</hp>
+			<mp>1823.1</mp>
+			<cp>4114.57</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5223.42</hp>
+			<mp>1851.75</mp>
+			<cp>4178.76</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5304.06</hp>
+			<mp>1880.55</mp>
+			<cp>4243.29</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5385.12</hp>
+			<mp>1909.5</mp>
+			<cp>4308.16</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5466.6</hp>
+			<mp>1938.6</mp>
+			<cp>4373.36</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5548.5</hp>
+			<mp>1967.85</mp>
+			<cp>4438.91</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5630.82</hp>
+			<mp>1997.25</mp>
+			<cp>4504.656</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Duelist.xml
+++ b/data/stats/chars/baseStats/Duelist.xml
@@ -1,798 +1,926 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>88</classId>
-    <staticData>
-        <baseINT>21</baseINT>
-        <baseSTR>40</baseSTR>
-        <baseCON>43</baseCON>
-        <baseMEN>25</baseMEN>
-        <baseDEX>30</baseDEX>
-        <baseWIT>11</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-71338" y="258271" z="-3104"/>
-            <node x="-71417" y="258270" z="-3104"/>
-            <node x="-71453" y="258305" z="-3104"/>
-            <node x="-71467" y="258378" z="-3104"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>80</walk>
-            <run>132</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>100</baseBreath>
-        <baseSafeFall>250</baseSafeFall>
-        <collisionMale>
-            <radius>9.0</radius>
-            <height>23</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>8.0</radius>
-            <height>23.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>80.0</hp>
-            <mp>30.0</mp>
-            <cp>72.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>91.83</hp>
-            <mp>35.46</mp>
-            <cp>82.647</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>103.79</hp>
-            <mp>40.98</mp>
-            <cp>93.411</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>115.88</hp>
-            <mp>46.56</mp>
-            <cp>104.292</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>128.1</hp>
-            <mp>52.2</mp>
-            <cp>115.29</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>140.45</hp>
-            <mp>57.9</mp>
-            <cp>126.405</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>152.93</hp>
-            <mp>63.66</mp>
-            <cp>137.637</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>165.54</hp>
-            <mp>69.48</mp>
-            <cp>148.986</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>178.28</hp>
-            <mp>75.36</mp>
-            <cp>160.452</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>191.15</hp>
-            <mp>81.3</mp>
-            <cp>172.035</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>204.15</hp>
-            <mp>87.3</mp>
-            <cp>183.735</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>217.28</hp>
-            <mp>93.36</mp>
-            <cp>195.552</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>230.54</hp>
-            <mp>99.48</mp>
-            <cp>207.486</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>243.93</hp>
-            <mp>105.66</mp>
-            <cp>219.537</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>257.45</hp>
-            <mp>111.9</mp>
-            <cp>231.705</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>271.1</hp>
-            <mp>118.2</mp>
-            <cp>243.99</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>284.88</hp>
-            <mp>124.56</mp>
-            <cp>256.392</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>298.79</hp>
-            <mp>130.98</mp>
-            <cp>268.911</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>312.83</hp>
-            <mp>137.46</mp>
-            <cp>281.547</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>327.0</hp>
-            <mp>144.0</mp>
-            <cp>294.3</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>360.0</hp>
-            <mp>153.9</mp>
-            <cp>324.0</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>393.3</hp>
-            <mp>163.89</mp>
-            <cp>353.97</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>426.9</hp>
-            <mp>173.97</mp>
-            <cp>384.21</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>460.8</hp>
-            <mp>184.14</mp>
-            <cp>414.72</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>495.0</hp>
-            <mp>194.4</mp>
-            <cp>445.5</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>529.5</hp>
-            <mp>204.75</mp>
-            <cp>476.55</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>564.3</hp>
-            <mp>215.19</mp>
-            <cp>507.87</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>599.4</hp>
-            <mp>225.72</mp>
-            <cp>539.46</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>634.8</hp>
-            <mp>236.34</mp>
-            <cp>571.32</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>670.5</hp>
-            <mp>247.05</mp>
-            <cp>603.45</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>706.5</hp>
-            <mp>257.85</mp>
-            <cp>635.85</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>742.8</hp>
-            <mp>268.74</mp>
-            <cp>668.52</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>779.4</hp>
-            <mp>279.72</mp>
-            <cp>701.46</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>816.3</hp>
-            <mp>290.79</mp>
-            <cp>734.67</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>853.5</hp>
-            <mp>301.95</mp>
-            <cp>768.15</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>891.0</hp>
-            <mp>313.2</mp>
-            <cp>801.9</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>928.8</hp>
-            <mp>324.54</mp>
-            <cp>835.92</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>966.9</hp>
-            <mp>335.97</mp>
-            <cp>870.21</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1005.3</hp>
-            <mp>347.49</mp>
-            <cp>904.77</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1044.0</hp>
-            <mp>359.1</mp>
-            <cp>939.6</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1093.4</hp>
-            <mp>378.6</mp>
-            <cp>984.06</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1143.18</hp>
-            <mp>398.25</mp>
-            <cp>1028.862</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1193.34</hp>
-            <mp>418.05</mp>
-            <cp>1074.006</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1243.88</hp>
-            <mp>438.0</mp>
-            <cp>1119.492</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1294.8</hp>
-            <mp>458.1</mp>
-            <cp>1165.32</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1346.1</hp>
-            <mp>478.35</mp>
-            <cp>1211.49</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1397.78</hp>
-            <mp>498.75</mp>
-            <cp>1258.002</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1449.84</hp>
-            <mp>519.3</mp>
-            <cp>1304.856</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1502.28</hp>
-            <mp>540.0</mp>
-            <cp>1352.052</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1555.1</hp>
-            <mp>560.85</mp>
-            <cp>1399.59</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1608.3</hp>
-            <mp>581.85</mp>
-            <cp>1447.47</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1661.88</hp>
-            <mp>603.0</mp>
-            <cp>1495.692</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1715.84</hp>
-            <mp>624.3</mp>
-            <cp>1544.256</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1770.18</hp>
-            <mp>645.75</mp>
-            <cp>1593.162</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1824.9</hp>
-            <mp>667.35</mp>
-            <cp>1642.41</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1880.0</hp>
-            <mp>689.1</mp>
-            <cp>1692.0</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1935.48</hp>
-            <mp>711.0</mp>
-            <cp>1741.932</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1991.34</hp>
-            <mp>733.05</mp>
-            <cp>1792.206</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2047.58</hp>
-            <mp>755.25</mp>
-            <cp>1842.822</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2104.2</hp>
-            <mp>777.6</mp>
-            <cp>1893.78</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2161.2</hp>
-            <mp>800.1</mp>
-            <cp>1945.08</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2218.58</hp>
-            <mp>822.75</mp>
-            <cp>1996.722</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2276.34</hp>
-            <mp>845.55</mp>
-            <cp>2048.706</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2334.48</hp>
-            <mp>868.5</mp>
-            <cp>2101.032</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2393.0</hp>
-            <mp>891.6</mp>
-            <cp>2153.7</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2451.9</hp>
-            <mp>914.85</mp>
-            <cp>2206.71</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2511.18</hp>
-            <mp>938.25</mp>
-            <cp>2260.062</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2570.84</hp>
-            <mp>961.8</mp>
-            <cp>2313.756</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2630.88</hp>
-            <mp>985.5</mp>
-            <cp>2367.792</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2691.3</hp>
-            <mp>1009.35</mp>
-            <cp>2422.17</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2752.1</hp>
-            <mp>1033.35</mp>
-            <cp>2476.89</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2813.28</hp>
-            <mp>1057.5</mp>
-            <cp>2531.952</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2874.84</hp>
-            <mp>1081.8</mp>
-            <cp>2587.356</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2936.78</hp>
-            <mp>1106.25</mp>
-            <cp>2643.102</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2999.1</hp>
-            <mp>1130.85</mp>
-            <cp>2699.19</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3061.8</hp>
-            <mp>1155.6</mp>
-            <cp>2755.62</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3124.88</hp>
-            <mp>1180.5</mp>
-            <cp>2812.392</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3188.34</hp>
-            <mp>1205.55</mp>
-            <cp>2869.506</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3252.18</hp>
-            <mp>1230.75</mp>
-            <cp>2926.962</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3316.4</hp>
-            <mp>1256.1</mp>
-            <cp>2984.76</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3381.0</hp>
-            <mp>1281.6</mp>
-            <cp>3042.9</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3445.98</hp>
-            <mp>1307.25</mp>
-            <cp>3101.382</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3511.34</hp>
-            <mp>1333.05</mp>
-            <cp>3160.206</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3577.08</hp>
-            <mp>1359.0</mp>
-            <cp>3219.372</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3643.2</hp>
-            <mp>1385.1</mp>
-            <cp>3278.88</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3709.7</hp>
-            <mp>1411.35</mp>
-            <cp>3338.73</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3776.58</hp>
-            <mp>1437.75</mp>
-            <cp>3398.922</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3843.84</hp>
-            <mp>1464.3</mp>
-            <cp>3459.456</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3911.48</hp>
-            <mp>1491.0</mp>
-            <cp>3520.332</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3979.5</hp>
-            <mp>1517.85</mp>
-            <cp>3581.55</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4047.9</hp>
-            <mp>1544.85</mp>
-            <cp>3643.11</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>88</classId>
+	<staticData>
+		<baseINT>21</baseINT>
+		<baseSTR>40</baseSTR>
+		<baseCON>43</baseCON>
+		<baseMEN>25</baseMEN>
+		<baseDEX>30</baseDEX>
+		<baseWIT>11</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-71338" y="258271" z="-3104" />
+			<node x="-71417" y="258270" z="-3104" />
+			<node x="-71453" y="258305" z="-3104" />
+			<node x="-71467" y="258378" z="-3104" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>80</walk>
+			<run>132</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>250</baseSafeFall>
+		<collisionMale>
+			<radius>9.0</radius>
+			<height>23</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>8.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>80.0</hp>
+			<mp>30.0</mp>
+			<cp>72.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>91.83</hp>
+			<mp>35.46</mp>
+			<cp>82.647</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>103.79</hp>
+			<mp>40.98</mp>
+			<cp>93.411</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>115.88</hp>
+			<mp>46.56</mp>
+			<cp>104.292</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>128.1</hp>
+			<mp>52.2</mp>
+			<cp>115.29</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>140.45</hp>
+			<mp>57.9</mp>
+			<cp>126.405</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>152.93</hp>
+			<mp>63.66</mp>
+			<cp>137.637</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>165.54</hp>
+			<mp>69.48</mp>
+			<cp>148.986</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>178.28</hp>
+			<mp>75.36</mp>
+			<cp>160.452</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>191.15</hp>
+			<mp>81.3</mp>
+			<cp>172.035</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>204.15</hp>
+			<mp>87.3</mp>
+			<cp>183.735</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>217.28</hp>
+			<mp>93.36</mp>
+			<cp>195.552</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>230.54</hp>
+			<mp>99.48</mp>
+			<cp>207.486</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>243.93</hp>
+			<mp>105.66</mp>
+			<cp>219.537</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>257.45</hp>
+			<mp>111.9</mp>
+			<cp>231.705</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>271.1</hp>
+			<mp>118.2</mp>
+			<cp>243.99</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>284.88</hp>
+			<mp>124.56</mp>
+			<cp>256.392</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>298.79</hp>
+			<mp>130.98</mp>
+			<cp>268.911</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>312.83</hp>
+			<mp>137.46</mp>
+			<cp>281.547</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>327.0</hp>
+			<mp>144.0</mp>
+			<cp>294.3</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>360.0</hp>
+			<mp>153.9</mp>
+			<cp>324.0</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>393.3</hp>
+			<mp>163.89</mp>
+			<cp>353.97</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>426.9</hp>
+			<mp>173.97</mp>
+			<cp>384.21</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>460.8</hp>
+			<mp>184.14</mp>
+			<cp>414.72</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>495.0</hp>
+			<mp>194.4</mp>
+			<cp>445.5</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>529.5</hp>
+			<mp>204.75</mp>
+			<cp>476.55</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>564.3</hp>
+			<mp>215.19</mp>
+			<cp>507.87</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>599.4</hp>
+			<mp>225.72</mp>
+			<cp>539.46</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>634.8</hp>
+			<mp>236.34</mp>
+			<cp>571.32</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>670.5</hp>
+			<mp>247.05</mp>
+			<cp>603.45</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>706.5</hp>
+			<mp>257.85</mp>
+			<cp>635.85</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>742.8</hp>
+			<mp>268.74</mp>
+			<cp>668.52</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>779.4</hp>
+			<mp>279.72</mp>
+			<cp>701.46</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>816.3</hp>
+			<mp>290.79</mp>
+			<cp>734.67</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>853.5</hp>
+			<mp>301.95</mp>
+			<cp>768.15</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>891.0</hp>
+			<mp>313.2</mp>
+			<cp>801.9</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>928.8</hp>
+			<mp>324.54</mp>
+			<cp>835.92</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>966.9</hp>
+			<mp>335.97</mp>
+			<cp>870.21</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1005.3</hp>
+			<mp>347.49</mp>
+			<cp>904.77</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1044.0</hp>
+			<mp>359.1</mp>
+			<cp>939.6</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1093.4</hp>
+			<mp>378.6</mp>
+			<cp>984.06</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1143.18</hp>
+			<mp>398.25</mp>
+			<cp>1028.862</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1193.34</hp>
+			<mp>418.05</mp>
+			<cp>1074.006</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1243.88</hp>
+			<mp>438.0</mp>
+			<cp>1119.492</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1294.8</hp>
+			<mp>458.1</mp>
+			<cp>1165.32</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1346.1</hp>
+			<mp>478.35</mp>
+			<cp>1211.49</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1397.78</hp>
+			<mp>498.75</mp>
+			<cp>1258.002</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1449.84</hp>
+			<mp>519.3</mp>
+			<cp>1304.856</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1502.28</hp>
+			<mp>540.0</mp>
+			<cp>1352.052</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1555.1</hp>
+			<mp>560.85</mp>
+			<cp>1399.59</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1608.3</hp>
+			<mp>581.85</mp>
+			<cp>1447.47</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1661.88</hp>
+			<mp>603.0</mp>
+			<cp>1495.692</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1715.84</hp>
+			<mp>624.3</mp>
+			<cp>1544.256</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1770.18</hp>
+			<mp>645.75</mp>
+			<cp>1593.162</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1824.9</hp>
+			<mp>667.35</mp>
+			<cp>1642.41</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1880.0</hp>
+			<mp>689.1</mp>
+			<cp>1692.0</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1935.48</hp>
+			<mp>711.0</mp>
+			<cp>1741.932</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1991.34</hp>
+			<mp>733.05</mp>
+			<cp>1792.206</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2047.58</hp>
+			<mp>755.25</mp>
+			<cp>1842.822</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2104.2</hp>
+			<mp>777.6</mp>
+			<cp>1893.78</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2161.2</hp>
+			<mp>800.1</mp>
+			<cp>1945.08</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2218.58</hp>
+			<mp>822.75</mp>
+			<cp>1996.722</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2276.34</hp>
+			<mp>845.55</mp>
+			<cp>2048.706</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2334.48</hp>
+			<mp>868.5</mp>
+			<cp>2101.032</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2393.0</hp>
+			<mp>891.6</mp>
+			<cp>2153.7</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2451.9</hp>
+			<mp>914.85</mp>
+			<cp>2206.71</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2511.18</hp>
+			<mp>938.25</mp>
+			<cp>2260.062</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2570.84</hp>
+			<mp>961.8</mp>
+			<cp>2313.756</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2630.88</hp>
+			<mp>985.5</mp>
+			<cp>2367.792</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2691.3</hp>
+			<mp>1009.35</mp>
+			<cp>2422.17</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2752.1</hp>
+			<mp>1033.35</mp>
+			<cp>2476.89</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2813.28</hp>
+			<mp>1057.5</mp>
+			<cp>2531.952</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2874.84</hp>
+			<mp>1081.8</mp>
+			<cp>2587.356</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2936.78</hp>
+			<mp>1106.25</mp>
+			<cp>2643.102</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2999.1</hp>
+			<mp>1130.85</mp>
+			<cp>2699.19</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3061.8</hp>
+			<mp>1155.6</mp>
+			<cp>2755.62</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3124.88</hp>
+			<mp>1180.5</mp>
+			<cp>2812.392</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3188.34</hp>
+			<mp>1205.55</mp>
+			<cp>2869.506</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3252.18</hp>
+			<mp>1230.75</mp>
+			<cp>2926.962</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3316.4</hp>
+			<mp>1256.1</mp>
+			<cp>2984.76</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3381.0</hp>
+			<mp>1281.6</mp>
+			<cp>3042.9</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3445.98</hp>
+			<mp>1307.25</mp>
+			<cp>3101.382</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3511.34</hp>
+			<mp>1333.05</mp>
+			<cp>3160.206</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3577.08</hp>
+			<mp>1359.0</mp>
+			<cp>3219.372</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3643.2</hp>
+			<mp>1385.1</mp>
+			<cp>3278.88</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3709.7</hp>
+			<mp>1411.35</mp>
+			<cp>3338.73</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3776.58</hp>
+			<mp>1437.75</mp>
+			<cp>3398.922</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3843.84</hp>
+			<mp>1464.3</mp>
+			<cp>3459.456</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3911.48</hp>
+			<mp>1491.0</mp>
+			<cp>3520.332</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3979.5</hp>
+			<mp>1517.85</mp>
+			<cp>3581.55</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4047.9</hp>
+			<mp>1544.85</mp>
+			<cp>3643.11</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4116.68</hp>
+			<mp>1572.0</mp>
+			<cp>3705.012</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4185.84</hp>
+			<mp>1599.3</mp>
+			<cp>3767.256</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4255.38</hp>
+			<mp>1626.75</mp>
+			<cp>3829.842</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4325.3</hp>
+			<mp>1654.35</mp>
+			<cp>3892.77</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4395.6</hp>
+			<mp>1682.1</mp>
+			<cp>3956.04</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4466.28</hp>
+			<mp>1710.0</mp>
+			<cp>4019.652</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4537.34</hp>
+			<mp>1738.05</mp>
+			<cp>4083.606</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4608.78</hp>
+			<mp>1766.25</mp>
+			<cp>4147.902</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4680.6</hp>
+			<mp>1794.6</mp>
+			<cp>4212.54</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4752.8</hp>
+			<mp>1823.1</mp>
+			<cp>4277.51</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4825.38</hp>
+			<mp>1851.75</mp>
+			<cp>4342.83</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4898.34</hp>
+			<mp>1880.55</mp>
+			<cp>4408.49</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4971.68</hp>
+			<mp>1909.5</mp>
+			<cp>4474.48</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5045.4</hp>
+			<mp>1938.6</mp>
+			<cp>4540.82</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5119.5</hp>
+			<mp>1967.85</mp>
+			<cp>4607.49</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5193.98</hp>
+			<mp>1997.25</mp>
+			<cp>4674.582</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/DwarvenFighter.xml
+++ b/data/stats/chars/baseStats/DwarvenFighter.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>53</classId>
-    <staticData>
-        <baseINT>20</baseINT>
-        <baseSTR>39</baseSTR>
-        <baseCON>45</baseCON>
-        <baseMEN>27</baseMEN>
-        <baseDEX>29</baseDEX>
-        <baseWIT>10</baseWIT>
-        <physicalAbnormalResist>15</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="108644" y="-173947" z="-400"/>
-            <node x="108678" y="-174002" z="-400"/>
-            <node x="108505" y="-173964" z="-400"/>
-            <node x="108512" y="-174026" z="-400"/>
-            <node x="108549" y="-174075" z="-400"/>
-            <node x="108576" y="-174122" z="-400"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>80</walk>
-            <run>131</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>80</baseBreath>
-        <baseSafeFall>180</baseSafeFall>
-        <collisionMale>
-            <radius>9.0</radius>
-            <height>18.0</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>5.0</radius>
-            <height>19.0</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>80.0</hp>
-            <mp>30.0</mp>
-            <cp>56.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>92.74</hp>
-            <mp>35.46</mp>
-            <cp>64.918</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>105.62</hp>
-            <mp>40.98</mp>
-            <cp>73.934</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>118.64</hp>
-            <mp>46.56</mp>
-            <cp>83.048</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>131.8</hp>
-            <mp>52.2</mp>
-            <cp>92.26</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>145.1</hp>
-            <mp>57.9</mp>
-            <cp>101.57</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>158.54</hp>
-            <mp>63.66</mp>
-            <cp>110.978</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>172.12</hp>
-            <mp>69.48</mp>
-            <cp>120.484</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>185.84</hp>
-            <mp>75.36</mp>
-            <cp>130.088</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>199.7</hp>
-            <mp>81.3</mp>
-            <cp>139.79</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>213.7</hp>
-            <mp>87.3</mp>
-            <cp>149.59</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>227.84</hp>
-            <mp>93.36</mp>
-            <cp>159.488</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>242.12</hp>
-            <mp>99.48</mp>
-            <cp>169.484</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>256.54</hp>
-            <mp>105.66</mp>
-            <cp>179.578</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>271.1</hp>
-            <mp>111.9</mp>
-            <cp>189.77</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>285.8</hp>
-            <mp>118.2</mp>
-            <cp>200.06</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>300.64</hp>
-            <mp>124.56</mp>
-            <cp>210.448</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>315.62</hp>
-            <mp>130.98</mp>
-            <cp>220.934</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>330.74</hp>
-            <mp>137.46</mp>
-            <cp>231.518</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>346.0</hp>
-            <mp>144.0</mp>
-            <cp>242.2</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>361.4</hp>
-            <mp>150.6</mp>
-            <cp>252.98</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>376.94</hp>
-            <mp>157.26</mp>
-            <cp>263.858</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>392.62</hp>
-            <mp>163.98</mp>
-            <cp>274.834</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>408.44</hp>
-            <mp>170.76</mp>
-            <cp>285.908</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>424.4</hp>
-            <mp>177.6</mp>
-            <cp>297.08</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>440.5</hp>
-            <mp>184.5</mp>
-            <cp>308.35</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>456.74</hp>
-            <mp>191.46</mp>
-            <cp>319.718</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>473.12</hp>
-            <mp>198.48</mp>
-            <cp>331.184</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>489.64</hp>
-            <mp>205.56</mp>
-            <cp>342.748</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>506.3</hp>
-            <mp>212.7</mp>
-            <cp>354.41</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>523.1</hp>
-            <mp>219.9</mp>
-            <cp>366.17</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>540.04</hp>
-            <mp>227.16</mp>
-            <cp>378.028</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>557.12</hp>
-            <mp>234.48</mp>
-            <cp>389.984</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>574.34</hp>
-            <mp>241.86</mp>
-            <cp>402.038</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>591.7</hp>
-            <mp>249.3</mp>
-            <cp>414.19</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>609.2</hp>
-            <mp>256.8</mp>
-            <cp>426.44</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>626.84</hp>
-            <mp>264.36</mp>
-            <cp>438.788</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>644.62</hp>
-            <mp>271.98</mp>
-            <cp>451.234</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>662.54</hp>
-            <mp>279.66</mp>
-            <cp>463.778</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>680.6</hp>
-            <mp>287.4</mp>
-            <cp>476.42</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>698.8</hp>
-            <mp>295.2</mp>
-            <cp>489.16</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>717.14</hp>
-            <mp>303.06</mp>
-            <cp>501.998</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>735.62</hp>
-            <mp>310.98</mp>
-            <cp>514.934</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>754.24</hp>
-            <mp>318.96</mp>
-            <cp>527.968</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>773.0</hp>
-            <mp>327.0</mp>
-            <cp>541.1</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>791.9</hp>
-            <mp>335.1</mp>
-            <cp>554.33</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>810.94</hp>
-            <mp>343.26</mp>
-            <cp>567.658</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>830.12</hp>
-            <mp>351.48</mp>
-            <cp>581.084</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>849.44</hp>
-            <mp>359.76</mp>
-            <cp>594.608</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>868.9</hp>
-            <mp>368.1</mp>
-            <cp>608.23</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>888.5</hp>
-            <mp>376.5</mp>
-            <cp>621.95</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>908.24</hp>
-            <mp>384.96</mp>
-            <cp>635.768</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>928.12</hp>
-            <mp>393.48</mp>
-            <cp>649.684</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>948.14</hp>
-            <mp>402.06</mp>
-            <cp>663.698</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>968.3</hp>
-            <mp>410.7</mp>
-            <cp>677.81</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>988.6</hp>
-            <mp>419.4</mp>
-            <cp>692.02</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1009.04</hp>
-            <mp>428.16</mp>
-            <cp>706.328</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1029.62</hp>
-            <mp>436.98</mp>
-            <cp>720.734</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>1050.34</hp>
-            <mp>445.86</mp>
-            <cp>735.238</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>1071.2</hp>
-            <mp>454.8</mp>
-            <cp>749.84</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>1092.2</hp>
-            <mp>463.8</mp>
-            <cp>764.54</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>1113.34</hp>
-            <mp>472.86</mp>
-            <cp>779.338</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>1134.62</hp>
-            <mp>481.98</mp>
-            <cp>794.234</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>1156.04</hp>
-            <mp>491.16</mp>
-            <cp>809.228</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>1177.6</hp>
-            <mp>500.4</mp>
-            <cp>824.32</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>1199.3</hp>
-            <mp>509.7</mp>
-            <cp>839.51</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>1221.14</hp>
-            <mp>519.06</mp>
-            <cp>854.798</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>1243.12</hp>
-            <mp>528.48</mp>
-            <cp>870.184</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>1265.24</hp>
-            <mp>537.96</mp>
-            <cp>885.668</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>1287.5</hp>
-            <mp>547.5</mp>
-            <cp>901.25</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>1309.9</hp>
-            <mp>557.1</mp>
-            <cp>916.93</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>1332.44</hp>
-            <mp>566.76</mp>
-            <cp>932.708</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>1355.12</hp>
-            <mp>576.48</mp>
-            <cp>948.584</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>1377.94</hp>
-            <mp>586.26</mp>
-            <cp>964.558</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>1400.9</hp>
-            <mp>596.1</mp>
-            <cp>980.63</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>1424.0</hp>
-            <mp>606.0</mp>
-            <cp>996.8</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>1447.24</hp>
-            <mp>615.96</mp>
-            <cp>1013.068</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>1470.62</hp>
-            <mp>625.98</mp>
-            <cp>1029.434</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>1494.14</hp>
-            <mp>636.06</mp>
-            <cp>1045.898</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>1517.8</hp>
-            <mp>646.2</mp>
-            <cp>1062.46</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>1541.6</hp>
-            <mp>656.4</mp>
-            <cp>1079.12</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>1565.54</hp>
-            <mp>666.66</mp>
-            <cp>1095.878</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>1589.62</hp>
-            <mp>676.98</mp>
-            <cp>1112.734</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>1613.84</hp>
-            <mp>687.36</mp>
-            <cp>1129.688</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>1638.2</hp>
-            <mp>697.8</mp>
-            <cp>1146.74</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>1662.7</hp>
-            <mp>708.3</mp>
-            <cp>619.86</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>1687.34</hp>
-            <mp>718.86</mp>
-            <cp>629.012</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>1712.12</hp>
-            <mp>729.48</mp>
-            <cp>638.216</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>1737.04</hp>
-            <mp>740.16</mp>
-            <cp>647.472</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>1762.1</hp>
-            <mp>750.9</mp>
-            <cp>656.78</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>1787.3</hp>
-            <mp>761.7</mp>
-            <cp>666.14</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>53</classId>
+	<staticData>
+		<baseINT>20</baseINT>
+		<baseSTR>39</baseSTR>
+		<baseCON>45</baseCON>
+		<baseMEN>27</baseMEN>
+		<baseDEX>29</baseDEX>
+		<baseWIT>10</baseWIT>
+		<physicalAbnormalResist>15</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="108644" y="-173947" z="-400" />
+			<node x="108678" y="-174002" z="-400" />
+			<node x="108505" y="-173964" z="-400" />
+			<node x="108512" y="-174026" z="-400" />
+			<node x="108549" y="-174075" z="-400" />
+			<node x="108576" y="-174122" z="-400" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>80</walk>
+			<run>131</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>80</baseBreath>
+		<baseSafeFall>180</baseSafeFall>
+		<collisionMale>
+			<radius>9.0</radius>
+			<height>18.0</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>5.0</radius>
+			<height>19.0</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>80.0</hp>
+			<mp>30.0</mp>
+			<cp>56.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>92.74</hp>
+			<mp>35.46</mp>
+			<cp>64.918</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>105.62</hp>
+			<mp>40.98</mp>
+			<cp>73.934</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>118.64</hp>
+			<mp>46.56</mp>
+			<cp>83.048</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>131.8</hp>
+			<mp>52.2</mp>
+			<cp>92.26</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>145.1</hp>
+			<mp>57.9</mp>
+			<cp>101.57</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>158.54</hp>
+			<mp>63.66</mp>
+			<cp>110.978</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>172.12</hp>
+			<mp>69.48</mp>
+			<cp>120.484</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>185.84</hp>
+			<mp>75.36</mp>
+			<cp>130.088</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>199.7</hp>
+			<mp>81.3</mp>
+			<cp>139.79</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>213.7</hp>
+			<mp>87.3</mp>
+			<cp>149.59</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>227.84</hp>
+			<mp>93.36</mp>
+			<cp>159.488</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>242.12</hp>
+			<mp>99.48</mp>
+			<cp>169.484</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>256.54</hp>
+			<mp>105.66</mp>
+			<cp>179.578</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>271.1</hp>
+			<mp>111.9</mp>
+			<cp>189.77</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>285.8</hp>
+			<mp>118.2</mp>
+			<cp>200.06</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>300.64</hp>
+			<mp>124.56</mp>
+			<cp>210.448</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>315.62</hp>
+			<mp>130.98</mp>
+			<cp>220.934</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>330.74</hp>
+			<mp>137.46</mp>
+			<cp>231.518</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>346.0</hp>
+			<mp>144.0</mp>
+			<cp>242.2</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>361.4</hp>
+			<mp>150.6</mp>
+			<cp>252.98</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>376.94</hp>
+			<mp>157.26</mp>
+			<cp>263.858</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>392.62</hp>
+			<mp>163.98</mp>
+			<cp>274.834</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>408.44</hp>
+			<mp>170.76</mp>
+			<cp>285.908</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>424.4</hp>
+			<mp>177.6</mp>
+			<cp>297.08</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>440.5</hp>
+			<mp>184.5</mp>
+			<cp>308.35</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>456.74</hp>
+			<mp>191.46</mp>
+			<cp>319.718</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>473.12</hp>
+			<mp>198.48</mp>
+			<cp>331.184</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>489.64</hp>
+			<mp>205.56</mp>
+			<cp>342.748</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>506.3</hp>
+			<mp>212.7</mp>
+			<cp>354.41</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>523.1</hp>
+			<mp>219.9</mp>
+			<cp>366.17</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>540.04</hp>
+			<mp>227.16</mp>
+			<cp>378.028</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>557.12</hp>
+			<mp>234.48</mp>
+			<cp>389.984</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>574.34</hp>
+			<mp>241.86</mp>
+			<cp>402.038</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>591.7</hp>
+			<mp>249.3</mp>
+			<cp>414.19</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>609.2</hp>
+			<mp>256.8</mp>
+			<cp>426.44</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>626.84</hp>
+			<mp>264.36</mp>
+			<cp>438.788</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>644.62</hp>
+			<mp>271.98</mp>
+			<cp>451.234</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>662.54</hp>
+			<mp>279.66</mp>
+			<cp>463.778</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>680.6</hp>
+			<mp>287.4</mp>
+			<cp>476.42</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>698.8</hp>
+			<mp>295.2</mp>
+			<cp>489.16</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>717.14</hp>
+			<mp>303.06</mp>
+			<cp>501.998</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>735.62</hp>
+			<mp>310.98</mp>
+			<cp>514.934</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>754.24</hp>
+			<mp>318.96</mp>
+			<cp>527.968</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>773.0</hp>
+			<mp>327.0</mp>
+			<cp>541.1</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>791.9</hp>
+			<mp>335.1</mp>
+			<cp>554.33</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>810.94</hp>
+			<mp>343.26</mp>
+			<cp>567.658</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>830.12</hp>
+			<mp>351.48</mp>
+			<cp>581.084</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>849.44</hp>
+			<mp>359.76</mp>
+			<cp>594.608</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>868.9</hp>
+			<mp>368.1</mp>
+			<cp>608.23</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>888.5</hp>
+			<mp>376.5</mp>
+			<cp>621.95</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>908.24</hp>
+			<mp>384.96</mp>
+			<cp>635.768</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>928.12</hp>
+			<mp>393.48</mp>
+			<cp>649.684</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>948.14</hp>
+			<mp>402.06</mp>
+			<cp>663.698</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>968.3</hp>
+			<mp>410.7</mp>
+			<cp>677.81</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>988.6</hp>
+			<mp>419.4</mp>
+			<cp>692.02</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1009.04</hp>
+			<mp>428.16</mp>
+			<cp>706.328</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1029.62</hp>
+			<mp>436.98</mp>
+			<cp>720.734</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1050.34</hp>
+			<mp>445.86</mp>
+			<cp>735.238</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1071.2</hp>
+			<mp>454.8</mp>
+			<cp>749.84</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>1092.2</hp>
+			<mp>463.8</mp>
+			<cp>764.54</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>1113.34</hp>
+			<mp>472.86</mp>
+			<cp>779.338</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>1134.62</hp>
+			<mp>481.98</mp>
+			<cp>794.234</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>1156.04</hp>
+			<mp>491.16</mp>
+			<cp>809.228</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>1177.6</hp>
+			<mp>500.4</mp>
+			<cp>824.32</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>1199.3</hp>
+			<mp>509.7</mp>
+			<cp>839.51</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>1221.14</hp>
+			<mp>519.06</mp>
+			<cp>854.798</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>1243.12</hp>
+			<mp>528.48</mp>
+			<cp>870.184</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>1265.24</hp>
+			<mp>537.96</mp>
+			<cp>885.668</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>1287.5</hp>
+			<mp>547.5</mp>
+			<cp>901.25</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>1309.9</hp>
+			<mp>557.1</mp>
+			<cp>916.93</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>1332.44</hp>
+			<mp>566.76</mp>
+			<cp>932.708</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>1355.12</hp>
+			<mp>576.48</mp>
+			<cp>948.584</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>1377.94</hp>
+			<mp>586.26</mp>
+			<cp>964.558</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>1400.9</hp>
+			<mp>596.1</mp>
+			<cp>980.63</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>1424.0</hp>
+			<mp>606.0</mp>
+			<cp>996.8</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>1447.24</hp>
+			<mp>615.96</mp>
+			<cp>1013.068</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>1470.62</hp>
+			<mp>625.98</mp>
+			<cp>1029.434</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>1494.14</hp>
+			<mp>636.06</mp>
+			<cp>1045.898</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>1517.8</hp>
+			<mp>646.2</mp>
+			<cp>1062.46</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>1541.6</hp>
+			<mp>656.4</mp>
+			<cp>1079.12</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>1565.54</hp>
+			<mp>666.66</mp>
+			<cp>1095.878</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>1589.62</hp>
+			<mp>676.98</mp>
+			<cp>1112.734</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>1613.84</hp>
+			<mp>687.36</mp>
+			<cp>1129.688</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>1638.2</hp>
+			<mp>697.8</mp>
+			<cp>1146.74</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>1662.7</hp>
+			<mp>708.3</mp>
+			<cp>619.86</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>1687.34</hp>
+			<mp>718.86</mp>
+			<cp>629.012</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>1712.12</hp>
+			<mp>729.48</mp>
+			<cp>638.216</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>1737.04</hp>
+			<mp>740.16</mp>
+			<cp>647.472</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>1762.1</hp>
+			<mp>750.9</mp>
+			<cp>656.78</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>1787.3</hp>
+			<mp>761.7</mp>
+			<cp>666.14</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>1812.64</hp>
+			<mp>772.56</mp>
+			<cp>675.552</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>1838.12</hp>
+			<mp>783.48</mp>
+			<cp>685.016</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>1863.74</hp>
+			<mp>794.46</mp>
+			<cp>694.532</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>1889.5</hp>
+			<mp>805.5</mp>
+			<cp>704.1</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>1915.4</hp>
+			<mp>816.6</mp>
+			<cp>713.72</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>1941.44</hp>
+			<mp>827.76</mp>
+			<cp>723.392</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>1967.62</hp>
+			<mp>838.98</mp>
+			<cp>733.116</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>1993.94</hp>
+			<mp>850.26</mp>
+			<cp>742.892</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>2020.4</hp>
+			<mp>861.6</mp>
+			<cp>752.72</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>2047</hp>
+			<mp>873</mp>
+			<cp>762.59</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>2073.74</hp>
+			<mp>884.46</mp>
+			<cp>772.52</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>2100.62</hp>
+			<mp>895.98</mp>
+			<cp>782.5</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>2127.64</hp>
+			<mp>907.56</mp>
+			<cp>792.52</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>2154.8</hp>
+			<mp>919.2</mp>
+			<cp>802.6</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>2182.1</hp>
+			<mp>930.9</mp>
+			<cp>812.72</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>2209.54</hp>
+			<mp>942.66</mp>
+			<cp>822.972</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/ElementalMaster.xml
+++ b/data/stats/chars/baseStats/ElementalMaster.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>104</classId>
-    <staticData>
-        <baseINT>37</baseINT>
-        <baseSTR>21</baseSTR>
-        <baseCON>25</baseCON>
-        <baseMEN>40</baseMEN>
-        <baseDEX>24</baseDEX>
-        <baseWIT>23</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>15</magicAbnormalResist>
-        <creationPoints>
-            <node x="46045" y="41251" z="-3440"/>
-            <node x="46117" y="41247" z="-3440"/>
-            <node x="46182" y="41198" z="-3440"/>
-            <node x="46115" y="41141" z="-3440"/>
-            <node x="46048" y="41141" z="-3440"/>
-            <node x="45978" y="41196" z="-3440"/>
-        </creationPoints>
-        <basePAtk>3</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>15</chest>
-            <legs>8</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>85</walk>
-            <run>129</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>150</baseBreath>
-        <baseSafeFall>300</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>24</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.5</radius>
-            <height>23</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>104.0</hp>
-            <mp>40.0</mp>
-            <cp>62.4</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>119.47</hp>
-            <mp>47.28</mp>
-            <cp>71.682</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>135.11</hp>
-            <mp>54.64</mp>
-            <cp>81.066</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>150.92</hp>
-            <mp>62.08</mp>
-            <cp>90.552</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>166.9</hp>
-            <mp>69.6</mp>
-            <cp>100.14</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>183.05</hp>
-            <mp>77.2</mp>
-            <cp>109.83</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>199.37</hp>
-            <mp>84.88</mp>
-            <cp>119.622</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>215.86</hp>
-            <mp>92.64</mp>
-            <cp>129.516</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>232.52</hp>
-            <mp>100.48</mp>
-            <cp>139.512</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>249.35</hp>
-            <mp>108.4</mp>
-            <cp>149.61</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>266.35</hp>
-            <mp>116.4</mp>
-            <cp>159.81</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>283.52</hp>
-            <mp>124.48</mp>
-            <cp>170.112</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>300.86</hp>
-            <mp>132.64</mp>
-            <cp>180.516</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>318.37</hp>
-            <mp>140.88</mp>
-            <cp>191.022</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>336.05</hp>
-            <mp>149.2</mp>
-            <cp>201.63</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>353.9</hp>
-            <mp>157.6</mp>
-            <cp>212.34</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>371.92</hp>
-            <mp>166.08</mp>
-            <cp>223.152</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>390.11</hp>
-            <mp>174.64</mp>
-            <cp>234.066</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>408.47</hp>
-            <mp>183.28</mp>
-            <cp>245.082</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>427.0</hp>
-            <mp>192.0</mp>
-            <cp>256.2</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>455.6</hp>
-            <mp>205.2</mp>
-            <cp>273.36</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>484.46</hp>
-            <mp>218.52</mp>
-            <cp>290.676</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>513.58</hp>
-            <mp>231.96</mp>
-            <cp>308.148</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>542.96</hp>
-            <mp>245.52</mp>
-            <cp>325.776</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>572.6</hp>
-            <mp>259.2</mp>
-            <cp>343.56</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>602.5</hp>
-            <mp>273.0</mp>
-            <cp>361.5</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>632.66</hp>
-            <mp>286.92</mp>
-            <cp>379.596</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>663.08</hp>
-            <mp>300.96</mp>
-            <cp>397.848</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>693.76</hp>
-            <mp>315.12</mp>
-            <cp>416.256</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>724.7</hp>
-            <mp>329.4</mp>
-            <cp>434.82</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>755.9</hp>
-            <mp>343.8</mp>
-            <cp>453.54</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>787.36</hp>
-            <mp>358.32</mp>
-            <cp>472.416</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>819.08</hp>
-            <mp>372.96</mp>
-            <cp>491.448</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>851.06</hp>
-            <mp>387.72</mp>
-            <cp>510.636</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>883.3</hp>
-            <mp>402.6</mp>
-            <cp>529.98</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>915.8</hp>
-            <mp>417.6</mp>
-            <cp>549.48</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>948.56</hp>
-            <mp>432.72</mp>
-            <cp>569.136</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>981.58</hp>
-            <mp>447.96</mp>
-            <cp>588.948</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1014.86</hp>
-            <mp>463.32</mp>
-            <cp>608.916</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1048.4</hp>
-            <mp>478.8</mp>
-            <cp>629.04</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1099.1</hp>
-            <mp>504.8</mp>
-            <cp>659.46</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1150.19</hp>
-            <mp>531.0</mp>
-            <cp>690.114</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1201.67</hp>
-            <mp>557.4</mp>
-            <cp>721.002</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1253.54</hp>
-            <mp>584.0</mp>
-            <cp>752.124</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1305.8</hp>
-            <mp>610.8</mp>
-            <cp>783.48</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1358.45</hp>
-            <mp>637.8</mp>
-            <cp>815.07</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1411.49</hp>
-            <mp>665.0</mp>
-            <cp>846.894</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1464.92</hp>
-            <mp>692.4</mp>
-            <cp>878.952</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1518.74</hp>
-            <mp>720.0</mp>
-            <cp>911.244</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1572.95</hp>
-            <mp>747.8</mp>
-            <cp>943.77</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1627.55</hp>
-            <mp>775.8</mp>
-            <cp>976.53</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1682.54</hp>
-            <mp>804.0</mp>
-            <cp>1009.524</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1737.92</hp>
-            <mp>832.4</mp>
-            <cp>1042.752</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1793.69</hp>
-            <mp>861.0</mp>
-            <cp>1076.214</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1849.85</hp>
-            <mp>889.8</mp>
-            <cp>1109.91</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1906.4</hp>
-            <mp>918.8</mp>
-            <cp>1143.84</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1963.34</hp>
-            <mp>948.0</mp>
-            <cp>1178.004</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2020.67</hp>
-            <mp>977.4</mp>
-            <cp>1212.402</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2078.39</hp>
-            <mp>1007.0</mp>
-            <cp>1247.034</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2136.5</hp>
-            <mp>1036.8</mp>
-            <cp>1281.9</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2195.0</hp>
-            <mp>1066.8</mp>
-            <cp>1317.0</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2253.89</hp>
-            <mp>1097.0</mp>
-            <cp>1352.334</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2313.17</hp>
-            <mp>1127.4</mp>
-            <cp>1387.902</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2372.84</hp>
-            <mp>1158.0</mp>
-            <cp>1423.704</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2432.9</hp>
-            <mp>1188.8</mp>
-            <cp>1459.74</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2493.35</hp>
-            <mp>1219.8</mp>
-            <cp>1496.01</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2554.19</hp>
-            <mp>1251.0</mp>
-            <cp>1532.514</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2615.42</hp>
-            <mp>1282.4</mp>
-            <cp>1569.252</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2677.04</hp>
-            <mp>1314.0</mp>
-            <cp>1606.224</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2739.05</hp>
-            <mp>1345.8</mp>
-            <cp>1643.43</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2801.45</hp>
-            <mp>1377.8</mp>
-            <cp>1680.87</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2864.24</hp>
-            <mp>1410.0</mp>
-            <cp>1718.544</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2927.42</hp>
-            <mp>1442.4</mp>
-            <cp>1756.452</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2990.99</hp>
-            <mp>1475.0</mp>
-            <cp>1794.594</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3054.95</hp>
-            <mp>1507.8</mp>
-            <cp>1832.97</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3119.3</hp>
-            <mp>1540.8</mp>
-            <cp>1871.58</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3184.04</hp>
-            <mp>1574.0</mp>
-            <cp>1910.424</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3249.17</hp>
-            <mp>1607.4</mp>
-            <cp>1949.502</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3314.69</hp>
-            <mp>1641.0</mp>
-            <cp>1988.814</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3380.6</hp>
-            <mp>1674.8</mp>
-            <cp>2028.36</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3446.9</hp>
-            <mp>1708.8</mp>
-            <cp>2068.14</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3513.59</hp>
-            <mp>1743.0</mp>
-            <cp>2108.154</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3580.67</hp>
-            <mp>1777.4</mp>
-            <cp>2148.402</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3648.14</hp>
-            <mp>1812.0</mp>
-            <cp>2188.884</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3716.0</hp>
-            <mp>1846.8</mp>
-            <cp>2229.6</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3784.25</hp>
-            <mp>1881.8</mp>
-            <cp>2270.55</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3852.89</hp>
-            <mp>1917.0</mp>
-            <cp>2311.734</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3921.92</hp>
-            <mp>1952.4</mp>
-            <cp>2353.152</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3991.34</hp>
-            <mp>1988.0</mp>
-            <cp>2394.804</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4061.15</hp>
-            <mp>2023.8</mp>
-            <cp>2436.69</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4131.35</hp>
-            <mp>2059.8</mp>
-            <cp>2478.81</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>104</classId>
+	<staticData>
+		<baseINT>37</baseINT>
+		<baseSTR>21</baseSTR>
+		<baseCON>25</baseCON>
+		<baseMEN>40</baseMEN>
+		<baseDEX>24</baseDEX>
+		<baseWIT>23</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="46045" y="41251" z="-3440" />
+			<node x="46117" y="41247" z="-3440" />
+			<node x="46182" y="41198" z="-3440" />
+			<node x="46115" y="41141" z="-3440" />
+			<node x="46048" y="41141" z="-3440" />
+			<node x="45978" y="41196" z="-3440" />
+		</creationPoints>
+		<basePAtk>3</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>15</chest>
+			<legs>8</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>85</walk>
+			<run>129</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>300</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.5</radius>
+			<height>23</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>104.0</hp>
+			<mp>40.0</mp>
+			<cp>62.4</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>119.47</hp>
+			<mp>47.28</mp>
+			<cp>71.682</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>135.11</hp>
+			<mp>54.64</mp>
+			<cp>81.066</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>150.92</hp>
+			<mp>62.08</mp>
+			<cp>90.552</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>166.9</hp>
+			<mp>69.6</mp>
+			<cp>100.14</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>183.05</hp>
+			<mp>77.2</mp>
+			<cp>109.83</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>199.37</hp>
+			<mp>84.88</mp>
+			<cp>119.622</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>215.86</hp>
+			<mp>92.64</mp>
+			<cp>129.516</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>232.52</hp>
+			<mp>100.48</mp>
+			<cp>139.512</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>249.35</hp>
+			<mp>108.4</mp>
+			<cp>149.61</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>266.35</hp>
+			<mp>116.4</mp>
+			<cp>159.81</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>283.52</hp>
+			<mp>124.48</mp>
+			<cp>170.112</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>300.86</hp>
+			<mp>132.64</mp>
+			<cp>180.516</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>318.37</hp>
+			<mp>140.88</mp>
+			<cp>191.022</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>336.05</hp>
+			<mp>149.2</mp>
+			<cp>201.63</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>353.9</hp>
+			<mp>157.6</mp>
+			<cp>212.34</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>371.92</hp>
+			<mp>166.08</mp>
+			<cp>223.152</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>390.11</hp>
+			<mp>174.64</mp>
+			<cp>234.066</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>408.47</hp>
+			<mp>183.28</mp>
+			<cp>245.082</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>427.0</hp>
+			<mp>192.0</mp>
+			<cp>256.2</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>455.6</hp>
+			<mp>205.2</mp>
+			<cp>273.36</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>484.46</hp>
+			<mp>218.52</mp>
+			<cp>290.676</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>513.58</hp>
+			<mp>231.96</mp>
+			<cp>308.148</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>542.96</hp>
+			<mp>245.52</mp>
+			<cp>325.776</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>572.6</hp>
+			<mp>259.2</mp>
+			<cp>343.56</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>602.5</hp>
+			<mp>273.0</mp>
+			<cp>361.5</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>632.66</hp>
+			<mp>286.92</mp>
+			<cp>379.596</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>663.08</hp>
+			<mp>300.96</mp>
+			<cp>397.848</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>693.76</hp>
+			<mp>315.12</mp>
+			<cp>416.256</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>724.7</hp>
+			<mp>329.4</mp>
+			<cp>434.82</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>755.9</hp>
+			<mp>343.8</mp>
+			<cp>453.54</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>787.36</hp>
+			<mp>358.32</mp>
+			<cp>472.416</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>819.08</hp>
+			<mp>372.96</mp>
+			<cp>491.448</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>851.06</hp>
+			<mp>387.72</mp>
+			<cp>510.636</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>883.3</hp>
+			<mp>402.6</mp>
+			<cp>529.98</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>915.8</hp>
+			<mp>417.6</mp>
+			<cp>549.48</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>948.56</hp>
+			<mp>432.72</mp>
+			<cp>569.136</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>981.58</hp>
+			<mp>447.96</mp>
+			<cp>588.948</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1014.86</hp>
+			<mp>463.32</mp>
+			<cp>608.916</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1048.4</hp>
+			<mp>478.8</mp>
+			<cp>629.04</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1099.1</hp>
+			<mp>504.8</mp>
+			<cp>659.46</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1150.19</hp>
+			<mp>531.0</mp>
+			<cp>690.114</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1201.67</hp>
+			<mp>557.4</mp>
+			<cp>721.002</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1253.54</hp>
+			<mp>584.0</mp>
+			<cp>752.124</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1305.8</hp>
+			<mp>610.8</mp>
+			<cp>783.48</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1358.45</hp>
+			<mp>637.8</mp>
+			<cp>815.07</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1411.49</hp>
+			<mp>665.0</mp>
+			<cp>846.894</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1464.92</hp>
+			<mp>692.4</mp>
+			<cp>878.952</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1518.74</hp>
+			<mp>720.0</mp>
+			<cp>911.244</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1572.95</hp>
+			<mp>747.8</mp>
+			<cp>943.77</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1627.55</hp>
+			<mp>775.8</mp>
+			<cp>976.53</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1682.54</hp>
+			<mp>804.0</mp>
+			<cp>1009.524</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1737.92</hp>
+			<mp>832.4</mp>
+			<cp>1042.752</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1793.69</hp>
+			<mp>861.0</mp>
+			<cp>1076.214</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1849.85</hp>
+			<mp>889.8</mp>
+			<cp>1109.91</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1906.4</hp>
+			<mp>918.8</mp>
+			<cp>1143.84</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1963.34</hp>
+			<mp>948.0</mp>
+			<cp>1178.004</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2020.67</hp>
+			<mp>977.4</mp>
+			<cp>1212.402</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2078.39</hp>
+			<mp>1007.0</mp>
+			<cp>1247.034</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2136.5</hp>
+			<mp>1036.8</mp>
+			<cp>1281.9</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2195.0</hp>
+			<mp>1066.8</mp>
+			<cp>1317.0</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2253.89</hp>
+			<mp>1097.0</mp>
+			<cp>1352.334</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2313.17</hp>
+			<mp>1127.4</mp>
+			<cp>1387.902</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2372.84</hp>
+			<mp>1158.0</mp>
+			<cp>1423.704</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2432.9</hp>
+			<mp>1188.8</mp>
+			<cp>1459.74</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2493.35</hp>
+			<mp>1219.8</mp>
+			<cp>1496.01</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2554.19</hp>
+			<mp>1251.0</mp>
+			<cp>1532.514</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2615.42</hp>
+			<mp>1282.4</mp>
+			<cp>1569.252</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2677.04</hp>
+			<mp>1314.0</mp>
+			<cp>1606.224</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2739.05</hp>
+			<mp>1345.8</mp>
+			<cp>1643.43</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2801.45</hp>
+			<mp>1377.8</mp>
+			<cp>1680.87</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2864.24</hp>
+			<mp>1410.0</mp>
+			<cp>1718.544</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2927.42</hp>
+			<mp>1442.4</mp>
+			<cp>1756.452</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2990.99</hp>
+			<mp>1475.0</mp>
+			<cp>1794.594</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3054.95</hp>
+			<mp>1507.8</mp>
+			<cp>1832.97</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3119.3</hp>
+			<mp>1540.8</mp>
+			<cp>1871.58</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3184.04</hp>
+			<mp>1574.0</mp>
+			<cp>1910.424</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3249.17</hp>
+			<mp>1607.4</mp>
+			<cp>1949.502</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3314.69</hp>
+			<mp>1641.0</mp>
+			<cp>1988.814</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3380.6</hp>
+			<mp>1674.8</mp>
+			<cp>2028.36</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3446.9</hp>
+			<mp>1708.8</mp>
+			<cp>2068.14</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3513.59</hp>
+			<mp>1743.0</mp>
+			<cp>2108.154</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3580.67</hp>
+			<mp>1777.4</mp>
+			<cp>2148.402</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3648.14</hp>
+			<mp>1812.0</mp>
+			<cp>2188.884</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3716.0</hp>
+			<mp>1846.8</mp>
+			<cp>2229.6</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3784.25</hp>
+			<mp>1881.8</mp>
+			<cp>2270.55</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3852.89</hp>
+			<mp>1917.0</mp>
+			<cp>2311.734</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3921.92</hp>
+			<mp>1952.4</mp>
+			<cp>2353.152</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3991.34</hp>
+			<mp>1988.0</mp>
+			<cp>2394.804</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4061.15</hp>
+			<mp>2023.8</mp>
+			<cp>2436.69</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4131.35</hp>
+			<mp>2059.8</mp>
+			<cp>2478.81</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4201.94</hp>
+			<mp>2096.0</mp>
+			<cp>2521.164</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4272.92</hp>
+			<mp>2132.4</mp>
+			<cp>2563.752</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4344.29</hp>
+			<mp>2169.0</mp>
+			<cp>2606.574</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4416.05</hp>
+			<mp>2205.8</mp>
+			<cp>2649.63</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4488.2</hp>
+			<mp>2242.8</mp>
+			<cp>2692.92</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4560.74</hp>
+			<mp>2280.0</mp>
+			<cp>2736.444</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4633.67</hp>
+			<mp>2317.4</mp>
+			<cp>2780.202</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4706.99</hp>
+			<mp>2355.0</mp>
+			<cp>2824.194</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4780.7</hp>
+			<mp>2392.8</mp>
+			<cp>2868.42</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4854.8</hp>
+			<mp>2430.8</mp>
+			<cp>2912.87</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4929.29</hp>
+			<mp>2469</mp>
+			<cp>2957.55</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5004.17</hp>
+			<mp>2507.4</mp>
+			<cp>3002.46</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5079.44</hp>
+			<mp>2546</mp>
+			<cp>3047.6</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5155.1</hp>
+			<mp>2584.8</mp>
+			<cp>3092.98</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5231.15</hp>
+			<mp>2623.8</mp>
+			<cp>3138.58</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5307.59</hp>
+			<mp>2663</mp>
+			<cp>3184.554</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/ElementalSummoner.xml
+++ b/data/stats/chars/baseStats/ElementalSummoner.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>28</classId>
-    <staticData>
-        <baseINT>37</baseINT>
-        <baseSTR>21</baseSTR>
-        <baseCON>25</baseCON>
-        <baseMEN>40</baseMEN>
-        <baseDEX>24</baseDEX>
-        <baseWIT>23</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>15</magicAbnormalResist>
-        <creationPoints>
-            <node x="46045" y="41251" z="-3440"/>
-            <node x="46117" y="41247" z="-3440"/>
-            <node x="46182" y="41198" z="-3440"/>
-            <node x="46115" y="41141" z="-3440"/>
-            <node x="46048" y="41141" z="-3440"/>
-            <node x="45978" y="41196" z="-3440"/>
-        </creationPoints>
-        <basePAtk>3</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>15</chest>
-            <legs>8</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>85</walk>
-            <run>129</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>150</baseBreath>
-        <baseSafeFall>300</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>24</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.5</radius>
-            <height>23</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>104.0</hp>
-            <mp>40.0</mp>
-            <cp>62.4</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>119.47</hp>
-            <mp>47.28</mp>
-            <cp>71.682</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>135.11</hp>
-            <mp>54.64</mp>
-            <cp>81.066</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>150.92</hp>
-            <mp>62.08</mp>
-            <cp>90.552</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>166.9</hp>
-            <mp>69.6</mp>
-            <cp>100.14</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>183.05</hp>
-            <mp>77.2</mp>
-            <cp>109.83</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>199.37</hp>
-            <mp>84.88</mp>
-            <cp>119.622</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>215.86</hp>
-            <mp>92.64</mp>
-            <cp>129.516</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>232.52</hp>
-            <mp>100.48</mp>
-            <cp>139.512</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>249.35</hp>
-            <mp>108.4</mp>
-            <cp>149.61</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>266.35</hp>
-            <mp>116.4</mp>
-            <cp>159.81</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>283.52</hp>
-            <mp>124.48</mp>
-            <cp>170.112</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>300.86</hp>
-            <mp>132.64</mp>
-            <cp>180.516</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>318.37</hp>
-            <mp>140.88</mp>
-            <cp>191.022</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>336.05</hp>
-            <mp>149.2</mp>
-            <cp>201.63</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>353.9</hp>
-            <mp>157.6</mp>
-            <cp>212.34</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>371.92</hp>
-            <mp>166.08</mp>
-            <cp>223.152</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>390.11</hp>
-            <mp>174.64</mp>
-            <cp>234.066</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>408.47</hp>
-            <mp>183.28</mp>
-            <cp>245.082</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>427.0</hp>
-            <mp>192.0</mp>
-            <cp>256.2</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>455.6</hp>
-            <mp>205.2</mp>
-            <cp>273.36</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>484.46</hp>
-            <mp>218.52</mp>
-            <cp>290.676</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>513.58</hp>
-            <mp>231.96</mp>
-            <cp>308.148</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>542.96</hp>
-            <mp>245.52</mp>
-            <cp>325.776</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>572.6</hp>
-            <mp>259.2</mp>
-            <cp>343.56</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>602.5</hp>
-            <mp>273.0</mp>
-            <cp>361.5</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>632.66</hp>
-            <mp>286.92</mp>
-            <cp>379.596</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>663.08</hp>
-            <mp>300.96</mp>
-            <cp>397.848</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>693.76</hp>
-            <mp>315.12</mp>
-            <cp>416.256</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>724.7</hp>
-            <mp>329.4</mp>
-            <cp>434.82</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>755.9</hp>
-            <mp>343.8</mp>
-            <cp>453.54</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>787.36</hp>
-            <mp>358.32</mp>
-            <cp>472.416</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>819.08</hp>
-            <mp>372.96</mp>
-            <cp>491.448</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>851.06</hp>
-            <mp>387.72</mp>
-            <cp>510.636</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>883.3</hp>
-            <mp>402.6</mp>
-            <cp>529.98</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>915.8</hp>
-            <mp>417.6</mp>
-            <cp>549.48</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>948.56</hp>
-            <mp>432.72</mp>
-            <cp>569.136</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>981.58</hp>
-            <mp>447.96</mp>
-            <cp>588.948</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1014.86</hp>
-            <mp>463.32</mp>
-            <cp>608.916</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1048.4</hp>
-            <mp>478.8</mp>
-            <cp>629.04</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1099.1</hp>
-            <mp>504.8</mp>
-            <cp>659.46</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1150.19</hp>
-            <mp>531.0</mp>
-            <cp>690.114</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1201.67</hp>
-            <mp>557.4</mp>
-            <cp>721.002</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1253.54</hp>
-            <mp>584.0</mp>
-            <cp>752.124</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1305.8</hp>
-            <mp>610.8</mp>
-            <cp>783.48</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1358.45</hp>
-            <mp>637.8</mp>
-            <cp>815.07</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1411.49</hp>
-            <mp>665.0</mp>
-            <cp>846.894</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1464.92</hp>
-            <mp>692.4</mp>
-            <cp>878.952</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1518.74</hp>
-            <mp>720.0</mp>
-            <cp>911.244</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1572.95</hp>
-            <mp>747.8</mp>
-            <cp>943.77</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1627.55</hp>
-            <mp>775.8</mp>
-            <cp>976.53</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1682.54</hp>
-            <mp>804.0</mp>
-            <cp>1009.524</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1737.92</hp>
-            <mp>832.4</mp>
-            <cp>1042.752</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1793.69</hp>
-            <mp>861.0</mp>
-            <cp>1076.214</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1849.85</hp>
-            <mp>889.8</mp>
-            <cp>1109.91</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1906.4</hp>
-            <mp>918.8</mp>
-            <cp>1143.84</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1963.34</hp>
-            <mp>948.0</mp>
-            <cp>1178.004</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2020.67</hp>
-            <mp>977.4</mp>
-            <cp>1212.402</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2078.39</hp>
-            <mp>1007.0</mp>
-            <cp>1247.034</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2136.5</hp>
-            <mp>1036.8</mp>
-            <cp>1281.9</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2195.0</hp>
-            <mp>1066.8</mp>
-            <cp>1317.0</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2253.89</hp>
-            <mp>1097.0</mp>
-            <cp>1352.334</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2313.17</hp>
-            <mp>1127.4</mp>
-            <cp>1387.902</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2372.84</hp>
-            <mp>1158.0</mp>
-            <cp>1423.704</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2432.9</hp>
-            <mp>1188.8</mp>
-            <cp>1459.74</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2493.35</hp>
-            <mp>1219.8</mp>
-            <cp>1496.01</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2554.19</hp>
-            <mp>1251.0</mp>
-            <cp>1532.514</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2615.42</hp>
-            <mp>1282.4</mp>
-            <cp>1569.252</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2677.04</hp>
-            <mp>1314.0</mp>
-            <cp>1606.224</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2739.05</hp>
-            <mp>1345.8</mp>
-            <cp>1643.43</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2801.45</hp>
-            <mp>1377.8</mp>
-            <cp>1680.87</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2864.24</hp>
-            <mp>1410.0</mp>
-            <cp>1718.544</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2927.42</hp>
-            <mp>1442.4</mp>
-            <cp>1756.452</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2990.99</hp>
-            <mp>1475.0</mp>
-            <cp>1794.594</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3054.95</hp>
-            <mp>1507.8</mp>
-            <cp>1832.97</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3119.3</hp>
-            <mp>1540.8</mp>
-            <cp>1871.58</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3184.04</hp>
-            <mp>1574.0</mp>
-            <cp>1910.424</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3249.17</hp>
-            <mp>1607.4</mp>
-            <cp>1949.502</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3314.69</hp>
-            <mp>1641.0</mp>
-            <cp>1988.814</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3380.6</hp>
-            <mp>1674.8</mp>
-            <cp>2028.36</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3446.9</hp>
-            <mp>1708.8</mp>
-            <cp>2068.14</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3513.59</hp>
-            <mp>1743.0</mp>
-            <cp>2108.154</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3580.67</hp>
-            <mp>1777.4</mp>
-            <cp>2148.402</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3648.14</hp>
-            <mp>1812.0</mp>
-            <cp>2188.884</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3716.0</hp>
-            <mp>1846.8</mp>
-            <cp>2229.6</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3784.25</hp>
-            <mp>1881.8</mp>
-            <cp>2270.55</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3852.89</hp>
-            <mp>1917.0</mp>
-            <cp>2311.734</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3921.92</hp>
-            <mp>1952.4</mp>
-            <cp>2353.152</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3991.34</hp>
-            <mp>1988.0</mp>
-            <cp>2394.804</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4061.15</hp>
-            <mp>2023.8</mp>
-            <cp>2436.69</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4131.35</hp>
-            <mp>2059.8</mp>
-            <cp>2478.81</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>28</classId>
+	<staticData>
+		<baseINT>37</baseINT>
+		<baseSTR>21</baseSTR>
+		<baseCON>25</baseCON>
+		<baseMEN>40</baseMEN>
+		<baseDEX>24</baseDEX>
+		<baseWIT>23</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="46045" y="41251" z="-3440" />
+			<node x="46117" y="41247" z="-3440" />
+			<node x="46182" y="41198" z="-3440" />
+			<node x="46115" y="41141" z="-3440" />
+			<node x="46048" y="41141" z="-3440" />
+			<node x="45978" y="41196" z="-3440" />
+		</creationPoints>
+		<basePAtk>3</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>15</chest>
+			<legs>8</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>85</walk>
+			<run>129</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>300</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.5</radius>
+			<height>23</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>104.0</hp>
+			<mp>40.0</mp>
+			<cp>62.4</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>119.47</hp>
+			<mp>47.28</mp>
+			<cp>71.682</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>135.11</hp>
+			<mp>54.64</mp>
+			<cp>81.066</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>150.92</hp>
+			<mp>62.08</mp>
+			<cp>90.552</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>166.9</hp>
+			<mp>69.6</mp>
+			<cp>100.14</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>183.05</hp>
+			<mp>77.2</mp>
+			<cp>109.83</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>199.37</hp>
+			<mp>84.88</mp>
+			<cp>119.622</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>215.86</hp>
+			<mp>92.64</mp>
+			<cp>129.516</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>232.52</hp>
+			<mp>100.48</mp>
+			<cp>139.512</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>249.35</hp>
+			<mp>108.4</mp>
+			<cp>149.61</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>266.35</hp>
+			<mp>116.4</mp>
+			<cp>159.81</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>283.52</hp>
+			<mp>124.48</mp>
+			<cp>170.112</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>300.86</hp>
+			<mp>132.64</mp>
+			<cp>180.516</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>318.37</hp>
+			<mp>140.88</mp>
+			<cp>191.022</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>336.05</hp>
+			<mp>149.2</mp>
+			<cp>201.63</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>353.9</hp>
+			<mp>157.6</mp>
+			<cp>212.34</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>371.92</hp>
+			<mp>166.08</mp>
+			<cp>223.152</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>390.11</hp>
+			<mp>174.64</mp>
+			<cp>234.066</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>408.47</hp>
+			<mp>183.28</mp>
+			<cp>245.082</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>427.0</hp>
+			<mp>192.0</mp>
+			<cp>256.2</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>455.6</hp>
+			<mp>205.2</mp>
+			<cp>273.36</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>484.46</hp>
+			<mp>218.52</mp>
+			<cp>290.676</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>513.58</hp>
+			<mp>231.96</mp>
+			<cp>308.148</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>542.96</hp>
+			<mp>245.52</mp>
+			<cp>325.776</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>572.6</hp>
+			<mp>259.2</mp>
+			<cp>343.56</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>602.5</hp>
+			<mp>273.0</mp>
+			<cp>361.5</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>632.66</hp>
+			<mp>286.92</mp>
+			<cp>379.596</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>663.08</hp>
+			<mp>300.96</mp>
+			<cp>397.848</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>693.76</hp>
+			<mp>315.12</mp>
+			<cp>416.256</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>724.7</hp>
+			<mp>329.4</mp>
+			<cp>434.82</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>755.9</hp>
+			<mp>343.8</mp>
+			<cp>453.54</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>787.36</hp>
+			<mp>358.32</mp>
+			<cp>472.416</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>819.08</hp>
+			<mp>372.96</mp>
+			<cp>491.448</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>851.06</hp>
+			<mp>387.72</mp>
+			<cp>510.636</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>883.3</hp>
+			<mp>402.6</mp>
+			<cp>529.98</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>915.8</hp>
+			<mp>417.6</mp>
+			<cp>549.48</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>948.56</hp>
+			<mp>432.72</mp>
+			<cp>569.136</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>981.58</hp>
+			<mp>447.96</mp>
+			<cp>588.948</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1014.86</hp>
+			<mp>463.32</mp>
+			<cp>608.916</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1048.4</hp>
+			<mp>478.8</mp>
+			<cp>629.04</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1099.1</hp>
+			<mp>504.8</mp>
+			<cp>659.46</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1150.19</hp>
+			<mp>531.0</mp>
+			<cp>690.114</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1201.67</hp>
+			<mp>557.4</mp>
+			<cp>721.002</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1253.54</hp>
+			<mp>584.0</mp>
+			<cp>752.124</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1305.8</hp>
+			<mp>610.8</mp>
+			<cp>783.48</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1358.45</hp>
+			<mp>637.8</mp>
+			<cp>815.07</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1411.49</hp>
+			<mp>665.0</mp>
+			<cp>846.894</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1464.92</hp>
+			<mp>692.4</mp>
+			<cp>878.952</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1518.74</hp>
+			<mp>720.0</mp>
+			<cp>911.244</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1572.95</hp>
+			<mp>747.8</mp>
+			<cp>943.77</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1627.55</hp>
+			<mp>775.8</mp>
+			<cp>976.53</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1682.54</hp>
+			<mp>804.0</mp>
+			<cp>1009.524</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1737.92</hp>
+			<mp>832.4</mp>
+			<cp>1042.752</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1793.69</hp>
+			<mp>861.0</mp>
+			<cp>1076.214</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1849.85</hp>
+			<mp>889.8</mp>
+			<cp>1109.91</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1906.4</hp>
+			<mp>918.8</mp>
+			<cp>1143.84</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1963.34</hp>
+			<mp>948.0</mp>
+			<cp>1178.004</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2020.67</hp>
+			<mp>977.4</mp>
+			<cp>1212.402</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2078.39</hp>
+			<mp>1007.0</mp>
+			<cp>1247.034</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2136.5</hp>
+			<mp>1036.8</mp>
+			<cp>1281.9</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2195.0</hp>
+			<mp>1066.8</mp>
+			<cp>1317.0</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2253.89</hp>
+			<mp>1097.0</mp>
+			<cp>1352.334</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2313.17</hp>
+			<mp>1127.4</mp>
+			<cp>1387.902</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2372.84</hp>
+			<mp>1158.0</mp>
+			<cp>1423.704</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2432.9</hp>
+			<mp>1188.8</mp>
+			<cp>1459.74</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2493.35</hp>
+			<mp>1219.8</mp>
+			<cp>1496.01</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2554.19</hp>
+			<mp>1251.0</mp>
+			<cp>1532.514</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2615.42</hp>
+			<mp>1282.4</mp>
+			<cp>1569.252</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2677.04</hp>
+			<mp>1314.0</mp>
+			<cp>1606.224</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2739.05</hp>
+			<mp>1345.8</mp>
+			<cp>1643.43</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2801.45</hp>
+			<mp>1377.8</mp>
+			<cp>1680.87</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2864.24</hp>
+			<mp>1410.0</mp>
+			<cp>1718.544</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2927.42</hp>
+			<mp>1442.4</mp>
+			<cp>1756.452</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2990.99</hp>
+			<mp>1475.0</mp>
+			<cp>1794.594</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3054.95</hp>
+			<mp>1507.8</mp>
+			<cp>1832.97</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3119.3</hp>
+			<mp>1540.8</mp>
+			<cp>1871.58</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3184.04</hp>
+			<mp>1574.0</mp>
+			<cp>1910.424</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3249.17</hp>
+			<mp>1607.4</mp>
+			<cp>1949.502</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3314.69</hp>
+			<mp>1641.0</mp>
+			<cp>1988.814</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3380.6</hp>
+			<mp>1674.8</mp>
+			<cp>2028.36</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3446.9</hp>
+			<mp>1708.8</mp>
+			<cp>2068.14</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3513.59</hp>
+			<mp>1743.0</mp>
+			<cp>2108.154</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3580.67</hp>
+			<mp>1777.4</mp>
+			<cp>2148.402</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3648.14</hp>
+			<mp>1812.0</mp>
+			<cp>2188.884</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3716.0</hp>
+			<mp>1846.8</mp>
+			<cp>2229.6</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3784.25</hp>
+			<mp>1881.8</mp>
+			<cp>2270.55</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3852.89</hp>
+			<mp>1917.0</mp>
+			<cp>2311.734</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3921.92</hp>
+			<mp>1952.4</mp>
+			<cp>2353.152</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3991.34</hp>
+			<mp>1988.0</mp>
+			<cp>2394.804</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4061.15</hp>
+			<mp>2023.8</mp>
+			<cp>2436.69</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4131.35</hp>
+			<mp>2059.8</mp>
+			<cp>2478.81</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4201.94</hp>
+			<mp>2096.0</mp>
+			<cp>2521.164</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4272.92</hp>
+			<mp>2132.4</mp>
+			<cp>2563.752</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4344.29</hp>
+			<mp>2169.0</mp>
+			<cp>2606.574</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4416.05</hp>
+			<mp>2205.8</mp>
+			<cp>2649.63</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4488.2</hp>
+			<mp>2242.8</mp>
+			<cp>2692.92</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4560.74</hp>
+			<mp>2280.0</mp>
+			<cp>2736.444</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4633.67</hp>
+			<mp>2317.4</mp>
+			<cp>2780.202</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4706.99</hp>
+			<mp>2355.0</mp>
+			<cp>2824.194</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4780.7</hp>
+			<mp>2392.8</mp>
+			<cp>2868.42</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4854.8</hp>
+			<mp>2430.8</mp>
+			<cp>2912.87</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4929.29</hp>
+			<mp>2469</mp>
+			<cp>2957.55</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5004.17</hp>
+			<mp>2507.4</mp>
+			<cp>3002.46</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5079.44</hp>
+			<mp>2546</mp>
+			<cp>3047.6</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5155.1</hp>
+			<mp>2584.8</mp>
+			<cp>3092.98</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5231.15</hp>
+			<mp>2623.8</mp>
+			<cp>3138.58</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5307.59</hp>
+			<mp>2663</mp>
+			<cp>3184.554</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/ElfDeathBlader.xml
+++ b/data/stats/chars/baseStats/ElfDeathBlader.xml
@@ -1,0 +1,923 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
+	<classId>201</classId>
+	<staticData>
+		<baseINT>20</baseINT>
+		<baseSTR>40</baseSTR>
+		<baseCON>40</baseCON>
+		<baseMEN>25</baseMEN>
+		<baseDEX>35</baseDEX>
+		<baseWIT>10</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="47417" y="153541" z="-2728" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>90</walk>
+			<run>143</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>350</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.5</radius>
+			<height>23</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>89.0</hp>
+			<mp>30.0</mp>
+			<cp>44.5</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>101.74</hp>
+			<mp>35.46</mp>
+			<cp>50.87</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>114.62</hp>
+			<mp>40.98</mp>
+			<cp>57.31</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>127.64</hp>
+			<mp>46.56</mp>
+			<cp>63.82</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>140.8</hp>
+			<mp>52.2</mp>
+			<cp>70.4</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>154.1</hp>
+			<mp>57.9</mp>
+			<cp>77.05</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>167.54</hp>
+			<mp>63.66</mp>
+			<cp>83.77</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>181.12</hp>
+			<mp>69.48</mp>
+			<cp>90.56</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>194.84</hp>
+			<mp>75.36</mp>
+			<cp>97.42</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>208.7</hp>
+			<mp>81.3</mp>
+			<cp>104.35</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>222.7</hp>
+			<mp>87.3</mp>
+			<cp>111.35</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>236.84</hp>
+			<mp>93.36</mp>
+			<cp>118.42</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>251.12</hp>
+			<mp>99.48</mp>
+			<cp>125.56</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>265.54</hp>
+			<mp>105.66</mp>
+			<cp>132.77</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>280.1</hp>
+			<mp>111.9</mp>
+			<cp>140.05</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>294.8</hp>
+			<mp>118.2</mp>
+			<cp>147.4</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>309.64</hp>
+			<mp>124.56</mp>
+			<cp>154.82</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>324.62</hp>
+			<mp>130.98</mp>
+			<cp>162.31</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>339.74</hp>
+			<mp>137.46</mp>
+			<cp>169.87</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>355.0</hp>
+			<mp>144.0</mp>
+			<cp>177.5</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>388.0</hp>
+			<mp>153.9</mp>
+			<cp>194.0</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>421.3</hp>
+			<mp>163.89</mp>
+			<cp>210.65</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>454.9</hp>
+			<mp>173.97</mp>
+			<cp>227.45</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>488.8</hp>
+			<mp>184.14</mp>
+			<cp>244.4</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>523.0</hp>
+			<mp>194.4</mp>
+			<cp>261.5</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>557.5</hp>
+			<mp>204.75</mp>
+			<cp>278.75</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>592.3</hp>
+			<mp>215.19</mp>
+			<cp>296.15</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>627.4</hp>
+			<mp>225.72</mp>
+			<cp>313.7</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>662.8</hp>
+			<mp>236.34</mp>
+			<cp>331.4</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>698.5</hp>
+			<mp>247.05</mp>
+			<cp>349.25</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>734.5</hp>
+			<mp>257.85</mp>
+			<cp>367.25</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>770.8</hp>
+			<mp>268.74</mp>
+			<cp>385.4</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>807.4</hp>
+			<mp>279.72</mp>
+			<cp>403.7</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>844.3</hp>
+			<mp>290.79</mp>
+			<cp>422.15</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>881.5</hp>
+			<mp>301.95</mp>
+			<cp>440.75</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>919.0</hp>
+			<mp>313.2</mp>
+			<cp>459.5</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>956.8</hp>
+			<mp>324.54</mp>
+			<cp>478.4</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>994.9</hp>
+			<mp>335.97</mp>
+			<cp>497.45</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1033.3</hp>
+			<mp>347.49</mp>
+			<cp>516.65</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1072.0</hp>
+			<mp>359.1</mp>
+			<cp>536.0</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1111.0</hp>
+			<mp>370.8</mp>
+			<cp>555.5</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1150.3</hp>
+			<mp>382.59</mp>
+			<cp>575.15</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1189.9</hp>
+			<mp>394.47</mp>
+			<cp>594.95</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1229.8</hp>
+			<mp>406.44</mp>
+			<cp>614.9</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1270.0</hp>
+			<mp>418.5</mp>
+			<cp>635.0</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1310.5</hp>
+			<mp>430.65</mp>
+			<cp>655.25</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1351.3</hp>
+			<mp>442.89</mp>
+			<cp>675.65</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1392.4</hp>
+			<mp>455.22</mp>
+			<cp>696.2</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1433.8</hp>
+			<mp>467.64</mp>
+			<cp>716.9</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1475.5</hp>
+			<mp>480.15</mp>
+			<cp>737.75</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1517.5</hp>
+			<mp>492.75</mp>
+			<cp>758.75</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1559.8</hp>
+			<mp>505.44</mp>
+			<cp>779.9</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1602.4</hp>
+			<mp>518.22</mp>
+			<cp>801.2</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1645.3</hp>
+			<mp>531.09</mp>
+			<cp>822.65</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1688.5</hp>
+			<mp>544.05</mp>
+			<cp>844.25</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1732.0</hp>
+			<mp>557.1</mp>
+			<cp>866.0</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1775.8</hp>
+			<mp>570.24</mp>
+			<cp>887.9</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1819.9</hp>
+			<mp>583.47</mp>
+			<cp>909.95</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1864.3</hp>
+			<mp>596.79</mp>
+			<cp>932.15</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1909.0</hp>
+			<mp>610.2</mp>
+			<cp>954.5</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>1954.0</hp>
+			<mp>623.7</mp>
+			<cp>977.0</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>1999.3</hp>
+			<mp>637.29</mp>
+			<cp>999.65</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2044.9</hp>
+			<mp>650.97</mp>
+			<cp>1022.45</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2090.8</hp>
+			<mp>664.74</mp>
+			<cp>1045.4</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2137.0</hp>
+			<mp>678.6</mp>
+			<cp>1068.5</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2183.5</hp>
+			<mp>692.55</mp>
+			<cp>1091.75</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2230.3</hp>
+			<mp>706.59</mp>
+			<cp>1115.15</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2277.4</hp>
+			<mp>720.72</mp>
+			<cp>1138.7</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2324.8</hp>
+			<mp>734.94</mp>
+			<cp>1162.4</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2372.5</hp>
+			<mp>749.25</mp>
+			<cp>1186.25</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2420.5</hp>
+			<mp>763.65</mp>
+			<cp>1210.25</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2468.8</hp>
+			<mp>778.14</mp>
+			<cp>1234.4</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2517.4</hp>
+			<mp>792.72</mp>
+			<cp>1258.7</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2566.3</hp>
+			<mp>807.39</mp>
+			<cp>1283.15</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2615.5</hp>
+			<mp>822.15</mp>
+			<cp>1307.75</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>2665.0</hp>
+			<mp>837.0</mp>
+			<cp>1332.5</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>2714.8</hp>
+			<mp>851.94</mp>
+			<cp>1357.4</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>2764.9</hp>
+			<mp>866.97</mp>
+			<cp>1382.45</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>2815.3</hp>
+			<mp>882.09</mp>
+			<cp>1407.65</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>2866.0</hp>
+			<mp>897.3</mp>
+			<cp>1433.0</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>2917.0</hp>
+			<mp>912.6</mp>
+			<cp>1458.5</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>2968.3</hp>
+			<mp>927.99</mp>
+			<cp>1484.15</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3019.9</hp>
+			<mp>943.47</mp>
+			<cp>1509.95</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3071.8</hp>
+			<mp>959.04</mp>
+			<cp>1535.9</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3124.0</hp>
+			<mp>974.7</mp>
+			<cp>1562.0</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3176.5</hp>
+			<mp>990.45</mp>
+			<cp>1588.25</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3229.3</hp>
+			<mp>1006.29</mp>
+			<cp>1614.65</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3282.4</hp>
+			<mp>1022.22</mp>
+			<cp>1641.2</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3335.8</hp>
+			<mp>1038.24</mp>
+			<cp>1667.9</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3389.5</hp>
+			<mp>1054.35</mp>
+			<cp>1694.75</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3443.5</hp>
+			<mp>1070.55</mp>
+			<cp>1721.75</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>3497.8</hp>
+			<mp>1086.84</mp>
+			<cp>1748.9</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>3552.4</hp>
+			<mp>1103.22</mp>
+			<cp>1776.2</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>3607.3</hp>
+			<mp>1119.69</mp>
+			<cp>1803.65</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>3662.5</hp>
+			<mp>1136.25</mp>
+			<cp>1831.25</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>3718.0</hp>
+			<mp>1152.9</mp>
+			<cp>1859.0</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>3773.8</hp>
+			<mp>1169.64</mp>
+			<cp>1886.9</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>3829.9</hp>
+			<mp>1186.47</mp>
+			<cp>1914.95</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>3886.3</hp>
+			<mp>1203.39</mp>
+			<cp>1943.15</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>3943</hp>
+			<mp>1220.4</mp>
+			<cp>1971.5</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4000</hp>
+			<mp>1237.5</mp>
+			<cp>2000</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4057.3</hp>
+			<mp>1254.69</mp>
+			<cp>2028.65</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4114.9</hp>
+			<mp>1271.97</mp>
+			<cp>2057.45</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4172.8</hp>
+			<mp>1289.34</mp>
+			<cp>2086.4</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>4231</hp>
+			<mp>1306.8</mp>
+			<cp>2115.5</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>4289.5</hp>
+			<mp>1324.35</mp>
+			<cp>2144.75</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>4348.3</hp>
+			<mp>1341.99</mp>
+			<cp>2174.15</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
+</list>

--- a/data/stats/chars/baseStats/ElfDeathKnight.xml
+++ b/data/stats/chars/baseStats/ElfDeathKnight.xml
@@ -1,0 +1,923 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
+	<classId>203</classId>
+	<staticData>
+		<baseINT>20</baseINT>
+		<baseSTR>40</baseSTR>
+		<baseCON>40</baseCON>
+		<baseMEN>25</baseMEN>
+		<baseDEX>35</baseDEX>
+		<baseWIT>10</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="47417" y="153541" z="-2728" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>90</walk>
+			<run>143</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>350</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.5</radius>
+			<height>23</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>89.0</hp>
+			<mp>30.0</mp>
+			<cp>53.4</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>101.74</hp>
+			<mp>35.46</mp>
+			<cp>61.044</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>114.62</hp>
+			<mp>40.98</mp>
+			<cp>68.772</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>127.64</hp>
+			<mp>46.56</mp>
+			<cp>76.584</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>140.8</hp>
+			<mp>52.2</mp>
+			<cp>84.48</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>154.1</hp>
+			<mp>57.9</mp>
+			<cp>92.46</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>167.54</hp>
+			<mp>63.66</mp>
+			<cp>100.524</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>181.12</hp>
+			<mp>69.48</mp>
+			<cp>108.672</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>194.84</hp>
+			<mp>75.36</mp>
+			<cp>116.904</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>208.7</hp>
+			<mp>81.3</mp>
+			<cp>125.22</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>222.7</hp>
+			<mp>87.3</mp>
+			<cp>133.62</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>236.84</hp>
+			<mp>93.36</mp>
+			<cp>142.104</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>251.12</hp>
+			<mp>99.48</mp>
+			<cp>150.672</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>265.54</hp>
+			<mp>105.66</mp>
+			<cp>159.324</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>280.1</hp>
+			<mp>111.9</mp>
+			<cp>168.06</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>294.8</hp>
+			<mp>118.2</mp>
+			<cp>176.88</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>309.64</hp>
+			<mp>124.56</mp>
+			<cp>185.784</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>324.62</hp>
+			<mp>130.98</mp>
+			<cp>194.772</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>339.74</hp>
+			<mp>137.46</mp>
+			<cp>203.844</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>355.0</hp>
+			<mp>144.0</mp>
+			<cp>213.0</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>388.0</hp>
+			<mp>153.9</mp>
+			<cp>232.8</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>421.3</hp>
+			<mp>163.89</mp>
+			<cp>252.78</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>454.9</hp>
+			<mp>173.97</mp>
+			<cp>272.94</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>488.8</hp>
+			<mp>184.14</mp>
+			<cp>293.28</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>523.0</hp>
+			<mp>194.4</mp>
+			<cp>313.8</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>557.5</hp>
+			<mp>204.75</mp>
+			<cp>334.5</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>592.3</hp>
+			<mp>215.19</mp>
+			<cp>355.38</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>627.4</hp>
+			<mp>225.72</mp>
+			<cp>376.44</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>662.8</hp>
+			<mp>236.34</mp>
+			<cp>397.68</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>698.5</hp>
+			<mp>247.05</mp>
+			<cp>419.1</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>734.5</hp>
+			<mp>257.85</mp>
+			<cp>440.7</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>770.8</hp>
+			<mp>268.74</mp>
+			<cp>462.48</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>807.4</hp>
+			<mp>279.72</mp>
+			<cp>484.44</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>844.3</hp>
+			<mp>290.79</mp>
+			<cp>506.58</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>881.5</hp>
+			<mp>301.95</mp>
+			<cp>528.9</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>919.0</hp>
+			<mp>313.2</mp>
+			<cp>551.4</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>956.8</hp>
+			<mp>324.54</mp>
+			<cp>574.08</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>994.9</hp>
+			<mp>335.97</mp>
+			<cp>596.94</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1033.3</hp>
+			<mp>347.49</mp>
+			<cp>619.98</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1072.0</hp>
+			<mp>359.1</mp>
+			<cp>643.2</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1124.0</hp>
+			<mp>378.6</mp>
+			<cp>674.4</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1176.4</hp>
+			<mp>398.25</mp>
+			<cp>705.84</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1229.2</hp>
+			<mp>418.05</mp>
+			<cp>737.52</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1282.4</hp>
+			<mp>438.0</mp>
+			<cp>769.44</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1336.0</hp>
+			<mp>458.1</mp>
+			<cp>801.6</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1390.0</hp>
+			<mp>478.35</mp>
+			<cp>834.0</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1444.4</hp>
+			<mp>498.75</mp>
+			<cp>866.64</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1499.2</hp>
+			<mp>519.3</mp>
+			<cp>899.52</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1554.4</hp>
+			<mp>540.0</mp>
+			<cp>932.64</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1610.0</hp>
+			<mp>560.85</mp>
+			<cp>966.0</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1666.0</hp>
+			<mp>581.85</mp>
+			<cp>999.6</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1722.4</hp>
+			<mp>603.0</mp>
+			<cp>1033.44</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1779.2</hp>
+			<mp>624.3</mp>
+			<cp>1067.52</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1836.4</hp>
+			<mp>645.75</mp>
+			<cp>1101.84</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1894.0</hp>
+			<mp>667.35</mp>
+			<cp>1136.4</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1952.0</hp>
+			<mp>689.1</mp>
+			<cp>1171.2</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2010.4</hp>
+			<mp>711.0</mp>
+			<cp>1206.24</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2069.2</hp>
+			<mp>733.05</mp>
+			<cp>1241.52</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2128.4</hp>
+			<mp>755.25</mp>
+			<cp>1277.04</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2188.0</hp>
+			<mp>777.6</mp>
+			<cp>1312.8</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2248.0</hp>
+			<mp>800.1</mp>
+			<cp>1348.8</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2308.4</hp>
+			<mp>822.75</mp>
+			<cp>1385.04</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2369.2</hp>
+			<mp>845.55</mp>
+			<cp>1421.52</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2430.4</hp>
+			<mp>868.5</mp>
+			<cp>1458.24</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2492.0</hp>
+			<mp>891.6</mp>
+			<cp>1495.2</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2554.0</hp>
+			<mp>914.85</mp>
+			<cp>1532.4</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2616.4</hp>
+			<mp>938.25</mp>
+			<cp>1569.84</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2679.2</hp>
+			<mp>961.8</mp>
+			<cp>1607.52</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2742.4</hp>
+			<mp>985.5</mp>
+			<cp>1645.44</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2806.0</hp>
+			<mp>1009.35</mp>
+			<cp>1683.6</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2870.0</hp>
+			<mp>1033.35</mp>
+			<cp>1722.0</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2934.4</hp>
+			<mp>1057.5</mp>
+			<cp>1760.64</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2999.2</hp>
+			<mp>1081.8</mp>
+			<cp>1799.52</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3064.4</hp>
+			<mp>1106.25</mp>
+			<cp>1838.64</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3130.0</hp>
+			<mp>1130.85</mp>
+			<cp>1878.0</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3196.0</hp>
+			<mp>1155.6</mp>
+			<cp>1917.6</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3262.4</hp>
+			<mp>1180.5</mp>
+			<cp>1957.44</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3329.2</hp>
+			<mp>1205.55</mp>
+			<cp>1997.52</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3396.4</hp>
+			<mp>1230.75</mp>
+			<cp>2037.84</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3464.0</hp>
+			<mp>1256.1</mp>
+			<cp>2078.4</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3532.0</hp>
+			<mp>1281.6</mp>
+			<cp>2119.2</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3600.4</hp>
+			<mp>1307.25</mp>
+			<cp>2160.24</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3669.2</hp>
+			<mp>1333.05</mp>
+			<cp>2201.52</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3738.4</hp>
+			<mp>1359.0</mp>
+			<cp>2243.04</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3808.0</hp>
+			<mp>1385.1</mp>
+			<cp>2284.8</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3878.0</hp>
+			<mp>1411.35</mp>
+			<cp>2326.8</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3948.4</hp>
+			<mp>1437.75</mp>
+			<cp>2369.04</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4019.2</hp>
+			<mp>1464.3</mp>
+			<cp>2411.52</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4090.4</hp>
+			<mp>1491.0</mp>
+			<cp>2454.24</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4162.0</hp>
+			<mp>1517.85</mp>
+			<cp>2497.2</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4234.0</hp>
+			<mp>1544.85</mp>
+			<cp>2540.4</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4306.4</hp>
+			<mp>1572.0</mp>
+			<cp>2583.84</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4379.2</hp>
+			<mp>1599.3</mp>
+			<cp>2627.52</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4452.4</hp>
+			<mp>1626.75</mp>
+			<cp>2671.44</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4526.0</hp>
+			<mp>1654.35</mp>
+			<cp>2715.6</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4600.0</hp>
+			<mp>1682.1</mp>
+			<cp>2760.0</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4674.4</hp>
+			<mp>1710.0</mp>
+			<cp>2804.64</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4749.2</hp>
+			<mp>1738.05</mp>
+			<cp>2849.52</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4824.4</hp>
+			<mp>1766.25</mp>
+			<cp>2894.64</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4900</hp>
+			<mp>1794.6</mp>
+			<cp>2940</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4976</hp>
+			<mp>1823.1</mp>
+			<cp>2985.6</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5052.4</hp>
+			<mp>1851.75</mp>
+			<cp>3031.44</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5129.2</hp>
+			<mp>1880.55</mp>
+			<cp>3077.52</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5206.4</hp>
+			<mp>1909.5</mp>
+			<cp>3123.84</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5284</hp>
+			<mp>1938.6</mp>
+			<cp>3170.4</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5362</hp>
+			<mp>1967.85</mp>
+			<cp>3217.2</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5440.4</hp>
+			<mp>1997.25</mp>
+			<cp>3264.24</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
+</list>

--- a/data/stats/chars/baseStats/ElfDeathWalker.xml
+++ b/data/stats/chars/baseStats/ElfDeathWalker.xml
@@ -1,0 +1,923 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
+	<classId>200</classId>
+	<staticData>
+		<baseINT>20</baseINT>
+		<baseSTR>40</baseSTR>
+		<baseCON>40</baseCON>
+		<baseMEN>25</baseMEN>
+		<baseDEX>35</baseDEX>
+		<baseWIT>10</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="47417" y="153541" z="-2728" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>90</walk>
+			<run>143</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>350</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.5</radius>
+			<height>23</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>89.0</hp>
+			<mp>30.0</mp>
+			<cp>35.6</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>101.74</hp>
+			<mp>35.46</mp>
+			<cp>40.696</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>114.62</hp>
+			<mp>40.98</mp>
+			<cp>45.848</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>127.64</hp>
+			<mp>46.56</mp>
+			<cp>51.056</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>140.8</hp>
+			<mp>52.2</mp>
+			<cp>56.32</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>154.1</hp>
+			<mp>57.9</mp>
+			<cp>61.64</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>167.54</hp>
+			<mp>63.66</mp>
+			<cp>67.016</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>181.12</hp>
+			<mp>69.48</mp>
+			<cp>72.448</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>194.84</hp>
+			<mp>75.36</mp>
+			<cp>77.936</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>208.7</hp>
+			<mp>81.3</mp>
+			<cp>83.48</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>222.7</hp>
+			<mp>87.3</mp>
+			<cp>89.08</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>236.84</hp>
+			<mp>93.36</mp>
+			<cp>94.736</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>251.12</hp>
+			<mp>99.48</mp>
+			<cp>100.448</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>265.54</hp>
+			<mp>105.66</mp>
+			<cp>106.216</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>280.1</hp>
+			<mp>111.9</mp>
+			<cp>112.04</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>294.8</hp>
+			<mp>118.2</mp>
+			<cp>117.92</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>309.64</hp>
+			<mp>124.56</mp>
+			<cp>123.856</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>324.62</hp>
+			<mp>130.98</mp>
+			<cp>129.848</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>339.74</hp>
+			<mp>137.46</mp>
+			<cp>135.896</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>355.0</hp>
+			<mp>144.0</mp>
+			<cp>142.0</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>370.4</hp>
+			<mp>150.6</mp>
+			<cp>148.16</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>385.94</hp>
+			<mp>157.26</mp>
+			<cp>154.376</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>401.62</hp>
+			<mp>163.98</mp>
+			<cp>160.648</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>417.44</hp>
+			<mp>170.76</mp>
+			<cp>166.976</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>433.4</hp>
+			<mp>177.6</mp>
+			<cp>173.36</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>449.5</hp>
+			<mp>184.5</mp>
+			<cp>179.8</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>465.74</hp>
+			<mp>191.46</mp>
+			<cp>186.296</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>482.12</hp>
+			<mp>198.48</mp>
+			<cp>192.848</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>498.64</hp>
+			<mp>205.56</mp>
+			<cp>199.456</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>515.3</hp>
+			<mp>212.7</mp>
+			<cp>206.12</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>532.1</hp>
+			<mp>219.9</mp>
+			<cp>212.84</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>549.04</hp>
+			<mp>227.16</mp>
+			<cp>219.616</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>566.12</hp>
+			<mp>234.48</mp>
+			<cp>226.448</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>583.34</hp>
+			<mp>241.86</mp>
+			<cp>233.336</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>600.7</hp>
+			<mp>249.3</mp>
+			<cp>240.28</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>618.2</hp>
+			<mp>256.8</mp>
+			<cp>247.28</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>635.84</hp>
+			<mp>264.36</mp>
+			<cp>254.336</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>653.62</hp>
+			<mp>271.98</mp>
+			<cp>261.448</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>671.54</hp>
+			<mp>279.66</mp>
+			<cp>268.616</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>689.6</hp>
+			<mp>287.4</mp>
+			<cp>275.84</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>707.8</hp>
+			<mp>295.2</mp>
+			<cp>283.12</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>726.14</hp>
+			<mp>303.06</mp>
+			<cp>290.456</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>744.62</hp>
+			<mp>310.98</mp>
+			<cp>297.848</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>763.24</hp>
+			<mp>318.96</mp>
+			<cp>305.296</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>782.0</hp>
+			<mp>327.0</mp>
+			<cp>312.8</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>800.9</hp>
+			<mp>335.1</mp>
+			<cp>320.36</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>819.94</hp>
+			<mp>343.26</mp>
+			<cp>327.976</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>839.12</hp>
+			<mp>351.48</mp>
+			<cp>335.648</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>858.44</hp>
+			<mp>359.76</mp>
+			<cp>343.376</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>877.9</hp>
+			<mp>368.1</mp>
+			<cp>351.16</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>897.5</hp>
+			<mp>376.5</mp>
+			<cp>359.0</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>917.24</hp>
+			<mp>384.96</mp>
+			<cp>366.896</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>937.12</hp>
+			<mp>393.48</mp>
+			<cp>374.848</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>957.14</hp>
+			<mp>402.06</mp>
+			<cp>382.856</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>977.3</hp>
+			<mp>410.7</mp>
+			<cp>390.92</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>997.6</hp>
+			<mp>419.4</mp>
+			<cp>399.04</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1018.04</hp>
+			<mp>428.16</mp>
+			<cp>407.216</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1038.62</hp>
+			<mp>436.98</mp>
+			<cp>415.448</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1059.34</hp>
+			<mp>445.86</mp>
+			<cp>423.736</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1080.2</hp>
+			<mp>454.8</mp>
+			<cp>432.08</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>1101.2</hp>
+			<mp>463.8</mp>
+			<cp>440.48</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>1122.34</hp>
+			<mp>472.86</mp>
+			<cp>448.936</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>1143.62</hp>
+			<mp>481.98</mp>
+			<cp>457.448</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>1165.04</hp>
+			<mp>491.16</mp>
+			<cp>466.016</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>1186.6</hp>
+			<mp>500.4</mp>
+			<cp>474.64</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>1208.3</hp>
+			<mp>509.7</mp>
+			<cp>483.32</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>1230.14</hp>
+			<mp>519.06</mp>
+			<cp>492.056</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>1252.12</hp>
+			<mp>528.48</mp>
+			<cp>500.848</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>1274.24</hp>
+			<mp>537.96</mp>
+			<cp>509.696</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>1296.5</hp>
+			<mp>547.5</mp>
+			<cp>518.6</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>1318.9</hp>
+			<mp>557.1</mp>
+			<cp>527.56</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>1341.44</hp>
+			<mp>566.76</mp>
+			<cp>536.576</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>1364.12</hp>
+			<mp>576.48</mp>
+			<cp>545.648</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>1386.94</hp>
+			<mp>586.26</mp>
+			<cp>554.776</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>1409.9</hp>
+			<mp>596.1</mp>
+			<cp>563.96</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>1433.0</hp>
+			<mp>606.0</mp>
+			<cp>573.2</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>1456.24</hp>
+			<mp>615.96</mp>
+			<cp>582.496</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>1479.62</hp>
+			<mp>625.98</mp>
+			<cp>591.848</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>1503.14</hp>
+			<mp>636.06</mp>
+			<cp>601.256</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>1526.8</hp>
+			<mp>646.2</mp>
+			<cp>610.72</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>1550.6</hp>
+			<mp>656.4</mp>
+			<cp>620.24</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>1574.54</hp>
+			<mp>666.66</mp>
+			<cp>629.816</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>1598.62</hp>
+			<mp>676.98</mp>
+			<cp>639.448</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>1622.84</hp>
+			<mp>687.36</mp>
+			<cp>649.136</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>1647.2</hp>
+			<mp>697.8</mp>
+			<cp>658.88</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>1671.7</hp>
+			<mp>708.3</mp>
+			<cp>668.68</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>1696.34</hp>
+			<mp>718.86</mp>
+			<cp>678.536</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>1721.12</hp>
+			<mp>729.48</mp>
+			<cp>688.448</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>1746.04</hp>
+			<mp>740.16</mp>
+			<cp>698.416</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>1771.1</hp>
+			<mp>750.9</mp>
+			<cp>708.44</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>1796.3</hp>
+			<mp>761.7</mp>
+			<cp>718.52</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>1821.64</hp>
+			<mp>772.56</mp>
+			<cp>728.656</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>1847.12</hp>
+			<mp>783.48</mp>
+			<cp>738.848</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>1872.74</hp>
+			<mp>794.46</mp>
+			<cp>749.096</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>1898.5</hp>
+			<mp>805.5</mp>
+			<cp>759.4</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>1924.4</hp>
+			<mp>816.6</mp>
+			<cp>769.76</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>1950.44</hp>
+			<mp>827.76</mp>
+			<cp>780.176</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>1976.62</hp>
+			<mp>838.98</mp>
+			<cp>790.648</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>2002.94</hp>
+			<mp>850.26</mp>
+			<cp>801.176</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>2029.4</hp>
+			<mp>861.6</mp>
+			<cp>811.76</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>2056</hp>
+			<mp>873</mp>
+			<cp>822.41</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>2082.74</hp>
+			<mp>884.46</mp>
+			<cp>833.12</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>2109.62</hp>
+			<mp>895.98</mp>
+			<cp>843.89</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>2136.64</hp>
+			<mp>907.56</mp>
+			<cp>854.72</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>2163.8</hp>
+			<mp>919.2</mp>
+			<cp>865.6</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>2191.1</hp>
+			<mp>930.9</mp>
+			<cp>876.55</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>2218.54</hp>
+			<mp>942.66</mp>
+			<cp>887.416</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
+</list>

--- a/data/stats/chars/baseStats/ElfUndertaker.xml
+++ b/data/stats/chars/baseStats/ElfUndertaker.xml
@@ -1,0 +1,923 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
+	<classId>202</classId>
+	<staticData>
+		<baseINT>20</baseINT>
+		<baseSTR>40</baseSTR>
+		<baseCON>40</baseCON>
+		<baseMEN>25</baseMEN>
+		<baseDEX>35</baseDEX>
+		<baseWIT>10</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="47417" y="153541" z="-2728" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>90</walk>
+			<run>143</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>350</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.5</radius>
+			<height>23</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>89.0</hp>
+			<mp>30.0</mp>
+			<cp>53.4</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>101.74</hp>
+			<mp>35.46</mp>
+			<cp>61.044</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>114.62</hp>
+			<mp>40.98</mp>
+			<cp>68.772</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>127.64</hp>
+			<mp>46.56</mp>
+			<cp>76.584</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>140.8</hp>
+			<mp>52.2</mp>
+			<cp>84.48</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>154.1</hp>
+			<mp>57.9</mp>
+			<cp>92.46</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>167.54</hp>
+			<mp>63.66</mp>
+			<cp>100.524</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>181.12</hp>
+			<mp>69.48</mp>
+			<cp>108.672</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>194.84</hp>
+			<mp>75.36</mp>
+			<cp>116.904</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>208.7</hp>
+			<mp>81.3</mp>
+			<cp>125.22</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>222.7</hp>
+			<mp>87.3</mp>
+			<cp>133.62</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>236.84</hp>
+			<mp>93.36</mp>
+			<cp>142.104</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>251.12</hp>
+			<mp>99.48</mp>
+			<cp>150.672</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>265.54</hp>
+			<mp>105.66</mp>
+			<cp>159.324</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>280.1</hp>
+			<mp>111.9</mp>
+			<cp>168.06</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>294.8</hp>
+			<mp>118.2</mp>
+			<cp>176.88</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>309.64</hp>
+			<mp>124.56</mp>
+			<cp>185.784</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>324.62</hp>
+			<mp>130.98</mp>
+			<cp>194.772</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>339.74</hp>
+			<mp>137.46</mp>
+			<cp>203.844</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>355.0</hp>
+			<mp>144.0</mp>
+			<cp>213.0</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>388.0</hp>
+			<mp>153.9</mp>
+			<cp>232.8</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>421.3</hp>
+			<mp>163.89</mp>
+			<cp>252.78</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>454.9</hp>
+			<mp>173.97</mp>
+			<cp>272.94</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>488.8</hp>
+			<mp>184.14</mp>
+			<cp>293.28</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>523.0</hp>
+			<mp>194.4</mp>
+			<cp>313.8</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>557.5</hp>
+			<mp>204.75</mp>
+			<cp>334.5</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>592.3</hp>
+			<mp>215.19</mp>
+			<cp>355.38</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>627.4</hp>
+			<mp>225.72</mp>
+			<cp>376.44</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>662.8</hp>
+			<mp>236.34</mp>
+			<cp>397.68</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>698.5</hp>
+			<mp>247.05</mp>
+			<cp>419.1</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>734.5</hp>
+			<mp>257.85</mp>
+			<cp>440.7</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>770.8</hp>
+			<mp>268.74</mp>
+			<cp>462.48</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>807.4</hp>
+			<mp>279.72</mp>
+			<cp>484.44</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>844.3</hp>
+			<mp>290.79</mp>
+			<cp>506.58</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>881.5</hp>
+			<mp>301.95</mp>
+			<cp>528.9</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>919.0</hp>
+			<mp>313.2</mp>
+			<cp>551.4</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>956.8</hp>
+			<mp>324.54</mp>
+			<cp>574.08</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>994.9</hp>
+			<mp>335.97</mp>
+			<cp>596.94</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1033.3</hp>
+			<mp>347.49</mp>
+			<cp>619.98</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1072.0</hp>
+			<mp>359.1</mp>
+			<cp>643.2</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1124.0</hp>
+			<mp>378.6</mp>
+			<cp>674.4</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1176.4</hp>
+			<mp>398.25</mp>
+			<cp>705.84</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1229.2</hp>
+			<mp>418.05</mp>
+			<cp>737.52</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1282.4</hp>
+			<mp>438.0</mp>
+			<cp>769.44</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1336.0</hp>
+			<mp>458.1</mp>
+			<cp>801.6</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1390.0</hp>
+			<mp>478.35</mp>
+			<cp>834.0</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1444.4</hp>
+			<mp>498.75</mp>
+			<cp>866.64</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1499.2</hp>
+			<mp>519.3</mp>
+			<cp>899.52</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1554.4</hp>
+			<mp>540.0</mp>
+			<cp>932.64</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1610.0</hp>
+			<mp>560.85</mp>
+			<cp>966.0</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1666.0</hp>
+			<mp>581.85</mp>
+			<cp>999.6</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1722.4</hp>
+			<mp>603.0</mp>
+			<cp>1033.44</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1779.2</hp>
+			<mp>624.3</mp>
+			<cp>1067.52</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1836.4</hp>
+			<mp>645.75</mp>
+			<cp>1101.84</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1894.0</hp>
+			<mp>667.35</mp>
+			<cp>1136.4</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1952.0</hp>
+			<mp>689.1</mp>
+			<cp>1171.2</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2010.4</hp>
+			<mp>711.0</mp>
+			<cp>1206.24</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2069.2</hp>
+			<mp>733.05</mp>
+			<cp>1241.52</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2128.4</hp>
+			<mp>755.25</mp>
+			<cp>1277.04</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2188.0</hp>
+			<mp>777.6</mp>
+			<cp>1312.8</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2248.0</hp>
+			<mp>800.1</mp>
+			<cp>1348.8</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2308.4</hp>
+			<mp>822.75</mp>
+			<cp>1385.04</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2369.2</hp>
+			<mp>845.55</mp>
+			<cp>1421.52</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2430.4</hp>
+			<mp>868.5</mp>
+			<cp>1458.24</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2492.0</hp>
+			<mp>891.6</mp>
+			<cp>1495.2</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2554.0</hp>
+			<mp>914.85</mp>
+			<cp>1532.4</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2616.4</hp>
+			<mp>938.25</mp>
+			<cp>1569.84</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2679.2</hp>
+			<mp>961.8</mp>
+			<cp>1607.52</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2742.4</hp>
+			<mp>985.5</mp>
+			<cp>1645.44</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2806.0</hp>
+			<mp>1009.35</mp>
+			<cp>1683.6</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2870.0</hp>
+			<mp>1033.35</mp>
+			<cp>1722.0</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2934.4</hp>
+			<mp>1057.5</mp>
+			<cp>1760.64</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2999.2</hp>
+			<mp>1081.8</mp>
+			<cp>1799.52</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3064.4</hp>
+			<mp>1106.25</mp>
+			<cp>1838.64</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3130.0</hp>
+			<mp>1130.85</mp>
+			<cp>1878.0</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3196.0</hp>
+			<mp>1155.6</mp>
+			<cp>1917.6</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3262.4</hp>
+			<mp>1180.5</mp>
+			<cp>1957.44</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3329.2</hp>
+			<mp>1205.55</mp>
+			<cp>1997.52</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3396.4</hp>
+			<mp>1230.75</mp>
+			<cp>2037.84</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3464.0</hp>
+			<mp>1256.1</mp>
+			<cp>2078.4</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3532.0</hp>
+			<mp>1281.6</mp>
+			<cp>2119.2</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3600.4</hp>
+			<mp>1307.25</mp>
+			<cp>2160.24</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3669.2</hp>
+			<mp>1333.05</mp>
+			<cp>2201.52</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3738.4</hp>
+			<mp>1359.0</mp>
+			<cp>2243.04</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3808.0</hp>
+			<mp>1385.1</mp>
+			<cp>2284.8</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3878.0</hp>
+			<mp>1411.35</mp>
+			<cp>2326.8</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3948.4</hp>
+			<mp>1437.75</mp>
+			<cp>2369.04</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4019.2</hp>
+			<mp>1464.3</mp>
+			<cp>2411.52</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4090.4</hp>
+			<mp>1491.0</mp>
+			<cp>2454.24</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4162.0</hp>
+			<mp>1517.85</mp>
+			<cp>2497.2</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4234.0</hp>
+			<mp>1544.85</mp>
+			<cp>2540.4</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4306.4</hp>
+			<mp>1572.0</mp>
+			<cp>2583.84</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4379.2</hp>
+			<mp>1599.3</mp>
+			<cp>2627.52</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4452.4</hp>
+			<mp>1626.75</mp>
+			<cp>2671.44</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4526.0</hp>
+			<mp>1654.35</mp>
+			<cp>2715.6</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4600.0</hp>
+			<mp>1682.1</mp>
+			<cp>2760.0</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4674.4</hp>
+			<mp>1710.0</mp>
+			<cp>2804.64</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4749.2</hp>
+			<mp>1738.05</mp>
+			<cp>2849.52</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4824.4</hp>
+			<mp>1766.25</mp>
+			<cp>2894.64</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4900</hp>
+			<mp>1794.6</mp>
+			<cp>2940</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4976</hp>
+			<mp>1823.1</mp>
+			<cp>2985.6</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5052.4</hp>
+			<mp>1851.75</mp>
+			<cp>3031.44</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5129.2</hp>
+			<mp>1880.55</mp>
+			<cp>3077.52</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5206.4</hp>
+			<mp>1909.5</mp>
+			<cp>3123.84</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5284</hp>
+			<mp>1938.6</mp>
+			<cp>3170.4</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5362</hp>
+			<mp>1967.85</mp>
+			<cp>3217.2</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5440.4</hp>
+			<mp>1997.25</mp>
+			<cp>3264.24</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
+</list>

--- a/data/stats/chars/baseStats/ElvenElder.xml
+++ b/data/stats/chars/baseStats/ElvenElder.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>30</classId>
-    <staticData>
-        <baseINT>37</baseINT>
-        <baseSTR>21</baseSTR>
-        <baseCON>25</baseCON>
-        <baseMEN>40</baseMEN>
-        <baseDEX>24</baseDEX>
-        <baseWIT>23</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>15</magicAbnormalResist>
-        <creationPoints>
-            <node x="46045" y="41251" z="-3440"/>
-            <node x="46117" y="41247" z="-3440"/>
-            <node x="46182" y="41198" z="-3440"/>
-            <node x="46115" y="41141" z="-3440"/>
-            <node x="46048" y="41141" z="-3440"/>
-            <node x="45978" y="41196" z="-3440"/>
-        </creationPoints>
-        <basePAtk>3</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>15</chest>
-            <legs>8</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>85</walk>
-            <run>129</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>150</baseBreath>
-        <baseSafeFall>300</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>24</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.5</radius>
-            <height>23</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>104.0</hp>
-            <mp>40.0</mp>
-            <cp>93.6</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>119.47</hp>
-            <mp>47.28</mp>
-            <cp>107.523</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>135.11</hp>
-            <mp>54.64</mp>
-            <cp>121.599</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>150.92</hp>
-            <mp>62.08</mp>
-            <cp>135.828</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>166.9</hp>
-            <mp>69.6</mp>
-            <cp>150.21</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>183.05</hp>
-            <mp>77.2</mp>
-            <cp>164.745</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>199.37</hp>
-            <mp>84.88</mp>
-            <cp>179.433</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>215.86</hp>
-            <mp>92.64</mp>
-            <cp>194.274</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>232.52</hp>
-            <mp>100.48</mp>
-            <cp>209.268</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>249.35</hp>
-            <mp>108.4</mp>
-            <cp>224.415</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>266.35</hp>
-            <mp>116.4</mp>
-            <cp>239.715</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>283.52</hp>
-            <mp>124.48</mp>
-            <cp>255.168</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>300.86</hp>
-            <mp>132.64</mp>
-            <cp>270.774</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>318.37</hp>
-            <mp>140.88</mp>
-            <cp>286.533</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>336.05</hp>
-            <mp>149.2</mp>
-            <cp>302.445</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>353.9</hp>
-            <mp>157.6</mp>
-            <cp>318.51</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>371.92</hp>
-            <mp>166.08</mp>
-            <cp>334.728</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>390.11</hp>
-            <mp>174.64</mp>
-            <cp>351.099</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>408.47</hp>
-            <mp>183.28</mp>
-            <cp>367.623</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>427.0</hp>
-            <mp>192.0</mp>
-            <cp>384.3</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>462.2</hp>
-            <mp>205.2</mp>
-            <cp>415.98</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>497.72</hp>
-            <mp>218.52</mp>
-            <cp>447.948</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>533.56</hp>
-            <mp>231.96</mp>
-            <cp>480.204</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>569.72</hp>
-            <mp>245.52</mp>
-            <cp>512.748</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>606.2</hp>
-            <mp>259.2</mp>
-            <cp>545.58</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>643.0</hp>
-            <mp>273.0</mp>
-            <cp>578.7</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>680.12</hp>
-            <mp>286.92</mp>
-            <cp>612.108</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>717.56</hp>
-            <mp>300.96</mp>
-            <cp>645.804</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>755.32</hp>
-            <mp>315.12</mp>
-            <cp>679.788</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>793.4</hp>
-            <mp>329.4</mp>
-            <cp>714.06</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>831.8</hp>
-            <mp>343.8</mp>
-            <cp>748.62</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>870.52</hp>
-            <mp>358.32</mp>
-            <cp>783.468</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>909.56</hp>
-            <mp>372.96</mp>
-            <cp>818.604</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>948.92</hp>
-            <mp>387.72</mp>
-            <cp>854.028</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>988.6</hp>
-            <mp>402.6</mp>
-            <cp>889.74</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>1028.6</hp>
-            <mp>417.6</mp>
-            <cp>925.74</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>1068.92</hp>
-            <mp>432.72</mp>
-            <cp>962.028</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1109.56</hp>
-            <mp>447.96</mp>
-            <cp>998.604</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1150.52</hp>
-            <mp>463.32</mp>
-            <cp>1035.468</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1191.8</hp>
-            <mp>478.8</mp>
-            <cp>1072.62</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1246.4</hp>
-            <mp>504.8</mp>
-            <cp>1121.76</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1301.42</hp>
-            <mp>531.0</mp>
-            <cp>1171.278</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1356.86</hp>
-            <mp>557.4</mp>
-            <cp>1221.174</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1412.72</hp>
-            <mp>584.0</mp>
-            <cp>1271.448</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1469.0</hp>
-            <mp>610.8</mp>
-            <cp>1322.1</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1525.7</hp>
-            <mp>637.8</mp>
-            <cp>1373.13</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1582.82</hp>
-            <mp>665.0</mp>
-            <cp>1424.538</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1640.36</hp>
-            <mp>692.4</mp>
-            <cp>1476.324</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1698.32</hp>
-            <mp>720.0</mp>
-            <cp>1528.488</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1756.7</hp>
-            <mp>747.8</mp>
-            <cp>1581.03</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1815.5</hp>
-            <mp>775.8</mp>
-            <cp>1633.95</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1874.72</hp>
-            <mp>804.0</mp>
-            <cp>1687.248</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1934.36</hp>
-            <mp>832.4</mp>
-            <cp>1740.924</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1994.42</hp>
-            <mp>861.0</mp>
-            <cp>1794.978</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>2054.9</hp>
-            <mp>889.8</mp>
-            <cp>1849.41</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>2115.8</hp>
-            <mp>918.8</mp>
-            <cp>1904.22</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>2177.12</hp>
-            <mp>948.0</mp>
-            <cp>1959.408</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2238.86</hp>
-            <mp>977.4</mp>
-            <cp>2014.974</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2301.02</hp>
-            <mp>1007.0</mp>
-            <cp>2070.918</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2363.6</hp>
-            <mp>1036.8</mp>
-            <cp>2127.24</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2426.6</hp>
-            <mp>1066.8</mp>
-            <cp>2183.94</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2490.02</hp>
-            <mp>1097.0</mp>
-            <cp>2241.018</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2553.86</hp>
-            <mp>1127.4</mp>
-            <cp>2298.474</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2618.12</hp>
-            <mp>1158.0</mp>
-            <cp>2356.308</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2682.8</hp>
-            <mp>1188.8</mp>
-            <cp>2414.52</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2747.9</hp>
-            <mp>1219.8</mp>
-            <cp>2473.11</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2813.42</hp>
-            <mp>1251.0</mp>
-            <cp>2532.078</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2879.36</hp>
-            <mp>1282.4</mp>
-            <cp>2591.424</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2945.72</hp>
-            <mp>1314.0</mp>
-            <cp>2651.148</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>3012.5</hp>
-            <mp>1345.8</mp>
-            <cp>2711.25</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>3079.7</hp>
-            <mp>1377.8</mp>
-            <cp>2771.73</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>3147.32</hp>
-            <mp>1410.0</mp>
-            <cp>2832.588</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>3215.36</hp>
-            <mp>1442.4</mp>
-            <cp>2893.824</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>3283.82</hp>
-            <mp>1475.0</mp>
-            <cp>2955.438</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3352.7</hp>
-            <mp>1507.8</mp>
-            <cp>3017.43</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3422.0</hp>
-            <mp>1540.8</mp>
-            <cp>3079.8</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3491.72</hp>
-            <mp>1574.0</mp>
-            <cp>3142.548</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3561.86</hp>
-            <mp>1607.4</mp>
-            <cp>3205.674</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3632.42</hp>
-            <mp>1641.0</mp>
-            <cp>3269.178</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3703.4</hp>
-            <mp>1674.8</mp>
-            <cp>3333.06</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3774.8</hp>
-            <mp>1708.8</mp>
-            <cp>3397.32</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3846.62</hp>
-            <mp>1743.0</mp>
-            <cp>3461.958</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3918.86</hp>
-            <mp>1777.4</mp>
-            <cp>3526.974</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3991.52</hp>
-            <mp>1812.0</mp>
-            <cp>3592.368</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>4064.6</hp>
-            <mp>1846.8</mp>
-            <cp>3658.14</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>4138.1</hp>
-            <mp>1881.8</mp>
-            <cp>3724.29</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>4212.02</hp>
-            <mp>1917.0</mp>
-            <cp>3790.818</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>4286.36</hp>
-            <mp>1952.4</mp>
-            <cp>3857.724</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>4361.12</hp>
-            <mp>1988.0</mp>
-            <cp>3925.008</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4436.3</hp>
-            <mp>2023.8</mp>
-            <cp>3992.67</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4511.9</hp>
-            <mp>2059.8</mp>
-            <cp>4060.71</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>30</classId>
+	<staticData>
+		<baseINT>37</baseINT>
+		<baseSTR>21</baseSTR>
+		<baseCON>25</baseCON>
+		<baseMEN>40</baseMEN>
+		<baseDEX>24</baseDEX>
+		<baseWIT>23</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="46045" y="41251" z="-3440" />
+			<node x="46117" y="41247" z="-3440" />
+			<node x="46182" y="41198" z="-3440" />
+			<node x="46115" y="41141" z="-3440" />
+			<node x="46048" y="41141" z="-3440" />
+			<node x="45978" y="41196" z="-3440" />
+		</creationPoints>
+		<basePAtk>3</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>15</chest>
+			<legs>8</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>85</walk>
+			<run>129</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>300</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.5</radius>
+			<height>23</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>104.0</hp>
+			<mp>40.0</mp>
+			<cp>93.6</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>119.47</hp>
+			<mp>47.28</mp>
+			<cp>107.523</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>135.11</hp>
+			<mp>54.64</mp>
+			<cp>121.599</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>150.92</hp>
+			<mp>62.08</mp>
+			<cp>135.828</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>166.9</hp>
+			<mp>69.6</mp>
+			<cp>150.21</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>183.05</hp>
+			<mp>77.2</mp>
+			<cp>164.745</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>199.37</hp>
+			<mp>84.88</mp>
+			<cp>179.433</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>215.86</hp>
+			<mp>92.64</mp>
+			<cp>194.274</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>232.52</hp>
+			<mp>100.48</mp>
+			<cp>209.268</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>249.35</hp>
+			<mp>108.4</mp>
+			<cp>224.415</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>266.35</hp>
+			<mp>116.4</mp>
+			<cp>239.715</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>283.52</hp>
+			<mp>124.48</mp>
+			<cp>255.168</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>300.86</hp>
+			<mp>132.64</mp>
+			<cp>270.774</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>318.37</hp>
+			<mp>140.88</mp>
+			<cp>286.533</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>336.05</hp>
+			<mp>149.2</mp>
+			<cp>302.445</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>353.9</hp>
+			<mp>157.6</mp>
+			<cp>318.51</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>371.92</hp>
+			<mp>166.08</mp>
+			<cp>334.728</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>390.11</hp>
+			<mp>174.64</mp>
+			<cp>351.099</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>408.47</hp>
+			<mp>183.28</mp>
+			<cp>367.623</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>427.0</hp>
+			<mp>192.0</mp>
+			<cp>384.3</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>462.2</hp>
+			<mp>205.2</mp>
+			<cp>415.98</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>497.72</hp>
+			<mp>218.52</mp>
+			<cp>447.948</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>533.56</hp>
+			<mp>231.96</mp>
+			<cp>480.204</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>569.72</hp>
+			<mp>245.52</mp>
+			<cp>512.748</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>606.2</hp>
+			<mp>259.2</mp>
+			<cp>545.58</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>643.0</hp>
+			<mp>273.0</mp>
+			<cp>578.7</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>680.12</hp>
+			<mp>286.92</mp>
+			<cp>612.108</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>717.56</hp>
+			<mp>300.96</mp>
+			<cp>645.804</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>755.32</hp>
+			<mp>315.12</mp>
+			<cp>679.788</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>793.4</hp>
+			<mp>329.4</mp>
+			<cp>714.06</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>831.8</hp>
+			<mp>343.8</mp>
+			<cp>748.62</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>870.52</hp>
+			<mp>358.32</mp>
+			<cp>783.468</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>909.56</hp>
+			<mp>372.96</mp>
+			<cp>818.604</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>948.92</hp>
+			<mp>387.72</mp>
+			<cp>854.028</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>988.6</hp>
+			<mp>402.6</mp>
+			<cp>889.74</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>1028.6</hp>
+			<mp>417.6</mp>
+			<cp>925.74</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>1068.92</hp>
+			<mp>432.72</mp>
+			<cp>962.028</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1109.56</hp>
+			<mp>447.96</mp>
+			<cp>998.604</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1150.52</hp>
+			<mp>463.32</mp>
+			<cp>1035.468</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1191.8</hp>
+			<mp>478.8</mp>
+			<cp>1072.62</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1246.4</hp>
+			<mp>504.8</mp>
+			<cp>1121.76</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1301.42</hp>
+			<mp>531.0</mp>
+			<cp>1171.278</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1356.86</hp>
+			<mp>557.4</mp>
+			<cp>1221.174</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1412.72</hp>
+			<mp>584.0</mp>
+			<cp>1271.448</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1469.0</hp>
+			<mp>610.8</mp>
+			<cp>1322.1</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1525.7</hp>
+			<mp>637.8</mp>
+			<cp>1373.13</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1582.82</hp>
+			<mp>665.0</mp>
+			<cp>1424.538</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1640.36</hp>
+			<mp>692.4</mp>
+			<cp>1476.324</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1698.32</hp>
+			<mp>720.0</mp>
+			<cp>1528.488</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1756.7</hp>
+			<mp>747.8</mp>
+			<cp>1581.03</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1815.5</hp>
+			<mp>775.8</mp>
+			<cp>1633.95</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1874.72</hp>
+			<mp>804.0</mp>
+			<cp>1687.248</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1934.36</hp>
+			<mp>832.4</mp>
+			<cp>1740.924</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1994.42</hp>
+			<mp>861.0</mp>
+			<cp>1794.978</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>2054.9</hp>
+			<mp>889.8</mp>
+			<cp>1849.41</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>2115.8</hp>
+			<mp>918.8</mp>
+			<cp>1904.22</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2177.12</hp>
+			<mp>948.0</mp>
+			<cp>1959.408</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2238.86</hp>
+			<mp>977.4</mp>
+			<cp>2014.974</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2301.02</hp>
+			<mp>1007.0</mp>
+			<cp>2070.918</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2363.6</hp>
+			<mp>1036.8</mp>
+			<cp>2127.24</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2426.6</hp>
+			<mp>1066.8</mp>
+			<cp>2183.94</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2490.02</hp>
+			<mp>1097.0</mp>
+			<cp>2241.018</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2553.86</hp>
+			<mp>1127.4</mp>
+			<cp>2298.474</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2618.12</hp>
+			<mp>1158.0</mp>
+			<cp>2356.308</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2682.8</hp>
+			<mp>1188.8</mp>
+			<cp>2414.52</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2747.9</hp>
+			<mp>1219.8</mp>
+			<cp>2473.11</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2813.42</hp>
+			<mp>1251.0</mp>
+			<cp>2532.078</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2879.36</hp>
+			<mp>1282.4</mp>
+			<cp>2591.424</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2945.72</hp>
+			<mp>1314.0</mp>
+			<cp>2651.148</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>3012.5</hp>
+			<mp>1345.8</mp>
+			<cp>2711.25</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>3079.7</hp>
+			<mp>1377.8</mp>
+			<cp>2771.73</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>3147.32</hp>
+			<mp>1410.0</mp>
+			<cp>2832.588</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>3215.36</hp>
+			<mp>1442.4</mp>
+			<cp>2893.824</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3283.82</hp>
+			<mp>1475.0</mp>
+			<cp>2955.438</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3352.7</hp>
+			<mp>1507.8</mp>
+			<cp>3017.43</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3422.0</hp>
+			<mp>1540.8</mp>
+			<cp>3079.8</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3491.72</hp>
+			<mp>1574.0</mp>
+			<cp>3142.548</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3561.86</hp>
+			<mp>1607.4</mp>
+			<cp>3205.674</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3632.42</hp>
+			<mp>1641.0</mp>
+			<cp>3269.178</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3703.4</hp>
+			<mp>1674.8</mp>
+			<cp>3333.06</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3774.8</hp>
+			<mp>1708.8</mp>
+			<cp>3397.32</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3846.62</hp>
+			<mp>1743.0</mp>
+			<cp>3461.958</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3918.86</hp>
+			<mp>1777.4</mp>
+			<cp>3526.974</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3991.52</hp>
+			<mp>1812.0</mp>
+			<cp>3592.368</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>4064.6</hp>
+			<mp>1846.8</mp>
+			<cp>3658.14</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>4138.1</hp>
+			<mp>1881.8</mp>
+			<cp>3724.29</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>4212.02</hp>
+			<mp>1917.0</mp>
+			<cp>3790.818</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4286.36</hp>
+			<mp>1952.4</mp>
+			<cp>3857.724</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4361.12</hp>
+			<mp>1988.0</mp>
+			<cp>3925.008</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4436.3</hp>
+			<mp>2023.8</mp>
+			<cp>3992.67</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4511.9</hp>
+			<mp>2059.8</mp>
+			<cp>4060.71</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4587.92</hp>
+			<mp>2096.0</mp>
+			<cp>4129.128</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4664.36</hp>
+			<mp>2132.4</mp>
+			<cp>4197.924</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4741.22</hp>
+			<mp>2169.0</mp>
+			<cp>4267.098</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4818.5</hp>
+			<mp>2205.8</mp>
+			<cp>4336.65</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4896.2</hp>
+			<mp>2242.8</mp>
+			<cp>4406.58</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4974.32</hp>
+			<mp>2280.0</mp>
+			<cp>4476.888</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>5052.86</hp>
+			<mp>2317.4</mp>
+			<cp>4547.574</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>5131.82</hp>
+			<mp>2355.0</mp>
+			<cp>4618.638</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>5211.2</hp>
+			<mp>2392.8</mp>
+			<cp>4690.08</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>5291</hp>
+			<mp>2430.8</mp>
+			<cp>4761.91</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5371.22</hp>
+			<mp>2469</mp>
+			<cp>4834.11</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5451.86</hp>
+			<mp>2507.4</mp>
+			<cp>4906.69</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5532.92</hp>
+			<mp>2546</mp>
+			<cp>4979.66</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5614.4</hp>
+			<mp>2584.8</mp>
+			<cp>5053</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5696.3</hp>
+			<mp>2623.8</mp>
+			<cp>5126.73</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5778.62</hp>
+			<mp>2663</mp>
+			<cp>5200.758</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/ElvenFighter.xml
+++ b/data/stats/chars/baseStats/ElvenFighter.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>18</classId>
-    <staticData>
-        <baseINT>23</baseINT>
-        <baseSTR>36</baseSTR>
-        <baseCON>36</baseCON>
-        <baseMEN>26</baseMEN>
-        <baseDEX>35</baseDEX>
-        <baseWIT>14</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>15</magicAbnormalResist>
-        <creationPoints>
-            <node x="46045" y="41251" z="-3440"/>
-            <node x="46117" y="41247" z="-3440"/>
-            <node x="46182" y="41198" z="-3440"/>
-            <node x="46115" y="41141" z="-3440"/>
-            <node x="46048" y="41141" z="-3440"/>
-            <node x="45978" y="41196" z="-3440"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>90</walk>
-            <run>143</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>150</baseBreath>
-        <baseSafeFall>350</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>24</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.5</radius>
-            <height>23</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>89.0</hp>
-            <mp>30.0</mp>
-            <cp>35.6</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>101.74</hp>
-            <mp>35.46</mp>
-            <cp>40.696</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>114.62</hp>
-            <mp>40.98</mp>
-            <cp>45.848</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>127.64</hp>
-            <mp>46.56</mp>
-            <cp>51.056</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>140.8</hp>
-            <mp>52.2</mp>
-            <cp>56.32</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>154.1</hp>
-            <mp>57.9</mp>
-            <cp>61.64</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>167.54</hp>
-            <mp>63.66</mp>
-            <cp>67.016</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>181.12</hp>
-            <mp>69.48</mp>
-            <cp>72.448</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>194.84</hp>
-            <mp>75.36</mp>
-            <cp>77.936</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>208.7</hp>
-            <mp>81.3</mp>
-            <cp>83.48</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>222.7</hp>
-            <mp>87.3</mp>
-            <cp>89.08</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>236.84</hp>
-            <mp>93.36</mp>
-            <cp>94.736</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>251.12</hp>
-            <mp>99.48</mp>
-            <cp>100.448</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>265.54</hp>
-            <mp>105.66</mp>
-            <cp>106.216</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>280.1</hp>
-            <mp>111.9</mp>
-            <cp>112.04</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>294.8</hp>
-            <mp>118.2</mp>
-            <cp>117.92</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>309.64</hp>
-            <mp>124.56</mp>
-            <cp>123.856</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>324.62</hp>
-            <mp>130.98</mp>
-            <cp>129.848</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>339.74</hp>
-            <mp>137.46</mp>
-            <cp>135.896</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>355.0</hp>
-            <mp>144.0</mp>
-            <cp>142.0</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>370.4</hp>
-            <mp>150.6</mp>
-            <cp>148.16</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>385.94</hp>
-            <mp>157.26</mp>
-            <cp>154.376</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>401.62</hp>
-            <mp>163.98</mp>
-            <cp>160.648</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>417.44</hp>
-            <mp>170.76</mp>
-            <cp>166.976</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>433.4</hp>
-            <mp>177.6</mp>
-            <cp>173.36</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>449.5</hp>
-            <mp>184.5</mp>
-            <cp>179.8</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>465.74</hp>
-            <mp>191.46</mp>
-            <cp>186.296</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>482.12</hp>
-            <mp>198.48</mp>
-            <cp>192.848</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>498.64</hp>
-            <mp>205.56</mp>
-            <cp>199.456</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>515.3</hp>
-            <mp>212.7</mp>
-            <cp>206.12</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>532.1</hp>
-            <mp>219.9</mp>
-            <cp>212.84</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>549.04</hp>
-            <mp>227.16</mp>
-            <cp>219.616</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>566.12</hp>
-            <mp>234.48</mp>
-            <cp>226.448</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>583.34</hp>
-            <mp>241.86</mp>
-            <cp>233.336</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>600.7</hp>
-            <mp>249.3</mp>
-            <cp>240.28</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>618.2</hp>
-            <mp>256.8</mp>
-            <cp>247.28</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>635.84</hp>
-            <mp>264.36</mp>
-            <cp>254.336</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>653.62</hp>
-            <mp>271.98</mp>
-            <cp>261.448</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>671.54</hp>
-            <mp>279.66</mp>
-            <cp>268.616</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>689.6</hp>
-            <mp>287.4</mp>
-            <cp>275.84</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>707.8</hp>
-            <mp>295.2</mp>
-            <cp>283.12</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>726.14</hp>
-            <mp>303.06</mp>
-            <cp>290.456</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>744.62</hp>
-            <mp>310.98</mp>
-            <cp>297.848</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>763.24</hp>
-            <mp>318.96</mp>
-            <cp>305.296</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>782.0</hp>
-            <mp>327.0</mp>
-            <cp>312.8</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>800.9</hp>
-            <mp>335.1</mp>
-            <cp>320.36</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>819.94</hp>
-            <mp>343.26</mp>
-            <cp>327.976</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>839.12</hp>
-            <mp>351.48</mp>
-            <cp>335.648</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>858.44</hp>
-            <mp>359.76</mp>
-            <cp>343.376</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>877.9</hp>
-            <mp>368.1</mp>
-            <cp>351.16</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>897.5</hp>
-            <mp>376.5</mp>
-            <cp>359.0</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>917.24</hp>
-            <mp>384.96</mp>
-            <cp>366.896</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>937.12</hp>
-            <mp>393.48</mp>
-            <cp>374.848</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>957.14</hp>
-            <mp>402.06</mp>
-            <cp>382.856</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>977.3</hp>
-            <mp>410.7</mp>
-            <cp>390.92</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>997.6</hp>
-            <mp>419.4</mp>
-            <cp>399.04</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1018.04</hp>
-            <mp>428.16</mp>
-            <cp>407.216</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1038.62</hp>
-            <mp>436.98</mp>
-            <cp>415.448</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>1059.34</hp>
-            <mp>445.86</mp>
-            <cp>423.736</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>1080.2</hp>
-            <mp>454.8</mp>
-            <cp>432.08</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>1101.2</hp>
-            <mp>463.8</mp>
-            <cp>440.48</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>1122.34</hp>
-            <mp>472.86</mp>
-            <cp>448.936</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>1143.62</hp>
-            <mp>481.98</mp>
-            <cp>457.448</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>1165.04</hp>
-            <mp>491.16</mp>
-            <cp>466.016</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>1186.6</hp>
-            <mp>500.4</mp>
-            <cp>474.64</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>1208.3</hp>
-            <mp>509.7</mp>
-            <cp>483.32</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>1230.14</hp>
-            <mp>519.06</mp>
-            <cp>492.056</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>1252.12</hp>
-            <mp>528.48</mp>
-            <cp>500.848</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>1274.24</hp>
-            <mp>537.96</mp>
-            <cp>509.696</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>1296.5</hp>
-            <mp>547.5</mp>
-            <cp>518.6</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>1318.9</hp>
-            <mp>557.1</mp>
-            <cp>527.56</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>1341.44</hp>
-            <mp>566.76</mp>
-            <cp>536.576</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>1364.12</hp>
-            <mp>576.48</mp>
-            <cp>545.648</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>1386.94</hp>
-            <mp>586.26</mp>
-            <cp>554.776</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>1409.9</hp>
-            <mp>596.1</mp>
-            <cp>563.96</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>1433.0</hp>
-            <mp>606.0</mp>
-            <cp>573.2</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>1456.24</hp>
-            <mp>615.96</mp>
-            <cp>582.496</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>1479.62</hp>
-            <mp>625.98</mp>
-            <cp>591.848</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>1503.14</hp>
-            <mp>636.06</mp>
-            <cp>601.256</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>1526.8</hp>
-            <mp>646.2</mp>
-            <cp>610.72</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>1550.6</hp>
-            <mp>656.4</mp>
-            <cp>620.24</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>1574.54</hp>
-            <mp>666.66</mp>
-            <cp>629.816</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>1598.62</hp>
-            <mp>676.98</mp>
-            <cp>639.448</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>1622.84</hp>
-            <mp>687.36</mp>
-            <cp>649.136</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>1647.2</hp>
-            <mp>697.8</mp>
-            <cp>658.88</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>1671.7</hp>
-            <mp>708.3</mp>
-            <cp>668.68</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>1696.34</hp>
-            <mp>718.86</mp>
-            <cp>678.536</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>1721.12</hp>
-            <mp>729.48</mp>
-            <cp>688.448</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>1746.04</hp>
-            <mp>740.16</mp>
-            <cp>698.416</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>1771.1</hp>
-            <mp>750.9</mp>
-            <cp>708.44</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>1796.3</hp>
-            <mp>761.7</mp>
-            <cp>718.52</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>18</classId>
+	<staticData>
+		<baseINT>23</baseINT>
+		<baseSTR>36</baseSTR>
+		<baseCON>36</baseCON>
+		<baseMEN>26</baseMEN>
+		<baseDEX>35</baseDEX>
+		<baseWIT>14</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="46045" y="41251" z="-3440" />
+			<node x="46117" y="41247" z="-3440" />
+			<node x="46182" y="41198" z="-3440" />
+			<node x="46115" y="41141" z="-3440" />
+			<node x="46048" y="41141" z="-3440" />
+			<node x="45978" y="41196" z="-3440" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>90</walk>
+			<run>143</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>350</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.5</radius>
+			<height>23</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>89.0</hp>
+			<mp>30.0</mp>
+			<cp>35.6</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>101.74</hp>
+			<mp>35.46</mp>
+			<cp>40.696</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>114.62</hp>
+			<mp>40.98</mp>
+			<cp>45.848</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>127.64</hp>
+			<mp>46.56</mp>
+			<cp>51.056</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>140.8</hp>
+			<mp>52.2</mp>
+			<cp>56.32</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>154.1</hp>
+			<mp>57.9</mp>
+			<cp>61.64</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>167.54</hp>
+			<mp>63.66</mp>
+			<cp>67.016</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>181.12</hp>
+			<mp>69.48</mp>
+			<cp>72.448</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>194.84</hp>
+			<mp>75.36</mp>
+			<cp>77.936</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>208.7</hp>
+			<mp>81.3</mp>
+			<cp>83.48</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>222.7</hp>
+			<mp>87.3</mp>
+			<cp>89.08</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>236.84</hp>
+			<mp>93.36</mp>
+			<cp>94.736</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>251.12</hp>
+			<mp>99.48</mp>
+			<cp>100.448</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>265.54</hp>
+			<mp>105.66</mp>
+			<cp>106.216</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>280.1</hp>
+			<mp>111.9</mp>
+			<cp>112.04</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>294.8</hp>
+			<mp>118.2</mp>
+			<cp>117.92</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>309.64</hp>
+			<mp>124.56</mp>
+			<cp>123.856</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>324.62</hp>
+			<mp>130.98</mp>
+			<cp>129.848</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>339.74</hp>
+			<mp>137.46</mp>
+			<cp>135.896</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>355.0</hp>
+			<mp>144.0</mp>
+			<cp>142.0</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>370.4</hp>
+			<mp>150.6</mp>
+			<cp>148.16</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>385.94</hp>
+			<mp>157.26</mp>
+			<cp>154.376</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>401.62</hp>
+			<mp>163.98</mp>
+			<cp>160.648</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>417.44</hp>
+			<mp>170.76</mp>
+			<cp>166.976</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>433.4</hp>
+			<mp>177.6</mp>
+			<cp>173.36</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>449.5</hp>
+			<mp>184.5</mp>
+			<cp>179.8</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>465.74</hp>
+			<mp>191.46</mp>
+			<cp>186.296</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>482.12</hp>
+			<mp>198.48</mp>
+			<cp>192.848</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>498.64</hp>
+			<mp>205.56</mp>
+			<cp>199.456</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>515.3</hp>
+			<mp>212.7</mp>
+			<cp>206.12</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>532.1</hp>
+			<mp>219.9</mp>
+			<cp>212.84</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>549.04</hp>
+			<mp>227.16</mp>
+			<cp>219.616</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>566.12</hp>
+			<mp>234.48</mp>
+			<cp>226.448</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>583.34</hp>
+			<mp>241.86</mp>
+			<cp>233.336</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>600.7</hp>
+			<mp>249.3</mp>
+			<cp>240.28</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>618.2</hp>
+			<mp>256.8</mp>
+			<cp>247.28</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>635.84</hp>
+			<mp>264.36</mp>
+			<cp>254.336</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>653.62</hp>
+			<mp>271.98</mp>
+			<cp>261.448</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>671.54</hp>
+			<mp>279.66</mp>
+			<cp>268.616</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>689.6</hp>
+			<mp>287.4</mp>
+			<cp>275.84</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>707.8</hp>
+			<mp>295.2</mp>
+			<cp>283.12</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>726.14</hp>
+			<mp>303.06</mp>
+			<cp>290.456</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>744.62</hp>
+			<mp>310.98</mp>
+			<cp>297.848</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>763.24</hp>
+			<mp>318.96</mp>
+			<cp>305.296</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>782.0</hp>
+			<mp>327.0</mp>
+			<cp>312.8</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>800.9</hp>
+			<mp>335.1</mp>
+			<cp>320.36</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>819.94</hp>
+			<mp>343.26</mp>
+			<cp>327.976</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>839.12</hp>
+			<mp>351.48</mp>
+			<cp>335.648</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>858.44</hp>
+			<mp>359.76</mp>
+			<cp>343.376</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>877.9</hp>
+			<mp>368.1</mp>
+			<cp>351.16</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>897.5</hp>
+			<mp>376.5</mp>
+			<cp>359.0</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>917.24</hp>
+			<mp>384.96</mp>
+			<cp>366.896</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>937.12</hp>
+			<mp>393.48</mp>
+			<cp>374.848</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>957.14</hp>
+			<mp>402.06</mp>
+			<cp>382.856</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>977.3</hp>
+			<mp>410.7</mp>
+			<cp>390.92</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>997.6</hp>
+			<mp>419.4</mp>
+			<cp>399.04</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1018.04</hp>
+			<mp>428.16</mp>
+			<cp>407.216</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1038.62</hp>
+			<mp>436.98</mp>
+			<cp>415.448</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1059.34</hp>
+			<mp>445.86</mp>
+			<cp>423.736</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1080.2</hp>
+			<mp>454.8</mp>
+			<cp>432.08</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>1101.2</hp>
+			<mp>463.8</mp>
+			<cp>440.48</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>1122.34</hp>
+			<mp>472.86</mp>
+			<cp>448.936</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>1143.62</hp>
+			<mp>481.98</mp>
+			<cp>457.448</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>1165.04</hp>
+			<mp>491.16</mp>
+			<cp>466.016</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>1186.6</hp>
+			<mp>500.4</mp>
+			<cp>474.64</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>1208.3</hp>
+			<mp>509.7</mp>
+			<cp>483.32</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>1230.14</hp>
+			<mp>519.06</mp>
+			<cp>492.056</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>1252.12</hp>
+			<mp>528.48</mp>
+			<cp>500.848</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>1274.24</hp>
+			<mp>537.96</mp>
+			<cp>509.696</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>1296.5</hp>
+			<mp>547.5</mp>
+			<cp>518.6</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>1318.9</hp>
+			<mp>557.1</mp>
+			<cp>527.56</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>1341.44</hp>
+			<mp>566.76</mp>
+			<cp>536.576</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>1364.12</hp>
+			<mp>576.48</mp>
+			<cp>545.648</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>1386.94</hp>
+			<mp>586.26</mp>
+			<cp>554.776</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>1409.9</hp>
+			<mp>596.1</mp>
+			<cp>563.96</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>1433.0</hp>
+			<mp>606.0</mp>
+			<cp>573.2</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>1456.24</hp>
+			<mp>615.96</mp>
+			<cp>582.496</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>1479.62</hp>
+			<mp>625.98</mp>
+			<cp>591.848</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>1503.14</hp>
+			<mp>636.06</mp>
+			<cp>601.256</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>1526.8</hp>
+			<mp>646.2</mp>
+			<cp>610.72</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>1550.6</hp>
+			<mp>656.4</mp>
+			<cp>620.24</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>1574.54</hp>
+			<mp>666.66</mp>
+			<cp>629.816</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>1598.62</hp>
+			<mp>676.98</mp>
+			<cp>639.448</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>1622.84</hp>
+			<mp>687.36</mp>
+			<cp>649.136</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>1647.2</hp>
+			<mp>697.8</mp>
+			<cp>658.88</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>1671.7</hp>
+			<mp>708.3</mp>
+			<cp>668.68</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>1696.34</hp>
+			<mp>718.86</mp>
+			<cp>678.536</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>1721.12</hp>
+			<mp>729.48</mp>
+			<cp>688.448</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>1746.04</hp>
+			<mp>740.16</mp>
+			<cp>698.416</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>1771.1</hp>
+			<mp>750.9</mp>
+			<cp>708.44</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>1796.3</hp>
+			<mp>761.7</mp>
+			<cp>718.52</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>1821.64</hp>
+			<mp>772.56</mp>
+			<cp>728.656</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>1847.12</hp>
+			<mp>783.48</mp>
+			<cp>738.848</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>1872.74</hp>
+			<mp>794.46</mp>
+			<cp>749.096</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>1898.5</hp>
+			<mp>805.5</mp>
+			<cp>759.4</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>1924.4</hp>
+			<mp>816.6</mp>
+			<cp>769.76</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>1950.44</hp>
+			<mp>827.76</mp>
+			<cp>780.176</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>1976.62</hp>
+			<mp>838.98</mp>
+			<cp>790.648</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>2002.94</hp>
+			<mp>850.26</mp>
+			<cp>801.176</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>2029.4</hp>
+			<mp>861.6</mp>
+			<cp>811.76</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>2056</hp>
+			<mp>873</mp>
+			<cp>822.41</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>2082.74</hp>
+			<mp>884.46</mp>
+			<cp>833.12</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>2109.62</hp>
+			<mp>895.98</mp>
+			<cp>843.89</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>2136.64</hp>
+			<mp>907.56</mp>
+			<cp>854.72</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>2163.8</hp>
+			<mp>919.2</mp>
+			<cp>865.6</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>2191.1</hp>
+			<mp>930.9</mp>
+			<cp>876.55</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>2218.54</hp>
+			<mp>942.66</mp>
+			<cp>887.416</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/ElvenKnight.xml
+++ b/data/stats/chars/baseStats/ElvenKnight.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>19</classId>
-    <staticData>
-        <baseINT>23</baseINT>
-        <baseSTR>36</baseSTR>
-        <baseCON>36</baseCON>
-        <baseMEN>26</baseMEN>
-        <baseDEX>35</baseDEX>
-        <baseWIT>14</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>15</magicAbnormalResist>
-        <creationPoints>
-            <node x="46045" y="41251" z="-3440"/>
-            <node x="46117" y="41247" z="-3440"/>
-            <node x="46182" y="41198" z="-3440"/>
-            <node x="46115" y="41141" z="-3440"/>
-            <node x="46048" y="41141" z="-3440"/>
-            <node x="45978" y="41196" z="-3440"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>90</walk>
-            <run>143</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>150</baseBreath>
-        <baseSafeFall>350</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>24</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.5</radius>
-            <height>23</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>89.0</hp>
-            <mp>30.0</mp>
-            <cp>44.5</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>101.74</hp>
-            <mp>35.46</mp>
-            <cp>50.87</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>114.62</hp>
-            <mp>40.98</mp>
-            <cp>57.31</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>127.64</hp>
-            <mp>46.56</mp>
-            <cp>63.82</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>140.8</hp>
-            <mp>52.2</mp>
-            <cp>70.4</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>154.1</hp>
-            <mp>57.9</mp>
-            <cp>77.05</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>167.54</hp>
-            <mp>63.66</mp>
-            <cp>83.77</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>181.12</hp>
-            <mp>69.48</mp>
-            <cp>90.56</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>194.84</hp>
-            <mp>75.36</mp>
-            <cp>97.42</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>208.7</hp>
-            <mp>81.3</mp>
-            <cp>104.35</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>222.7</hp>
-            <mp>87.3</mp>
-            <cp>111.35</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>236.84</hp>
-            <mp>93.36</mp>
-            <cp>118.42</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>251.12</hp>
-            <mp>99.48</mp>
-            <cp>125.56</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>265.54</hp>
-            <mp>105.66</mp>
-            <cp>132.77</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>280.1</hp>
-            <mp>111.9</mp>
-            <cp>140.05</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>294.8</hp>
-            <mp>118.2</mp>
-            <cp>147.4</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>309.64</hp>
-            <mp>124.56</mp>
-            <cp>154.82</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>324.62</hp>
-            <mp>130.98</mp>
-            <cp>162.31</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>339.74</hp>
-            <mp>137.46</mp>
-            <cp>169.87</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>355.0</hp>
-            <mp>144.0</mp>
-            <cp>177.5</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>388.0</hp>
-            <mp>153.9</mp>
-            <cp>194.0</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>421.3</hp>
-            <mp>163.89</mp>
-            <cp>210.65</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>454.9</hp>
-            <mp>173.97</mp>
-            <cp>227.45</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>488.8</hp>
-            <mp>184.14</mp>
-            <cp>244.4</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>523.0</hp>
-            <mp>194.4</mp>
-            <cp>261.5</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>557.5</hp>
-            <mp>204.75</mp>
-            <cp>278.75</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>592.3</hp>
-            <mp>215.19</mp>
-            <cp>296.15</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>627.4</hp>
-            <mp>225.72</mp>
-            <cp>313.7</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>662.8</hp>
-            <mp>236.34</mp>
-            <cp>331.4</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>698.5</hp>
-            <mp>247.05</mp>
-            <cp>349.25</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>734.5</hp>
-            <mp>257.85</mp>
-            <cp>367.25</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>770.8</hp>
-            <mp>268.74</mp>
-            <cp>385.4</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>807.4</hp>
-            <mp>279.72</mp>
-            <cp>403.7</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>844.3</hp>
-            <mp>290.79</mp>
-            <cp>422.15</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>881.5</hp>
-            <mp>301.95</mp>
-            <cp>440.75</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>919.0</hp>
-            <mp>313.2</mp>
-            <cp>459.5</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>956.8</hp>
-            <mp>324.54</mp>
-            <cp>478.4</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>994.9</hp>
-            <mp>335.97</mp>
-            <cp>497.45</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1033.3</hp>
-            <mp>347.49</mp>
-            <cp>516.65</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1072.0</hp>
-            <mp>359.1</mp>
-            <cp>536.0</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1111.0</hp>
-            <mp>370.8</mp>
-            <cp>555.5</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1150.3</hp>
-            <mp>382.59</mp>
-            <cp>575.15</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1189.9</hp>
-            <mp>394.47</mp>
-            <cp>594.95</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1229.8</hp>
-            <mp>406.44</mp>
-            <cp>614.9</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1270.0</hp>
-            <mp>418.5</mp>
-            <cp>635.0</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1310.5</hp>
-            <mp>430.65</mp>
-            <cp>655.25</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1351.3</hp>
-            <mp>442.89</mp>
-            <cp>675.65</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1392.4</hp>
-            <mp>455.22</mp>
-            <cp>696.2</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1433.8</hp>
-            <mp>467.64</mp>
-            <cp>716.9</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1475.5</hp>
-            <mp>480.15</mp>
-            <cp>737.75</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1517.5</hp>
-            <mp>492.75</mp>
-            <cp>758.75</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1559.8</hp>
-            <mp>505.44</mp>
-            <cp>779.9</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1602.4</hp>
-            <mp>518.22</mp>
-            <cp>801.2</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1645.3</hp>
-            <mp>531.09</mp>
-            <cp>822.65</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1688.5</hp>
-            <mp>544.05</mp>
-            <cp>844.25</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1732.0</hp>
-            <mp>557.1</mp>
-            <cp>866.0</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1775.8</hp>
-            <mp>570.24</mp>
-            <cp>887.9</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1819.9</hp>
-            <mp>583.47</mp>
-            <cp>909.95</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>1864.3</hp>
-            <mp>596.79</mp>
-            <cp>932.15</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>1909.0</hp>
-            <mp>610.2</mp>
-            <cp>954.5</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>1954.0</hp>
-            <mp>623.7</mp>
-            <cp>977.0</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>1999.3</hp>
-            <mp>637.29</mp>
-            <cp>999.65</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2044.9</hp>
-            <mp>650.97</mp>
-            <cp>1022.45</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2090.8</hp>
-            <mp>664.74</mp>
-            <cp>1045.4</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2137.0</hp>
-            <mp>678.6</mp>
-            <cp>1068.5</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2183.5</hp>
-            <mp>692.55</mp>
-            <cp>1091.75</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2230.3</hp>
-            <mp>706.59</mp>
-            <cp>1115.15</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2277.4</hp>
-            <mp>720.72</mp>
-            <cp>1138.7</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2324.8</hp>
-            <mp>734.94</mp>
-            <cp>1162.4</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2372.5</hp>
-            <mp>749.25</mp>
-            <cp>1186.25</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2420.5</hp>
-            <mp>763.65</mp>
-            <cp>1210.25</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2468.8</hp>
-            <mp>778.14</mp>
-            <cp>1234.4</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2517.4</hp>
-            <mp>792.72</mp>
-            <cp>1258.7</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2566.3</hp>
-            <mp>807.39</mp>
-            <cp>1283.15</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2615.5</hp>
-            <mp>822.15</mp>
-            <cp>1307.75</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>2665.0</hp>
-            <mp>837.0</mp>
-            <cp>1332.5</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>2714.8</hp>
-            <mp>851.94</mp>
-            <cp>1357.4</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>2764.9</hp>
-            <mp>866.97</mp>
-            <cp>1382.45</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>2815.3</hp>
-            <mp>882.09</mp>
-            <cp>1407.65</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>2866.0</hp>
-            <mp>897.3</mp>
-            <cp>1433.0</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>2917.0</hp>
-            <mp>912.6</mp>
-            <cp>1458.5</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>2968.3</hp>
-            <mp>927.99</mp>
-            <cp>1484.15</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3019.9</hp>
-            <mp>943.47</mp>
-            <cp>1509.95</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3071.8</hp>
-            <mp>959.04</mp>
-            <cp>1535.9</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3124.0</hp>
-            <mp>974.7</mp>
-            <cp>1562.0</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3176.5</hp>
-            <mp>990.45</mp>
-            <cp>1588.25</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3229.3</hp>
-            <mp>1006.29</mp>
-            <cp>1614.65</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3282.4</hp>
-            <mp>1022.22</mp>
-            <cp>1641.2</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3335.8</hp>
-            <mp>1038.24</mp>
-            <cp>1667.9</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3389.5</hp>
-            <mp>1054.35</mp>
-            <cp>1694.75</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>3443.5</hp>
-            <mp>1070.55</mp>
-            <cp>1721.75</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>19</classId>
+	<staticData>
+		<baseINT>23</baseINT>
+		<baseSTR>36</baseSTR>
+		<baseCON>36</baseCON>
+		<baseMEN>26</baseMEN>
+		<baseDEX>35</baseDEX>
+		<baseWIT>14</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="46045" y="41251" z="-3440" />
+			<node x="46117" y="41247" z="-3440" />
+			<node x="46182" y="41198" z="-3440" />
+			<node x="46115" y="41141" z="-3440" />
+			<node x="46048" y="41141" z="-3440" />
+			<node x="45978" y="41196" z="-3440" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>90</walk>
+			<run>143</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>350</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.5</radius>
+			<height>23</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>89.0</hp>
+			<mp>30.0</mp>
+			<cp>44.5</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>101.74</hp>
+			<mp>35.46</mp>
+			<cp>50.87</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>114.62</hp>
+			<mp>40.98</mp>
+			<cp>57.31</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>127.64</hp>
+			<mp>46.56</mp>
+			<cp>63.82</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>140.8</hp>
+			<mp>52.2</mp>
+			<cp>70.4</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>154.1</hp>
+			<mp>57.9</mp>
+			<cp>77.05</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>167.54</hp>
+			<mp>63.66</mp>
+			<cp>83.77</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>181.12</hp>
+			<mp>69.48</mp>
+			<cp>90.56</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>194.84</hp>
+			<mp>75.36</mp>
+			<cp>97.42</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>208.7</hp>
+			<mp>81.3</mp>
+			<cp>104.35</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>222.7</hp>
+			<mp>87.3</mp>
+			<cp>111.35</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>236.84</hp>
+			<mp>93.36</mp>
+			<cp>118.42</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>251.12</hp>
+			<mp>99.48</mp>
+			<cp>125.56</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>265.54</hp>
+			<mp>105.66</mp>
+			<cp>132.77</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>280.1</hp>
+			<mp>111.9</mp>
+			<cp>140.05</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>294.8</hp>
+			<mp>118.2</mp>
+			<cp>147.4</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>309.64</hp>
+			<mp>124.56</mp>
+			<cp>154.82</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>324.62</hp>
+			<mp>130.98</mp>
+			<cp>162.31</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>339.74</hp>
+			<mp>137.46</mp>
+			<cp>169.87</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>355.0</hp>
+			<mp>144.0</mp>
+			<cp>177.5</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>388.0</hp>
+			<mp>153.9</mp>
+			<cp>194.0</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>421.3</hp>
+			<mp>163.89</mp>
+			<cp>210.65</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>454.9</hp>
+			<mp>173.97</mp>
+			<cp>227.45</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>488.8</hp>
+			<mp>184.14</mp>
+			<cp>244.4</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>523.0</hp>
+			<mp>194.4</mp>
+			<cp>261.5</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>557.5</hp>
+			<mp>204.75</mp>
+			<cp>278.75</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>592.3</hp>
+			<mp>215.19</mp>
+			<cp>296.15</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>627.4</hp>
+			<mp>225.72</mp>
+			<cp>313.7</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>662.8</hp>
+			<mp>236.34</mp>
+			<cp>331.4</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>698.5</hp>
+			<mp>247.05</mp>
+			<cp>349.25</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>734.5</hp>
+			<mp>257.85</mp>
+			<cp>367.25</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>770.8</hp>
+			<mp>268.74</mp>
+			<cp>385.4</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>807.4</hp>
+			<mp>279.72</mp>
+			<cp>403.7</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>844.3</hp>
+			<mp>290.79</mp>
+			<cp>422.15</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>881.5</hp>
+			<mp>301.95</mp>
+			<cp>440.75</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>919.0</hp>
+			<mp>313.2</mp>
+			<cp>459.5</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>956.8</hp>
+			<mp>324.54</mp>
+			<cp>478.4</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>994.9</hp>
+			<mp>335.97</mp>
+			<cp>497.45</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1033.3</hp>
+			<mp>347.49</mp>
+			<cp>516.65</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1072.0</hp>
+			<mp>359.1</mp>
+			<cp>536.0</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1111.0</hp>
+			<mp>370.8</mp>
+			<cp>555.5</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1150.3</hp>
+			<mp>382.59</mp>
+			<cp>575.15</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1189.9</hp>
+			<mp>394.47</mp>
+			<cp>594.95</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1229.8</hp>
+			<mp>406.44</mp>
+			<cp>614.9</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1270.0</hp>
+			<mp>418.5</mp>
+			<cp>635.0</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1310.5</hp>
+			<mp>430.65</mp>
+			<cp>655.25</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1351.3</hp>
+			<mp>442.89</mp>
+			<cp>675.65</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1392.4</hp>
+			<mp>455.22</mp>
+			<cp>696.2</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1433.8</hp>
+			<mp>467.64</mp>
+			<cp>716.9</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1475.5</hp>
+			<mp>480.15</mp>
+			<cp>737.75</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1517.5</hp>
+			<mp>492.75</mp>
+			<cp>758.75</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1559.8</hp>
+			<mp>505.44</mp>
+			<cp>779.9</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1602.4</hp>
+			<mp>518.22</mp>
+			<cp>801.2</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1645.3</hp>
+			<mp>531.09</mp>
+			<cp>822.65</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1688.5</hp>
+			<mp>544.05</mp>
+			<cp>844.25</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1732.0</hp>
+			<mp>557.1</mp>
+			<cp>866.0</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1775.8</hp>
+			<mp>570.24</mp>
+			<cp>887.9</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1819.9</hp>
+			<mp>583.47</mp>
+			<cp>909.95</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1864.3</hp>
+			<mp>596.79</mp>
+			<cp>932.15</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1909.0</hp>
+			<mp>610.2</mp>
+			<cp>954.5</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>1954.0</hp>
+			<mp>623.7</mp>
+			<cp>977.0</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>1999.3</hp>
+			<mp>637.29</mp>
+			<cp>999.65</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2044.9</hp>
+			<mp>650.97</mp>
+			<cp>1022.45</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2090.8</hp>
+			<mp>664.74</mp>
+			<cp>1045.4</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2137.0</hp>
+			<mp>678.6</mp>
+			<cp>1068.5</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2183.5</hp>
+			<mp>692.55</mp>
+			<cp>1091.75</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2230.3</hp>
+			<mp>706.59</mp>
+			<cp>1115.15</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2277.4</hp>
+			<mp>720.72</mp>
+			<cp>1138.7</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2324.8</hp>
+			<mp>734.94</mp>
+			<cp>1162.4</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2372.5</hp>
+			<mp>749.25</mp>
+			<cp>1186.25</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2420.5</hp>
+			<mp>763.65</mp>
+			<cp>1210.25</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2468.8</hp>
+			<mp>778.14</mp>
+			<cp>1234.4</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2517.4</hp>
+			<mp>792.72</mp>
+			<cp>1258.7</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2566.3</hp>
+			<mp>807.39</mp>
+			<cp>1283.15</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2615.5</hp>
+			<mp>822.15</mp>
+			<cp>1307.75</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>2665.0</hp>
+			<mp>837.0</mp>
+			<cp>1332.5</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>2714.8</hp>
+			<mp>851.94</mp>
+			<cp>1357.4</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>2764.9</hp>
+			<mp>866.97</mp>
+			<cp>1382.45</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>2815.3</hp>
+			<mp>882.09</mp>
+			<cp>1407.65</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>2866.0</hp>
+			<mp>897.3</mp>
+			<cp>1433.0</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>2917.0</hp>
+			<mp>912.6</mp>
+			<cp>1458.5</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>2968.3</hp>
+			<mp>927.99</mp>
+			<cp>1484.15</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3019.9</hp>
+			<mp>943.47</mp>
+			<cp>1509.95</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3071.8</hp>
+			<mp>959.04</mp>
+			<cp>1535.9</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3124.0</hp>
+			<mp>974.7</mp>
+			<cp>1562.0</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3176.5</hp>
+			<mp>990.45</mp>
+			<cp>1588.25</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3229.3</hp>
+			<mp>1006.29</mp>
+			<cp>1614.65</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3282.4</hp>
+			<mp>1022.22</mp>
+			<cp>1641.2</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3335.8</hp>
+			<mp>1038.24</mp>
+			<cp>1667.9</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3389.5</hp>
+			<mp>1054.35</mp>
+			<cp>1694.75</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3443.5</hp>
+			<mp>1070.55</mp>
+			<cp>1721.75</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>3497.8</hp>
+			<mp>1086.84</mp>
+			<cp>1748.9</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>3552.4</hp>
+			<mp>1103.22</mp>
+			<cp>1776.2</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>3607.3</hp>
+			<mp>1119.69</mp>
+			<cp>1803.65</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>3662.5</hp>
+			<mp>1136.25</mp>
+			<cp>1831.25</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>3718.0</hp>
+			<mp>1152.9</mp>
+			<cp>1859.0</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>3773.8</hp>
+			<mp>1169.64</mp>
+			<cp>1886.9</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>3829.9</hp>
+			<mp>1186.47</mp>
+			<cp>1914.95</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>3886.3</hp>
+			<mp>1203.39</mp>
+			<cp>1943.15</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>3943</hp>
+			<mp>1220.4</mp>
+			<cp>1971.5</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4000</hp>
+			<mp>1237.5</mp>
+			<cp>2000</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4057.3</hp>
+			<mp>1254.69</mp>
+			<cp>2028.65</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4114.9</hp>
+			<mp>1271.97</mp>
+			<cp>2057.45</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4172.8</hp>
+			<mp>1289.34</mp>
+			<cp>2086.4</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>4231</hp>
+			<mp>1306.8</mp>
+			<cp>2115.5</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>4289.5</hp>
+			<mp>1324.35</mp>
+			<cp>2144.75</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>4348.3</hp>
+			<mp>1341.99</mp>
+			<cp>2174.15</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/ElvenMystic.xml
+++ b/data/stats/chars/baseStats/ElvenMystic.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>25</classId>
-    <staticData>
-        <baseINT>37</baseINT>
-        <baseSTR>21</baseSTR>
-        <baseCON>25</baseCON>
-        <baseMEN>40</baseMEN>
-        <baseDEX>24</baseDEX>
-        <baseWIT>23</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>15</magicAbnormalResist>
-        <creationPoints>
-            <node x="46045" y="41251" z="-3440"/>
-            <node x="46117" y="41247" z="-3440"/>
-            <node x="46182" y="41198" z="-3440"/>
-            <node x="46115" y="41141" z="-3440"/>
-            <node x="46048" y="41141" z="-3440"/>
-            <node x="45978" y="41196" z="-3440"/>
-        </creationPoints>
-        <basePAtk>3</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>15</chest>
-            <legs>8</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>85</walk>
-            <run>129</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>150</baseBreath>
-        <baseSafeFall>300</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>24</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.5</radius>
-            <height>23</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>104.0</hp>
-            <mp>40.0</mp>
-            <cp>52.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>119.47</hp>
-            <mp>47.28</mp>
-            <cp>59.735</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>135.11</hp>
-            <mp>54.64</mp>
-            <cp>67.555</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>150.92</hp>
-            <mp>62.08</mp>
-            <cp>75.46</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>166.9</hp>
-            <mp>69.6</mp>
-            <cp>83.45</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>183.05</hp>
-            <mp>77.2</mp>
-            <cp>91.525</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>199.37</hp>
-            <mp>84.88</mp>
-            <cp>99.685</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>215.86</hp>
-            <mp>92.64</mp>
-            <cp>107.93</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>232.52</hp>
-            <mp>100.48</mp>
-            <cp>116.26</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>249.35</hp>
-            <mp>108.4</mp>
-            <cp>124.675</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>266.35</hp>
-            <mp>116.4</mp>
-            <cp>133.175</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>283.52</hp>
-            <mp>124.48</mp>
-            <cp>141.76</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>300.86</hp>
-            <mp>132.64</mp>
-            <cp>150.43</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>318.37</hp>
-            <mp>140.88</mp>
-            <cp>159.185</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>336.05</hp>
-            <mp>149.2</mp>
-            <cp>168.025</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>353.9</hp>
-            <mp>157.6</mp>
-            <cp>176.95</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>371.92</hp>
-            <mp>166.08</mp>
-            <cp>185.96</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>390.11</hp>
-            <mp>174.64</mp>
-            <cp>195.055</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>408.47</hp>
-            <mp>183.28</mp>
-            <cp>204.235</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>427.0</hp>
-            <mp>192.0</mp>
-            <cp>213.5</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>445.7</hp>
-            <mp>200.8</mp>
-            <cp>222.85</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>464.57</hp>
-            <mp>209.68</mp>
-            <cp>232.285</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>483.61</hp>
-            <mp>218.64</mp>
-            <cp>241.805</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>502.82</hp>
-            <mp>227.68</mp>
-            <cp>251.41</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>522.2</hp>
-            <mp>236.8</mp>
-            <cp>261.1</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>541.75</hp>
-            <mp>246.0</mp>
-            <cp>270.875</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>561.47</hp>
-            <mp>255.28</mp>
-            <cp>280.735</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>581.36</hp>
-            <mp>264.64</mp>
-            <cp>290.68</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>601.42</hp>
-            <mp>274.08</mp>
-            <cp>300.71</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>621.65</hp>
-            <mp>283.6</mp>
-            <cp>310.825</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>642.05</hp>
-            <mp>293.2</mp>
-            <cp>321.025</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>662.62</hp>
-            <mp>302.88</mp>
-            <cp>331.31</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>683.36</hp>
-            <mp>312.64</mp>
-            <cp>341.68</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>704.27</hp>
-            <mp>322.48</mp>
-            <cp>352.135</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>725.35</hp>
-            <mp>332.4</mp>
-            <cp>362.675</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>746.6</hp>
-            <mp>342.4</mp>
-            <cp>373.3</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>768.02</hp>
-            <mp>352.48</mp>
-            <cp>384.01</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>789.61</hp>
-            <mp>362.64</mp>
-            <cp>394.805</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>811.37</hp>
-            <mp>372.88</mp>
-            <cp>405.685</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>833.3</hp>
-            <mp>383.2</mp>
-            <cp>416.65</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>855.4</hp>
-            <mp>393.6</mp>
-            <cp>427.7</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>877.67</hp>
-            <mp>404.08</mp>
-            <cp>438.835</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>900.11</hp>
-            <mp>414.64</mp>
-            <cp>450.055</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>922.72</hp>
-            <mp>425.28</mp>
-            <cp>461.36</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>945.5</hp>
-            <mp>436.0</mp>
-            <cp>472.75</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>968.45</hp>
-            <mp>446.8</mp>
-            <cp>484.225</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>991.57</hp>
-            <mp>457.68</mp>
-            <cp>495.785</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1014.86</hp>
-            <mp>468.64</mp>
-            <cp>507.43</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1038.32</hp>
-            <mp>479.68</mp>
-            <cp>519.16</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1061.95</hp>
-            <mp>490.8</mp>
-            <cp>530.975</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1085.75</hp>
-            <mp>502.0</mp>
-            <cp>542.875</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1109.72</hp>
-            <mp>513.28</mp>
-            <cp>554.86</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1133.86</hp>
-            <mp>524.64</mp>
-            <cp>566.93</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1158.17</hp>
-            <mp>536.08</mp>
-            <cp>579.085</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1182.65</hp>
-            <mp>547.6</mp>
-            <cp>591.325</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1207.3</hp>
-            <mp>559.2</mp>
-            <cp>603.65</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1232.12</hp>
-            <mp>570.88</mp>
-            <cp>616.06</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1257.11</hp>
-            <mp>582.64</mp>
-            <cp>628.555</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>1282.27</hp>
-            <mp>594.48</mp>
-            <cp>641.135</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>1307.6</hp>
-            <mp>606.4</mp>
-            <cp>653.8</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>1333.1</hp>
-            <mp>618.4</mp>
-            <cp>666.55</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>1358.77</hp>
-            <mp>630.48</mp>
-            <cp>679.385</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>1384.61</hp>
-            <mp>642.64</mp>
-            <cp>692.305</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>1410.62</hp>
-            <mp>654.88</mp>
-            <cp>705.31</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>1436.8</hp>
-            <mp>667.2</mp>
-            <cp>718.4</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>1463.15</hp>
-            <mp>679.6</mp>
-            <cp>731.575</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>1489.67</hp>
-            <mp>692.08</mp>
-            <cp>744.835</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>1516.36</hp>
-            <mp>704.64</mp>
-            <cp>758.18</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>1543.22</hp>
-            <mp>717.28</mp>
-            <cp>771.61</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>1570.25</hp>
-            <mp>730.0</mp>
-            <cp>785.125</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>1597.45</hp>
-            <mp>742.8</mp>
-            <cp>798.725</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>1624.82</hp>
-            <mp>755.68</mp>
-            <cp>812.41</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>1652.36</hp>
-            <mp>768.64</mp>
-            <cp>826.18</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>1680.07</hp>
-            <mp>781.68</mp>
-            <cp>840.035</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>1707.95</hp>
-            <mp>794.8</mp>
-            <cp>853.975</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>1736.0</hp>
-            <mp>808.0</mp>
-            <cp>868.0</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>1764.22</hp>
-            <mp>821.28</mp>
-            <cp>882.11</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>1792.61</hp>
-            <mp>834.64</mp>
-            <cp>896.305</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>1821.17</hp>
-            <mp>848.08</mp>
-            <cp>910.585</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>1849.9</hp>
-            <mp>861.6</mp>
-            <cp>924.95</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>1878.8</hp>
-            <mp>875.2</mp>
-            <cp>939.4</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>1907.87</hp>
-            <mp>888.88</mp>
-            <cp>953.935</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>1937.11</hp>
-            <mp>902.64</mp>
-            <cp>968.555</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>1966.52</hp>
-            <mp>916.48</mp>
-            <cp>983.26</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>1996.1</hp>
-            <mp>930.4</mp>
-            <cp>998.05</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>2025.85</hp>
-            <mp>944.4</mp>
-            <cp>1012.925</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>2055.77</hp>
-            <mp>958.48</mp>
-            <cp>1027.885</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>2085.86</hp>
-            <mp>972.64</mp>
-            <cp>1042.93</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>2116.12</hp>
-            <mp>986.88</mp>
-            <cp>1058.06</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>2146.55</hp>
-            <mp>1001.2</mp>
-            <cp>1073.275</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>2177.15</hp>
-            <mp>1015.6</mp>
-            <cp>1088.575</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>25</classId>
+	<staticData>
+		<baseINT>37</baseINT>
+		<baseSTR>21</baseSTR>
+		<baseCON>25</baseCON>
+		<baseMEN>40</baseMEN>
+		<baseDEX>24</baseDEX>
+		<baseWIT>23</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="46045" y="41251" z="-3440" />
+			<node x="46117" y="41247" z="-3440" />
+			<node x="46182" y="41198" z="-3440" />
+			<node x="46115" y="41141" z="-3440" />
+			<node x="46048" y="41141" z="-3440" />
+			<node x="45978" y="41196" z="-3440" />
+		</creationPoints>
+		<basePAtk>3</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>15</chest>
+			<legs>8</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>85</walk>
+			<run>129</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>300</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.5</radius>
+			<height>23</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>104.0</hp>
+			<mp>40.0</mp>
+			<cp>52.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>119.47</hp>
+			<mp>47.28</mp>
+			<cp>59.735</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>135.11</hp>
+			<mp>54.64</mp>
+			<cp>67.555</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>150.92</hp>
+			<mp>62.08</mp>
+			<cp>75.46</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>166.9</hp>
+			<mp>69.6</mp>
+			<cp>83.45</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>183.05</hp>
+			<mp>77.2</mp>
+			<cp>91.525</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>199.37</hp>
+			<mp>84.88</mp>
+			<cp>99.685</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>215.86</hp>
+			<mp>92.64</mp>
+			<cp>107.93</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>232.52</hp>
+			<mp>100.48</mp>
+			<cp>116.26</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>249.35</hp>
+			<mp>108.4</mp>
+			<cp>124.675</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>266.35</hp>
+			<mp>116.4</mp>
+			<cp>133.175</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>283.52</hp>
+			<mp>124.48</mp>
+			<cp>141.76</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>300.86</hp>
+			<mp>132.64</mp>
+			<cp>150.43</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>318.37</hp>
+			<mp>140.88</mp>
+			<cp>159.185</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>336.05</hp>
+			<mp>149.2</mp>
+			<cp>168.025</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>353.9</hp>
+			<mp>157.6</mp>
+			<cp>176.95</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>371.92</hp>
+			<mp>166.08</mp>
+			<cp>185.96</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>390.11</hp>
+			<mp>174.64</mp>
+			<cp>195.055</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>408.47</hp>
+			<mp>183.28</mp>
+			<cp>204.235</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>427.0</hp>
+			<mp>192.0</mp>
+			<cp>213.5</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>445.7</hp>
+			<mp>200.8</mp>
+			<cp>222.85</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>464.57</hp>
+			<mp>209.68</mp>
+			<cp>232.285</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>483.61</hp>
+			<mp>218.64</mp>
+			<cp>241.805</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>502.82</hp>
+			<mp>227.68</mp>
+			<cp>251.41</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>522.2</hp>
+			<mp>236.8</mp>
+			<cp>261.1</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>541.75</hp>
+			<mp>246.0</mp>
+			<cp>270.875</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>561.47</hp>
+			<mp>255.28</mp>
+			<cp>280.735</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>581.36</hp>
+			<mp>264.64</mp>
+			<cp>290.68</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>601.42</hp>
+			<mp>274.08</mp>
+			<cp>300.71</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>621.65</hp>
+			<mp>283.6</mp>
+			<cp>310.825</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>642.05</hp>
+			<mp>293.2</mp>
+			<cp>321.025</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>662.62</hp>
+			<mp>302.88</mp>
+			<cp>331.31</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>683.36</hp>
+			<mp>312.64</mp>
+			<cp>341.68</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>704.27</hp>
+			<mp>322.48</mp>
+			<cp>352.135</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>725.35</hp>
+			<mp>332.4</mp>
+			<cp>362.675</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>746.6</hp>
+			<mp>342.4</mp>
+			<cp>373.3</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>768.02</hp>
+			<mp>352.48</mp>
+			<cp>384.01</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>789.61</hp>
+			<mp>362.64</mp>
+			<cp>394.805</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>811.37</hp>
+			<mp>372.88</mp>
+			<cp>405.685</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>833.3</hp>
+			<mp>383.2</mp>
+			<cp>416.65</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>855.4</hp>
+			<mp>393.6</mp>
+			<cp>427.7</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>877.67</hp>
+			<mp>404.08</mp>
+			<cp>438.835</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>900.11</hp>
+			<mp>414.64</mp>
+			<cp>450.055</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>922.72</hp>
+			<mp>425.28</mp>
+			<cp>461.36</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>945.5</hp>
+			<mp>436.0</mp>
+			<cp>472.75</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>968.45</hp>
+			<mp>446.8</mp>
+			<cp>484.225</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>991.57</hp>
+			<mp>457.68</mp>
+			<cp>495.785</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1014.86</hp>
+			<mp>468.64</mp>
+			<cp>507.43</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1038.32</hp>
+			<mp>479.68</mp>
+			<cp>519.16</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1061.95</hp>
+			<mp>490.8</mp>
+			<cp>530.975</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1085.75</hp>
+			<mp>502.0</mp>
+			<cp>542.875</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1109.72</hp>
+			<mp>513.28</mp>
+			<cp>554.86</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1133.86</hp>
+			<mp>524.64</mp>
+			<cp>566.93</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1158.17</hp>
+			<mp>536.08</mp>
+			<cp>579.085</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1182.65</hp>
+			<mp>547.6</mp>
+			<cp>591.325</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1207.3</hp>
+			<mp>559.2</mp>
+			<cp>603.65</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1232.12</hp>
+			<mp>570.88</mp>
+			<cp>616.06</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1257.11</hp>
+			<mp>582.64</mp>
+			<cp>628.555</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1282.27</hp>
+			<mp>594.48</mp>
+			<cp>641.135</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1307.6</hp>
+			<mp>606.4</mp>
+			<cp>653.8</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>1333.1</hp>
+			<mp>618.4</mp>
+			<cp>666.55</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>1358.77</hp>
+			<mp>630.48</mp>
+			<cp>679.385</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>1384.61</hp>
+			<mp>642.64</mp>
+			<cp>692.305</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>1410.62</hp>
+			<mp>654.88</mp>
+			<cp>705.31</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>1436.8</hp>
+			<mp>667.2</mp>
+			<cp>718.4</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>1463.15</hp>
+			<mp>679.6</mp>
+			<cp>731.575</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>1489.67</hp>
+			<mp>692.08</mp>
+			<cp>744.835</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>1516.36</hp>
+			<mp>704.64</mp>
+			<cp>758.18</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>1543.22</hp>
+			<mp>717.28</mp>
+			<cp>771.61</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>1570.25</hp>
+			<mp>730.0</mp>
+			<cp>785.125</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>1597.45</hp>
+			<mp>742.8</mp>
+			<cp>798.725</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>1624.82</hp>
+			<mp>755.68</mp>
+			<cp>812.41</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>1652.36</hp>
+			<mp>768.64</mp>
+			<cp>826.18</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>1680.07</hp>
+			<mp>781.68</mp>
+			<cp>840.035</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>1707.95</hp>
+			<mp>794.8</mp>
+			<cp>853.975</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>1736.0</hp>
+			<mp>808.0</mp>
+			<cp>868.0</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>1764.22</hp>
+			<mp>821.28</mp>
+			<cp>882.11</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>1792.61</hp>
+			<mp>834.64</mp>
+			<cp>896.305</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>1821.17</hp>
+			<mp>848.08</mp>
+			<cp>910.585</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>1849.9</hp>
+			<mp>861.6</mp>
+			<cp>924.95</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>1878.8</hp>
+			<mp>875.2</mp>
+			<cp>939.4</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>1907.87</hp>
+			<mp>888.88</mp>
+			<cp>953.935</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>1937.11</hp>
+			<mp>902.64</mp>
+			<cp>968.555</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>1966.52</hp>
+			<mp>916.48</mp>
+			<cp>983.26</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>1996.1</hp>
+			<mp>930.4</mp>
+			<cp>998.05</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>2025.85</hp>
+			<mp>944.4</mp>
+			<cp>1012.925</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>2055.77</hp>
+			<mp>958.48</mp>
+			<cp>1027.885</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>2085.86</hp>
+			<mp>972.64</mp>
+			<cp>1042.93</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>2116.12</hp>
+			<mp>986.88</mp>
+			<cp>1058.06</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>2146.55</hp>
+			<mp>1001.2</mp>
+			<cp>1073.275</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>2177.15</hp>
+			<mp>1015.6</mp>
+			<cp>1088.575</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>2207.92</hp>
+			<mp>1030.08</mp>
+			<cp>1103.96</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>2238.86</hp>
+			<mp>1044.64</mp>
+			<cp>1119.43</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>2269.97</hp>
+			<mp>1059.28</mp>
+			<cp>1134.985</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>2301.25</hp>
+			<mp>1074.0</mp>
+			<cp>1150.625</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>2332.7</hp>
+			<mp>1088.8</mp>
+			<cp>1166.35</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>2364.32</hp>
+			<mp>1103.68</mp>
+			<cp>1182.16</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>2396.11</hp>
+			<mp>1118.64</mp>
+			<cp>1198.055</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>2428.07</hp>
+			<mp>1133.68</mp>
+			<cp>1214.035</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>2460.2</hp>
+			<mp>1148.8</mp>
+			<cp>1230.11</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>2492.5</hp>
+			<mp>1164</mp>
+			<cp>1246.27</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>2524.97</hp>
+			<mp>1179.28</mp>
+			<cp>1262.52</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>2557.61</hp>
+			<mp>1194.64</mp>
+			<cp>1278.86</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>2590.42</hp>
+			<mp>1210.08</mp>
+			<cp>1295.29</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>2623.4</hp>
+			<mp>1225.6</mp>
+			<cp>1311.81</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>2656.55</hp>
+			<mp>1241.2</mp>
+			<cp>1328.42</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>2689.87</hp>
+			<mp>1256.88</mp>
+			<cp>1344.935</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/ElvenOracle.xml
+++ b/data/stats/chars/baseStats/ElvenOracle.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>29</classId>
-    <staticData>
-        <baseINT>37</baseINT>
-        <baseSTR>21</baseSTR>
-        <baseCON>25</baseCON>
-        <baseMEN>40</baseMEN>
-        <baseDEX>24</baseDEX>
-        <baseWIT>23</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>15</magicAbnormalResist>
-        <creationPoints>
-            <node x="46045" y="41251" z="-3440"/>
-            <node x="46117" y="41247" z="-3440"/>
-            <node x="46182" y="41198" z="-3440"/>
-            <node x="46115" y="41141" z="-3440"/>
-            <node x="46048" y="41141" z="-3440"/>
-            <node x="45978" y="41196" z="-3440"/>
-        </creationPoints>
-        <basePAtk>3</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>15</chest>
-            <legs>8</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>85</walk>
-            <run>129</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>150</baseBreath>
-        <baseSafeFall>300</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>24</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.5</radius>
-            <height>23</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>104.0</hp>
-            <mp>40.0</mp>
-            <cp>52.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>119.47</hp>
-            <mp>47.28</mp>
-            <cp>59.735</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>135.11</hp>
-            <mp>54.64</mp>
-            <cp>67.555</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>150.92</hp>
-            <mp>62.08</mp>
-            <cp>75.46</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>166.9</hp>
-            <mp>69.6</mp>
-            <cp>83.45</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>183.05</hp>
-            <mp>77.2</mp>
-            <cp>91.525</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>199.37</hp>
-            <mp>84.88</mp>
-            <cp>99.685</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>215.86</hp>
-            <mp>92.64</mp>
-            <cp>107.93</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>232.52</hp>
-            <mp>100.48</mp>
-            <cp>116.26</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>249.35</hp>
-            <mp>108.4</mp>
-            <cp>124.675</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>266.35</hp>
-            <mp>116.4</mp>
-            <cp>133.175</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>283.52</hp>
-            <mp>124.48</mp>
-            <cp>141.76</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>300.86</hp>
-            <mp>132.64</mp>
-            <cp>150.43</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>318.37</hp>
-            <mp>140.88</mp>
-            <cp>159.185</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>336.05</hp>
-            <mp>149.2</mp>
-            <cp>168.025</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>353.9</hp>
-            <mp>157.6</mp>
-            <cp>176.95</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>371.92</hp>
-            <mp>166.08</mp>
-            <cp>185.96</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>390.11</hp>
-            <mp>174.64</mp>
-            <cp>195.055</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>408.47</hp>
-            <mp>183.28</mp>
-            <cp>204.235</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>427.0</hp>
-            <mp>192.0</mp>
-            <cp>213.5</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>462.2</hp>
-            <mp>205.2</mp>
-            <cp>231.1</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>497.72</hp>
-            <mp>218.52</mp>
-            <cp>248.86</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>533.56</hp>
-            <mp>231.96</mp>
-            <cp>266.78</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>569.72</hp>
-            <mp>245.52</mp>
-            <cp>284.86</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>606.2</hp>
-            <mp>259.2</mp>
-            <cp>303.1</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>643.0</hp>
-            <mp>273.0</mp>
-            <cp>321.5</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>680.12</hp>
-            <mp>286.92</mp>
-            <cp>340.06</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>717.56</hp>
-            <mp>300.96</mp>
-            <cp>358.78</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>755.32</hp>
-            <mp>315.12</mp>
-            <cp>377.66</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>793.4</hp>
-            <mp>329.4</mp>
-            <cp>396.7</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>831.8</hp>
-            <mp>343.8</mp>
-            <cp>415.9</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>870.52</hp>
-            <mp>358.32</mp>
-            <cp>435.26</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>909.56</hp>
-            <mp>372.96</mp>
-            <cp>454.78</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>948.92</hp>
-            <mp>387.72</mp>
-            <cp>474.46</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>988.6</hp>
-            <mp>402.6</mp>
-            <cp>494.3</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>1028.6</hp>
-            <mp>417.6</mp>
-            <cp>514.3</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>1068.92</hp>
-            <mp>432.72</mp>
-            <cp>534.46</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1109.56</hp>
-            <mp>447.96</mp>
-            <cp>554.78</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1150.52</hp>
-            <mp>463.32</mp>
-            <cp>575.26</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1191.8</hp>
-            <mp>478.8</mp>
-            <cp>595.9</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1233.4</hp>
-            <mp>494.4</mp>
-            <cp>616.7</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1275.32</hp>
-            <mp>510.12</mp>
-            <cp>637.66</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1317.56</hp>
-            <mp>525.96</mp>
-            <cp>658.78</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1360.12</hp>
-            <mp>541.92</mp>
-            <cp>680.06</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1403.0</hp>
-            <mp>558.0</mp>
-            <cp>701.5</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1446.2</hp>
-            <mp>574.2</mp>
-            <cp>723.1</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1489.72</hp>
-            <mp>590.52</mp>
-            <cp>744.86</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1533.56</hp>
-            <mp>606.96</mp>
-            <cp>766.78</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1577.72</hp>
-            <mp>623.52</mp>
-            <cp>788.86</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1622.2</hp>
-            <mp>640.2</mp>
-            <cp>811.1</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1667.0</hp>
-            <mp>657.0</mp>
-            <cp>833.5</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1712.12</hp>
-            <mp>673.92</mp>
-            <cp>856.06</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1757.56</hp>
-            <mp>690.96</mp>
-            <cp>878.78</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1803.32</hp>
-            <mp>708.12</mp>
-            <cp>901.66</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1849.4</hp>
-            <mp>725.4</mp>
-            <cp>924.7</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1895.8</hp>
-            <mp>742.8</mp>
-            <cp>947.9</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1942.52</hp>
-            <mp>760.32</mp>
-            <cp>971.26</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1989.56</hp>
-            <mp>777.96</mp>
-            <cp>994.78</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2036.92</hp>
-            <mp>795.72</mp>
-            <cp>1018.46</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2084.6</hp>
-            <mp>813.6</mp>
-            <cp>1042.3</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2132.6</hp>
-            <mp>831.6</mp>
-            <cp>1066.3</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2180.92</hp>
-            <mp>849.72</mp>
-            <cp>1090.46</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2229.56</hp>
-            <mp>867.96</mp>
-            <cp>1114.78</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2278.52</hp>
-            <mp>886.32</mp>
-            <cp>1139.26</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2327.8</hp>
-            <mp>904.8</mp>
-            <cp>1163.9</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2377.4</hp>
-            <mp>923.4</mp>
-            <cp>1188.7</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2427.32</hp>
-            <mp>942.12</mp>
-            <cp>1213.66</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2477.56</hp>
-            <mp>960.96</mp>
-            <cp>1238.78</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2528.12</hp>
-            <mp>979.92</mp>
-            <cp>1264.06</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2579.0</hp>
-            <mp>999.0</mp>
-            <cp>1289.5</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2630.2</hp>
-            <mp>1018.2</mp>
-            <cp>1315.1</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2681.72</hp>
-            <mp>1037.52</mp>
-            <cp>1340.86</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2733.56</hp>
-            <mp>1056.96</mp>
-            <cp>1366.78</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2785.72</hp>
-            <mp>1076.52</mp>
-            <cp>1392.86</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2838.2</hp>
-            <mp>1096.2</mp>
-            <cp>1419.1</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>2891.0</hp>
-            <mp>1116.0</mp>
-            <cp>1445.5</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>2944.12</hp>
-            <mp>1135.92</mp>
-            <cp>1472.06</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>2997.56</hp>
-            <mp>1155.96</mp>
-            <cp>1498.78</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3051.32</hp>
-            <mp>1176.12</mp>
-            <cp>1525.66</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3105.4</hp>
-            <mp>1196.4</mp>
-            <cp>1552.7</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3159.8</hp>
-            <mp>1216.8</mp>
-            <cp>1579.9</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3214.52</hp>
-            <mp>1237.32</mp>
-            <cp>1607.26</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3269.56</hp>
-            <mp>1257.96</mp>
-            <cp>1634.78</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3324.92</hp>
-            <mp>1278.72</mp>
-            <cp>1662.46</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3380.6</hp>
-            <mp>1299.6</mp>
-            <cp>1690.3</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3436.6</hp>
-            <mp>1320.6</mp>
-            <cp>1718.3</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3492.92</hp>
-            <mp>1341.72</mp>
-            <cp>1746.46</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3549.56</hp>
-            <mp>1362.96</mp>
-            <cp>1774.78</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3606.52</hp>
-            <mp>1384.32</mp>
-            <cp>1803.26</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3663.8</hp>
-            <mp>1405.8</mp>
-            <cp>1831.9</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>3721.4</hp>
-            <mp>1427.4</mp>
-            <cp>1860.7</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>29</classId>
+	<staticData>
+		<baseINT>37</baseINT>
+		<baseSTR>21</baseSTR>
+		<baseCON>25</baseCON>
+		<baseMEN>40</baseMEN>
+		<baseDEX>24</baseDEX>
+		<baseWIT>23</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="46045" y="41251" z="-3440" />
+			<node x="46117" y="41247" z="-3440" />
+			<node x="46182" y="41198" z="-3440" />
+			<node x="46115" y="41141" z="-3440" />
+			<node x="46048" y="41141" z="-3440" />
+			<node x="45978" y="41196" z="-3440" />
+		</creationPoints>
+		<basePAtk>3</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>15</chest>
+			<legs>8</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>85</walk>
+			<run>129</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>300</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.5</radius>
+			<height>23</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>104.0</hp>
+			<mp>40.0</mp>
+			<cp>52.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>119.47</hp>
+			<mp>47.28</mp>
+			<cp>59.735</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>135.11</hp>
+			<mp>54.64</mp>
+			<cp>67.555</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>150.92</hp>
+			<mp>62.08</mp>
+			<cp>75.46</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>166.9</hp>
+			<mp>69.6</mp>
+			<cp>83.45</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>183.05</hp>
+			<mp>77.2</mp>
+			<cp>91.525</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>199.37</hp>
+			<mp>84.88</mp>
+			<cp>99.685</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>215.86</hp>
+			<mp>92.64</mp>
+			<cp>107.93</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>232.52</hp>
+			<mp>100.48</mp>
+			<cp>116.26</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>249.35</hp>
+			<mp>108.4</mp>
+			<cp>124.675</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>266.35</hp>
+			<mp>116.4</mp>
+			<cp>133.175</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>283.52</hp>
+			<mp>124.48</mp>
+			<cp>141.76</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>300.86</hp>
+			<mp>132.64</mp>
+			<cp>150.43</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>318.37</hp>
+			<mp>140.88</mp>
+			<cp>159.185</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>336.05</hp>
+			<mp>149.2</mp>
+			<cp>168.025</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>353.9</hp>
+			<mp>157.6</mp>
+			<cp>176.95</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>371.92</hp>
+			<mp>166.08</mp>
+			<cp>185.96</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>390.11</hp>
+			<mp>174.64</mp>
+			<cp>195.055</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>408.47</hp>
+			<mp>183.28</mp>
+			<cp>204.235</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>427.0</hp>
+			<mp>192.0</mp>
+			<cp>213.5</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>462.2</hp>
+			<mp>205.2</mp>
+			<cp>231.1</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>497.72</hp>
+			<mp>218.52</mp>
+			<cp>248.86</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>533.56</hp>
+			<mp>231.96</mp>
+			<cp>266.78</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>569.72</hp>
+			<mp>245.52</mp>
+			<cp>284.86</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>606.2</hp>
+			<mp>259.2</mp>
+			<cp>303.1</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>643.0</hp>
+			<mp>273.0</mp>
+			<cp>321.5</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>680.12</hp>
+			<mp>286.92</mp>
+			<cp>340.06</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>717.56</hp>
+			<mp>300.96</mp>
+			<cp>358.78</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>755.32</hp>
+			<mp>315.12</mp>
+			<cp>377.66</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>793.4</hp>
+			<mp>329.4</mp>
+			<cp>396.7</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>831.8</hp>
+			<mp>343.8</mp>
+			<cp>415.9</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>870.52</hp>
+			<mp>358.32</mp>
+			<cp>435.26</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>909.56</hp>
+			<mp>372.96</mp>
+			<cp>454.78</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>948.92</hp>
+			<mp>387.72</mp>
+			<cp>474.46</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>988.6</hp>
+			<mp>402.6</mp>
+			<cp>494.3</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>1028.6</hp>
+			<mp>417.6</mp>
+			<cp>514.3</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>1068.92</hp>
+			<mp>432.72</mp>
+			<cp>534.46</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1109.56</hp>
+			<mp>447.96</mp>
+			<cp>554.78</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1150.52</hp>
+			<mp>463.32</mp>
+			<cp>575.26</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1191.8</hp>
+			<mp>478.8</mp>
+			<cp>595.9</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1233.4</hp>
+			<mp>494.4</mp>
+			<cp>616.7</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1275.32</hp>
+			<mp>510.12</mp>
+			<cp>637.66</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1317.56</hp>
+			<mp>525.96</mp>
+			<cp>658.78</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1360.12</hp>
+			<mp>541.92</mp>
+			<cp>680.06</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1403.0</hp>
+			<mp>558.0</mp>
+			<cp>701.5</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1446.2</hp>
+			<mp>574.2</mp>
+			<cp>723.1</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1489.72</hp>
+			<mp>590.52</mp>
+			<cp>744.86</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1533.56</hp>
+			<mp>606.96</mp>
+			<cp>766.78</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1577.72</hp>
+			<mp>623.52</mp>
+			<cp>788.86</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1622.2</hp>
+			<mp>640.2</mp>
+			<cp>811.1</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1667.0</hp>
+			<mp>657.0</mp>
+			<cp>833.5</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1712.12</hp>
+			<mp>673.92</mp>
+			<cp>856.06</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1757.56</hp>
+			<mp>690.96</mp>
+			<cp>878.78</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1803.32</hp>
+			<mp>708.12</mp>
+			<cp>901.66</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1849.4</hp>
+			<mp>725.4</mp>
+			<cp>924.7</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1895.8</hp>
+			<mp>742.8</mp>
+			<cp>947.9</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1942.52</hp>
+			<mp>760.32</mp>
+			<cp>971.26</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1989.56</hp>
+			<mp>777.96</mp>
+			<cp>994.78</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2036.92</hp>
+			<mp>795.72</mp>
+			<cp>1018.46</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2084.6</hp>
+			<mp>813.6</mp>
+			<cp>1042.3</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2132.6</hp>
+			<mp>831.6</mp>
+			<cp>1066.3</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2180.92</hp>
+			<mp>849.72</mp>
+			<cp>1090.46</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2229.56</hp>
+			<mp>867.96</mp>
+			<cp>1114.78</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2278.52</hp>
+			<mp>886.32</mp>
+			<cp>1139.26</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2327.8</hp>
+			<mp>904.8</mp>
+			<cp>1163.9</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2377.4</hp>
+			<mp>923.4</mp>
+			<cp>1188.7</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2427.32</hp>
+			<mp>942.12</mp>
+			<cp>1213.66</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2477.56</hp>
+			<mp>960.96</mp>
+			<cp>1238.78</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2528.12</hp>
+			<mp>979.92</mp>
+			<cp>1264.06</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2579.0</hp>
+			<mp>999.0</mp>
+			<cp>1289.5</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2630.2</hp>
+			<mp>1018.2</mp>
+			<cp>1315.1</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2681.72</hp>
+			<mp>1037.52</mp>
+			<cp>1340.86</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2733.56</hp>
+			<mp>1056.96</mp>
+			<cp>1366.78</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2785.72</hp>
+			<mp>1076.52</mp>
+			<cp>1392.86</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2838.2</hp>
+			<mp>1096.2</mp>
+			<cp>1419.1</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>2891.0</hp>
+			<mp>1116.0</mp>
+			<cp>1445.5</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>2944.12</hp>
+			<mp>1135.92</mp>
+			<cp>1472.06</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>2997.56</hp>
+			<mp>1155.96</mp>
+			<cp>1498.78</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3051.32</hp>
+			<mp>1176.12</mp>
+			<cp>1525.66</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3105.4</hp>
+			<mp>1196.4</mp>
+			<cp>1552.7</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3159.8</hp>
+			<mp>1216.8</mp>
+			<cp>1579.9</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3214.52</hp>
+			<mp>1237.32</mp>
+			<cp>1607.26</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3269.56</hp>
+			<mp>1257.96</mp>
+			<cp>1634.78</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3324.92</hp>
+			<mp>1278.72</mp>
+			<cp>1662.46</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3380.6</hp>
+			<mp>1299.6</mp>
+			<cp>1690.3</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3436.6</hp>
+			<mp>1320.6</mp>
+			<cp>1718.3</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3492.92</hp>
+			<mp>1341.72</mp>
+			<cp>1746.46</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3549.56</hp>
+			<mp>1362.96</mp>
+			<cp>1774.78</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3606.52</hp>
+			<mp>1384.32</mp>
+			<cp>1803.26</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3663.8</hp>
+			<mp>1405.8</mp>
+			<cp>1831.9</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3721.4</hp>
+			<mp>1427.4</mp>
+			<cp>1860.7</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>3779.32</hp>
+			<mp>1449.12</mp>
+			<cp>1889.66</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>3837.56</hp>
+			<mp>1470.96</mp>
+			<cp>1918.78</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>3896.12</hp>
+			<mp>1492.92</mp>
+			<cp>1948.06</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>3955.0</hp>
+			<mp>1515.0</mp>
+			<cp>1977.5</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4014.2</hp>
+			<mp>1537.2</mp>
+			<cp>2007.1</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4073.72</hp>
+			<mp>1559.52</mp>
+			<cp>2036.86</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4133.56</hp>
+			<mp>1581.96</mp>
+			<cp>2066.78</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4193.72</hp>
+			<mp>1604.52</mp>
+			<cp>2096.86</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4254.2</hp>
+			<mp>1627.2</mp>
+			<cp>2127.1</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4315</hp>
+			<mp>1650</mp>
+			<cp>2157.5</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4376.12</hp>
+			<mp>1672.92</mp>
+			<cp>2188.06</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4437.56</hp>
+			<mp>1695.96</mp>
+			<cp>2218.78</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4499.32</hp>
+			<mp>1719.12</mp>
+			<cp>2249.66</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>4561.4</hp>
+			<mp>1742.4</mp>
+			<cp>2280.7</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>4623.8</hp>
+			<mp>1765.8</mp>
+			<cp>2311.9</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>4686.52</hp>
+			<mp>1789.32</mp>
+			<cp>2343.26</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/ElvenScout.xml
+++ b/data/stats/chars/baseStats/ElvenScout.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>22</classId>
-    <staticData>
-        <baseINT>23</baseINT>
-        <baseSTR>36</baseSTR>
-        <baseCON>36</baseCON>
-        <baseMEN>26</baseMEN>
-        <baseDEX>35</baseDEX>
-        <baseWIT>14</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>15</magicAbnormalResist>
-        <creationPoints>
-            <node x="46045" y="41251" z="-3440"/>
-            <node x="46117" y="41247" z="-3440"/>
-            <node x="46182" y="41198" z="-3440"/>
-            <node x="46115" y="41141" z="-3440"/>
-            <node x="46048" y="41141" z="-3440"/>
-            <node x="45978" y="41196" z="-3440"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>90</walk>
-            <run>143</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>150</baseBreath>
-        <baseSafeFall>350</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>24</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.5</radius>
-            <height>23</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>89.0</hp>
-            <mp>30.0</mp>
-            <cp>44.5</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>101.74</hp>
-            <mp>35.46</mp>
-            <cp>50.87</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>114.62</hp>
-            <mp>40.98</mp>
-            <cp>57.31</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>127.64</hp>
-            <mp>46.56</mp>
-            <cp>63.82</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>140.8</hp>
-            <mp>52.2</mp>
-            <cp>70.4</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>154.1</hp>
-            <mp>57.9</mp>
-            <cp>77.05</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>167.54</hp>
-            <mp>63.66</mp>
-            <cp>83.77</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>181.12</hp>
-            <mp>69.48</mp>
-            <cp>90.56</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>194.84</hp>
-            <mp>75.36</mp>
-            <cp>97.42</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>208.7</hp>
-            <mp>81.3</mp>
-            <cp>104.35</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>222.7</hp>
-            <mp>87.3</mp>
-            <cp>111.35</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>236.84</hp>
-            <mp>93.36</mp>
-            <cp>118.42</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>251.12</hp>
-            <mp>99.48</mp>
-            <cp>125.56</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>265.54</hp>
-            <mp>105.66</mp>
-            <cp>132.77</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>280.1</hp>
-            <mp>111.9</mp>
-            <cp>140.05</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>294.8</hp>
-            <mp>118.2</mp>
-            <cp>147.4</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>309.64</hp>
-            <mp>124.56</mp>
-            <cp>154.82</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>324.62</hp>
-            <mp>130.98</mp>
-            <cp>162.31</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>339.74</hp>
-            <mp>137.46</mp>
-            <cp>169.87</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>355.0</hp>
-            <mp>144.0</mp>
-            <cp>177.5</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>385.8</hp>
-            <mp>153.9</mp>
-            <cp>192.9</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>416.88</hp>
-            <mp>163.89</mp>
-            <cp>208.44</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>448.24</hp>
-            <mp>173.97</mp>
-            <cp>224.12</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>479.88</hp>
-            <mp>184.14</mp>
-            <cp>239.94</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>511.8</hp>
-            <mp>194.4</mp>
-            <cp>255.9</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>544.0</hp>
-            <mp>204.75</mp>
-            <cp>272.0</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>576.48</hp>
-            <mp>215.19</mp>
-            <cp>288.24</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>609.24</hp>
-            <mp>225.72</mp>
-            <cp>304.62</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>642.28</hp>
-            <mp>236.34</mp>
-            <cp>321.14</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>675.6</hp>
-            <mp>247.05</mp>
-            <cp>337.8</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>709.2</hp>
-            <mp>257.85</mp>
-            <cp>354.6</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>743.08</hp>
-            <mp>268.74</mp>
-            <cp>371.54</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>777.24</hp>
-            <mp>279.72</mp>
-            <cp>388.62</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>811.68</hp>
-            <mp>290.79</mp>
-            <cp>405.84</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>846.4</hp>
-            <mp>301.95</mp>
-            <cp>423.2</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>881.4</hp>
-            <mp>313.2</mp>
-            <cp>440.7</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>916.68</hp>
-            <mp>324.54</mp>
-            <cp>458.34</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>952.24</hp>
-            <mp>335.97</mp>
-            <cp>476.12</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>988.08</hp>
-            <mp>347.49</mp>
-            <cp>494.04</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1024.2</hp>
-            <mp>359.1</mp>
-            <cp>512.1</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1060.6</hp>
-            <mp>370.8</mp>
-            <cp>530.3</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1097.28</hp>
-            <mp>382.59</mp>
-            <cp>548.64</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1134.24</hp>
-            <mp>394.47</mp>
-            <cp>567.12</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1171.48</hp>
-            <mp>406.44</mp>
-            <cp>585.74</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1209.0</hp>
-            <mp>418.5</mp>
-            <cp>604.5</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1246.8</hp>
-            <mp>430.65</mp>
-            <cp>623.4</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1284.88</hp>
-            <mp>442.89</mp>
-            <cp>642.44</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1323.24</hp>
-            <mp>455.22</mp>
-            <cp>661.62</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1361.88</hp>
-            <mp>467.64</mp>
-            <cp>680.94</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1400.8</hp>
-            <mp>480.15</mp>
-            <cp>700.4</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1440.0</hp>
-            <mp>492.75</mp>
-            <cp>720.0</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1479.48</hp>
-            <mp>505.44</mp>
-            <cp>739.74</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1519.24</hp>
-            <mp>518.22</mp>
-            <cp>759.62</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1559.28</hp>
-            <mp>531.09</mp>
-            <cp>779.64</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1599.6</hp>
-            <mp>544.05</mp>
-            <cp>799.8</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1640.2</hp>
-            <mp>557.1</mp>
-            <cp>820.1</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1681.08</hp>
-            <mp>570.24</mp>
-            <cp>840.54</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1722.24</hp>
-            <mp>583.47</mp>
-            <cp>861.12</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>1763.68</hp>
-            <mp>596.79</mp>
-            <cp>881.84</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>1805.4</hp>
-            <mp>610.2</mp>
-            <cp>902.7</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>1847.4</hp>
-            <mp>623.7</mp>
-            <cp>923.7</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>1889.68</hp>
-            <mp>637.29</mp>
-            <cp>944.84</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>1932.24</hp>
-            <mp>650.97</mp>
-            <cp>966.12</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>1975.08</hp>
-            <mp>664.74</mp>
-            <cp>987.54</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2018.2</hp>
-            <mp>678.6</mp>
-            <cp>1009.1</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2061.6</hp>
-            <mp>692.55</mp>
-            <cp>1030.8</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2105.28</hp>
-            <mp>706.59</mp>
-            <cp>1052.64</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2149.24</hp>
-            <mp>720.72</mp>
-            <cp>1074.62</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2193.48</hp>
-            <mp>734.94</mp>
-            <cp>1096.74</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2238.0</hp>
-            <mp>749.25</mp>
-            <cp>1119.0</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2282.8</hp>
-            <mp>763.65</mp>
-            <cp>1141.4</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2327.88</hp>
-            <mp>778.14</mp>
-            <cp>1163.94</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2373.24</hp>
-            <mp>792.72</mp>
-            <cp>1186.62</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2418.88</hp>
-            <mp>807.39</mp>
-            <cp>1209.44</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2464.8</hp>
-            <mp>822.15</mp>
-            <cp>1232.4</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>2511.0</hp>
-            <mp>837.0</mp>
-            <cp>1255.5</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>2557.48</hp>
-            <mp>851.94</mp>
-            <cp>1278.74</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>2604.24</hp>
-            <mp>866.97</mp>
-            <cp>1302.12</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>2651.28</hp>
-            <mp>882.09</mp>
-            <cp>1325.64</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>2698.6</hp>
-            <mp>897.3</mp>
-            <cp>1349.3</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>2746.2</hp>
-            <mp>912.6</mp>
-            <cp>1373.1</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>2794.08</hp>
-            <mp>927.99</mp>
-            <cp>1397.04</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>2842.24</hp>
-            <mp>943.47</mp>
-            <cp>1421.12</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>2890.68</hp>
-            <mp>959.04</mp>
-            <cp>1445.34</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>2939.4</hp>
-            <mp>974.7</mp>
-            <cp>1469.7</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>2988.4</hp>
-            <mp>990.45</mp>
-            <cp>1494.2</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3037.68</hp>
-            <mp>1006.29</mp>
-            <cp>1518.84</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3087.24</hp>
-            <mp>1022.22</mp>
-            <cp>1543.62</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3137.08</hp>
-            <mp>1038.24</mp>
-            <cp>1568.54</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3187.2</hp>
-            <mp>1054.35</mp>
-            <cp>1593.6</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>3237.6</hp>
-            <mp>1070.55</mp>
-            <cp>1618.8</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>22</classId>
+	<staticData>
+		<baseINT>23</baseINT>
+		<baseSTR>36</baseSTR>
+		<baseCON>36</baseCON>
+		<baseMEN>26</baseMEN>
+		<baseDEX>35</baseDEX>
+		<baseWIT>14</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="46045" y="41251" z="-3440" />
+			<node x="46117" y="41247" z="-3440" />
+			<node x="46182" y="41198" z="-3440" />
+			<node x="46115" y="41141" z="-3440" />
+			<node x="46048" y="41141" z="-3440" />
+			<node x="45978" y="41196" z="-3440" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>90</walk>
+			<run>143</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>350</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.5</radius>
+			<height>23</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>89.0</hp>
+			<mp>30.0</mp>
+			<cp>44.5</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>101.74</hp>
+			<mp>35.46</mp>
+			<cp>50.87</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>114.62</hp>
+			<mp>40.98</mp>
+			<cp>57.31</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>127.64</hp>
+			<mp>46.56</mp>
+			<cp>63.82</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>140.8</hp>
+			<mp>52.2</mp>
+			<cp>70.4</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>154.1</hp>
+			<mp>57.9</mp>
+			<cp>77.05</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>167.54</hp>
+			<mp>63.66</mp>
+			<cp>83.77</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>181.12</hp>
+			<mp>69.48</mp>
+			<cp>90.56</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>194.84</hp>
+			<mp>75.36</mp>
+			<cp>97.42</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>208.7</hp>
+			<mp>81.3</mp>
+			<cp>104.35</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>222.7</hp>
+			<mp>87.3</mp>
+			<cp>111.35</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>236.84</hp>
+			<mp>93.36</mp>
+			<cp>118.42</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>251.12</hp>
+			<mp>99.48</mp>
+			<cp>125.56</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>265.54</hp>
+			<mp>105.66</mp>
+			<cp>132.77</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>280.1</hp>
+			<mp>111.9</mp>
+			<cp>140.05</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>294.8</hp>
+			<mp>118.2</mp>
+			<cp>147.4</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>309.64</hp>
+			<mp>124.56</mp>
+			<cp>154.82</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>324.62</hp>
+			<mp>130.98</mp>
+			<cp>162.31</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>339.74</hp>
+			<mp>137.46</mp>
+			<cp>169.87</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>355.0</hp>
+			<mp>144.0</mp>
+			<cp>177.5</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>385.8</hp>
+			<mp>153.9</mp>
+			<cp>192.9</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>416.88</hp>
+			<mp>163.89</mp>
+			<cp>208.44</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>448.24</hp>
+			<mp>173.97</mp>
+			<cp>224.12</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>479.88</hp>
+			<mp>184.14</mp>
+			<cp>239.94</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>511.8</hp>
+			<mp>194.4</mp>
+			<cp>255.9</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>544.0</hp>
+			<mp>204.75</mp>
+			<cp>272.0</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>576.48</hp>
+			<mp>215.19</mp>
+			<cp>288.24</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>609.24</hp>
+			<mp>225.72</mp>
+			<cp>304.62</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>642.28</hp>
+			<mp>236.34</mp>
+			<cp>321.14</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>675.6</hp>
+			<mp>247.05</mp>
+			<cp>337.8</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>709.2</hp>
+			<mp>257.85</mp>
+			<cp>354.6</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>743.08</hp>
+			<mp>268.74</mp>
+			<cp>371.54</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>777.24</hp>
+			<mp>279.72</mp>
+			<cp>388.62</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>811.68</hp>
+			<mp>290.79</mp>
+			<cp>405.84</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>846.4</hp>
+			<mp>301.95</mp>
+			<cp>423.2</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>881.4</hp>
+			<mp>313.2</mp>
+			<cp>440.7</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>916.68</hp>
+			<mp>324.54</mp>
+			<cp>458.34</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>952.24</hp>
+			<mp>335.97</mp>
+			<cp>476.12</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>988.08</hp>
+			<mp>347.49</mp>
+			<cp>494.04</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1024.2</hp>
+			<mp>359.1</mp>
+			<cp>512.1</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1060.6</hp>
+			<mp>370.8</mp>
+			<cp>530.3</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1097.28</hp>
+			<mp>382.59</mp>
+			<cp>548.64</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1134.24</hp>
+			<mp>394.47</mp>
+			<cp>567.12</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1171.48</hp>
+			<mp>406.44</mp>
+			<cp>585.74</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1209.0</hp>
+			<mp>418.5</mp>
+			<cp>604.5</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1246.8</hp>
+			<mp>430.65</mp>
+			<cp>623.4</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1284.88</hp>
+			<mp>442.89</mp>
+			<cp>642.44</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1323.24</hp>
+			<mp>455.22</mp>
+			<cp>661.62</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1361.88</hp>
+			<mp>467.64</mp>
+			<cp>680.94</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1400.8</hp>
+			<mp>480.15</mp>
+			<cp>700.4</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1440.0</hp>
+			<mp>492.75</mp>
+			<cp>720.0</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1479.48</hp>
+			<mp>505.44</mp>
+			<cp>739.74</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1519.24</hp>
+			<mp>518.22</mp>
+			<cp>759.62</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1559.28</hp>
+			<mp>531.09</mp>
+			<cp>779.64</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1599.6</hp>
+			<mp>544.05</mp>
+			<cp>799.8</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1640.2</hp>
+			<mp>557.1</mp>
+			<cp>820.1</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1681.08</hp>
+			<mp>570.24</mp>
+			<cp>840.54</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1722.24</hp>
+			<mp>583.47</mp>
+			<cp>861.12</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1763.68</hp>
+			<mp>596.79</mp>
+			<cp>881.84</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1805.4</hp>
+			<mp>610.2</mp>
+			<cp>902.7</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>1847.4</hp>
+			<mp>623.7</mp>
+			<cp>923.7</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>1889.68</hp>
+			<mp>637.29</mp>
+			<cp>944.84</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>1932.24</hp>
+			<mp>650.97</mp>
+			<cp>966.12</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>1975.08</hp>
+			<mp>664.74</mp>
+			<cp>987.54</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2018.2</hp>
+			<mp>678.6</mp>
+			<cp>1009.1</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2061.6</hp>
+			<mp>692.55</mp>
+			<cp>1030.8</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2105.28</hp>
+			<mp>706.59</mp>
+			<cp>1052.64</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2149.24</hp>
+			<mp>720.72</mp>
+			<cp>1074.62</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2193.48</hp>
+			<mp>734.94</mp>
+			<cp>1096.74</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2238.0</hp>
+			<mp>749.25</mp>
+			<cp>1119.0</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2282.8</hp>
+			<mp>763.65</mp>
+			<cp>1141.4</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2327.88</hp>
+			<mp>778.14</mp>
+			<cp>1163.94</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2373.24</hp>
+			<mp>792.72</mp>
+			<cp>1186.62</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2418.88</hp>
+			<mp>807.39</mp>
+			<cp>1209.44</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2464.8</hp>
+			<mp>822.15</mp>
+			<cp>1232.4</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>2511.0</hp>
+			<mp>837.0</mp>
+			<cp>1255.5</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>2557.48</hp>
+			<mp>851.94</mp>
+			<cp>1278.74</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>2604.24</hp>
+			<mp>866.97</mp>
+			<cp>1302.12</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>2651.28</hp>
+			<mp>882.09</mp>
+			<cp>1325.64</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>2698.6</hp>
+			<mp>897.3</mp>
+			<cp>1349.3</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>2746.2</hp>
+			<mp>912.6</mp>
+			<cp>1373.1</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>2794.08</hp>
+			<mp>927.99</mp>
+			<cp>1397.04</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>2842.24</hp>
+			<mp>943.47</mp>
+			<cp>1421.12</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>2890.68</hp>
+			<mp>959.04</mp>
+			<cp>1445.34</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>2939.4</hp>
+			<mp>974.7</mp>
+			<cp>1469.7</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>2988.4</hp>
+			<mp>990.45</mp>
+			<cp>1494.2</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3037.68</hp>
+			<mp>1006.29</mp>
+			<cp>1518.84</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3087.24</hp>
+			<mp>1022.22</mp>
+			<cp>1543.62</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3137.08</hp>
+			<mp>1038.24</mp>
+			<cp>1568.54</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3187.2</hp>
+			<mp>1054.35</mp>
+			<cp>1593.6</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3237.6</hp>
+			<mp>1070.55</mp>
+			<cp>1618.8</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>3288.28</hp>
+			<mp>1086.84</mp>
+			<cp>1644.14</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>3339.24</hp>
+			<mp>1103.22</mp>
+			<cp>1669.62</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>3390.48</hp>
+			<mp>1119.69</mp>
+			<cp>1695.24</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>3442.0</hp>
+			<mp>1136.25</mp>
+			<cp>1721.0</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>3493.8</hp>
+			<mp>1152.9</mp>
+			<cp>1746.9</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>3545.88</hp>
+			<mp>1169.64</mp>
+			<cp>1772.94</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>3598.24</hp>
+			<mp>1186.47</mp>
+			<cp>1799.12</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>3650.88</hp>
+			<mp>1203.39</mp>
+			<cp>1825.44</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>3703.8</hp>
+			<mp>1220.4</mp>
+			<cp>1851.9</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>3757</hp>
+			<mp>1237.5</mp>
+			<cp>1878.5</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>3810.48</hp>
+			<mp>1254.69</mp>
+			<cp>1905.24</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>3864.24</hp>
+			<mp>1271.97</mp>
+			<cp>1932.12</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>3918.28</hp>
+			<mp>1289.34</mp>
+			<cp>1959.14</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>3972.6</hp>
+			<mp>1306.8</mp>
+			<cp>1986.3</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>4027.2</hp>
+			<mp>1324.35</mp>
+			<cp>2013.6</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>4082.08</hp>
+			<mp>1341.99</mp>
+			<cp>2041.04</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/ElvenWizard.xml
+++ b/data/stats/chars/baseStats/ElvenWizard.xml
@@ -1,801 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>26</classId>
-    <staticData>
-        <baseINT>37</baseINT>
-        <baseSTR>21</baseSTR>
-        <baseCON>25</baseCON>
-        <baseMEN>40</baseMEN>
-        <baseDEX>24</baseDEX>
-        <baseWIT>23</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>15</magicAbnormalResist>
-        <creationPoints>
-            <node x="46045" y="41251" z="-3440"/>
-            <node x="46117" y="41247" z="-3440"/>
-            <node x="46182" y="41198" z="-3440"/>
-            <node x="46115" y="41141" z="-3440"/>
-            <node x="46048" y="41141" z="-3440"/>
-            <node x="45978" y="41196" z="-3440"/>
-        </creationPoints>
-        <basePAtk>3</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>15</chest>
-            <legs>8</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>85</walk>
-            <run>129</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>150</baseBreath>
-        <baseSafeFall>300</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>24</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.5</radius>
-            <height>23</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>104.0</hp>
-            <mp>40.0</mp>
-            <cp>52.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>119.47</hp>
-            <mp>47.28</mp>
-            <cp>59.735</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>135.11</hp>
-            <mp>54.64</mp>
-            <cp>67.555</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>150.92</hp>
-            <mp>62.08</mp>
-            <cp>75.46</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>166.9</hp>
-            <mp>69.6</mp>
-            <cp>83.45</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>183.05</hp>
-            <mp>77.2</mp>
-            <cp>91.525</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>199.37</hp>
-            <mp>84.88</mp>
-            <cp>99.685</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>215.86</hp>
-            <mp>92.64</mp>
-            <cp>107.93</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>232.52</hp>
-            <mp>100.48</mp>
-            <cp>116.26</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>249.35</hp>
-            <mp>108.4</mp>
-            <cp>124.675</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>266.35</hp>
-            <mp>116.4</mp>
-            <cp>133.175</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>283.52</hp>
-            <mp>124.48</mp>
-            <cp>141.76</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>300.86</hp>
-            <mp>132.64</mp>
-            <cp>150.43</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>318.37</hp>
-            <mp>140.88</mp>
-            <cp>159.185</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>336.05</hp>
-            <mp>149.2</mp>
-            <cp>168.025</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>353.9</hp>
-            <mp>157.6</mp>
-            <cp>176.95</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>371.92</hp>
-            <mp>166.08</mp>
-            <cp>185.96</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>390.11</hp>
-            <mp>174.64</mp>
-            <cp>195.055</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>408.47</hp>
-            <mp>183.28</mp>
-            <cp>204.235</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>427.0</hp>
-            <mp>192.0</mp>
-            <cp>213.5</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>455.6</hp>
-            <mp>205.2</mp>
-            <cp>227.8</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>484.46</hp>
-            <mp>218.52</mp>
-            <cp>242.23</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>513.58</hp>
-            <mp>231.96</mp>
-            <cp>256.79</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>542.96</hp>
-            <mp>245.52</mp>
-            <cp>271.48</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>572.6</hp>
-            <mp>259.2</mp>
-            <cp>286.3</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>602.5</hp>
-            <mp>273.0</mp>
-            <cp>301.25</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>632.66</hp>
-            <mp>286.92</mp>
-            <cp>316.33</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>663.08</hp>
-            <mp>300.96</mp>
-            <cp>331.54</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>693.76</hp>
-            <mp>315.12</mp>
-            <cp>346.88</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>724.7</hp>
-            <mp>329.4</mp>
-            <cp>362.35</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>755.9</hp>
-            <mp>343.8</mp>
-            <cp>377.95</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>787.36</hp>
-            <mp>358.32</mp>
-            <cp>393.68</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>819.08</hp>
-            <mp>372.96</mp>
-            <cp>409.54</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>851.06</hp>
-            <mp>387.72</mp>
-            <cp>425.53</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>883.3</hp>
-            <mp>402.6</mp>
-            <cp>441.65</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>915.8</hp>
-            <mp>417.6</mp>
-            <cp>457.9</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>948.56</hp>
-            <mp>432.72</mp>
-            <cp>474.28</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>981.58</hp>
-            <mp>447.96</mp>
-            <cp>490.79</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1014.86</hp>
-            <mp>463.32</mp>
-            <cp>507.43</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1048.4</hp>
-            <mp>478.8</mp>
-            <cp>524.2</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1082.2</hp>
-            <mp>494.4</mp>
-            <cp>541.1</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1116.26</hp>
-            <mp>510.12</mp>
-            <cp>558.13</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1150.58</hp>
-            <mp>525.96</mp>
-            <cp>575.29</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1185.16</hp>
-            <mp>541.92</mp>
-            <cp>592.58</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1220.0</hp>
-            <mp>558.0</mp>
-            <cp>610.0</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1255.1</hp>
-            <mp>574.2</mp>
-            <cp>627.55</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1290.46</hp>
-            <mp>590.52</mp>
-            <cp>645.23</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1326.08</hp>
-            <mp>606.96</mp>
-            <cp>663.04</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1361.96</hp>
-            <mp>623.52</mp>
-            <cp>680.98</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1398.1</hp>
-            <mp>640.2</mp>
-            <cp>699.05</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1434.5</hp>
-            <mp>657.0</mp>
-            <cp>717.25</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1471.16</hp>
-            <mp>673.92</mp>
-            <cp>735.58</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1508.08</hp>
-            <mp>690.96</mp>
-            <cp>754.04</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1545.26</hp>
-            <mp>708.12</mp>
-            <cp>772.63</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1582.7</hp>
-            <mp>725.4</mp>
-            <cp>791.35</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1620.4</hp>
-            <mp>742.8</mp>
-            <cp>810.2</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1658.36</hp>
-            <mp>760.32</mp>
-            <cp>829.18</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1696.58</hp>
-            <mp>777.96</mp>
-            <cp>848.29</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>1735.06</hp>
-            <mp>795.72</mp>
-            <cp>867.53</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>1773.8</hp>
-            <mp>813.6</mp>
-            <cp>886.9</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>1812.8</hp>
-            <mp>831.6</mp>
-            <cp>906.4</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>1852.06</hp>
-            <mp>849.72</mp>
-            <cp>926.03</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>1891.58</hp>
-            <mp>867.96</mp>
-            <cp>945.79</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>1931.36</hp>
-            <mp>886.32</mp>
-            <cp>965.68</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>1971.4</hp>
-            <mp>904.8</mp>
-            <cp>985.7</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2011.7</hp>
-            <mp>923.4</mp>
-            <cp>1005.85</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2052.26</hp>
-            <mp>942.12</mp>
-            <cp>1026.13</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2093.08</hp>
-            <mp>960.96</mp>
-            <cp>1046.54</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2134.16</hp>
-            <mp>979.92</mp>
-            <cp>1067.08</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2175.5</hp>
-            <mp>999.0</mp>
-            <cp>1087.75</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2217.1</hp>
-            <mp>1018.2</mp>
-            <cp>1108.55</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2258.96</hp>
-            <mp>1037.52</mp>
-            <cp>1129.48</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2301.08</hp>
-            <mp>1056.96</mp>
-            <cp>1150.54</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2343.46</hp>
-            <mp>1076.52</mp>
-            <cp>1171.73</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2386.1</hp>
-            <mp>1096.2</mp>
-            <cp>1193.05</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>2429.0</hp>
-            <mp>1116.0</mp>
-            <cp>1214.5</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>2472.16</hp>
-            <mp>1135.92</mp>
-            <cp>1236.08</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>2515.58</hp>
-            <mp>1155.96</mp>
-            <cp>1257.79</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>2559.26</hp>
-            <mp>1176.12</mp>
-            <cp>1279.63</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>2603.2</hp>
-            <mp>1196.4</mp>
-            <cp>1301.6</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>2647.4</hp>
-            <mp>1216.8</mp>
-            <cp>1323.7</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>2691.86</hp>
-            <mp>1237.32</mp>
-            <cp>1345.93</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>2736.58</hp>
-            <mp>1257.96</mp>
-            <cp>1368.29</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>2781.56</hp>
-            <mp>1278.72</mp>
-            <cp>1390.78</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>2826.8</hp>
-            <mp>1299.6</mp>
-            <cp>1413.4</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>2872.3</hp>
-            <mp>1320.6</mp>
-            <cp>1436.15</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>2918.06</hp>
-            <mp>1341.72</mp>
-            <cp>1459.03</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>2964.08</hp>
-            <mp>1362.96</mp>
-            <cp>1482.04</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3010.36</hp>
-            <mp>1384.32</mp>
-            <cp>1505.18</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3056.9</hp>
-            <mp>1405.8</mp>
-            <cp>1528.45</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>3103.7</hp>
-            <mp>1427.4</mp>
-            <cp>1551.85</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>26</classId>
+	<staticData>
+		<baseINT>37</baseINT>
+		<baseSTR>21</baseSTR>
+		<baseCON>25</baseCON>
+		<baseMEN>40</baseMEN>
+		<baseDEX>24</baseDEX>
+		<baseWIT>23</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="46045" y="41251" z="-3440" />
+			<node x="46117" y="41247" z="-3440" />
+			<node x="46182" y="41198" z="-3440" />
+			<node x="46115" y="41141" z="-3440" />
+			<node x="46048" y="41141" z="-3440" />
+			<node x="45978" y="41196" z="-3440" />
+		</creationPoints>
+		<basePAtk>3</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>15</chest>
+			<legs>8</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>85</walk>
+			<run>129</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>300</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.5</radius>
+			<height>23</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>104.0</hp>
+			<mp>40.0</mp>
+			<cp>52.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>119.47</hp>
+			<mp>47.28</mp>
+			<cp>59.735</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>135.11</hp>
+			<mp>54.64</mp>
+			<cp>67.555</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>150.92</hp>
+			<mp>62.08</mp>
+			<cp>75.46</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>166.9</hp>
+			<mp>69.6</mp>
+			<cp>83.45</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>183.05</hp>
+			<mp>77.2</mp>
+			<cp>91.525</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>199.37</hp>
+			<mp>84.88</mp>
+			<cp>99.685</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>215.86</hp>
+			<mp>92.64</mp>
+			<cp>107.93</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>232.52</hp>
+			<mp>100.48</mp>
+			<cp>116.26</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>249.35</hp>
+			<mp>108.4</mp>
+			<cp>124.675</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>266.35</hp>
+			<mp>116.4</mp>
+			<cp>133.175</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>283.52</hp>
+			<mp>124.48</mp>
+			<cp>141.76</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>300.86</hp>
+			<mp>132.64</mp>
+			<cp>150.43</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>318.37</hp>
+			<mp>140.88</mp>
+			<cp>159.185</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>336.05</hp>
+			<mp>149.2</mp>
+			<cp>168.025</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>353.9</hp>
+			<mp>157.6</mp>
+			<cp>176.95</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>371.92</hp>
+			<mp>166.08</mp>
+			<cp>185.96</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>390.11</hp>
+			<mp>174.64</mp>
+			<cp>195.055</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>408.47</hp>
+			<mp>183.28</mp>
+			<cp>204.235</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>427.0</hp>
+			<mp>192.0</mp>
+			<cp>213.5</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>455.6</hp>
+			<mp>205.2</mp>
+			<cp>227.8</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>484.46</hp>
+			<mp>218.52</mp>
+			<cp>242.23</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>513.58</hp>
+			<mp>231.96</mp>
+			<cp>256.79</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>542.96</hp>
+			<mp>245.52</mp>
+			<cp>271.48</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>572.6</hp>
+			<mp>259.2</mp>
+			<cp>286.3</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>602.5</hp>
+			<mp>273.0</mp>
+			<cp>301.25</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>632.66</hp>
+			<mp>286.92</mp>
+			<cp>316.33</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>663.08</hp>
+			<mp>300.96</mp>
+			<cp>331.54</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>693.76</hp>
+			<mp>315.12</mp>
+			<cp>346.88</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>724.7</hp>
+			<mp>329.4</mp>
+			<cp>362.35</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>755.9</hp>
+			<mp>343.8</mp>
+			<cp>377.95</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>787.36</hp>
+			<mp>358.32</mp>
+			<cp>393.68</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>819.08</hp>
+			<mp>372.96</mp>
+			<cp>409.54</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>851.06</hp>
+			<mp>387.72</mp>
+			<cp>425.53</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>883.3</hp>
+			<mp>402.6</mp>
+			<cp>441.65</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>915.8</hp>
+			<mp>417.6</mp>
+			<cp>457.9</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>948.56</hp>
+			<mp>432.72</mp>
+			<cp>474.28</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>981.58</hp>
+			<mp>447.96</mp>
+			<cp>490.79</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1014.86</hp>
+			<mp>463.32</mp>
+			<cp>507.43</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1048.4</hp>
+			<mp>478.8</mp>
+			<cp>524.2</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1082.2</hp>
+			<mp>494.4</mp>
+			<cp>541.1</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1116.26</hp>
+			<mp>510.12</mp>
+			<cp>558.13</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1150.58</hp>
+			<mp>525.96</mp>
+			<cp>575.29</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1185.16</hp>
+			<mp>541.92</mp>
+			<cp>592.58</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1220.0</hp>
+			<mp>558.0</mp>
+			<cp>610.0</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1255.1</hp>
+			<mp>574.2</mp>
+			<cp>627.55</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1290.46</hp>
+			<mp>590.52</mp>
+			<cp>645.23</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1326.08</hp>
+			<mp>606.96</mp>
+			<cp>663.04</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1361.96</hp>
+			<mp>623.52</mp>
+			<cp>680.98</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1398.1</hp>
+			<mp>640.2</mp>
+			<cp>699.05</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1434.5</hp>
+			<mp>657.0</mp>
+			<cp>717.25</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1471.16</hp>
+			<mp>673.92</mp>
+			<cp>735.58</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1508.08</hp>
+			<mp>690.96</mp>
+			<cp>754.04</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1545.26</hp>
+			<mp>708.12</mp>
+			<cp>772.63</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1582.7</hp>
+			<mp>725.4</mp>
+			<cp>791.35</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1620.4</hp>
+			<mp>742.8</mp>
+			<cp>810.2</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1658.36</hp>
+			<mp>760.32</mp>
+			<cp>829.18</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1696.58</hp>
+			<mp>777.96</mp>
+			<cp>848.29</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1735.06</hp>
+			<mp>795.72</mp>
+			<cp>867.53</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1773.8</hp>
+			<mp>813.6</mp>
+			<cp>886.9</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>1812.8</hp>
+			<mp>831.6</mp>
+			<cp>906.4</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>1852.06</hp>
+			<mp>849.72</mp>
+			<cp>926.03</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>1891.58</hp>
+			<mp>867.96</mp>
+			<cp>945.79</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>1931.36</hp>
+			<mp>886.32</mp>
+			<cp>965.68</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>1971.4</hp>
+			<mp>904.8</mp>
+			<cp>985.7</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2011.7</hp>
+			<mp>923.4</mp>
+			<cp>1005.85</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2052.26</hp>
+			<mp>942.12</mp>
+			<cp>1026.13</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2093.08</hp>
+			<mp>960.96</mp>
+			<cp>1046.54</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2134.16</hp>
+			<mp>979.92</mp>
+			<cp>1067.08</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2175.5</hp>
+			<mp>999.0</mp>
+			<cp>1087.75</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2217.1</hp>
+			<mp>1018.2</mp>
+			<cp>1108.55</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2258.96</hp>
+			<mp>1037.52</mp>
+			<cp>1129.48</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2301.08</hp>
+			<mp>1056.96</mp>
+			<cp>1150.54</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2343.46</hp>
+			<mp>1076.52</mp>
+			<cp>1171.73</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2386.1</hp>
+			<mp>1096.2</mp>
+			<cp>1193.05</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>2429.0</hp>
+			<mp>1116.0</mp>
+			<cp>1214.5</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>2472.16</hp>
+			<mp>1135.92</mp>
+			<cp>1236.08</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>2515.58</hp>
+			<mp>1155.96</mp>
+			<cp>1257.79</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>2559.26</hp>
+			<mp>1176.12</mp>
+			<cp>1279.63</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>2603.2</hp>
+			<mp>1196.4</mp>
+			<cp>1301.6</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>2647.4</hp>
+			<mp>1216.8</mp>
+			<cp>1323.7</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>2691.86</hp>
+			<mp>1237.32</mp>
+			<cp>1345.93</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>2736.58</hp>
+			<mp>1257.96</mp>
+			<cp>1368.29</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>2781.56</hp>
+			<mp>1278.72</mp>
+			<cp>1390.78</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>2826.8</hp>
+			<mp>1299.6</mp>
+			<cp>1413.4</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>2872.3</hp>
+			<mp>1320.6</mp>
+			<cp>1436.15</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>2918.06</hp>
+			<mp>1341.72</mp>
+			<cp>1459.03</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>2964.08</hp>
+			<mp>1362.96</mp>
+			<cp>1482.04</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3010.36</hp>
+			<mp>1384.32</mp>
+			<cp>1505.18</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3056.9</hp>
+			<mp>1405.8</mp>
+			<cp>1528.45</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3103.7</hp>
+			<mp>1427.4</mp>
+			<cp>1551.85</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>3150.76</hp>
+			<mp>1449.12</mp>
+			<cp>1575.38</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>3198.08</hp>
+			<mp>1470.96</mp>
+			<cp>1599.04</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>3245.66</hp>
+			<mp>1492.92</mp>
+			<cp>1622.83</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>3293.5</hp>
+			<mp>1515.0</mp>
+			<cp>1646.75</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>3341.6</hp>
+			<mp>1537.2</mp>
+			<cp>1670.8</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>3389.96</hp>
+			<mp>1559.52</mp>
+			<cp>1694.98</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>3438.58</hp>
+			<mp>1581.96</mp>
+			<cp>1719.29</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>3487.46</hp>
+			<mp>1604.52</mp>
+			<cp>1743.73</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>3536.6</hp>
+			<mp>1627.2</mp>
+			<cp>1768.3</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>3586</hp>
+			<mp>1650</mp>
+			<cp>1793</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>3635.66</hp>
+			<mp>1672.92</mp>
+			<cp>1817.83</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>3685.58</hp>
+			<mp>1695.96</mp>
+			<cp>1842.79</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>3735.76</hp>
+			<mp>1719.12</mp>
+			<cp>1867.88</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>3786.2</hp>
+			<mp>1742.4</mp>
+			<cp>1893.1</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>3836.9</hp>
+			<mp>1765.8</mp>
+			<cp>1918.45</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>3887.86</hp>
+			<mp>1789.32</mp>
+			<cp>1943.93</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Eva'sSaint.xml
+++ b/data/stats/chars/baseStats/Eva'sSaint.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>105</classId>
-    <staticData>
-        <baseINT>37</baseINT>
-        <baseSTR>21</baseSTR>
-        <baseCON>25</baseCON>
-        <baseMEN>40</baseMEN>
-        <baseDEX>24</baseDEX>
-        <baseWIT>23</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>15</magicAbnormalResist>
-        <creationPoints>
-            <node x="46045" y="41251" z="-3440"/>
-            <node x="46117" y="41247" z="-3440"/>
-            <node x="46182" y="41198" z="-3440"/>
-            <node x="46115" y="41141" z="-3440"/>
-            <node x="46048" y="41141" z="-3440"/>
-            <node x="45978" y="41196" z="-3440"/>
-        </creationPoints>
-        <basePAtk>3</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>15</chest>
-            <legs>8</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>85</walk>
-            <run>129</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>150</baseBreath>
-        <baseSafeFall>300</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>24</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.5</radius>
-            <height>23</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>104.0</hp>
-            <mp>40.0</mp>
-            <cp>93.6</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>119.47</hp>
-            <mp>47.28</mp>
-            <cp>107.523</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>135.11</hp>
-            <mp>54.64</mp>
-            <cp>121.599</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>150.92</hp>
-            <mp>62.08</mp>
-            <cp>135.828</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>166.9</hp>
-            <mp>69.6</mp>
-            <cp>150.21</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>183.05</hp>
-            <mp>77.2</mp>
-            <cp>164.745</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>199.37</hp>
-            <mp>84.88</mp>
-            <cp>179.433</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>215.86</hp>
-            <mp>92.64</mp>
-            <cp>194.274</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>232.52</hp>
-            <mp>100.48</mp>
-            <cp>209.268</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>249.35</hp>
-            <mp>108.4</mp>
-            <cp>224.415</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>266.35</hp>
-            <mp>116.4</mp>
-            <cp>239.715</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>283.52</hp>
-            <mp>124.48</mp>
-            <cp>255.168</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>300.86</hp>
-            <mp>132.64</mp>
-            <cp>270.774</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>318.37</hp>
-            <mp>140.88</mp>
-            <cp>286.533</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>336.05</hp>
-            <mp>149.2</mp>
-            <cp>302.445</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>353.9</hp>
-            <mp>157.6</mp>
-            <cp>318.51</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>371.92</hp>
-            <mp>166.08</mp>
-            <cp>334.728</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>390.11</hp>
-            <mp>174.64</mp>
-            <cp>351.099</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>408.47</hp>
-            <mp>183.28</mp>
-            <cp>367.623</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>427.0</hp>
-            <mp>192.0</mp>
-            <cp>384.3</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>462.2</hp>
-            <mp>205.2</mp>
-            <cp>415.98</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>497.72</hp>
-            <mp>218.52</mp>
-            <cp>447.948</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>533.56</hp>
-            <mp>231.96</mp>
-            <cp>480.204</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>569.72</hp>
-            <mp>245.52</mp>
-            <cp>512.748</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>606.2</hp>
-            <mp>259.2</mp>
-            <cp>545.58</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>643.0</hp>
-            <mp>273.0</mp>
-            <cp>578.7</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>680.12</hp>
-            <mp>286.92</mp>
-            <cp>612.108</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>717.56</hp>
-            <mp>300.96</mp>
-            <cp>645.804</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>755.32</hp>
-            <mp>315.12</mp>
-            <cp>679.788</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>793.4</hp>
-            <mp>329.4</mp>
-            <cp>714.06</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>831.8</hp>
-            <mp>343.8</mp>
-            <cp>748.62</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>870.52</hp>
-            <mp>358.32</mp>
-            <cp>783.468</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>909.56</hp>
-            <mp>372.96</mp>
-            <cp>818.604</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>948.92</hp>
-            <mp>387.72</mp>
-            <cp>854.028</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>988.6</hp>
-            <mp>402.6</mp>
-            <cp>889.74</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>1028.6</hp>
-            <mp>417.6</mp>
-            <cp>925.74</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>1068.92</hp>
-            <mp>432.72</mp>
-            <cp>962.028</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1109.56</hp>
-            <mp>447.96</mp>
-            <cp>998.604</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1150.52</hp>
-            <mp>463.32</mp>
-            <cp>1035.468</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1191.8</hp>
-            <mp>478.8</mp>
-            <cp>1072.62</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1246.4</hp>
-            <mp>504.8</mp>
-            <cp>1121.76</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1301.42</hp>
-            <mp>531.0</mp>
-            <cp>1171.278</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1356.86</hp>
-            <mp>557.4</mp>
-            <cp>1221.174</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1412.72</hp>
-            <mp>584.0</mp>
-            <cp>1271.448</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1469.0</hp>
-            <mp>610.8</mp>
-            <cp>1322.1</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1525.7</hp>
-            <mp>637.8</mp>
-            <cp>1373.13</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1582.82</hp>
-            <mp>665.0</mp>
-            <cp>1424.538</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1640.36</hp>
-            <mp>692.4</mp>
-            <cp>1476.324</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1698.32</hp>
-            <mp>720.0</mp>
-            <cp>1528.488</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1756.7</hp>
-            <mp>747.8</mp>
-            <cp>1581.03</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1815.5</hp>
-            <mp>775.8</mp>
-            <cp>1633.95</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1874.72</hp>
-            <mp>804.0</mp>
-            <cp>1687.248</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1934.36</hp>
-            <mp>832.4</mp>
-            <cp>1740.924</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1994.42</hp>
-            <mp>861.0</mp>
-            <cp>1794.978</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>2054.9</hp>
-            <mp>889.8</mp>
-            <cp>1849.41</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>2115.8</hp>
-            <mp>918.8</mp>
-            <cp>1904.22</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>2177.12</hp>
-            <mp>948.0</mp>
-            <cp>1959.408</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2238.86</hp>
-            <mp>977.4</mp>
-            <cp>2014.974</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2301.02</hp>
-            <mp>1007.0</mp>
-            <cp>2070.918</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2363.6</hp>
-            <mp>1036.8</mp>
-            <cp>2127.24</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2426.6</hp>
-            <mp>1066.8</mp>
-            <cp>2183.94</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2490.02</hp>
-            <mp>1097.0</mp>
-            <cp>2241.018</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2553.86</hp>
-            <mp>1127.4</mp>
-            <cp>2298.474</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2618.12</hp>
-            <mp>1158.0</mp>
-            <cp>2356.308</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2682.8</hp>
-            <mp>1188.8</mp>
-            <cp>2414.52</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2747.9</hp>
-            <mp>1219.8</mp>
-            <cp>2473.11</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2813.42</hp>
-            <mp>1251.0</mp>
-            <cp>2532.078</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2879.36</hp>
-            <mp>1282.4</mp>
-            <cp>2591.424</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2945.72</hp>
-            <mp>1314.0</mp>
-            <cp>2651.148</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>3012.5</hp>
-            <mp>1345.8</mp>
-            <cp>2711.25</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>3079.7</hp>
-            <mp>1377.8</mp>
-            <cp>2771.73</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>3147.32</hp>
-            <mp>1410.0</mp>
-            <cp>2832.588</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>3215.36</hp>
-            <mp>1442.4</mp>
-            <cp>2893.824</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>3283.82</hp>
-            <mp>1475.0</mp>
-            <cp>2955.438</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3352.7</hp>
-            <mp>1507.8</mp>
-            <cp>3017.43</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3422.0</hp>
-            <mp>1540.8</mp>
-            <cp>3079.8</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3491.72</hp>
-            <mp>1574.0</mp>
-            <cp>3142.548</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3561.86</hp>
-            <mp>1607.4</mp>
-            <cp>3205.674</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3632.42</hp>
-            <mp>1641.0</mp>
-            <cp>3269.178</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3703.4</hp>
-            <mp>1674.8</mp>
-            <cp>3333.06</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3774.8</hp>
-            <mp>1708.8</mp>
-            <cp>3397.32</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3846.62</hp>
-            <mp>1743.0</mp>
-            <cp>3461.958</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3918.86</hp>
-            <mp>1777.4</mp>
-            <cp>3526.974</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3991.52</hp>
-            <mp>1812.0</mp>
-            <cp>3592.368</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>4064.6</hp>
-            <mp>1846.8</mp>
-            <cp>3658.14</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>4138.1</hp>
-            <mp>1881.8</mp>
-            <cp>3724.29</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>4212.02</hp>
-            <mp>1917.0</mp>
-            <cp>3790.818</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>4286.36</hp>
-            <mp>1952.4</mp>
-            <cp>3857.724</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>4361.12</hp>
-            <mp>1988.0</mp>
-            <cp>3925.008</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4436.3</hp>
-            <mp>2023.8</mp>
-            <cp>3992.67</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4511.9</hp>
-            <mp>2059.8</mp>
-            <cp>4060.71</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>105</classId>
+	<staticData>
+		<baseINT>37</baseINT>
+		<baseSTR>21</baseSTR>
+		<baseCON>25</baseCON>
+		<baseMEN>40</baseMEN>
+		<baseDEX>24</baseDEX>
+		<baseWIT>23</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="46045" y="41251" z="-3440" />
+			<node x="46117" y="41247" z="-3440" />
+			<node x="46182" y="41198" z="-3440" />
+			<node x="46115" y="41141" z="-3440" />
+			<node x="46048" y="41141" z="-3440" />
+			<node x="45978" y="41196" z="-3440" />
+		</creationPoints>
+		<basePAtk>3</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>15</chest>
+			<legs>8</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>85</walk>
+			<run>129</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>300</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.5</radius>
+			<height>23</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>104.0</hp>
+			<mp>40.0</mp>
+			<cp>93.6</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>119.47</hp>
+			<mp>47.28</mp>
+			<cp>107.523</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>135.11</hp>
+			<mp>54.64</mp>
+			<cp>121.599</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>150.92</hp>
+			<mp>62.08</mp>
+			<cp>135.828</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>166.9</hp>
+			<mp>69.6</mp>
+			<cp>150.21</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>183.05</hp>
+			<mp>77.2</mp>
+			<cp>164.745</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>199.37</hp>
+			<mp>84.88</mp>
+			<cp>179.433</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>215.86</hp>
+			<mp>92.64</mp>
+			<cp>194.274</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>232.52</hp>
+			<mp>100.48</mp>
+			<cp>209.268</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>249.35</hp>
+			<mp>108.4</mp>
+			<cp>224.415</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>266.35</hp>
+			<mp>116.4</mp>
+			<cp>239.715</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>283.52</hp>
+			<mp>124.48</mp>
+			<cp>255.168</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>300.86</hp>
+			<mp>132.64</mp>
+			<cp>270.774</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>318.37</hp>
+			<mp>140.88</mp>
+			<cp>286.533</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>336.05</hp>
+			<mp>149.2</mp>
+			<cp>302.445</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>353.9</hp>
+			<mp>157.6</mp>
+			<cp>318.51</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>371.92</hp>
+			<mp>166.08</mp>
+			<cp>334.728</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>390.11</hp>
+			<mp>174.64</mp>
+			<cp>351.099</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>408.47</hp>
+			<mp>183.28</mp>
+			<cp>367.623</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>427.0</hp>
+			<mp>192.0</mp>
+			<cp>384.3</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>462.2</hp>
+			<mp>205.2</mp>
+			<cp>415.98</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>497.72</hp>
+			<mp>218.52</mp>
+			<cp>447.948</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>533.56</hp>
+			<mp>231.96</mp>
+			<cp>480.204</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>569.72</hp>
+			<mp>245.52</mp>
+			<cp>512.748</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>606.2</hp>
+			<mp>259.2</mp>
+			<cp>545.58</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>643.0</hp>
+			<mp>273.0</mp>
+			<cp>578.7</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>680.12</hp>
+			<mp>286.92</mp>
+			<cp>612.108</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>717.56</hp>
+			<mp>300.96</mp>
+			<cp>645.804</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>755.32</hp>
+			<mp>315.12</mp>
+			<cp>679.788</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>793.4</hp>
+			<mp>329.4</mp>
+			<cp>714.06</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>831.8</hp>
+			<mp>343.8</mp>
+			<cp>748.62</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>870.52</hp>
+			<mp>358.32</mp>
+			<cp>783.468</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>909.56</hp>
+			<mp>372.96</mp>
+			<cp>818.604</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>948.92</hp>
+			<mp>387.72</mp>
+			<cp>854.028</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>988.6</hp>
+			<mp>402.6</mp>
+			<cp>889.74</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>1028.6</hp>
+			<mp>417.6</mp>
+			<cp>925.74</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>1068.92</hp>
+			<mp>432.72</mp>
+			<cp>962.028</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1109.56</hp>
+			<mp>447.96</mp>
+			<cp>998.604</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1150.52</hp>
+			<mp>463.32</mp>
+			<cp>1035.468</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1191.8</hp>
+			<mp>478.8</mp>
+			<cp>1072.62</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1246.4</hp>
+			<mp>504.8</mp>
+			<cp>1121.76</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1301.42</hp>
+			<mp>531.0</mp>
+			<cp>1171.278</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1356.86</hp>
+			<mp>557.4</mp>
+			<cp>1221.174</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1412.72</hp>
+			<mp>584.0</mp>
+			<cp>1271.448</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1469.0</hp>
+			<mp>610.8</mp>
+			<cp>1322.1</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1525.7</hp>
+			<mp>637.8</mp>
+			<cp>1373.13</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1582.82</hp>
+			<mp>665.0</mp>
+			<cp>1424.538</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1640.36</hp>
+			<mp>692.4</mp>
+			<cp>1476.324</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1698.32</hp>
+			<mp>720.0</mp>
+			<cp>1528.488</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1756.7</hp>
+			<mp>747.8</mp>
+			<cp>1581.03</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1815.5</hp>
+			<mp>775.8</mp>
+			<cp>1633.95</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1874.72</hp>
+			<mp>804.0</mp>
+			<cp>1687.248</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1934.36</hp>
+			<mp>832.4</mp>
+			<cp>1740.924</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1994.42</hp>
+			<mp>861.0</mp>
+			<cp>1794.978</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>2054.9</hp>
+			<mp>889.8</mp>
+			<cp>1849.41</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>2115.8</hp>
+			<mp>918.8</mp>
+			<cp>1904.22</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2177.12</hp>
+			<mp>948.0</mp>
+			<cp>1959.408</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2238.86</hp>
+			<mp>977.4</mp>
+			<cp>2014.974</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2301.02</hp>
+			<mp>1007.0</mp>
+			<cp>2070.918</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2363.6</hp>
+			<mp>1036.8</mp>
+			<cp>2127.24</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2426.6</hp>
+			<mp>1066.8</mp>
+			<cp>2183.94</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2490.02</hp>
+			<mp>1097.0</mp>
+			<cp>2241.018</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2553.86</hp>
+			<mp>1127.4</mp>
+			<cp>2298.474</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2618.12</hp>
+			<mp>1158.0</mp>
+			<cp>2356.308</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2682.8</hp>
+			<mp>1188.8</mp>
+			<cp>2414.52</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2747.9</hp>
+			<mp>1219.8</mp>
+			<cp>2473.11</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2813.42</hp>
+			<mp>1251.0</mp>
+			<cp>2532.078</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2879.36</hp>
+			<mp>1282.4</mp>
+			<cp>2591.424</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2945.72</hp>
+			<mp>1314.0</mp>
+			<cp>2651.148</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>3012.5</hp>
+			<mp>1345.8</mp>
+			<cp>2711.25</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>3079.7</hp>
+			<mp>1377.8</mp>
+			<cp>2771.73</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>3147.32</hp>
+			<mp>1410.0</mp>
+			<cp>2832.588</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>3215.36</hp>
+			<mp>1442.4</mp>
+			<cp>2893.824</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3283.82</hp>
+			<mp>1475.0</mp>
+			<cp>2955.438</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3352.7</hp>
+			<mp>1507.8</mp>
+			<cp>3017.43</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3422.0</hp>
+			<mp>1540.8</mp>
+			<cp>3079.8</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3491.72</hp>
+			<mp>1574.0</mp>
+			<cp>3142.548</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3561.86</hp>
+			<mp>1607.4</mp>
+			<cp>3205.674</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3632.42</hp>
+			<mp>1641.0</mp>
+			<cp>3269.178</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3703.4</hp>
+			<mp>1674.8</mp>
+			<cp>3333.06</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3774.8</hp>
+			<mp>1708.8</mp>
+			<cp>3397.32</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3846.62</hp>
+			<mp>1743.0</mp>
+			<cp>3461.958</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3918.86</hp>
+			<mp>1777.4</mp>
+			<cp>3526.974</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3991.52</hp>
+			<mp>1812.0</mp>
+			<cp>3592.368</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>4064.6</hp>
+			<mp>1846.8</mp>
+			<cp>3658.14</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>4138.1</hp>
+			<mp>1881.8</mp>
+			<cp>3724.29</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>4212.02</hp>
+			<mp>1917.0</mp>
+			<cp>3790.818</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4286.36</hp>
+			<mp>1952.4</mp>
+			<cp>3857.724</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4361.12</hp>
+			<mp>1988.0</mp>
+			<cp>3925.008</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4436.3</hp>
+			<mp>2023.8</mp>
+			<cp>3992.67</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4511.9</hp>
+			<mp>2059.8</mp>
+			<cp>4060.71</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4587.92</hp>
+			<mp>2096.0</mp>
+			<cp>4129.128</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4664.36</hp>
+			<mp>2132.4</mp>
+			<cp>4197.924</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4741.22</hp>
+			<mp>2169.0</mp>
+			<cp>4267.098</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4818.5</hp>
+			<mp>2205.8</mp>
+			<cp>4336.65</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4896.2</hp>
+			<mp>2242.8</mp>
+			<cp>4406.58</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4974.32</hp>
+			<mp>2280.0</mp>
+			<cp>4476.888</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>5052.86</hp>
+			<mp>2317.4</mp>
+			<cp>4547.574</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>5131.82</hp>
+			<mp>2355.0</mp>
+			<cp>4618.638</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>5211.2</hp>
+			<mp>2392.8</mp>
+			<cp>4690.08</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>5291</hp>
+			<mp>2430.8</mp>
+			<cp>4761.91</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5371.22</hp>
+			<mp>2469</mp>
+			<cp>4834.11</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5451.86</hp>
+			<mp>2507.4</mp>
+			<cp>4906.69</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5532.92</hp>
+			<mp>2546</mp>
+			<cp>4979.66</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5614.4</hp>
+			<mp>2584.8</mp>
+			<cp>5053</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5696.3</hp>
+			<mp>2623.8</mp>
+			<cp>5126.73</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5778.62</hp>
+			<mp>2663</mp>
+			<cp>5200.758</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Eva'sTemplar.xml
+++ b/data/stats/chars/baseStats/Eva'sTemplar.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>99</classId>
-    <staticData>
-        <baseINT>23</baseINT>
-        <baseSTR>36</baseSTR>
-        <baseCON>36</baseCON>
-        <baseMEN>26</baseMEN>
-        <baseDEX>35</baseDEX>
-        <baseWIT>14</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>15</magicAbnormalResist>
-        <creationPoints>
-            <node x="46045" y="41251" z="-3440"/>
-            <node x="46117" y="41247" z="-3440"/>
-            <node x="46182" y="41198" z="-3440"/>
-            <node x="46115" y="41141" z="-3440"/>
-            <node x="46048" y="41141" z="-3440"/>
-            <node x="45978" y="41196" z="-3440"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>90</walk>
-            <run>143</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>150</baseBreath>
-        <baseSafeFall>350</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>24</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.5</radius>
-            <height>23</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>89.0</hp>
-            <mp>30.0</mp>
-            <cp>53.4</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>101.74</hp>
-            <mp>35.46</mp>
-            <cp>61.044</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>114.62</hp>
-            <mp>40.98</mp>
-            <cp>68.772</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>127.64</hp>
-            <mp>46.56</mp>
-            <cp>76.584</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>140.8</hp>
-            <mp>52.2</mp>
-            <cp>84.48</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>154.1</hp>
-            <mp>57.9</mp>
-            <cp>92.46</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>167.54</hp>
-            <mp>63.66</mp>
-            <cp>100.524</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>181.12</hp>
-            <mp>69.48</mp>
-            <cp>108.672</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>194.84</hp>
-            <mp>75.36</mp>
-            <cp>116.904</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>208.7</hp>
-            <mp>81.3</mp>
-            <cp>125.22</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>222.7</hp>
-            <mp>87.3</mp>
-            <cp>133.62</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>236.84</hp>
-            <mp>93.36</mp>
-            <cp>142.104</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>251.12</hp>
-            <mp>99.48</mp>
-            <cp>150.672</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>265.54</hp>
-            <mp>105.66</mp>
-            <cp>159.324</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>280.1</hp>
-            <mp>111.9</mp>
-            <cp>168.06</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>294.8</hp>
-            <mp>118.2</mp>
-            <cp>176.88</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>309.64</hp>
-            <mp>124.56</mp>
-            <cp>185.784</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>324.62</hp>
-            <mp>130.98</mp>
-            <cp>194.772</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>339.74</hp>
-            <mp>137.46</mp>
-            <cp>203.844</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>355.0</hp>
-            <mp>144.0</mp>
-            <cp>213.0</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>388.0</hp>
-            <mp>153.9</mp>
-            <cp>232.8</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>421.3</hp>
-            <mp>163.89</mp>
-            <cp>252.78</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>454.9</hp>
-            <mp>173.97</mp>
-            <cp>272.94</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>488.8</hp>
-            <mp>184.14</mp>
-            <cp>293.28</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>523.0</hp>
-            <mp>194.4</mp>
-            <cp>313.8</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>557.5</hp>
-            <mp>204.75</mp>
-            <cp>334.5</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>592.3</hp>
-            <mp>215.19</mp>
-            <cp>355.38</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>627.4</hp>
-            <mp>225.72</mp>
-            <cp>376.44</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>662.8</hp>
-            <mp>236.34</mp>
-            <cp>397.68</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>698.5</hp>
-            <mp>247.05</mp>
-            <cp>419.1</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>734.5</hp>
-            <mp>257.85</mp>
-            <cp>440.7</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>770.8</hp>
-            <mp>268.74</mp>
-            <cp>462.48</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>807.4</hp>
-            <mp>279.72</mp>
-            <cp>484.44</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>844.3</hp>
-            <mp>290.79</mp>
-            <cp>506.58</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>881.5</hp>
-            <mp>301.95</mp>
-            <cp>528.9</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>919.0</hp>
-            <mp>313.2</mp>
-            <cp>551.4</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>956.8</hp>
-            <mp>324.54</mp>
-            <cp>574.08</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>994.9</hp>
-            <mp>335.97</mp>
-            <cp>596.94</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1033.3</hp>
-            <mp>347.49</mp>
-            <cp>619.98</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1072.0</hp>
-            <mp>359.1</mp>
-            <cp>643.2</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1124.0</hp>
-            <mp>378.6</mp>
-            <cp>674.4</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1176.4</hp>
-            <mp>398.25</mp>
-            <cp>705.84</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1229.2</hp>
-            <mp>418.05</mp>
-            <cp>737.52</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1282.4</hp>
-            <mp>438.0</mp>
-            <cp>769.44</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1336.0</hp>
-            <mp>458.1</mp>
-            <cp>801.6</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1390.0</hp>
-            <mp>478.35</mp>
-            <cp>834.0</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1444.4</hp>
-            <mp>498.75</mp>
-            <cp>866.64</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1499.2</hp>
-            <mp>519.3</mp>
-            <cp>899.52</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1554.4</hp>
-            <mp>540.0</mp>
-            <cp>932.64</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1610.0</hp>
-            <mp>560.85</mp>
-            <cp>966.0</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1666.0</hp>
-            <mp>581.85</mp>
-            <cp>999.6</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1722.4</hp>
-            <mp>603.0</mp>
-            <cp>1033.44</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1779.2</hp>
-            <mp>624.3</mp>
-            <cp>1067.52</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1836.4</hp>
-            <mp>645.75</mp>
-            <cp>1101.84</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1894.0</hp>
-            <mp>667.35</mp>
-            <cp>1136.4</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1952.0</hp>
-            <mp>689.1</mp>
-            <cp>1171.2</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>2010.4</hp>
-            <mp>711.0</mp>
-            <cp>1206.24</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2069.2</hp>
-            <mp>733.05</mp>
-            <cp>1241.52</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2128.4</hp>
-            <mp>755.25</mp>
-            <cp>1277.04</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2188.0</hp>
-            <mp>777.6</mp>
-            <cp>1312.8</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2248.0</hp>
-            <mp>800.1</mp>
-            <cp>1348.8</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2308.4</hp>
-            <mp>822.75</mp>
-            <cp>1385.04</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2369.2</hp>
-            <mp>845.55</mp>
-            <cp>1421.52</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2430.4</hp>
-            <mp>868.5</mp>
-            <cp>1458.24</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2492.0</hp>
-            <mp>891.6</mp>
-            <cp>1495.2</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2554.0</hp>
-            <mp>914.85</mp>
-            <cp>1532.4</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2616.4</hp>
-            <mp>938.25</mp>
-            <cp>1569.84</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2679.2</hp>
-            <mp>961.8</mp>
-            <cp>1607.52</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2742.4</hp>
-            <mp>985.5</mp>
-            <cp>1645.44</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2806.0</hp>
-            <mp>1009.35</mp>
-            <cp>1683.6</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2870.0</hp>
-            <mp>1033.35</mp>
-            <cp>1722.0</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2934.4</hp>
-            <mp>1057.5</mp>
-            <cp>1760.64</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2999.2</hp>
-            <mp>1081.8</mp>
-            <cp>1799.52</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>3064.4</hp>
-            <mp>1106.25</mp>
-            <cp>1838.64</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3130.0</hp>
-            <mp>1130.85</mp>
-            <cp>1878.0</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3196.0</hp>
-            <mp>1155.6</mp>
-            <cp>1917.6</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3262.4</hp>
-            <mp>1180.5</mp>
-            <cp>1957.44</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3329.2</hp>
-            <mp>1205.55</mp>
-            <cp>1997.52</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3396.4</hp>
-            <mp>1230.75</mp>
-            <cp>2037.84</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3464.0</hp>
-            <mp>1256.1</mp>
-            <cp>2078.4</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3532.0</hp>
-            <mp>1281.6</mp>
-            <cp>2119.2</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3600.4</hp>
-            <mp>1307.25</mp>
-            <cp>2160.24</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3669.2</hp>
-            <mp>1333.05</mp>
-            <cp>2201.52</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3738.4</hp>
-            <mp>1359.0</mp>
-            <cp>2243.04</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3808.0</hp>
-            <mp>1385.1</mp>
-            <cp>2284.8</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3878.0</hp>
-            <mp>1411.35</mp>
-            <cp>2326.8</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3948.4</hp>
-            <mp>1437.75</mp>
-            <cp>2369.04</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>4019.2</hp>
-            <mp>1464.3</mp>
-            <cp>2411.52</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>4090.4</hp>
-            <mp>1491.0</mp>
-            <cp>2454.24</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4162.0</hp>
-            <mp>1517.85</mp>
-            <cp>2497.2</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4234.0</hp>
-            <mp>1544.85</mp>
-            <cp>2540.4</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>99</classId>
+	<staticData>
+		<baseINT>23</baseINT>
+		<baseSTR>36</baseSTR>
+		<baseCON>36</baseCON>
+		<baseMEN>26</baseMEN>
+		<baseDEX>35</baseDEX>
+		<baseWIT>14</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="46045" y="41251" z="-3440" />
+			<node x="46117" y="41247" z="-3440" />
+			<node x="46182" y="41198" z="-3440" />
+			<node x="46115" y="41141" z="-3440" />
+			<node x="46048" y="41141" z="-3440" />
+			<node x="45978" y="41196" z="-3440" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>90</walk>
+			<run>143</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>350</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.5</radius>
+			<height>23</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>89.0</hp>
+			<mp>30.0</mp>
+			<cp>53.4</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>101.74</hp>
+			<mp>35.46</mp>
+			<cp>61.044</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>114.62</hp>
+			<mp>40.98</mp>
+			<cp>68.772</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>127.64</hp>
+			<mp>46.56</mp>
+			<cp>76.584</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>140.8</hp>
+			<mp>52.2</mp>
+			<cp>84.48</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>154.1</hp>
+			<mp>57.9</mp>
+			<cp>92.46</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>167.54</hp>
+			<mp>63.66</mp>
+			<cp>100.524</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>181.12</hp>
+			<mp>69.48</mp>
+			<cp>108.672</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>194.84</hp>
+			<mp>75.36</mp>
+			<cp>116.904</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>208.7</hp>
+			<mp>81.3</mp>
+			<cp>125.22</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>222.7</hp>
+			<mp>87.3</mp>
+			<cp>133.62</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>236.84</hp>
+			<mp>93.36</mp>
+			<cp>142.104</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>251.12</hp>
+			<mp>99.48</mp>
+			<cp>150.672</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>265.54</hp>
+			<mp>105.66</mp>
+			<cp>159.324</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>280.1</hp>
+			<mp>111.9</mp>
+			<cp>168.06</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>294.8</hp>
+			<mp>118.2</mp>
+			<cp>176.88</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>309.64</hp>
+			<mp>124.56</mp>
+			<cp>185.784</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>324.62</hp>
+			<mp>130.98</mp>
+			<cp>194.772</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>339.74</hp>
+			<mp>137.46</mp>
+			<cp>203.844</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>355.0</hp>
+			<mp>144.0</mp>
+			<cp>213.0</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>388.0</hp>
+			<mp>153.9</mp>
+			<cp>232.8</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>421.3</hp>
+			<mp>163.89</mp>
+			<cp>252.78</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>454.9</hp>
+			<mp>173.97</mp>
+			<cp>272.94</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>488.8</hp>
+			<mp>184.14</mp>
+			<cp>293.28</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>523.0</hp>
+			<mp>194.4</mp>
+			<cp>313.8</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>557.5</hp>
+			<mp>204.75</mp>
+			<cp>334.5</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>592.3</hp>
+			<mp>215.19</mp>
+			<cp>355.38</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>627.4</hp>
+			<mp>225.72</mp>
+			<cp>376.44</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>662.8</hp>
+			<mp>236.34</mp>
+			<cp>397.68</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>698.5</hp>
+			<mp>247.05</mp>
+			<cp>419.1</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>734.5</hp>
+			<mp>257.85</mp>
+			<cp>440.7</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>770.8</hp>
+			<mp>268.74</mp>
+			<cp>462.48</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>807.4</hp>
+			<mp>279.72</mp>
+			<cp>484.44</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>844.3</hp>
+			<mp>290.79</mp>
+			<cp>506.58</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>881.5</hp>
+			<mp>301.95</mp>
+			<cp>528.9</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>919.0</hp>
+			<mp>313.2</mp>
+			<cp>551.4</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>956.8</hp>
+			<mp>324.54</mp>
+			<cp>574.08</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>994.9</hp>
+			<mp>335.97</mp>
+			<cp>596.94</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1033.3</hp>
+			<mp>347.49</mp>
+			<cp>619.98</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1072.0</hp>
+			<mp>359.1</mp>
+			<cp>643.2</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1124.0</hp>
+			<mp>378.6</mp>
+			<cp>674.4</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1176.4</hp>
+			<mp>398.25</mp>
+			<cp>705.84</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1229.2</hp>
+			<mp>418.05</mp>
+			<cp>737.52</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1282.4</hp>
+			<mp>438.0</mp>
+			<cp>769.44</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1336.0</hp>
+			<mp>458.1</mp>
+			<cp>801.6</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1390.0</hp>
+			<mp>478.35</mp>
+			<cp>834.0</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1444.4</hp>
+			<mp>498.75</mp>
+			<cp>866.64</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1499.2</hp>
+			<mp>519.3</mp>
+			<cp>899.52</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1554.4</hp>
+			<mp>540.0</mp>
+			<cp>932.64</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1610.0</hp>
+			<mp>560.85</mp>
+			<cp>966.0</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1666.0</hp>
+			<mp>581.85</mp>
+			<cp>999.6</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1722.4</hp>
+			<mp>603.0</mp>
+			<cp>1033.44</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1779.2</hp>
+			<mp>624.3</mp>
+			<cp>1067.52</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1836.4</hp>
+			<mp>645.75</mp>
+			<cp>1101.84</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1894.0</hp>
+			<mp>667.35</mp>
+			<cp>1136.4</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1952.0</hp>
+			<mp>689.1</mp>
+			<cp>1171.2</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2010.4</hp>
+			<mp>711.0</mp>
+			<cp>1206.24</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2069.2</hp>
+			<mp>733.05</mp>
+			<cp>1241.52</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2128.4</hp>
+			<mp>755.25</mp>
+			<cp>1277.04</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2188.0</hp>
+			<mp>777.6</mp>
+			<cp>1312.8</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2248.0</hp>
+			<mp>800.1</mp>
+			<cp>1348.8</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2308.4</hp>
+			<mp>822.75</mp>
+			<cp>1385.04</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2369.2</hp>
+			<mp>845.55</mp>
+			<cp>1421.52</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2430.4</hp>
+			<mp>868.5</mp>
+			<cp>1458.24</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2492.0</hp>
+			<mp>891.6</mp>
+			<cp>1495.2</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2554.0</hp>
+			<mp>914.85</mp>
+			<cp>1532.4</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2616.4</hp>
+			<mp>938.25</mp>
+			<cp>1569.84</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2679.2</hp>
+			<mp>961.8</mp>
+			<cp>1607.52</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2742.4</hp>
+			<mp>985.5</mp>
+			<cp>1645.44</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2806.0</hp>
+			<mp>1009.35</mp>
+			<cp>1683.6</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2870.0</hp>
+			<mp>1033.35</mp>
+			<cp>1722.0</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2934.4</hp>
+			<mp>1057.5</mp>
+			<cp>1760.64</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2999.2</hp>
+			<mp>1081.8</mp>
+			<cp>1799.52</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3064.4</hp>
+			<mp>1106.25</mp>
+			<cp>1838.64</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3130.0</hp>
+			<mp>1130.85</mp>
+			<cp>1878.0</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3196.0</hp>
+			<mp>1155.6</mp>
+			<cp>1917.6</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3262.4</hp>
+			<mp>1180.5</mp>
+			<cp>1957.44</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3329.2</hp>
+			<mp>1205.55</mp>
+			<cp>1997.52</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3396.4</hp>
+			<mp>1230.75</mp>
+			<cp>2037.84</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3464.0</hp>
+			<mp>1256.1</mp>
+			<cp>2078.4</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3532.0</hp>
+			<mp>1281.6</mp>
+			<cp>2119.2</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3600.4</hp>
+			<mp>1307.25</mp>
+			<cp>2160.24</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3669.2</hp>
+			<mp>1333.05</mp>
+			<cp>2201.52</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3738.4</hp>
+			<mp>1359.0</mp>
+			<cp>2243.04</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3808.0</hp>
+			<mp>1385.1</mp>
+			<cp>2284.8</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3878.0</hp>
+			<mp>1411.35</mp>
+			<cp>2326.8</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3948.4</hp>
+			<mp>1437.75</mp>
+			<cp>2369.04</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4019.2</hp>
+			<mp>1464.3</mp>
+			<cp>2411.52</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4090.4</hp>
+			<mp>1491.0</mp>
+			<cp>2454.24</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4162.0</hp>
+			<mp>1517.85</mp>
+			<cp>2497.2</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4234.0</hp>
+			<mp>1544.85</mp>
+			<cp>2540.4</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4306.4</hp>
+			<mp>1572.0</mp>
+			<cp>2583.84</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4379.2</hp>
+			<mp>1599.3</mp>
+			<cp>2627.52</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4452.4</hp>
+			<mp>1626.75</mp>
+			<cp>2671.44</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4526.0</hp>
+			<mp>1654.35</mp>
+			<cp>2715.6</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4600.0</hp>
+			<mp>1682.1</mp>
+			<cp>2760.0</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4674.4</hp>
+			<mp>1710.0</mp>
+			<cp>2804.64</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4749.2</hp>
+			<mp>1738.05</mp>
+			<cp>2849.52</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4824.4</hp>
+			<mp>1766.25</mp>
+			<cp>2894.64</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4900</hp>
+			<mp>1794.6</mp>
+			<cp>2940</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4976</hp>
+			<mp>1823.1</mp>
+			<cp>2985.6</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5052.4</hp>
+			<mp>1851.75</mp>
+			<cp>3031.44</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5129.2</hp>
+			<mp>1880.55</mp>
+			<cp>3077.52</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5206.4</hp>
+			<mp>1909.5</mp>
+			<cp>3123.84</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5284</hp>
+			<mp>1938.6</mp>
+			<cp>3170.4</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5362</hp>
+			<mp>1967.85</mp>
+			<cp>3217.2</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5440.4</hp>
+			<mp>1997.25</mp>
+			<cp>3264.24</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/FortuneSeeker.xml
+++ b/data/stats/chars/baseStats/FortuneSeeker.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>117</classId>
-    <staticData>
-        <baseINT>20</baseINT>
-        <baseSTR>39</baseSTR>
-        <baseCON>45</baseCON>
-        <baseMEN>27</baseMEN>
-        <baseDEX>29</baseDEX>
-        <baseWIT>10</baseWIT>
-        <physicalAbnormalResist>15</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="108644" y="-173947" z="-400"/>
-            <node x="108678" y="-174002" z="-400"/>
-            <node x="108505" y="-173964" z="-400"/>
-            <node x="108512" y="-174026" z="-400"/>
-            <node x="108549" y="-174075" z="-400"/>
-            <node x="108576" y="-174122" z="-400"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>80</walk>
-            <run>131</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>80</baseBreath>
-        <baseSafeFall>180</baseSafeFall>
-        <collisionMale>
-            <radius>9.0</radius>
-            <height>18.0</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>5.0</radius>
-            <height>19.0</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>80.0</hp>
-            <mp>30.0</mp>
-            <cp>56.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>92.74</hp>
-            <mp>35.46</mp>
-            <cp>64.918</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>105.62</hp>
-            <mp>40.98</mp>
-            <cp>73.934</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>118.64</hp>
-            <mp>46.56</mp>
-            <cp>83.048</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>131.8</hp>
-            <mp>52.2</mp>
-            <cp>92.26</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>145.1</hp>
-            <mp>57.9</mp>
-            <cp>101.57</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>158.54</hp>
-            <mp>63.66</mp>
-            <cp>110.978</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>172.12</hp>
-            <mp>69.48</mp>
-            <cp>120.484</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>185.84</hp>
-            <mp>75.36</mp>
-            <cp>130.088</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>199.7</hp>
-            <mp>81.3</mp>
-            <cp>139.79</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>213.7</hp>
-            <mp>87.3</mp>
-            <cp>149.59</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>227.84</hp>
-            <mp>93.36</mp>
-            <cp>159.488</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>242.12</hp>
-            <mp>99.48</mp>
-            <cp>169.484</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>256.54</hp>
-            <mp>105.66</mp>
-            <cp>179.578</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>271.1</hp>
-            <mp>111.9</mp>
-            <cp>189.77</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>285.8</hp>
-            <mp>118.2</mp>
-            <cp>200.06</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>300.64</hp>
-            <mp>124.56</mp>
-            <cp>210.448</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>315.62</hp>
-            <mp>130.98</mp>
-            <cp>220.934</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>330.74</hp>
-            <mp>137.46</mp>
-            <cp>231.518</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>346.0</hp>
-            <mp>144.0</mp>
-            <cp>242.2</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>381.2</hp>
-            <mp>153.9</mp>
-            <cp>266.84</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>416.72</hp>
-            <mp>163.89</mp>
-            <cp>291.704</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>452.56</hp>
-            <mp>173.97</mp>
-            <cp>316.792</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>488.72</hp>
-            <mp>184.14</mp>
-            <cp>342.104</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>525.2</hp>
-            <mp>194.4</mp>
-            <cp>367.64</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>562.0</hp>
-            <mp>204.75</mp>
-            <cp>393.4</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>599.12</hp>
-            <mp>215.19</mp>
-            <cp>419.384</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>636.56</hp>
-            <mp>225.72</mp>
-            <cp>445.592</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>674.32</hp>
-            <mp>236.34</mp>
-            <cp>472.024</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>712.4</hp>
-            <mp>247.05</mp>
-            <cp>498.68</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>750.8</hp>
-            <mp>257.85</mp>
-            <cp>525.56</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>789.52</hp>
-            <mp>268.74</mp>
-            <cp>552.664</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>828.56</hp>
-            <mp>279.72</mp>
-            <cp>579.992</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>867.92</hp>
-            <mp>290.79</mp>
-            <cp>607.544</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>907.6</hp>
-            <mp>301.95</mp>
-            <cp>635.32</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>947.6</hp>
-            <mp>313.2</mp>
-            <cp>663.32</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>987.92</hp>
-            <mp>324.54</mp>
-            <cp>691.544</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1028.56</hp>
-            <mp>335.97</mp>
-            <cp>719.992</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1069.52</hp>
-            <mp>347.49</mp>
-            <cp>748.664</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1110.8</hp>
-            <mp>359.1</mp>
-            <cp>777.56</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1168.0</hp>
-            <mp>378.6</mp>
-            <cp>817.6</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1225.64</hp>
-            <mp>398.25</mp>
-            <cp>857.948</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1283.72</hp>
-            <mp>418.05</mp>
-            <cp>898.604</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1342.24</hp>
-            <mp>438.0</mp>
-            <cp>939.568</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1401.2</hp>
-            <mp>458.1</mp>
-            <cp>980.84</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1460.6</hp>
-            <mp>478.35</mp>
-            <cp>1022.42</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1520.44</hp>
-            <mp>498.75</mp>
-            <cp>1064.308</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1580.72</hp>
-            <mp>519.3</mp>
-            <cp>1106.504</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1641.44</hp>
-            <mp>540.0</mp>
-            <cp>1149.008</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1702.6</hp>
-            <mp>560.85</mp>
-            <cp>1191.82</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1764.2</hp>
-            <mp>581.85</mp>
-            <cp>1234.94</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1826.24</hp>
-            <mp>603.0</mp>
-            <cp>1278.368</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1888.72</hp>
-            <mp>624.3</mp>
-            <cp>1322.104</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1951.64</hp>
-            <mp>645.75</mp>
-            <cp>1366.148</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>2015.0</hp>
-            <mp>667.35</mp>
-            <cp>1410.5</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>2078.8</hp>
-            <mp>689.1</mp>
-            <cp>1455.16</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>2143.04</hp>
-            <mp>711.0</mp>
-            <cp>1500.128</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2207.72</hp>
-            <mp>733.05</mp>
-            <cp>1545.404</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2272.84</hp>
-            <mp>755.25</mp>
-            <cp>1590.988</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2338.4</hp>
-            <mp>777.6</mp>
-            <cp>1636.88</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2404.4</hp>
-            <mp>800.1</mp>
-            <cp>1683.08</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2470.84</hp>
-            <mp>822.75</mp>
-            <cp>1729.588</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2537.72</hp>
-            <mp>845.55</mp>
-            <cp>1776.404</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2605.04</hp>
-            <mp>868.5</mp>
-            <cp>1823.528</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2672.8</hp>
-            <mp>891.6</mp>
-            <cp>1870.96</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2741.0</hp>
-            <mp>914.85</mp>
-            <cp>1918.7</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2809.64</hp>
-            <mp>938.25</mp>
-            <cp>1966.748</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2878.72</hp>
-            <mp>961.8</mp>
-            <cp>2015.104</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2948.24</hp>
-            <mp>985.5</mp>
-            <cp>2063.768</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>3018.2</hp>
-            <mp>1009.35</mp>
-            <cp>2112.74</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>3088.6</hp>
-            <mp>1033.35</mp>
-            <cp>2162.02</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>3159.44</hp>
-            <mp>1057.5</mp>
-            <cp>2211.608</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>3230.72</hp>
-            <mp>1081.8</mp>
-            <cp>2261.504</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>3302.44</hp>
-            <mp>1106.25</mp>
-            <cp>2311.708</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3374.6</hp>
-            <mp>1130.85</mp>
-            <cp>2362.22</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3447.2</hp>
-            <mp>1155.6</mp>
-            <cp>2413.04</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3520.24</hp>
-            <mp>1180.5</mp>
-            <cp>2464.168</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3593.72</hp>
-            <mp>1205.55</mp>
-            <cp>2515.604</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3667.64</hp>
-            <mp>1230.75</mp>
-            <cp>2567.348</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3742.0</hp>
-            <mp>1256.1</mp>
-            <cp>2619.4</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3816.8</hp>
-            <mp>1281.6</mp>
-            <cp>2671.76</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3892.04</hp>
-            <mp>1307.25</mp>
-            <cp>2724.428</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3967.72</hp>
-            <mp>1333.05</mp>
-            <cp>2777.404</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>4043.84</hp>
-            <mp>1359.0</mp>
-            <cp>2830.688</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>4120.4</hp>
-            <mp>1385.1</mp>
-            <cp>2884.28</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>4197.4</hp>
-            <mp>1411.35</mp>
-            <cp>2938.18</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>4274.84</hp>
-            <mp>1437.75</mp>
-            <cp>2992.388</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>4352.72</hp>
-            <mp>1464.3</mp>
-            <cp>3046.904</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>4431.04</hp>
-            <mp>1491.0</mp>
-            <cp>3101.728</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4509.8</hp>
-            <mp>1517.85</mp>
-            <cp>3156.86</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4589.0</hp>
-            <mp>1544.85</mp>
-            <cp>3212.3</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>117</classId>
+	<staticData>
+		<baseINT>20</baseINT>
+		<baseSTR>39</baseSTR>
+		<baseCON>45</baseCON>
+		<baseMEN>27</baseMEN>
+		<baseDEX>29</baseDEX>
+		<baseWIT>10</baseWIT>
+		<physicalAbnormalResist>15</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="108644" y="-173947" z="-400" />
+			<node x="108678" y="-174002" z="-400" />
+			<node x="108505" y="-173964" z="-400" />
+			<node x="108512" y="-174026" z="-400" />
+			<node x="108549" y="-174075" z="-400" />
+			<node x="108576" y="-174122" z="-400" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>80</walk>
+			<run>131</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>80</baseBreath>
+		<baseSafeFall>180</baseSafeFall>
+		<collisionMale>
+			<radius>9.0</radius>
+			<height>18.0</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>5.0</radius>
+			<height>19.0</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>80.0</hp>
+			<mp>30.0</mp>
+			<cp>56.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>92.74</hp>
+			<mp>35.46</mp>
+			<cp>64.918</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>105.62</hp>
+			<mp>40.98</mp>
+			<cp>73.934</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>118.64</hp>
+			<mp>46.56</mp>
+			<cp>83.048</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>131.8</hp>
+			<mp>52.2</mp>
+			<cp>92.26</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>145.1</hp>
+			<mp>57.9</mp>
+			<cp>101.57</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>158.54</hp>
+			<mp>63.66</mp>
+			<cp>110.978</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>172.12</hp>
+			<mp>69.48</mp>
+			<cp>120.484</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>185.84</hp>
+			<mp>75.36</mp>
+			<cp>130.088</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>199.7</hp>
+			<mp>81.3</mp>
+			<cp>139.79</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>213.7</hp>
+			<mp>87.3</mp>
+			<cp>149.59</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>227.84</hp>
+			<mp>93.36</mp>
+			<cp>159.488</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>242.12</hp>
+			<mp>99.48</mp>
+			<cp>169.484</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>256.54</hp>
+			<mp>105.66</mp>
+			<cp>179.578</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>271.1</hp>
+			<mp>111.9</mp>
+			<cp>189.77</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>285.8</hp>
+			<mp>118.2</mp>
+			<cp>200.06</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>300.64</hp>
+			<mp>124.56</mp>
+			<cp>210.448</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>315.62</hp>
+			<mp>130.98</mp>
+			<cp>220.934</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>330.74</hp>
+			<mp>137.46</mp>
+			<cp>231.518</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>346.0</hp>
+			<mp>144.0</mp>
+			<cp>242.2</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>381.2</hp>
+			<mp>153.9</mp>
+			<cp>266.84</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>416.72</hp>
+			<mp>163.89</mp>
+			<cp>291.704</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>452.56</hp>
+			<mp>173.97</mp>
+			<cp>316.792</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>488.72</hp>
+			<mp>184.14</mp>
+			<cp>342.104</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>525.2</hp>
+			<mp>194.4</mp>
+			<cp>367.64</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>562.0</hp>
+			<mp>204.75</mp>
+			<cp>393.4</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>599.12</hp>
+			<mp>215.19</mp>
+			<cp>419.384</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>636.56</hp>
+			<mp>225.72</mp>
+			<cp>445.592</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>674.32</hp>
+			<mp>236.34</mp>
+			<cp>472.024</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>712.4</hp>
+			<mp>247.05</mp>
+			<cp>498.68</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>750.8</hp>
+			<mp>257.85</mp>
+			<cp>525.56</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>789.52</hp>
+			<mp>268.74</mp>
+			<cp>552.664</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>828.56</hp>
+			<mp>279.72</mp>
+			<cp>579.992</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>867.92</hp>
+			<mp>290.79</mp>
+			<cp>607.544</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>907.6</hp>
+			<mp>301.95</mp>
+			<cp>635.32</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>947.6</hp>
+			<mp>313.2</mp>
+			<cp>663.32</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>987.92</hp>
+			<mp>324.54</mp>
+			<cp>691.544</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1028.56</hp>
+			<mp>335.97</mp>
+			<cp>719.992</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1069.52</hp>
+			<mp>347.49</mp>
+			<cp>748.664</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1110.8</hp>
+			<mp>359.1</mp>
+			<cp>777.56</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1168.0</hp>
+			<mp>378.6</mp>
+			<cp>817.6</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1225.64</hp>
+			<mp>398.25</mp>
+			<cp>857.948</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1283.72</hp>
+			<mp>418.05</mp>
+			<cp>898.604</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1342.24</hp>
+			<mp>438.0</mp>
+			<cp>939.568</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1401.2</hp>
+			<mp>458.1</mp>
+			<cp>980.84</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1460.6</hp>
+			<mp>478.35</mp>
+			<cp>1022.42</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1520.44</hp>
+			<mp>498.75</mp>
+			<cp>1064.308</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1580.72</hp>
+			<mp>519.3</mp>
+			<cp>1106.504</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1641.44</hp>
+			<mp>540.0</mp>
+			<cp>1149.008</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1702.6</hp>
+			<mp>560.85</mp>
+			<cp>1191.82</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1764.2</hp>
+			<mp>581.85</mp>
+			<cp>1234.94</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1826.24</hp>
+			<mp>603.0</mp>
+			<cp>1278.368</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1888.72</hp>
+			<mp>624.3</mp>
+			<cp>1322.104</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1951.64</hp>
+			<mp>645.75</mp>
+			<cp>1366.148</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>2015.0</hp>
+			<mp>667.35</mp>
+			<cp>1410.5</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>2078.8</hp>
+			<mp>689.1</mp>
+			<cp>1455.16</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2143.04</hp>
+			<mp>711.0</mp>
+			<cp>1500.128</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2207.72</hp>
+			<mp>733.05</mp>
+			<cp>1545.404</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2272.84</hp>
+			<mp>755.25</mp>
+			<cp>1590.988</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2338.4</hp>
+			<mp>777.6</mp>
+			<cp>1636.88</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2404.4</hp>
+			<mp>800.1</mp>
+			<cp>1683.08</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2470.84</hp>
+			<mp>822.75</mp>
+			<cp>1729.588</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2537.72</hp>
+			<mp>845.55</mp>
+			<cp>1776.404</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2605.04</hp>
+			<mp>868.5</mp>
+			<cp>1823.528</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2672.8</hp>
+			<mp>891.6</mp>
+			<cp>1870.96</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2741.0</hp>
+			<mp>914.85</mp>
+			<cp>1918.7</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2809.64</hp>
+			<mp>938.25</mp>
+			<cp>1966.748</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2878.72</hp>
+			<mp>961.8</mp>
+			<cp>2015.104</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2948.24</hp>
+			<mp>985.5</mp>
+			<cp>2063.768</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>3018.2</hp>
+			<mp>1009.35</mp>
+			<cp>2112.74</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>3088.6</hp>
+			<mp>1033.35</mp>
+			<cp>2162.02</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>3159.44</hp>
+			<mp>1057.5</mp>
+			<cp>2211.608</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>3230.72</hp>
+			<mp>1081.8</mp>
+			<cp>2261.504</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3302.44</hp>
+			<mp>1106.25</mp>
+			<cp>2311.708</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3374.6</hp>
+			<mp>1130.85</mp>
+			<cp>2362.22</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3447.2</hp>
+			<mp>1155.6</mp>
+			<cp>2413.04</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3520.24</hp>
+			<mp>1180.5</mp>
+			<cp>2464.168</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3593.72</hp>
+			<mp>1205.55</mp>
+			<cp>2515.604</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3667.64</hp>
+			<mp>1230.75</mp>
+			<cp>2567.348</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3742.0</hp>
+			<mp>1256.1</mp>
+			<cp>2619.4</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3816.8</hp>
+			<mp>1281.6</mp>
+			<cp>2671.76</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3892.04</hp>
+			<mp>1307.25</mp>
+			<cp>2724.428</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3967.72</hp>
+			<mp>1333.05</mp>
+			<cp>2777.404</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>4043.84</hp>
+			<mp>1359.0</mp>
+			<cp>2830.688</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>4120.4</hp>
+			<mp>1385.1</mp>
+			<cp>2884.28</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>4197.4</hp>
+			<mp>1411.35</mp>
+			<cp>2938.18</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>4274.84</hp>
+			<mp>1437.75</mp>
+			<cp>2992.388</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4352.72</hp>
+			<mp>1464.3</mp>
+			<cp>3046.904</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4431.04</hp>
+			<mp>1491.0</mp>
+			<cp>3101.728</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4509.8</hp>
+			<mp>1517.85</mp>
+			<cp>3156.86</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4589.0</hp>
+			<mp>1544.85</mp>
+			<cp>3212.3</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4668.64</hp>
+			<mp>1572.0</mp>
+			<cp>3268.048</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4748.72</hp>
+			<mp>1599.3</mp>
+			<cp>3324.104</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4829.24</hp>
+			<mp>1626.75</mp>
+			<cp>3380.468</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4910.2</hp>
+			<mp>1654.35</mp>
+			<cp>3437.14</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4991.6</hp>
+			<mp>1682.1</mp>
+			<cp>3494.12</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>5073.44</hp>
+			<mp>1710.0</mp>
+			<cp>3551.408</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>5155.72</hp>
+			<mp>1738.05</mp>
+			<cp>3609.004</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>5238.44</hp>
+			<mp>1766.25</mp>
+			<cp>3666.908</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>5321.6</hp>
+			<mp>1794.6</mp>
+			<cp>3725.12</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>5405.2</hp>
+			<mp>1823.1</mp>
+			<cp>3783.65</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5489.24</hp>
+			<mp>1851.75</mp>
+			<cp>3842.48</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5573.72</hp>
+			<mp>1880.55</mp>
+			<cp>3901.62</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5658.64</hp>
+			<mp>1909.5</mp>
+			<cp>3961.08</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5744</hp>
+			<mp>1938.6</mp>
+			<cp>4020.84</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5829.8</hp>
+			<mp>1967.85</mp>
+			<cp>4080.92</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5916.04</hp>
+			<mp>1997.25</mp>
+			<cp>4141.228</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/GhostHunter.xml
+++ b/data/stats/chars/baseStats/GhostHunter.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>108</classId>
-    <staticData>
-        <baseINT>25</baseINT>
-        <baseSTR>41</baseSTR>
-        <baseCON>32</baseCON>
-        <baseMEN>26</baseMEN>
-        <baseDEX>34</baseDEX>
-        <baseWIT>12</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>15</magicAbnormalResist>
-        <creationPoints>
-            <node x="28295" y="11063" z="-4224"/>
-            <node x="28302" y="11008" z="-4224"/>
-            <node x="28377" y="10916" z="-4224"/>
-            <node x="28456" y="10997" z="-4224"/>
-            <node x="28461" y="11044" z="-4224"/>
-            <node x="28395" y="11127" z="-4224"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>85</walk>
-            <run>139</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>150</baseBreath>
-        <baseSafeFall>350</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>24</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.0</radius>
-            <height>23.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>94.0</hp>
-            <mp>30.0</mp>
-            <cp>51.7</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>107.65</hp>
-            <mp>35.46</mp>
-            <cp>59.2075</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>121.45</hp>
-            <mp>40.98</mp>
-            <cp>66.7975</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>135.4</hp>
-            <mp>46.56</mp>
-            <cp>74.47</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>149.5</hp>
-            <mp>52.2</mp>
-            <cp>82.225</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>163.75</hp>
-            <mp>57.9</mp>
-            <cp>90.0625</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>178.15</hp>
-            <mp>63.66</mp>
-            <cp>97.9825</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>192.7</hp>
-            <mp>69.48</mp>
-            <cp>105.985</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>207.4</hp>
-            <mp>75.36</mp>
-            <cp>114.07</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>222.25</hp>
-            <mp>81.3</mp>
-            <cp>122.2375</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>237.25</hp>
-            <mp>87.3</mp>
-            <cp>130.4875</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>252.4</hp>
-            <mp>93.36</mp>
-            <cp>138.82</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>267.7</hp>
-            <mp>99.48</mp>
-            <cp>147.235</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>283.15</hp>
-            <mp>105.66</mp>
-            <cp>155.7325</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>298.75</hp>
-            <mp>111.9</mp>
-            <cp>164.3125</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>314.5</hp>
-            <mp>118.2</mp>
-            <cp>172.975</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>330.4</hp>
-            <mp>124.56</mp>
-            <cp>181.72</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>346.45</hp>
-            <mp>130.98</mp>
-            <cp>190.5475</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>362.65</hp>
-            <mp>137.46</mp>
-            <cp>199.4575</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>379.0</hp>
-            <mp>144.0</mp>
-            <cp>208.45</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>412.0</hp>
-            <mp>153.9</mp>
-            <cp>226.6</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>445.3</hp>
-            <mp>163.89</mp>
-            <cp>244.915</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>478.9</hp>
-            <mp>173.97</mp>
-            <cp>263.395</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>512.8</hp>
-            <mp>184.14</mp>
-            <cp>282.04</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>547.0</hp>
-            <mp>194.4</mp>
-            <cp>300.85</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>581.5</hp>
-            <mp>204.75</mp>
-            <cp>319.825</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>616.3</hp>
-            <mp>215.19</mp>
-            <cp>338.965</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>651.4</hp>
-            <mp>225.72</mp>
-            <cp>358.27</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>686.8</hp>
-            <mp>236.34</mp>
-            <cp>377.74</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>722.5</hp>
-            <mp>247.05</mp>
-            <cp>397.375</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>758.5</hp>
-            <mp>257.85</mp>
-            <cp>417.175</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>794.8</hp>
-            <mp>268.74</mp>
-            <cp>437.14</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>831.4</hp>
-            <mp>279.72</mp>
-            <cp>457.27</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>868.3</hp>
-            <mp>290.79</mp>
-            <cp>477.565</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>905.5</hp>
-            <mp>301.95</mp>
-            <cp>498.025</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>943.0</hp>
-            <mp>313.2</mp>
-            <cp>518.65</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>980.8</hp>
-            <mp>324.54</mp>
-            <cp>539.44</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1018.9</hp>
-            <mp>335.97</mp>
-            <cp>560.395</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1057.3</hp>
-            <mp>347.49</mp>
-            <cp>581.515</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1096.0</hp>
-            <mp>359.1</mp>
-            <cp>602.8</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1145.4</hp>
-            <mp>378.6</mp>
-            <cp>629.97</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1195.18</hp>
-            <mp>398.25</mp>
-            <cp>657.349</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1245.34</hp>
-            <mp>418.05</mp>
-            <cp>684.937</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1295.88</hp>
-            <mp>438.0</mp>
-            <cp>712.734</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1346.8</hp>
-            <mp>458.1</mp>
-            <cp>740.74</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1398.1</hp>
-            <mp>478.35</mp>
-            <cp>768.955</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1449.78</hp>
-            <mp>498.75</mp>
-            <cp>797.379</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1501.84</hp>
-            <mp>519.3</mp>
-            <cp>826.012</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1554.28</hp>
-            <mp>540.0</mp>
-            <cp>854.854</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1607.1</hp>
-            <mp>560.85</mp>
-            <cp>883.905</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1660.3</hp>
-            <mp>581.85</mp>
-            <cp>913.165</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1713.88</hp>
-            <mp>603.0</mp>
-            <cp>942.634</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1767.84</hp>
-            <mp>624.3</mp>
-            <cp>972.312</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1822.18</hp>
-            <mp>645.75</mp>
-            <cp>1002.199</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1876.9</hp>
-            <mp>667.35</mp>
-            <cp>1032.295</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1932.0</hp>
-            <mp>689.1</mp>
-            <cp>1062.6</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1987.48</hp>
-            <mp>711.0</mp>
-            <cp>1093.114</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2043.34</hp>
-            <mp>733.05</mp>
-            <cp>1123.837</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2099.58</hp>
-            <mp>755.25</mp>
-            <cp>1154.769</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2156.2</hp>
-            <mp>777.6</mp>
-            <cp>1185.91</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2213.2</hp>
-            <mp>800.1</mp>
-            <cp>1217.26</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2270.58</hp>
-            <mp>822.75</mp>
-            <cp>1248.819</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2328.34</hp>
-            <mp>845.55</mp>
-            <cp>1280.587</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2386.48</hp>
-            <mp>868.5</mp>
-            <cp>1312.564</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2445.0</hp>
-            <mp>891.6</mp>
-            <cp>1344.75</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2503.9</hp>
-            <mp>914.85</mp>
-            <cp>1377.145</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2563.18</hp>
-            <mp>938.25</mp>
-            <cp>1409.749</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2622.84</hp>
-            <mp>961.8</mp>
-            <cp>1442.562</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2682.88</hp>
-            <mp>985.5</mp>
-            <cp>1475.584</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2743.3</hp>
-            <mp>1009.35</mp>
-            <cp>1508.815</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2804.1</hp>
-            <mp>1033.35</mp>
-            <cp>1542.255</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2865.28</hp>
-            <mp>1057.5</mp>
-            <cp>1575.904</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2926.84</hp>
-            <mp>1081.8</mp>
-            <cp>1609.762</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2988.78</hp>
-            <mp>1106.25</mp>
-            <cp>1643.829</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3051.1</hp>
-            <mp>1130.85</mp>
-            <cp>1678.105</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3113.8</hp>
-            <mp>1155.6</mp>
-            <cp>1712.59</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3176.88</hp>
-            <mp>1180.5</mp>
-            <cp>1747.284</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3240.34</hp>
-            <mp>1205.55</mp>
-            <cp>1782.187</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3304.18</hp>
-            <mp>1230.75</mp>
-            <cp>1817.299</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3368.4</hp>
-            <mp>1256.1</mp>
-            <cp>1852.62</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3433.0</hp>
-            <mp>1281.6</mp>
-            <cp>1888.15</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3497.98</hp>
-            <mp>1307.25</mp>
-            <cp>1923.889</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3563.34</hp>
-            <mp>1333.05</mp>
-            <cp>1959.837</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3629.08</hp>
-            <mp>1359.0</mp>
-            <cp>1995.994</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3695.2</hp>
-            <mp>1385.1</mp>
-            <cp>2032.36</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3761.7</hp>
-            <mp>1411.35</mp>
-            <cp>2068.935</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3828.58</hp>
-            <mp>1437.75</mp>
-            <cp>2105.719</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3895.84</hp>
-            <mp>1464.3</mp>
-            <cp>2142.712</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3963.48</hp>
-            <mp>1491.0</mp>
-            <cp>2179.914</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4031.5</hp>
-            <mp>1517.85</mp>
-            <cp>2217.325</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4099.9</hp>
-            <mp>1544.85</mp>
-            <cp>2254.945</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>108</classId>
+	<staticData>
+		<baseINT>25</baseINT>
+		<baseSTR>41</baseSTR>
+		<baseCON>32</baseCON>
+		<baseMEN>26</baseMEN>
+		<baseDEX>34</baseDEX>
+		<baseWIT>12</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="28295" y="11063" z="-4224" />
+			<node x="28302" y="11008" z="-4224" />
+			<node x="28377" y="10916" z="-4224" />
+			<node x="28456" y="10997" z="-4224" />
+			<node x="28461" y="11044" z="-4224" />
+			<node x="28395" y="11127" z="-4224" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>85</walk>
+			<run>139</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>350</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>94.0</hp>
+			<mp>30.0</mp>
+			<cp>51.7</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>107.65</hp>
+			<mp>35.46</mp>
+			<cp>59.2075</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>121.45</hp>
+			<mp>40.98</mp>
+			<cp>66.7975</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>135.4</hp>
+			<mp>46.56</mp>
+			<cp>74.47</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>149.5</hp>
+			<mp>52.2</mp>
+			<cp>82.225</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>163.75</hp>
+			<mp>57.9</mp>
+			<cp>90.0625</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>178.15</hp>
+			<mp>63.66</mp>
+			<cp>97.9825</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>192.7</hp>
+			<mp>69.48</mp>
+			<cp>105.985</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>207.4</hp>
+			<mp>75.36</mp>
+			<cp>114.07</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>222.25</hp>
+			<mp>81.3</mp>
+			<cp>122.2375</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>237.25</hp>
+			<mp>87.3</mp>
+			<cp>130.4875</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>252.4</hp>
+			<mp>93.36</mp>
+			<cp>138.82</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>267.7</hp>
+			<mp>99.48</mp>
+			<cp>147.235</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>283.15</hp>
+			<mp>105.66</mp>
+			<cp>155.7325</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>298.75</hp>
+			<mp>111.9</mp>
+			<cp>164.3125</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>314.5</hp>
+			<mp>118.2</mp>
+			<cp>172.975</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>330.4</hp>
+			<mp>124.56</mp>
+			<cp>181.72</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>346.45</hp>
+			<mp>130.98</mp>
+			<cp>190.5475</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>362.65</hp>
+			<mp>137.46</mp>
+			<cp>199.4575</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>379.0</hp>
+			<mp>144.0</mp>
+			<cp>208.45</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>412.0</hp>
+			<mp>153.9</mp>
+			<cp>226.6</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>445.3</hp>
+			<mp>163.89</mp>
+			<cp>244.915</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>478.9</hp>
+			<mp>173.97</mp>
+			<cp>263.395</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>512.8</hp>
+			<mp>184.14</mp>
+			<cp>282.04</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>547.0</hp>
+			<mp>194.4</mp>
+			<cp>300.85</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>581.5</hp>
+			<mp>204.75</mp>
+			<cp>319.825</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>616.3</hp>
+			<mp>215.19</mp>
+			<cp>338.965</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>651.4</hp>
+			<mp>225.72</mp>
+			<cp>358.27</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>686.8</hp>
+			<mp>236.34</mp>
+			<cp>377.74</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>722.5</hp>
+			<mp>247.05</mp>
+			<cp>397.375</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>758.5</hp>
+			<mp>257.85</mp>
+			<cp>417.175</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>794.8</hp>
+			<mp>268.74</mp>
+			<cp>437.14</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>831.4</hp>
+			<mp>279.72</mp>
+			<cp>457.27</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>868.3</hp>
+			<mp>290.79</mp>
+			<cp>477.565</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>905.5</hp>
+			<mp>301.95</mp>
+			<cp>498.025</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>943.0</hp>
+			<mp>313.2</mp>
+			<cp>518.65</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>980.8</hp>
+			<mp>324.54</mp>
+			<cp>539.44</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1018.9</hp>
+			<mp>335.97</mp>
+			<cp>560.395</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1057.3</hp>
+			<mp>347.49</mp>
+			<cp>581.515</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1096.0</hp>
+			<mp>359.1</mp>
+			<cp>602.8</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1145.4</hp>
+			<mp>378.6</mp>
+			<cp>629.97</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1195.18</hp>
+			<mp>398.25</mp>
+			<cp>657.349</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1245.34</hp>
+			<mp>418.05</mp>
+			<cp>684.937</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1295.88</hp>
+			<mp>438.0</mp>
+			<cp>712.734</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1346.8</hp>
+			<mp>458.1</mp>
+			<cp>740.74</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1398.1</hp>
+			<mp>478.35</mp>
+			<cp>768.955</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1449.78</hp>
+			<mp>498.75</mp>
+			<cp>797.379</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1501.84</hp>
+			<mp>519.3</mp>
+			<cp>826.012</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1554.28</hp>
+			<mp>540.0</mp>
+			<cp>854.854</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1607.1</hp>
+			<mp>560.85</mp>
+			<cp>883.905</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1660.3</hp>
+			<mp>581.85</mp>
+			<cp>913.165</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1713.88</hp>
+			<mp>603.0</mp>
+			<cp>942.634</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1767.84</hp>
+			<mp>624.3</mp>
+			<cp>972.312</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1822.18</hp>
+			<mp>645.75</mp>
+			<cp>1002.199</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1876.9</hp>
+			<mp>667.35</mp>
+			<cp>1032.295</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1932.0</hp>
+			<mp>689.1</mp>
+			<cp>1062.6</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1987.48</hp>
+			<mp>711.0</mp>
+			<cp>1093.114</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2043.34</hp>
+			<mp>733.05</mp>
+			<cp>1123.837</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2099.58</hp>
+			<mp>755.25</mp>
+			<cp>1154.769</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2156.2</hp>
+			<mp>777.6</mp>
+			<cp>1185.91</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2213.2</hp>
+			<mp>800.1</mp>
+			<cp>1217.26</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2270.58</hp>
+			<mp>822.75</mp>
+			<cp>1248.819</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2328.34</hp>
+			<mp>845.55</mp>
+			<cp>1280.587</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2386.48</hp>
+			<mp>868.5</mp>
+			<cp>1312.564</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2445.0</hp>
+			<mp>891.6</mp>
+			<cp>1344.75</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2503.9</hp>
+			<mp>914.85</mp>
+			<cp>1377.145</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2563.18</hp>
+			<mp>938.25</mp>
+			<cp>1409.749</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2622.84</hp>
+			<mp>961.8</mp>
+			<cp>1442.562</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2682.88</hp>
+			<mp>985.5</mp>
+			<cp>1475.584</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2743.3</hp>
+			<mp>1009.35</mp>
+			<cp>1508.815</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2804.1</hp>
+			<mp>1033.35</mp>
+			<cp>1542.255</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2865.28</hp>
+			<mp>1057.5</mp>
+			<cp>1575.904</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2926.84</hp>
+			<mp>1081.8</mp>
+			<cp>1609.762</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2988.78</hp>
+			<mp>1106.25</mp>
+			<cp>1643.829</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3051.1</hp>
+			<mp>1130.85</mp>
+			<cp>1678.105</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3113.8</hp>
+			<mp>1155.6</mp>
+			<cp>1712.59</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3176.88</hp>
+			<mp>1180.5</mp>
+			<cp>1747.284</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3240.34</hp>
+			<mp>1205.55</mp>
+			<cp>1782.187</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3304.18</hp>
+			<mp>1230.75</mp>
+			<cp>1817.299</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3368.4</hp>
+			<mp>1256.1</mp>
+			<cp>1852.62</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3433.0</hp>
+			<mp>1281.6</mp>
+			<cp>1888.15</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3497.98</hp>
+			<mp>1307.25</mp>
+			<cp>1923.889</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3563.34</hp>
+			<mp>1333.05</mp>
+			<cp>1959.837</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3629.08</hp>
+			<mp>1359.0</mp>
+			<cp>1995.994</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3695.2</hp>
+			<mp>1385.1</mp>
+			<cp>2032.36</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3761.7</hp>
+			<mp>1411.35</mp>
+			<cp>2068.935</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3828.58</hp>
+			<mp>1437.75</mp>
+			<cp>2105.719</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3895.84</hp>
+			<mp>1464.3</mp>
+			<cp>2142.712</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3963.48</hp>
+			<mp>1491.0</mp>
+			<cp>2179.914</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4031.5</hp>
+			<mp>1517.85</mp>
+			<cp>2217.325</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4099.9</hp>
+			<mp>1544.85</mp>
+			<cp>2254.945</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4168.68</hp>
+			<mp>1572.0</mp>
+			<cp>2292.774</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4237.84</hp>
+			<mp>1599.3</mp>
+			<cp>2330.812</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4307.38</hp>
+			<mp>1626.75</mp>
+			<cp>2369.059</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4377.3</hp>
+			<mp>1654.35</mp>
+			<cp>2407.515</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4447.6</hp>
+			<mp>1682.1</mp>
+			<cp>2446.18</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4518.28</hp>
+			<mp>1710.0</mp>
+			<cp>2485.054</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4589.34</hp>
+			<mp>1738.05</mp>
+			<cp>2524.137</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4660.78</hp>
+			<mp>1766.25</mp>
+			<cp>2563.429</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4732.6</hp>
+			<mp>1794.6</mp>
+			<cp>2602.93</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4804.8</hp>
+			<mp>1823.1</mp>
+			<cp>2642.64</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4877.38</hp>
+			<mp>1851.75</mp>
+			<cp>2682.57</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4950.34</hp>
+			<mp>1880.55</mp>
+			<cp>2722.7</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5023.68</hp>
+			<mp>1909.5</mp>
+			<cp>2763.04</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5097.4</hp>
+			<mp>1938.6</mp>
+			<cp>2803.59</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5171.5</hp>
+			<mp>1967.85</mp>
+			<cp>2844.35</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5245.98</hp>
+			<mp>1997.25</mp>
+			<cp>2885.289</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/GhostSentinel.xml
+++ b/data/stats/chars/baseStats/GhostSentinel.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>109</classId>
-    <staticData>
-        <baseINT>25</baseINT>
-        <baseSTR>41</baseSTR>
-        <baseCON>32</baseCON>
-        <baseMEN>26</baseMEN>
-        <baseDEX>34</baseDEX>
-        <baseWIT>12</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>15</magicAbnormalResist>
-        <creationPoints>
-            <node x="28295" y="11063" z="-4224"/>
-            <node x="28302" y="11008" z="-4224"/>
-            <node x="28377" y="10916" z="-4224"/>
-            <node x="28456" y="10997" z="-4224"/>
-            <node x="28461" y="11044" z="-4224"/>
-            <node x="28395" y="11127" z="-4224"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>85</walk>
-            <run>139</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>150</baseBreath>
-        <baseSafeFall>350</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>24</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.0</radius>
-            <height>23.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>94.0</hp>
-            <mp>30.0</mp>
-            <cp>47.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>107.65</hp>
-            <mp>35.46</mp>
-            <cp>53.825</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>121.45</hp>
-            <mp>40.98</mp>
-            <cp>60.725</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>135.4</hp>
-            <mp>46.56</mp>
-            <cp>67.7</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>149.5</hp>
-            <mp>52.2</mp>
-            <cp>74.75</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>163.75</hp>
-            <mp>57.9</mp>
-            <cp>81.875</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>178.15</hp>
-            <mp>63.66</mp>
-            <cp>89.075</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>192.7</hp>
-            <mp>69.48</mp>
-            <cp>96.35</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>207.4</hp>
-            <mp>75.36</mp>
-            <cp>103.7</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>222.25</hp>
-            <mp>81.3</mp>
-            <cp>111.125</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>237.25</hp>
-            <mp>87.3</mp>
-            <cp>118.625</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>252.4</hp>
-            <mp>93.36</mp>
-            <cp>126.2</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>267.7</hp>
-            <mp>99.48</mp>
-            <cp>133.85</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>283.15</hp>
-            <mp>105.66</mp>
-            <cp>141.575</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>298.75</hp>
-            <mp>111.9</mp>
-            <cp>149.375</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>314.5</hp>
-            <mp>118.2</mp>
-            <cp>157.25</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>330.4</hp>
-            <mp>124.56</mp>
-            <cp>165.2</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>346.45</hp>
-            <mp>130.98</mp>
-            <cp>173.225</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>362.65</hp>
-            <mp>137.46</mp>
-            <cp>181.325</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>379.0</hp>
-            <mp>144.0</mp>
-            <cp>189.5</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>412.0</hp>
-            <mp>153.9</mp>
-            <cp>206.0</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>445.3</hp>
-            <mp>163.89</mp>
-            <cp>222.65</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>478.9</hp>
-            <mp>173.97</mp>
-            <cp>239.45</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>512.8</hp>
-            <mp>184.14</mp>
-            <cp>256.4</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>547.0</hp>
-            <mp>194.4</mp>
-            <cp>273.5</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>581.5</hp>
-            <mp>204.75</mp>
-            <cp>290.75</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>616.3</hp>
-            <mp>215.19</mp>
-            <cp>308.15</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>651.4</hp>
-            <mp>225.72</mp>
-            <cp>325.7</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>686.8</hp>
-            <mp>236.34</mp>
-            <cp>343.4</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>722.5</hp>
-            <mp>247.05</mp>
-            <cp>361.25</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>758.5</hp>
-            <mp>257.85</mp>
-            <cp>379.25</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>794.8</hp>
-            <mp>268.74</mp>
-            <cp>397.4</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>831.4</hp>
-            <mp>279.72</mp>
-            <cp>415.7</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>868.3</hp>
-            <mp>290.79</mp>
-            <cp>434.15</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>905.5</hp>
-            <mp>301.95</mp>
-            <cp>452.75</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>943.0</hp>
-            <mp>313.2</mp>
-            <cp>471.5</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>980.8</hp>
-            <mp>324.54</mp>
-            <cp>490.4</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1018.9</hp>
-            <mp>335.97</mp>
-            <cp>509.45</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1057.3</hp>
-            <mp>347.49</mp>
-            <cp>528.65</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1096.0</hp>
-            <mp>359.1</mp>
-            <cp>548.0</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1148.0</hp>
-            <mp>378.6</mp>
-            <cp>574.0</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1200.4</hp>
-            <mp>398.25</mp>
-            <cp>600.2</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1253.2</hp>
-            <mp>418.05</mp>
-            <cp>626.6</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1306.4</hp>
-            <mp>438.0</mp>
-            <cp>653.2</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1360.0</hp>
-            <mp>458.1</mp>
-            <cp>680.0</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1414.0</hp>
-            <mp>478.35</mp>
-            <cp>707.0</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1468.4</hp>
-            <mp>498.75</mp>
-            <cp>734.2</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1523.2</hp>
-            <mp>519.3</mp>
-            <cp>761.6</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1578.4</hp>
-            <mp>540.0</mp>
-            <cp>789.2</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1634.0</hp>
-            <mp>560.85</mp>
-            <cp>817.0</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1690.0</hp>
-            <mp>581.85</mp>
-            <cp>845.0</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1746.4</hp>
-            <mp>603.0</mp>
-            <cp>873.2</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1803.2</hp>
-            <mp>624.3</mp>
-            <cp>901.6</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1860.4</hp>
-            <mp>645.75</mp>
-            <cp>930.2</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1918.0</hp>
-            <mp>667.35</mp>
-            <cp>959.0</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1976.0</hp>
-            <mp>689.1</mp>
-            <cp>988.0</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>2034.4</hp>
-            <mp>711.0</mp>
-            <cp>1017.2</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2093.2</hp>
-            <mp>733.05</mp>
-            <cp>1046.6</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2152.4</hp>
-            <mp>755.25</mp>
-            <cp>1076.2</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2212.0</hp>
-            <mp>777.6</mp>
-            <cp>1106.0</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2272.0</hp>
-            <mp>800.1</mp>
-            <cp>1136.0</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2332.4</hp>
-            <mp>822.75</mp>
-            <cp>1166.2</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2393.2</hp>
-            <mp>845.55</mp>
-            <cp>1196.6</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2454.4</hp>
-            <mp>868.5</mp>
-            <cp>1227.2</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2516.0</hp>
-            <mp>891.6</mp>
-            <cp>1258.0</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2578.0</hp>
-            <mp>914.85</mp>
-            <cp>1289.0</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2640.4</hp>
-            <mp>938.25</mp>
-            <cp>1320.2</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2703.2</hp>
-            <mp>961.8</mp>
-            <cp>1351.6</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2766.4</hp>
-            <mp>985.5</mp>
-            <cp>1383.2</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2830.0</hp>
-            <mp>1009.35</mp>
-            <cp>1415.0</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2894.0</hp>
-            <mp>1033.35</mp>
-            <cp>1447.0</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2958.4</hp>
-            <mp>1057.5</mp>
-            <cp>1479.2</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>3023.2</hp>
-            <mp>1081.8</mp>
-            <cp>1511.6</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>3088.4</hp>
-            <mp>1106.25</mp>
-            <cp>1544.2</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3154.0</hp>
-            <mp>1130.85</mp>
-            <cp>1577.0</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3220.0</hp>
-            <mp>1155.6</mp>
-            <cp>1610.0</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3286.4</hp>
-            <mp>1180.5</mp>
-            <cp>1643.2</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3353.2</hp>
-            <mp>1205.55</mp>
-            <cp>1676.6</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3420.4</hp>
-            <mp>1230.75</mp>
-            <cp>1710.2</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3488.0</hp>
-            <mp>1256.1</mp>
-            <cp>1744.0</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3556.0</hp>
-            <mp>1281.6</mp>
-            <cp>1778.0</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3624.4</hp>
-            <mp>1307.25</mp>
-            <cp>1812.2</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3693.2</hp>
-            <mp>1333.05</mp>
-            <cp>1846.6</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3762.4</hp>
-            <mp>1359.0</mp>
-            <cp>1881.2</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3832.0</hp>
-            <mp>1385.1</mp>
-            <cp>1916.0</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3902.0</hp>
-            <mp>1411.35</mp>
-            <cp>1951.0</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3972.4</hp>
-            <mp>1437.75</mp>
-            <cp>1986.2</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>4043.2</hp>
-            <mp>1464.3</mp>
-            <cp>2021.6</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>4114.4</hp>
-            <mp>1491.0</mp>
-            <cp>2057.2</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4186.0</hp>
-            <mp>1517.85</mp>
-            <cp>2093.0</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4258.0</hp>
-            <mp>1544.85</mp>
-            <cp>2129.0</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>109</classId>
+	<staticData>
+		<baseINT>25</baseINT>
+		<baseSTR>41</baseSTR>
+		<baseCON>32</baseCON>
+		<baseMEN>26</baseMEN>
+		<baseDEX>34</baseDEX>
+		<baseWIT>12</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="28295" y="11063" z="-4224" />
+			<node x="28302" y="11008" z="-4224" />
+			<node x="28377" y="10916" z="-4224" />
+			<node x="28456" y="10997" z="-4224" />
+			<node x="28461" y="11044" z="-4224" />
+			<node x="28395" y="11127" z="-4224" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>85</walk>
+			<run>139</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>350</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>94.0</hp>
+			<mp>30.0</mp>
+			<cp>47.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>107.65</hp>
+			<mp>35.46</mp>
+			<cp>53.825</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>121.45</hp>
+			<mp>40.98</mp>
+			<cp>60.725</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>135.4</hp>
+			<mp>46.56</mp>
+			<cp>67.7</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>149.5</hp>
+			<mp>52.2</mp>
+			<cp>74.75</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>163.75</hp>
+			<mp>57.9</mp>
+			<cp>81.875</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>178.15</hp>
+			<mp>63.66</mp>
+			<cp>89.075</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>192.7</hp>
+			<mp>69.48</mp>
+			<cp>96.35</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>207.4</hp>
+			<mp>75.36</mp>
+			<cp>103.7</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>222.25</hp>
+			<mp>81.3</mp>
+			<cp>111.125</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>237.25</hp>
+			<mp>87.3</mp>
+			<cp>118.625</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>252.4</hp>
+			<mp>93.36</mp>
+			<cp>126.2</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>267.7</hp>
+			<mp>99.48</mp>
+			<cp>133.85</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>283.15</hp>
+			<mp>105.66</mp>
+			<cp>141.575</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>298.75</hp>
+			<mp>111.9</mp>
+			<cp>149.375</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>314.5</hp>
+			<mp>118.2</mp>
+			<cp>157.25</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>330.4</hp>
+			<mp>124.56</mp>
+			<cp>165.2</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>346.45</hp>
+			<mp>130.98</mp>
+			<cp>173.225</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>362.65</hp>
+			<mp>137.46</mp>
+			<cp>181.325</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>379.0</hp>
+			<mp>144.0</mp>
+			<cp>189.5</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>412.0</hp>
+			<mp>153.9</mp>
+			<cp>206.0</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>445.3</hp>
+			<mp>163.89</mp>
+			<cp>222.65</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>478.9</hp>
+			<mp>173.97</mp>
+			<cp>239.45</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>512.8</hp>
+			<mp>184.14</mp>
+			<cp>256.4</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>547.0</hp>
+			<mp>194.4</mp>
+			<cp>273.5</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>581.5</hp>
+			<mp>204.75</mp>
+			<cp>290.75</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>616.3</hp>
+			<mp>215.19</mp>
+			<cp>308.15</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>651.4</hp>
+			<mp>225.72</mp>
+			<cp>325.7</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>686.8</hp>
+			<mp>236.34</mp>
+			<cp>343.4</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>722.5</hp>
+			<mp>247.05</mp>
+			<cp>361.25</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>758.5</hp>
+			<mp>257.85</mp>
+			<cp>379.25</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>794.8</hp>
+			<mp>268.74</mp>
+			<cp>397.4</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>831.4</hp>
+			<mp>279.72</mp>
+			<cp>415.7</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>868.3</hp>
+			<mp>290.79</mp>
+			<cp>434.15</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>905.5</hp>
+			<mp>301.95</mp>
+			<cp>452.75</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>943.0</hp>
+			<mp>313.2</mp>
+			<cp>471.5</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>980.8</hp>
+			<mp>324.54</mp>
+			<cp>490.4</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1018.9</hp>
+			<mp>335.97</mp>
+			<cp>509.45</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1057.3</hp>
+			<mp>347.49</mp>
+			<cp>528.65</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1096.0</hp>
+			<mp>359.1</mp>
+			<cp>548.0</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1148.0</hp>
+			<mp>378.6</mp>
+			<cp>574.0</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1200.4</hp>
+			<mp>398.25</mp>
+			<cp>600.2</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1253.2</hp>
+			<mp>418.05</mp>
+			<cp>626.6</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1306.4</hp>
+			<mp>438.0</mp>
+			<cp>653.2</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1360.0</hp>
+			<mp>458.1</mp>
+			<cp>680.0</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1414.0</hp>
+			<mp>478.35</mp>
+			<cp>707.0</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1468.4</hp>
+			<mp>498.75</mp>
+			<cp>734.2</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1523.2</hp>
+			<mp>519.3</mp>
+			<cp>761.6</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1578.4</hp>
+			<mp>540.0</mp>
+			<cp>789.2</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1634.0</hp>
+			<mp>560.85</mp>
+			<cp>817.0</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1690.0</hp>
+			<mp>581.85</mp>
+			<cp>845.0</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1746.4</hp>
+			<mp>603.0</mp>
+			<cp>873.2</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1803.2</hp>
+			<mp>624.3</mp>
+			<cp>901.6</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1860.4</hp>
+			<mp>645.75</mp>
+			<cp>930.2</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1918.0</hp>
+			<mp>667.35</mp>
+			<cp>959.0</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1976.0</hp>
+			<mp>689.1</mp>
+			<cp>988.0</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2034.4</hp>
+			<mp>711.0</mp>
+			<cp>1017.2</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2093.2</hp>
+			<mp>733.05</mp>
+			<cp>1046.6</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2152.4</hp>
+			<mp>755.25</mp>
+			<cp>1076.2</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2212.0</hp>
+			<mp>777.6</mp>
+			<cp>1106.0</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2272.0</hp>
+			<mp>800.1</mp>
+			<cp>1136.0</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2332.4</hp>
+			<mp>822.75</mp>
+			<cp>1166.2</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2393.2</hp>
+			<mp>845.55</mp>
+			<cp>1196.6</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2454.4</hp>
+			<mp>868.5</mp>
+			<cp>1227.2</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2516.0</hp>
+			<mp>891.6</mp>
+			<cp>1258.0</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2578.0</hp>
+			<mp>914.85</mp>
+			<cp>1289.0</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2640.4</hp>
+			<mp>938.25</mp>
+			<cp>1320.2</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2703.2</hp>
+			<mp>961.8</mp>
+			<cp>1351.6</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2766.4</hp>
+			<mp>985.5</mp>
+			<cp>1383.2</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2830.0</hp>
+			<mp>1009.35</mp>
+			<cp>1415.0</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2894.0</hp>
+			<mp>1033.35</mp>
+			<cp>1447.0</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2958.4</hp>
+			<mp>1057.5</mp>
+			<cp>1479.2</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>3023.2</hp>
+			<mp>1081.8</mp>
+			<cp>1511.6</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3088.4</hp>
+			<mp>1106.25</mp>
+			<cp>1544.2</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3154.0</hp>
+			<mp>1130.85</mp>
+			<cp>1577.0</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3220.0</hp>
+			<mp>1155.6</mp>
+			<cp>1610.0</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3286.4</hp>
+			<mp>1180.5</mp>
+			<cp>1643.2</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3353.2</hp>
+			<mp>1205.55</mp>
+			<cp>1676.6</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3420.4</hp>
+			<mp>1230.75</mp>
+			<cp>1710.2</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3488.0</hp>
+			<mp>1256.1</mp>
+			<cp>1744.0</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3556.0</hp>
+			<mp>1281.6</mp>
+			<cp>1778.0</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3624.4</hp>
+			<mp>1307.25</mp>
+			<cp>1812.2</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3693.2</hp>
+			<mp>1333.05</mp>
+			<cp>1846.6</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3762.4</hp>
+			<mp>1359.0</mp>
+			<cp>1881.2</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3832.0</hp>
+			<mp>1385.1</mp>
+			<cp>1916.0</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3902.0</hp>
+			<mp>1411.35</mp>
+			<cp>1951.0</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3972.4</hp>
+			<mp>1437.75</mp>
+			<cp>1986.2</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4043.2</hp>
+			<mp>1464.3</mp>
+			<cp>2021.6</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4114.4</hp>
+			<mp>1491.0</mp>
+			<cp>2057.2</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4186.0</hp>
+			<mp>1517.85</mp>
+			<cp>2093.0</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4258.0</hp>
+			<mp>1544.85</mp>
+			<cp>2129.0</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4330.4</hp>
+			<mp>1572.0</mp>
+			<cp>2165.2</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4403.2</hp>
+			<mp>1599.3</mp>
+			<cp>2201.6</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4476.4</hp>
+			<mp>1626.75</mp>
+			<cp>2238.2</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4550.0</hp>
+			<mp>1654.35</mp>
+			<cp>2275.0</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4624.0</hp>
+			<mp>1682.1</mp>
+			<cp>2312.0</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4698.4</hp>
+			<mp>1710.0</mp>
+			<cp>2349.2</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4773.2</hp>
+			<mp>1738.05</mp>
+			<cp>2386.6</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4848.4</hp>
+			<mp>1766.25</mp>
+			<cp>2424.2</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4924</hp>
+			<mp>1794.6</mp>
+			<cp>2462</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>5000</hp>
+			<mp>1823.1</mp>
+			<cp>2500</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5076.4</hp>
+			<mp>1851.75</mp>
+			<cp>2538.2</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5153.2</hp>
+			<mp>1880.55</mp>
+			<cp>2576.6</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5230.4</hp>
+			<mp>1909.5</mp>
+			<cp>2615.2</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5308</hp>
+			<mp>1938.6</mp>
+			<cp>2654</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5386</hp>
+			<mp>1967.85</mp>
+			<cp>2693</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5464.4</hp>
+			<mp>1997.25</mp>
+			<cp>2732.2</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Gladiator.xml
+++ b/data/stats/chars/baseStats/Gladiator.xml
@@ -1,798 +1,926 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>2</classId>
-    <staticData>
-        <baseINT>21</baseINT>
-        <baseSTR>40</baseSTR>
-        <baseCON>43</baseCON>
-        <baseMEN>25</baseMEN>
-        <baseDEX>30</baseDEX>
-        <baseWIT>11</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-71338" y="258271" z="-3104"/>
-            <node x="-71417" y="258270" z="-3104"/>
-            <node x="-71453" y="258305" z="-3104"/>
-            <node x="-71467" y="258378" z="-3104"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>80</walk>
-            <run>132</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>100</baseBreath>
-        <baseSafeFall>250</baseSafeFall>
-        <collisionMale>
-            <radius>9.0</radius>
-            <height>23</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>8.0</radius>
-            <height>23.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>80.0</hp>
-            <mp>30.0</mp>
-            <cp>72.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>91.83</hp>
-            <mp>35.46</mp>
-            <cp>82.647</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>103.79</hp>
-            <mp>40.98</mp>
-            <cp>93.411</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>115.88</hp>
-            <mp>46.56</mp>
-            <cp>104.292</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>128.1</hp>
-            <mp>52.2</mp>
-            <cp>115.29</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>140.45</hp>
-            <mp>57.9</mp>
-            <cp>126.405</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>152.93</hp>
-            <mp>63.66</mp>
-            <cp>137.637</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>165.54</hp>
-            <mp>69.48</mp>
-            <cp>148.986</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>178.28</hp>
-            <mp>75.36</mp>
-            <cp>160.452</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>191.15</hp>
-            <mp>81.3</mp>
-            <cp>172.035</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>204.15</hp>
-            <mp>87.3</mp>
-            <cp>183.735</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>217.28</hp>
-            <mp>93.36</mp>
-            <cp>195.552</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>230.54</hp>
-            <mp>99.48</mp>
-            <cp>207.486</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>243.93</hp>
-            <mp>105.66</mp>
-            <cp>219.537</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>257.45</hp>
-            <mp>111.9</mp>
-            <cp>231.705</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>271.1</hp>
-            <mp>118.2</mp>
-            <cp>243.99</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>284.88</hp>
-            <mp>124.56</mp>
-            <cp>256.392</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>298.79</hp>
-            <mp>130.98</mp>
-            <cp>268.911</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>312.83</hp>
-            <mp>137.46</mp>
-            <cp>281.547</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>327.0</hp>
-            <mp>144.0</mp>
-            <cp>294.3</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>360.0</hp>
-            <mp>153.9</mp>
-            <cp>324.0</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>393.3</hp>
-            <mp>163.89</mp>
-            <cp>353.97</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>426.9</hp>
-            <mp>173.97</mp>
-            <cp>384.21</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>460.8</hp>
-            <mp>184.14</mp>
-            <cp>414.72</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>495.0</hp>
-            <mp>194.4</mp>
-            <cp>445.5</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>529.5</hp>
-            <mp>204.75</mp>
-            <cp>476.55</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>564.3</hp>
-            <mp>215.19</mp>
-            <cp>507.87</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>599.4</hp>
-            <mp>225.72</mp>
-            <cp>539.46</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>634.8</hp>
-            <mp>236.34</mp>
-            <cp>571.32</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>670.5</hp>
-            <mp>247.05</mp>
-            <cp>603.45</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>706.5</hp>
-            <mp>257.85</mp>
-            <cp>635.85</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>742.8</hp>
-            <mp>268.74</mp>
-            <cp>668.52</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>779.4</hp>
-            <mp>279.72</mp>
-            <cp>701.46</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>816.3</hp>
-            <mp>290.79</mp>
-            <cp>734.67</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>853.5</hp>
-            <mp>301.95</mp>
-            <cp>768.15</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>891.0</hp>
-            <mp>313.2</mp>
-            <cp>801.9</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>928.8</hp>
-            <mp>324.54</mp>
-            <cp>835.92</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>966.9</hp>
-            <mp>335.97</mp>
-            <cp>870.21</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1005.3</hp>
-            <mp>347.49</mp>
-            <cp>904.77</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1044.0</hp>
-            <mp>359.1</mp>
-            <cp>939.6</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1093.4</hp>
-            <mp>378.6</mp>
-            <cp>984.06</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1143.18</hp>
-            <mp>398.25</mp>
-            <cp>1028.862</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1193.34</hp>
-            <mp>418.05</mp>
-            <cp>1074.006</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1243.88</hp>
-            <mp>438.0</mp>
-            <cp>1119.492</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1294.8</hp>
-            <mp>458.1</mp>
-            <cp>1165.32</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1346.1</hp>
-            <mp>478.35</mp>
-            <cp>1211.49</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1397.78</hp>
-            <mp>498.75</mp>
-            <cp>1258.002</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1449.84</hp>
-            <mp>519.3</mp>
-            <cp>1304.856</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1502.28</hp>
-            <mp>540.0</mp>
-            <cp>1352.052</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1555.1</hp>
-            <mp>560.85</mp>
-            <cp>1399.59</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1608.3</hp>
-            <mp>581.85</mp>
-            <cp>1447.47</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1661.88</hp>
-            <mp>603.0</mp>
-            <cp>1495.692</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1715.84</hp>
-            <mp>624.3</mp>
-            <cp>1544.256</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1770.18</hp>
-            <mp>645.75</mp>
-            <cp>1593.162</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1824.9</hp>
-            <mp>667.35</mp>
-            <cp>1642.41</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1880.0</hp>
-            <mp>689.1</mp>
-            <cp>1692.0</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1935.48</hp>
-            <mp>711.0</mp>
-            <cp>1741.932</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1991.34</hp>
-            <mp>733.05</mp>
-            <cp>1792.206</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2047.58</hp>
-            <mp>755.25</mp>
-            <cp>1842.822</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2104.2</hp>
-            <mp>777.6</mp>
-            <cp>1893.78</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2161.2</hp>
-            <mp>800.1</mp>
-            <cp>1945.08</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2218.58</hp>
-            <mp>822.75</mp>
-            <cp>1996.722</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2276.34</hp>
-            <mp>845.55</mp>
-            <cp>2048.706</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2334.48</hp>
-            <mp>868.5</mp>
-            <cp>2101.032</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2393.0</hp>
-            <mp>891.6</mp>
-            <cp>2153.7</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2451.9</hp>
-            <mp>914.85</mp>
-            <cp>2206.71</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2511.18</hp>
-            <mp>938.25</mp>
-            <cp>2260.062</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2570.84</hp>
-            <mp>961.8</mp>
-            <cp>2313.756</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2630.88</hp>
-            <mp>985.5</mp>
-            <cp>2367.792</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2691.3</hp>
-            <mp>1009.35</mp>
-            <cp>2422.17</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2752.1</hp>
-            <mp>1033.35</mp>
-            <cp>2476.89</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2813.28</hp>
-            <mp>1057.5</mp>
-            <cp>2531.952</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2874.84</hp>
-            <mp>1081.8</mp>
-            <cp>2587.356</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2936.78</hp>
-            <mp>1106.25</mp>
-            <cp>2643.102</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2999.1</hp>
-            <mp>1130.85</mp>
-            <cp>2699.19</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3061.8</hp>
-            <mp>1155.6</mp>
-            <cp>2755.62</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3124.88</hp>
-            <mp>1180.5</mp>
-            <cp>2812.392</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3188.34</hp>
-            <mp>1205.55</mp>
-            <cp>2869.506</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3252.18</hp>
-            <mp>1230.75</mp>
-            <cp>2926.962</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3316.4</hp>
-            <mp>1256.1</mp>
-            <cp>2984.76</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3381.0</hp>
-            <mp>1281.6</mp>
-            <cp>3042.9</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3445.98</hp>
-            <mp>1307.25</mp>
-            <cp>3101.382</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3511.34</hp>
-            <mp>1333.05</mp>
-            <cp>3160.206</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3577.08</hp>
-            <mp>1359.0</mp>
-            <cp>3219.372</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3643.2</hp>
-            <mp>1385.1</mp>
-            <cp>3278.88</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3709.67</hp>
-            <mp>1411.35</mp>
-            <cp>3338.73</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3776.58</hp>
-            <mp>1437.75</mp>
-            <cp>3398.922</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3843.84</hp>
-            <mp>1464.3</mp>
-            <cp>3459.456</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3911.48</hp>
-            <mp>1491</mp>
-            <cp>3520.332</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3979.5</hp>
-            <mp>1517.85</mp>
-            <cp>3581.55</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4047.9</hp>
-            <mp>1544.85</mp>
-            <cp>3643.11</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>2</classId>
+	<staticData>
+		<baseINT>21</baseINT>
+		<baseSTR>40</baseSTR>
+		<baseCON>43</baseCON>
+		<baseMEN>25</baseMEN>
+		<baseDEX>30</baseDEX>
+		<baseWIT>11</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-71338" y="258271" z="-3104" />
+			<node x="-71417" y="258270" z="-3104" />
+			<node x="-71453" y="258305" z="-3104" />
+			<node x="-71467" y="258378" z="-3104" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>80</walk>
+			<run>132</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>250</baseSafeFall>
+		<collisionMale>
+			<radius>9.0</radius>
+			<height>23</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>8.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>80.0</hp>
+			<mp>30.0</mp>
+			<cp>72.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>91.83</hp>
+			<mp>35.46</mp>
+			<cp>82.647</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>103.79</hp>
+			<mp>40.98</mp>
+			<cp>93.411</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>115.88</hp>
+			<mp>46.56</mp>
+			<cp>104.292</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>128.1</hp>
+			<mp>52.2</mp>
+			<cp>115.29</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>140.45</hp>
+			<mp>57.9</mp>
+			<cp>126.405</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>152.93</hp>
+			<mp>63.66</mp>
+			<cp>137.637</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>165.54</hp>
+			<mp>69.48</mp>
+			<cp>148.986</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>178.28</hp>
+			<mp>75.36</mp>
+			<cp>160.452</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>191.15</hp>
+			<mp>81.3</mp>
+			<cp>172.035</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>204.15</hp>
+			<mp>87.3</mp>
+			<cp>183.735</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>217.28</hp>
+			<mp>93.36</mp>
+			<cp>195.552</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>230.54</hp>
+			<mp>99.48</mp>
+			<cp>207.486</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>243.93</hp>
+			<mp>105.66</mp>
+			<cp>219.537</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>257.45</hp>
+			<mp>111.9</mp>
+			<cp>231.705</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>271.1</hp>
+			<mp>118.2</mp>
+			<cp>243.99</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>284.88</hp>
+			<mp>124.56</mp>
+			<cp>256.392</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>298.79</hp>
+			<mp>130.98</mp>
+			<cp>268.911</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>312.83</hp>
+			<mp>137.46</mp>
+			<cp>281.547</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>327.0</hp>
+			<mp>144.0</mp>
+			<cp>294.3</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>360.0</hp>
+			<mp>153.9</mp>
+			<cp>324.0</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>393.3</hp>
+			<mp>163.89</mp>
+			<cp>353.97</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>426.9</hp>
+			<mp>173.97</mp>
+			<cp>384.21</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>460.8</hp>
+			<mp>184.14</mp>
+			<cp>414.72</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>495.0</hp>
+			<mp>194.4</mp>
+			<cp>445.5</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>529.5</hp>
+			<mp>204.75</mp>
+			<cp>476.55</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>564.3</hp>
+			<mp>215.19</mp>
+			<cp>507.87</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>599.4</hp>
+			<mp>225.72</mp>
+			<cp>539.46</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>634.8</hp>
+			<mp>236.34</mp>
+			<cp>571.32</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>670.5</hp>
+			<mp>247.05</mp>
+			<cp>603.45</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>706.5</hp>
+			<mp>257.85</mp>
+			<cp>635.85</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>742.8</hp>
+			<mp>268.74</mp>
+			<cp>668.52</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>779.4</hp>
+			<mp>279.72</mp>
+			<cp>701.46</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>816.3</hp>
+			<mp>290.79</mp>
+			<cp>734.67</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>853.5</hp>
+			<mp>301.95</mp>
+			<cp>768.15</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>891.0</hp>
+			<mp>313.2</mp>
+			<cp>801.9</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>928.8</hp>
+			<mp>324.54</mp>
+			<cp>835.92</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>966.9</hp>
+			<mp>335.97</mp>
+			<cp>870.21</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1005.3</hp>
+			<mp>347.49</mp>
+			<cp>904.77</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1044.0</hp>
+			<mp>359.1</mp>
+			<cp>939.6</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1093.4</hp>
+			<mp>378.6</mp>
+			<cp>984.06</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1143.18</hp>
+			<mp>398.25</mp>
+			<cp>1028.862</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1193.34</hp>
+			<mp>418.05</mp>
+			<cp>1074.006</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1243.88</hp>
+			<mp>438.0</mp>
+			<cp>1119.492</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1294.8</hp>
+			<mp>458.1</mp>
+			<cp>1165.32</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1346.1</hp>
+			<mp>478.35</mp>
+			<cp>1211.49</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1397.78</hp>
+			<mp>498.75</mp>
+			<cp>1258.002</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1449.84</hp>
+			<mp>519.3</mp>
+			<cp>1304.856</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1502.28</hp>
+			<mp>540.0</mp>
+			<cp>1352.052</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1555.1</hp>
+			<mp>560.85</mp>
+			<cp>1399.59</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1608.3</hp>
+			<mp>581.85</mp>
+			<cp>1447.47</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1661.88</hp>
+			<mp>603.0</mp>
+			<cp>1495.692</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1715.84</hp>
+			<mp>624.3</mp>
+			<cp>1544.256</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1770.18</hp>
+			<mp>645.75</mp>
+			<cp>1593.162</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1824.9</hp>
+			<mp>667.35</mp>
+			<cp>1642.41</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1880.0</hp>
+			<mp>689.1</mp>
+			<cp>1692.0</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1935.48</hp>
+			<mp>711.0</mp>
+			<cp>1741.932</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1991.34</hp>
+			<mp>733.05</mp>
+			<cp>1792.206</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2047.58</hp>
+			<mp>755.25</mp>
+			<cp>1842.822</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2104.2</hp>
+			<mp>777.6</mp>
+			<cp>1893.78</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2161.2</hp>
+			<mp>800.1</mp>
+			<cp>1945.08</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2218.58</hp>
+			<mp>822.75</mp>
+			<cp>1996.722</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2276.34</hp>
+			<mp>845.55</mp>
+			<cp>2048.706</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2334.48</hp>
+			<mp>868.5</mp>
+			<cp>2101.032</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2393.0</hp>
+			<mp>891.6</mp>
+			<cp>2153.7</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2451.9</hp>
+			<mp>914.85</mp>
+			<cp>2206.71</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2511.18</hp>
+			<mp>938.25</mp>
+			<cp>2260.062</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2570.84</hp>
+			<mp>961.8</mp>
+			<cp>2313.756</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2630.88</hp>
+			<mp>985.5</mp>
+			<cp>2367.792</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2691.3</hp>
+			<mp>1009.35</mp>
+			<cp>2422.17</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2752.1</hp>
+			<mp>1033.35</mp>
+			<cp>2476.89</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2813.28</hp>
+			<mp>1057.5</mp>
+			<cp>2531.952</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2874.84</hp>
+			<mp>1081.8</mp>
+			<cp>2587.356</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2936.78</hp>
+			<mp>1106.25</mp>
+			<cp>2643.102</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2999.1</hp>
+			<mp>1130.85</mp>
+			<cp>2699.19</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3061.8</hp>
+			<mp>1155.6</mp>
+			<cp>2755.62</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3124.88</hp>
+			<mp>1180.5</mp>
+			<cp>2812.392</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3188.34</hp>
+			<mp>1205.55</mp>
+			<cp>2869.506</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3252.18</hp>
+			<mp>1230.75</mp>
+			<cp>2926.962</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3316.4</hp>
+			<mp>1256.1</mp>
+			<cp>2984.76</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3381.0</hp>
+			<mp>1281.6</mp>
+			<cp>3042.9</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3445.98</hp>
+			<mp>1307.25</mp>
+			<cp>3101.382</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3511.34</hp>
+			<mp>1333.05</mp>
+			<cp>3160.206</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3577.08</hp>
+			<mp>1359.0</mp>
+			<cp>3219.372</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3643.2</hp>
+			<mp>1385.1</mp>
+			<cp>3278.88</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3709.67</hp>
+			<mp>1411.35</mp>
+			<cp>3338.73</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3776.58</hp>
+			<mp>1437.75</mp>
+			<cp>3398.922</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3843.84</hp>
+			<mp>1464.3</mp>
+			<cp>3459.456</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3911.48</hp>
+			<mp>1491</mp>
+			<cp>3520.332</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3979.5</hp>
+			<mp>1517.85</mp>
+			<cp>3581.55</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4047.9</hp>
+			<mp>1544.85</mp>
+			<cp>3643.11</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4116.68</hp>
+			<mp>1572</mp>
+			<cp>3705.012</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4185.84</hp>
+			<mp>1599.3</mp>
+			<cp>3767.256</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4255.38</hp>
+			<mp>1626.75</mp>
+			<cp>3829.842</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4325.3</hp>
+			<mp>1654.35</mp>
+			<cp>3892.77</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4395.6</hp>
+			<mp>1682.1</mp>
+			<cp>3956.04</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4466.28</hp>
+			<mp>1710</mp>
+			<cp>4019.652</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4537.34</hp>
+			<mp>1738.05</mp>
+			<cp>4083.606</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4608.78</hp>
+			<mp>1766.25</mp>
+			<cp>4147.902</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4680.6</hp>
+			<mp>1794.6</mp>
+			<cp>4212.54</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4752.8</hp>
+			<mp>1823.1</mp>
+			<cp>4277.51</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4825.38</hp>
+			<mp>1851.75</mp>
+			<cp>4342.83</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4898.34</hp>
+			<mp>1880.55</mp>
+			<cp>4408.49</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4971.68</hp>
+			<mp>1909.5</mp>
+			<cp>4474.48</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5045.4</hp>
+			<mp>1938.6</mp>
+			<cp>4540.82</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5119.5</hp>
+			<mp>1967.85</mp>
+			<cp>4607.49</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5193.98</hp>
+			<mp>1997.25</mp>
+			<cp>4674.582</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/GrandKhavatari.xml
+++ b/data/stats/chars/baseStats/GrandKhavatari.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>114</classId>
-    <staticData>
-        <baseINT>18</baseINT>
-        <baseSTR>40</baseSTR>
-        <baseCON>47</baseCON>
-        <baseMEN>27</baseMEN>
-        <baseDEX>26</baseDEX>
-        <baseWIT>12</baseWIT>
-        <physicalAbnormalResist>15</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-56733" y="-113459" z="-690"/>
-            <node x="-56686" y="-113470" z="-690"/>
-            <node x="-56728" y="-113610" z="-690"/>
-            <node x="-56693" y="-113610" z="-690"/>
-            <node x="-56743" y="-113757" z="-690"/>
-            <node x="-56682" y="-113730" z="-690"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>25</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>70</walk>
-            <run>130</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>90</baseBreath>
-        <baseSafeFall>200</baseSafeFall>
-        <collisionMale>
-            <radius>11</radius>
-            <height>28.0</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7</radius>
-            <height>27.0</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>80.0</hp>
-            <mp>30.0</mp>
-            <cp>40.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>92.74</hp>
-            <mp>35.46</mp>
-            <cp>46.37</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>105.62</hp>
-            <mp>40.98</mp>
-            <cp>52.81</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>118.64</hp>
-            <mp>46.56</mp>
-            <cp>59.32</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>131.8</hp>
-            <mp>52.2</mp>
-            <cp>65.9</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>145.1</hp>
-            <mp>57.9</mp>
-            <cp>72.55</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>158.54</hp>
-            <mp>63.66</mp>
-            <cp>79.27</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>172.12</hp>
-            <mp>69.48</mp>
-            <cp>86.06</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>185.84</hp>
-            <mp>75.36</mp>
-            <cp>92.92</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>199.7</hp>
-            <mp>81.3</mp>
-            <cp>99.85</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>213.7</hp>
-            <mp>87.3</mp>
-            <cp>106.85</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>227.84</hp>
-            <mp>93.36</mp>
-            <cp>113.92</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>242.12</hp>
-            <mp>99.48</mp>
-            <cp>121.06</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>256.54</hp>
-            <mp>105.66</mp>
-            <cp>128.27</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>271.1</hp>
-            <mp>111.9</mp>
-            <cp>135.55</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>285.8</hp>
-            <mp>118.2</mp>
-            <cp>142.9</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>300.64</hp>
-            <mp>124.56</mp>
-            <cp>150.32</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>315.62</hp>
-            <mp>130.98</mp>
-            <cp>157.81</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>330.74</hp>
-            <mp>137.46</mp>
-            <cp>165.37</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>346.0</hp>
-            <mp>144.0</mp>
-            <cp>173.0</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>379.0</hp>
-            <mp>153.9</mp>
-            <cp>189.5</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>412.3</hp>
-            <mp>163.89</mp>
-            <cp>206.15</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>445.9</hp>
-            <mp>173.97</mp>
-            <cp>222.95</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>479.8</hp>
-            <mp>184.14</mp>
-            <cp>239.9</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>514.0</hp>
-            <mp>194.4</mp>
-            <cp>257.0</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>548.5</hp>
-            <mp>204.75</mp>
-            <cp>274.25</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>583.3</hp>
-            <mp>215.19</mp>
-            <cp>291.65</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>618.4</hp>
-            <mp>225.72</mp>
-            <cp>309.2</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>653.8</hp>
-            <mp>236.34</mp>
-            <cp>326.9</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>689.5</hp>
-            <mp>247.05</mp>
-            <cp>344.75</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>725.5</hp>
-            <mp>257.85</mp>
-            <cp>362.75</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>761.8</hp>
-            <mp>268.74</mp>
-            <cp>380.9</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>798.4</hp>
-            <mp>279.72</mp>
-            <cp>399.2</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>835.3</hp>
-            <mp>290.79</mp>
-            <cp>417.65</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>872.5</hp>
-            <mp>301.95</mp>
-            <cp>436.25</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>910.0</hp>
-            <mp>313.2</mp>
-            <cp>455.0</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>947.8</hp>
-            <mp>324.54</mp>
-            <cp>473.9</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>985.9</hp>
-            <mp>335.97</mp>
-            <cp>492.95</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1024.3</hp>
-            <mp>347.49</mp>
-            <cp>512.15</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1063.0</hp>
-            <mp>359.1</mp>
-            <cp>531.5</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1117.6</hp>
-            <mp>378.6</mp>
-            <cp>558.8</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1172.62</hp>
-            <mp>398.25</mp>
-            <cp>586.31</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1228.06</hp>
-            <mp>418.05</mp>
-            <cp>614.03</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1283.92</hp>
-            <mp>438.0</mp>
-            <cp>641.96</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1340.2</hp>
-            <mp>458.1</mp>
-            <cp>670.1</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1396.9</hp>
-            <mp>478.35</mp>
-            <cp>698.45</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1454.02</hp>
-            <mp>498.75</mp>
-            <cp>727.01</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1511.56</hp>
-            <mp>519.3</mp>
-            <cp>755.78</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1569.52</hp>
-            <mp>540.0</mp>
-            <cp>784.76</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1627.9</hp>
-            <mp>560.85</mp>
-            <cp>813.95</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1686.7</hp>
-            <mp>581.85</mp>
-            <cp>843.35</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1745.92</hp>
-            <mp>603.0</mp>
-            <cp>872.96</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1805.56</hp>
-            <mp>624.3</mp>
-            <cp>902.78</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1865.62</hp>
-            <mp>645.75</mp>
-            <cp>932.81</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1926.1</hp>
-            <mp>667.35</mp>
-            <cp>963.05</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1987.0</hp>
-            <mp>689.1</mp>
-            <cp>993.5</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>2048.32</hp>
-            <mp>711.0</mp>
-            <cp>1024.16</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2110.06</hp>
-            <mp>733.05</mp>
-            <cp>1055.03</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2172.22</hp>
-            <mp>755.25</mp>
-            <cp>1086.11</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2234.8</hp>
-            <mp>777.6</mp>
-            <cp>1117.4</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2297.8</hp>
-            <mp>800.1</mp>
-            <cp>1148.9</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2361.22</hp>
-            <mp>822.75</mp>
-            <cp>1180.61</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2425.06</hp>
-            <mp>845.55</mp>
-            <cp>1212.53</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2489.32</hp>
-            <mp>868.5</mp>
-            <cp>1244.66</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2554.0</hp>
-            <mp>891.6</mp>
-            <cp>1277.0</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2619.1</hp>
-            <mp>914.85</mp>
-            <cp>1309.55</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2684.62</hp>
-            <mp>938.25</mp>
-            <cp>1342.31</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2750.56</hp>
-            <mp>961.8</mp>
-            <cp>1375.28</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2816.92</hp>
-            <mp>985.5</mp>
-            <cp>1408.46</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2883.7</hp>
-            <mp>1009.35</mp>
-            <cp>1441.85</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2950.9</hp>
-            <mp>1033.35</mp>
-            <cp>1475.45</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>3018.52</hp>
-            <mp>1057.5</mp>
-            <cp>1509.26</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>3086.56</hp>
-            <mp>1081.8</mp>
-            <cp>1543.28</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>3155.02</hp>
-            <mp>1106.25</mp>
-            <cp>1577.51</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3223.9</hp>
-            <mp>1130.85</mp>
-            <cp>1611.95</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3293.2</hp>
-            <mp>1155.6</mp>
-            <cp>1646.6</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3362.92</hp>
-            <mp>1180.5</mp>
-            <cp>1681.46</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3433.06</hp>
-            <mp>1205.55</mp>
-            <cp>1716.53</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3503.62</hp>
-            <mp>1230.75</mp>
-            <cp>1751.81</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3574.6</hp>
-            <mp>1256.1</mp>
-            <cp>1787.3</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3646.0</hp>
-            <mp>1281.6</mp>
-            <cp>1823.0</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3717.82</hp>
-            <mp>1307.25</mp>
-            <cp>1858.91</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3790.06</hp>
-            <mp>1333.05</mp>
-            <cp>1895.03</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3862.72</hp>
-            <mp>1359.0</mp>
-            <cp>1931.36</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3935.8</hp>
-            <mp>1385.1</mp>
-            <cp>1967.9</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>4009.3</hp>
-            <mp>1411.35</mp>
-            <cp>2004.65</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>4083.22</hp>
-            <mp>1437.75</mp>
-            <cp>2041.61</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>4157.56</hp>
-            <mp>1464.3</mp>
-            <cp>2078.78</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>4232.32</hp>
-            <mp>1491.0</mp>
-            <cp>2116.16</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4307.5</hp>
-            <mp>1517.85</mp>
-            <cp>2153.75</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4383.1</hp>
-            <mp>1544.85</mp>
-            <cp>2191.55</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>114</classId>
+	<staticData>
+		<baseINT>18</baseINT>
+		<baseSTR>40</baseSTR>
+		<baseCON>47</baseCON>
+		<baseMEN>27</baseMEN>
+		<baseDEX>26</baseDEX>
+		<baseWIT>12</baseWIT>
+		<physicalAbnormalResist>15</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-56733" y="-113459" z="-690" />
+			<node x="-56686" y="-113470" z="-690" />
+			<node x="-56728" y="-113610" z="-690" />
+			<node x="-56693" y="-113610" z="-690" />
+			<node x="-56743" y="-113757" z="-690" />
+			<node x="-56682" y="-113730" z="-690" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>25</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>70</walk>
+			<run>130</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>90</baseBreath>
+		<baseSafeFall>200</baseSafeFall>
+		<collisionMale>
+			<radius>11</radius>
+			<height>28.0</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7</radius>
+			<height>27.0</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>80.0</hp>
+			<mp>30.0</mp>
+			<cp>40.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>92.74</hp>
+			<mp>35.46</mp>
+			<cp>46.37</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>105.62</hp>
+			<mp>40.98</mp>
+			<cp>52.81</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>118.64</hp>
+			<mp>46.56</mp>
+			<cp>59.32</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>131.8</hp>
+			<mp>52.2</mp>
+			<cp>65.9</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>145.1</hp>
+			<mp>57.9</mp>
+			<cp>72.55</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>158.54</hp>
+			<mp>63.66</mp>
+			<cp>79.27</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>172.12</hp>
+			<mp>69.48</mp>
+			<cp>86.06</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>185.84</hp>
+			<mp>75.36</mp>
+			<cp>92.92</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>199.7</hp>
+			<mp>81.3</mp>
+			<cp>99.85</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>213.7</hp>
+			<mp>87.3</mp>
+			<cp>106.85</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>227.84</hp>
+			<mp>93.36</mp>
+			<cp>113.92</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>242.12</hp>
+			<mp>99.48</mp>
+			<cp>121.06</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>256.54</hp>
+			<mp>105.66</mp>
+			<cp>128.27</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>271.1</hp>
+			<mp>111.9</mp>
+			<cp>135.55</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>285.8</hp>
+			<mp>118.2</mp>
+			<cp>142.9</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>300.64</hp>
+			<mp>124.56</mp>
+			<cp>150.32</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>315.62</hp>
+			<mp>130.98</mp>
+			<cp>157.81</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>330.74</hp>
+			<mp>137.46</mp>
+			<cp>165.37</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>346.0</hp>
+			<mp>144.0</mp>
+			<cp>173.0</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>379.0</hp>
+			<mp>153.9</mp>
+			<cp>189.5</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>412.3</hp>
+			<mp>163.89</mp>
+			<cp>206.15</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>445.9</hp>
+			<mp>173.97</mp>
+			<cp>222.95</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>479.8</hp>
+			<mp>184.14</mp>
+			<cp>239.9</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>514.0</hp>
+			<mp>194.4</mp>
+			<cp>257.0</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>548.5</hp>
+			<mp>204.75</mp>
+			<cp>274.25</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>583.3</hp>
+			<mp>215.19</mp>
+			<cp>291.65</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>618.4</hp>
+			<mp>225.72</mp>
+			<cp>309.2</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>653.8</hp>
+			<mp>236.34</mp>
+			<cp>326.9</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>689.5</hp>
+			<mp>247.05</mp>
+			<cp>344.75</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>725.5</hp>
+			<mp>257.85</mp>
+			<cp>362.75</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>761.8</hp>
+			<mp>268.74</mp>
+			<cp>380.9</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>798.4</hp>
+			<mp>279.72</mp>
+			<cp>399.2</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>835.3</hp>
+			<mp>290.79</mp>
+			<cp>417.65</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>872.5</hp>
+			<mp>301.95</mp>
+			<cp>436.25</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>910.0</hp>
+			<mp>313.2</mp>
+			<cp>455.0</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>947.8</hp>
+			<mp>324.54</mp>
+			<cp>473.9</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>985.9</hp>
+			<mp>335.97</mp>
+			<cp>492.95</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1024.3</hp>
+			<mp>347.49</mp>
+			<cp>512.15</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1063.0</hp>
+			<mp>359.1</mp>
+			<cp>531.5</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1117.6</hp>
+			<mp>378.6</mp>
+			<cp>558.8</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1172.62</hp>
+			<mp>398.25</mp>
+			<cp>586.31</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1228.06</hp>
+			<mp>418.05</mp>
+			<cp>614.03</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1283.92</hp>
+			<mp>438.0</mp>
+			<cp>641.96</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1340.2</hp>
+			<mp>458.1</mp>
+			<cp>670.1</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1396.9</hp>
+			<mp>478.35</mp>
+			<cp>698.45</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1454.02</hp>
+			<mp>498.75</mp>
+			<cp>727.01</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1511.56</hp>
+			<mp>519.3</mp>
+			<cp>755.78</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1569.52</hp>
+			<mp>540.0</mp>
+			<cp>784.76</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1627.9</hp>
+			<mp>560.85</mp>
+			<cp>813.95</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1686.7</hp>
+			<mp>581.85</mp>
+			<cp>843.35</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1745.92</hp>
+			<mp>603.0</mp>
+			<cp>872.96</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1805.56</hp>
+			<mp>624.3</mp>
+			<cp>902.78</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1865.62</hp>
+			<mp>645.75</mp>
+			<cp>932.81</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1926.1</hp>
+			<mp>667.35</mp>
+			<cp>963.05</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1987.0</hp>
+			<mp>689.1</mp>
+			<cp>993.5</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2048.32</hp>
+			<mp>711.0</mp>
+			<cp>1024.16</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2110.06</hp>
+			<mp>733.05</mp>
+			<cp>1055.03</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2172.22</hp>
+			<mp>755.25</mp>
+			<cp>1086.11</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2234.8</hp>
+			<mp>777.6</mp>
+			<cp>1117.4</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2297.8</hp>
+			<mp>800.1</mp>
+			<cp>1148.9</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2361.22</hp>
+			<mp>822.75</mp>
+			<cp>1180.61</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2425.06</hp>
+			<mp>845.55</mp>
+			<cp>1212.53</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2489.32</hp>
+			<mp>868.5</mp>
+			<cp>1244.66</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2554.0</hp>
+			<mp>891.6</mp>
+			<cp>1277.0</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2619.1</hp>
+			<mp>914.85</mp>
+			<cp>1309.55</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2684.62</hp>
+			<mp>938.25</mp>
+			<cp>1342.31</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2750.56</hp>
+			<mp>961.8</mp>
+			<cp>1375.28</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2816.92</hp>
+			<mp>985.5</mp>
+			<cp>1408.46</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2883.7</hp>
+			<mp>1009.35</mp>
+			<cp>1441.85</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2950.9</hp>
+			<mp>1033.35</mp>
+			<cp>1475.45</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>3018.52</hp>
+			<mp>1057.5</mp>
+			<cp>1509.26</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>3086.56</hp>
+			<mp>1081.8</mp>
+			<cp>1543.28</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3155.02</hp>
+			<mp>1106.25</mp>
+			<cp>1577.51</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3223.9</hp>
+			<mp>1130.85</mp>
+			<cp>1611.95</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3293.2</hp>
+			<mp>1155.6</mp>
+			<cp>1646.6</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3362.92</hp>
+			<mp>1180.5</mp>
+			<cp>1681.46</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3433.06</hp>
+			<mp>1205.55</mp>
+			<cp>1716.53</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3503.62</hp>
+			<mp>1230.75</mp>
+			<cp>1751.81</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3574.6</hp>
+			<mp>1256.1</mp>
+			<cp>1787.3</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3646.0</hp>
+			<mp>1281.6</mp>
+			<cp>1823.0</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3717.82</hp>
+			<mp>1307.25</mp>
+			<cp>1858.91</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3790.06</hp>
+			<mp>1333.05</mp>
+			<cp>1895.03</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3862.72</hp>
+			<mp>1359.0</mp>
+			<cp>1931.36</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3935.8</hp>
+			<mp>1385.1</mp>
+			<cp>1967.9</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>4009.3</hp>
+			<mp>1411.35</mp>
+			<cp>2004.65</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>4083.22</hp>
+			<mp>1437.75</mp>
+			<cp>2041.61</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4157.56</hp>
+			<mp>1464.3</mp>
+			<cp>2078.78</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4232.32</hp>
+			<mp>1491.0</mp>
+			<cp>2116.16</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4307.5</hp>
+			<mp>1517.85</mp>
+			<cp>2153.75</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4383.1</hp>
+			<mp>1544.85</mp>
+			<cp>2191.55</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4459.12</hp>
+			<mp>1572.0</mp>
+			<cp>2229.56</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4535.56</hp>
+			<mp>1599.3</mp>
+			<cp>2267.78</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4612.42</hp>
+			<mp>1626.75</mp>
+			<cp>2306.21</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4689.7</hp>
+			<mp>1654.35</mp>
+			<cp>2344.85</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4767.4</hp>
+			<mp>1682.1</mp>
+			<cp>2383.7</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4845.52</hp>
+			<mp>1710.0</mp>
+			<cp>2422.76</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4924.06</hp>
+			<mp>1738.05</mp>
+			<cp>2462.03</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>5003.02</hp>
+			<mp>1766.25</mp>
+			<cp>2501.51</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>5082.4</hp>
+			<mp>1794.6</mp>
+			<cp>2541.2</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>5162.2</hp>
+			<mp>1823.1</mp>
+			<cp>2581.1</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5242.42</hp>
+			<mp>1851.75</mp>
+			<cp>2621.21</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5323.06</hp>
+			<mp>1880.55</mp>
+			<cp>2661.53</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5404.12</hp>
+			<mp>1909.5</mp>
+			<cp>2702.06</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5485.6</hp>
+			<mp>1938.6</mp>
+			<cp>2742.8</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5567.5</hp>
+			<mp>1967.85</mp>
+			<cp>2783.75</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5649.82</hp>
+			<mp>1997.25</mp>
+			<cp>2824.91</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/HawkEye.xml
+++ b/data/stats/chars/baseStats/HawkEye.xml
@@ -1,798 +1,926 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>9</classId>
-    <staticData>
-        <baseINT>21</baseINT>
-        <baseSTR>40</baseSTR>
-        <baseCON>43</baseCON>
-        <baseMEN>25</baseMEN>
-        <baseDEX>30</baseDEX>
-        <baseWIT>11</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-71338" y="258271" z="-3104"/>
-            <node x="-71417" y="258270" z="-3104"/>
-            <node x="-71453" y="258305" z="-3104"/>
-            <node x="-71467" y="258378" z="-3104"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>80</walk>
-            <run>132</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>100</baseBreath>
-        <baseSafeFall>250</baseSafeFall>
-        <collisionMale>
-            <radius>9.0</radius>
-            <height>23</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>8.0</radius>
-            <height>23.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>80.0</hp>
-            <mp>30.0</mp>
-            <cp>56.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>91.83</hp>
-            <mp>35.46</mp>
-            <cp>64.281</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>103.79</hp>
-            <mp>40.98</mp>
-            <cp>72.653</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>115.88</hp>
-            <mp>46.56</mp>
-            <cp>81.116</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>128.1</hp>
-            <mp>52.2</mp>
-            <cp>89.67</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>140.45</hp>
-            <mp>57.9</mp>
-            <cp>98.315</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>152.93</hp>
-            <mp>63.66</mp>
-            <cp>107.051</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>165.54</hp>
-            <mp>69.48</mp>
-            <cp>115.878</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>178.28</hp>
-            <mp>75.36</mp>
-            <cp>124.796</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>191.15</hp>
-            <mp>81.3</mp>
-            <cp>133.805</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>204.15</hp>
-            <mp>87.3</mp>
-            <cp>142.905</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>217.28</hp>
-            <mp>93.36</mp>
-            <cp>152.096</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>230.54</hp>
-            <mp>99.48</mp>
-            <cp>161.378</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>243.93</hp>
-            <mp>105.66</mp>
-            <cp>170.751</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>257.45</hp>
-            <mp>111.9</mp>
-            <cp>180.215</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>271.1</hp>
-            <mp>118.2</mp>
-            <cp>189.77</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>284.88</hp>
-            <mp>124.56</mp>
-            <cp>199.416</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>298.79</hp>
-            <mp>130.98</mp>
-            <cp>209.153</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>312.83</hp>
-            <mp>137.46</mp>
-            <cp>218.981</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>327.0</hp>
-            <mp>144.0</mp>
-            <cp>228.9</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>354.5</hp>
-            <mp>153.9</mp>
-            <cp>248.15</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>382.25</hp>
-            <mp>163.89</mp>
-            <cp>267.575</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>410.25</hp>
-            <mp>173.97</mp>
-            <cp>287.175</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>438.5</hp>
-            <mp>184.14</mp>
-            <cp>306.95</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>467.0</hp>
-            <mp>194.4</mp>
-            <cp>326.9</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>495.75</hp>
-            <mp>204.75</mp>
-            <cp>347.025</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>524.75</hp>
-            <mp>215.19</mp>
-            <cp>367.325</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>554.0</hp>
-            <mp>225.72</mp>
-            <cp>387.8</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>583.5</hp>
-            <mp>236.34</mp>
-            <cp>408.45</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>613.25</hp>
-            <mp>247.05</mp>
-            <cp>429.275</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>643.25</hp>
-            <mp>257.85</mp>
-            <cp>450.275</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>673.5</hp>
-            <mp>268.74</mp>
-            <cp>471.45</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>704.0</hp>
-            <mp>279.72</mp>
-            <cp>492.8</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>734.75</hp>
-            <mp>290.79</mp>
-            <cp>514.325</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>765.75</hp>
-            <mp>301.95</mp>
-            <cp>536.025</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>797.0</hp>
-            <mp>313.2</mp>
-            <cp>557.9</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>828.5</hp>
-            <mp>324.54</mp>
-            <cp>579.95</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>860.25</hp>
-            <mp>335.97</mp>
-            <cp>602.175</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>892.25</hp>
-            <mp>347.49</mp>
-            <cp>624.575</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>924.5</hp>
-            <mp>359.1</mp>
-            <cp>647.15</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>968.7</hp>
-            <mp>378.6</mp>
-            <cp>678.09</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1013.24</hp>
-            <mp>398.25</mp>
-            <cp>709.268</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1058.12</hp>
-            <mp>418.05</mp>
-            <cp>740.684</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1103.34</hp>
-            <mp>438.0</mp>
-            <cp>772.338</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1148.9</hp>
-            <mp>458.1</mp>
-            <cp>804.23</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1194.8</hp>
-            <mp>478.35</mp>
-            <cp>836.36</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1241.04</hp>
-            <mp>498.75</mp>
-            <cp>868.728</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1287.62</hp>
-            <mp>519.3</mp>
-            <cp>901.334</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1334.54</hp>
-            <mp>540.0</mp>
-            <cp>934.178</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1381.8</hp>
-            <mp>560.85</mp>
-            <cp>967.26</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1429.4</hp>
-            <mp>581.85</mp>
-            <cp>1000.58</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1477.34</hp>
-            <mp>603.0</mp>
-            <cp>1034.138</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1525.62</hp>
-            <mp>624.3</mp>
-            <cp>1067.934</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1574.24</hp>
-            <mp>645.75</mp>
-            <cp>1101.968</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1623.2</hp>
-            <mp>667.35</mp>
-            <cp>1136.24</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1672.5</hp>
-            <mp>689.1</mp>
-            <cp>1170.75</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1722.14</hp>
-            <mp>711.0</mp>
-            <cp>1205.498</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1772.12</hp>
-            <mp>733.05</mp>
-            <cp>1240.484</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>1822.44</hp>
-            <mp>755.25</mp>
-            <cp>1275.708</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>1873.1</hp>
-            <mp>777.6</mp>
-            <cp>1311.17</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>1924.1</hp>
-            <mp>800.1</mp>
-            <cp>1346.87</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>1975.44</hp>
-            <mp>822.75</mp>
-            <cp>1382.808</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2027.12</hp>
-            <mp>845.55</mp>
-            <cp>1418.984</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2079.14</hp>
-            <mp>868.5</mp>
-            <cp>1455.398</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2131.5</hp>
-            <mp>891.6</mp>
-            <cp>1492.05</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2184.2</hp>
-            <mp>914.85</mp>
-            <cp>1528.94</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2237.24</hp>
-            <mp>938.25</mp>
-            <cp>1566.068</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2290.62</hp>
-            <mp>961.8</mp>
-            <cp>1603.434</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2344.34</hp>
-            <mp>985.5</mp>
-            <cp>1641.038</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2398.4</hp>
-            <mp>1009.35</mp>
-            <cp>1678.88</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2452.8</hp>
-            <mp>1033.35</mp>
-            <cp>1716.96</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2507.54</hp>
-            <mp>1057.5</mp>
-            <cp>1755.278</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2562.62</hp>
-            <mp>1081.8</mp>
-            <cp>1793.834</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2618.04</hp>
-            <mp>1106.25</mp>
-            <cp>1832.628</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2673.8</hp>
-            <mp>1130.85</mp>
-            <cp>1871.66</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>2729.9</hp>
-            <mp>1155.6</mp>
-            <cp>1910.93</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>2786.34</hp>
-            <mp>1180.5</mp>
-            <cp>1950.438</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>2843.12</hp>
-            <mp>1205.55</mp>
-            <cp>1990.184</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>2900.24</hp>
-            <mp>1230.75</mp>
-            <cp>2030.168</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>2957.7</hp>
-            <mp>1256.1</mp>
-            <cp>2070.39</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3015.5</hp>
-            <mp>1281.6</mp>
-            <cp>2110.85</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3073.64</hp>
-            <mp>1307.25</mp>
-            <cp>2151.548</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3132.12</hp>
-            <mp>1333.05</mp>
-            <cp>2192.484</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3190.94</hp>
-            <mp>1359.0</mp>
-            <cp>2233.658</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3250.1</hp>
-            <mp>1385.1</mp>
-            <cp>2275.07</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3309.6</hp>
-            <mp>1411.35</mp>
-            <cp>2316.72</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3369.44</hp>
-            <mp>1437.75</mp>
-            <cp>2358.608</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3429.62</hp>
-            <mp>1464.3</mp>
-            <cp>2400.734</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3490.14</hp>
-            <mp>1491.0</mp>
-            <cp>2443.098</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3551.0</hp>
-            <mp>1517.85</mp>
-            <cp>2485.7</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>3612.2</hp>
-            <mp>1544.85</mp>
-            <cp>2528.54</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>9</classId>
+	<staticData>
+		<baseINT>21</baseINT>
+		<baseSTR>40</baseSTR>
+		<baseCON>43</baseCON>
+		<baseMEN>25</baseMEN>
+		<baseDEX>30</baseDEX>
+		<baseWIT>11</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-71338" y="258271" z="-3104" />
+			<node x="-71417" y="258270" z="-3104" />
+			<node x="-71453" y="258305" z="-3104" />
+			<node x="-71467" y="258378" z="-3104" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>80</walk>
+			<run>132</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>250</baseSafeFall>
+		<collisionMale>
+			<radius>9.0</radius>
+			<height>23</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>8.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>80.0</hp>
+			<mp>30.0</mp>
+			<cp>56.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>91.83</hp>
+			<mp>35.46</mp>
+			<cp>64.281</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>103.79</hp>
+			<mp>40.98</mp>
+			<cp>72.653</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>115.88</hp>
+			<mp>46.56</mp>
+			<cp>81.116</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>128.1</hp>
+			<mp>52.2</mp>
+			<cp>89.67</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>140.45</hp>
+			<mp>57.9</mp>
+			<cp>98.315</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>152.93</hp>
+			<mp>63.66</mp>
+			<cp>107.051</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>165.54</hp>
+			<mp>69.48</mp>
+			<cp>115.878</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>178.28</hp>
+			<mp>75.36</mp>
+			<cp>124.796</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>191.15</hp>
+			<mp>81.3</mp>
+			<cp>133.805</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>204.15</hp>
+			<mp>87.3</mp>
+			<cp>142.905</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>217.28</hp>
+			<mp>93.36</mp>
+			<cp>152.096</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>230.54</hp>
+			<mp>99.48</mp>
+			<cp>161.378</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>243.93</hp>
+			<mp>105.66</mp>
+			<cp>170.751</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>257.45</hp>
+			<mp>111.9</mp>
+			<cp>180.215</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>271.1</hp>
+			<mp>118.2</mp>
+			<cp>189.77</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>284.88</hp>
+			<mp>124.56</mp>
+			<cp>199.416</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>298.79</hp>
+			<mp>130.98</mp>
+			<cp>209.153</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>312.83</hp>
+			<mp>137.46</mp>
+			<cp>218.981</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>327.0</hp>
+			<mp>144.0</mp>
+			<cp>228.9</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>354.5</hp>
+			<mp>153.9</mp>
+			<cp>248.15</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>382.25</hp>
+			<mp>163.89</mp>
+			<cp>267.575</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>410.25</hp>
+			<mp>173.97</mp>
+			<cp>287.175</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>438.5</hp>
+			<mp>184.14</mp>
+			<cp>306.95</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>467.0</hp>
+			<mp>194.4</mp>
+			<cp>326.9</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>495.75</hp>
+			<mp>204.75</mp>
+			<cp>347.025</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>524.75</hp>
+			<mp>215.19</mp>
+			<cp>367.325</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>554.0</hp>
+			<mp>225.72</mp>
+			<cp>387.8</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>583.5</hp>
+			<mp>236.34</mp>
+			<cp>408.45</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>613.25</hp>
+			<mp>247.05</mp>
+			<cp>429.275</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>643.25</hp>
+			<mp>257.85</mp>
+			<cp>450.275</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>673.5</hp>
+			<mp>268.74</mp>
+			<cp>471.45</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>704.0</hp>
+			<mp>279.72</mp>
+			<cp>492.8</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>734.75</hp>
+			<mp>290.79</mp>
+			<cp>514.325</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>765.75</hp>
+			<mp>301.95</mp>
+			<cp>536.025</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>797.0</hp>
+			<mp>313.2</mp>
+			<cp>557.9</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>828.5</hp>
+			<mp>324.54</mp>
+			<cp>579.95</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>860.25</hp>
+			<mp>335.97</mp>
+			<cp>602.175</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>892.25</hp>
+			<mp>347.49</mp>
+			<cp>624.575</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>924.5</hp>
+			<mp>359.1</mp>
+			<cp>647.15</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>968.7</hp>
+			<mp>378.6</mp>
+			<cp>678.09</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1013.24</hp>
+			<mp>398.25</mp>
+			<cp>709.268</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1058.12</hp>
+			<mp>418.05</mp>
+			<cp>740.684</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1103.34</hp>
+			<mp>438.0</mp>
+			<cp>772.338</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1148.9</hp>
+			<mp>458.1</mp>
+			<cp>804.23</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1194.8</hp>
+			<mp>478.35</mp>
+			<cp>836.36</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1241.04</hp>
+			<mp>498.75</mp>
+			<cp>868.728</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1287.62</hp>
+			<mp>519.3</mp>
+			<cp>901.334</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1334.54</hp>
+			<mp>540.0</mp>
+			<cp>934.178</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1381.8</hp>
+			<mp>560.85</mp>
+			<cp>967.26</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1429.4</hp>
+			<mp>581.85</mp>
+			<cp>1000.58</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1477.34</hp>
+			<mp>603.0</mp>
+			<cp>1034.138</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1525.62</hp>
+			<mp>624.3</mp>
+			<cp>1067.934</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1574.24</hp>
+			<mp>645.75</mp>
+			<cp>1101.968</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1623.2</hp>
+			<mp>667.35</mp>
+			<cp>1136.24</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1672.5</hp>
+			<mp>689.1</mp>
+			<cp>1170.75</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1722.14</hp>
+			<mp>711.0</mp>
+			<cp>1205.498</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1772.12</hp>
+			<mp>733.05</mp>
+			<cp>1240.484</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1822.44</hp>
+			<mp>755.25</mp>
+			<cp>1275.708</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1873.1</hp>
+			<mp>777.6</mp>
+			<cp>1311.17</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>1924.1</hp>
+			<mp>800.1</mp>
+			<cp>1346.87</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>1975.44</hp>
+			<mp>822.75</mp>
+			<cp>1382.808</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2027.12</hp>
+			<mp>845.55</mp>
+			<cp>1418.984</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2079.14</hp>
+			<mp>868.5</mp>
+			<cp>1455.398</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2131.5</hp>
+			<mp>891.6</mp>
+			<cp>1492.05</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2184.2</hp>
+			<mp>914.85</mp>
+			<cp>1528.94</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2237.24</hp>
+			<mp>938.25</mp>
+			<cp>1566.068</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2290.62</hp>
+			<mp>961.8</mp>
+			<cp>1603.434</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2344.34</hp>
+			<mp>985.5</mp>
+			<cp>1641.038</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2398.4</hp>
+			<mp>1009.35</mp>
+			<cp>1678.88</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2452.8</hp>
+			<mp>1033.35</mp>
+			<cp>1716.96</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2507.54</hp>
+			<mp>1057.5</mp>
+			<cp>1755.278</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2562.62</hp>
+			<mp>1081.8</mp>
+			<cp>1793.834</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2618.04</hp>
+			<mp>1106.25</mp>
+			<cp>1832.628</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2673.8</hp>
+			<mp>1130.85</mp>
+			<cp>1871.66</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>2729.9</hp>
+			<mp>1155.6</mp>
+			<cp>1910.93</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>2786.34</hp>
+			<mp>1180.5</mp>
+			<cp>1950.438</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>2843.12</hp>
+			<mp>1205.55</mp>
+			<cp>1990.184</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>2900.24</hp>
+			<mp>1230.75</mp>
+			<cp>2030.168</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>2957.7</hp>
+			<mp>1256.1</mp>
+			<cp>2070.39</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3015.5</hp>
+			<mp>1281.6</mp>
+			<cp>2110.85</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3073.64</hp>
+			<mp>1307.25</mp>
+			<cp>2151.548</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3132.12</hp>
+			<mp>1333.05</mp>
+			<cp>2192.484</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3190.94</hp>
+			<mp>1359.0</mp>
+			<cp>2233.658</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3250.1</hp>
+			<mp>1385.1</mp>
+			<cp>2275.07</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3309.6</hp>
+			<mp>1411.35</mp>
+			<cp>2316.72</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3369.44</hp>
+			<mp>1437.75</mp>
+			<cp>2358.608</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3429.62</hp>
+			<mp>1464.3</mp>
+			<cp>2400.734</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3490.14</hp>
+			<mp>1491.0</mp>
+			<cp>2443.098</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3551.0</hp>
+			<mp>1517.85</mp>
+			<cp>2485.7</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3612.2</hp>
+			<mp>1544.85</mp>
+			<cp>2528.54</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>3673.74</hp>
+			<mp>1572.0</mp>
+			<cp>2571.618</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>3735.62</hp>
+			<mp>1599.3</mp>
+			<cp>2614.934</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>3797.84</hp>
+			<mp>1626.75</mp>
+			<cp>2658.488</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>3860.4</hp>
+			<mp>1654.35</mp>
+			<cp>2702.28</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>3923.3</hp>
+			<mp>1682.1</mp>
+			<cp>2746.31</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>3986.54</hp>
+			<mp>1710.0</mp>
+			<cp>2790.578</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4050.12</hp>
+			<mp>1738.05</mp>
+			<cp>2835.084</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4114.04</hp>
+			<mp>1766.25</mp>
+			<cp>2879.828</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4178.3</hp>
+			<mp>1794.6</mp>
+			<cp>2924.81</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4242.9</hp>
+			<mp>1823.1</mp>
+			<cp>2970.04</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4307.84</hp>
+			<mp>1851.75</mp>
+			<cp>3015.5</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4373.12</hp>
+			<mp>1880.55</mp>
+			<cp>3061.2</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4438.74</hp>
+			<mp>1909.5</mp>
+			<cp>3107.15</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>4504.7</hp>
+			<mp>1938.6</mp>
+			<cp>3153.33</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>4571</hp>
+			<mp>1967.85</mp>
+			<cp>3199.76</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>4637.64</hp>
+			<mp>1997.25</mp>
+			<cp>3246.348</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/HellKnight.xml
+++ b/data/stats/chars/baseStats/HellKnight.xml
@@ -1,798 +1,926 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>91</classId>
-    <staticData>
-        <baseINT>21</baseINT>
-        <baseSTR>40</baseSTR>
-        <baseCON>43</baseCON>
-        <baseMEN>25</baseMEN>
-        <baseDEX>30</baseDEX>
-        <baseWIT>11</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-71338" y="258271" z="-3104"/>
-            <node x="-71417" y="258270" z="-3104"/>
-            <node x="-71453" y="258305" z="-3104"/>
-            <node x="-71467" y="258378" z="-3104"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>80</walk>
-            <run>132</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>100</baseBreath>
-        <baseSafeFall>250</baseSafeFall>
-        <collisionMale>
-            <radius>9.0</radius>
-            <height>23</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>8.0</radius>
-            <height>23.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>80.0</hp>
-            <mp>30.0</mp>
-            <cp>48.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>91.83</hp>
-            <mp>35.46</mp>
-            <cp>55.098</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>103.79</hp>
-            <mp>40.98</mp>
-            <cp>62.274</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>115.88</hp>
-            <mp>46.56</mp>
-            <cp>69.528</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>128.1</hp>
-            <mp>52.2</mp>
-            <cp>76.86</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>140.45</hp>
-            <mp>57.9</mp>
-            <cp>84.27</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>152.93</hp>
-            <mp>63.66</mp>
-            <cp>91.758</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>165.54</hp>
-            <mp>69.48</mp>
-            <cp>99.324</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>178.28</hp>
-            <mp>75.36</mp>
-            <cp>106.968</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>191.15</hp>
-            <mp>81.3</mp>
-            <cp>114.69</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>204.15</hp>
-            <mp>87.3</mp>
-            <cp>122.49</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>217.28</hp>
-            <mp>93.36</mp>
-            <cp>130.368</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>230.54</hp>
-            <mp>99.48</mp>
-            <cp>138.324</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>243.93</hp>
-            <mp>105.66</mp>
-            <cp>146.358</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>257.45</hp>
-            <mp>111.9</mp>
-            <cp>154.47</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>271.1</hp>
-            <mp>118.2</mp>
-            <cp>162.66</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>284.88</hp>
-            <mp>124.56</mp>
-            <cp>170.928</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>298.79</hp>
-            <mp>130.98</mp>
-            <cp>179.274</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>312.83</hp>
-            <mp>137.46</mp>
-            <cp>187.698</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>327.0</hp>
-            <mp>144.0</mp>
-            <cp>196.2</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>356.7</hp>
-            <mp>153.9</mp>
-            <cp>214.02</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>386.67</hp>
-            <mp>163.89</mp>
-            <cp>232.002</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>416.91</hp>
-            <mp>173.97</mp>
-            <cp>250.146</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>447.42</hp>
-            <mp>184.14</mp>
-            <cp>268.452</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>478.2</hp>
-            <mp>194.4</mp>
-            <cp>286.92</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>509.25</hp>
-            <mp>204.75</mp>
-            <cp>305.55</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>540.57</hp>
-            <mp>215.19</mp>
-            <cp>324.342</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>572.16</hp>
-            <mp>225.72</mp>
-            <cp>343.296</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>604.02</hp>
-            <mp>236.34</mp>
-            <cp>362.412</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>636.15</hp>
-            <mp>247.05</mp>
-            <cp>381.69</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>668.55</hp>
-            <mp>257.85</mp>
-            <cp>401.13</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>701.22</hp>
-            <mp>268.74</mp>
-            <cp>420.732</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>734.16</hp>
-            <mp>279.72</mp>
-            <cp>440.496</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>767.37</hp>
-            <mp>290.79</mp>
-            <cp>460.422</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>800.85</hp>
-            <mp>301.95</mp>
-            <cp>480.51</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>834.6</hp>
-            <mp>313.2</mp>
-            <cp>500.76</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>868.62</hp>
-            <mp>324.54</mp>
-            <cp>521.172</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>902.91</hp>
-            <mp>335.97</mp>
-            <cp>541.746</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>937.47</hp>
-            <mp>347.49</mp>
-            <cp>562.482</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>972.3</hp>
-            <mp>359.1</mp>
-            <cp>583.38</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1019.1</hp>
-            <mp>378.6</mp>
-            <cp>611.46</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1066.26</hp>
-            <mp>398.25</mp>
-            <cp>639.756</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1113.78</hp>
-            <mp>418.05</mp>
-            <cp>668.268</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1161.66</hp>
-            <mp>438.0</mp>
-            <cp>696.996</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1209.9</hp>
-            <mp>458.1</mp>
-            <cp>725.94</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1258.5</hp>
-            <mp>478.35</mp>
-            <cp>755.1</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1307.46</hp>
-            <mp>498.75</mp>
-            <cp>784.476</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1356.78</hp>
-            <mp>519.3</mp>
-            <cp>814.068</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1406.46</hp>
-            <mp>540.0</mp>
-            <cp>843.876</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1456.5</hp>
-            <mp>560.85</mp>
-            <cp>873.9</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1506.9</hp>
-            <mp>581.85</mp>
-            <cp>904.14</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1557.66</hp>
-            <mp>603.0</mp>
-            <cp>934.596</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1608.78</hp>
-            <mp>624.3</mp>
-            <cp>965.268</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1660.26</hp>
-            <mp>645.75</mp>
-            <cp>996.156</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1712.1</hp>
-            <mp>667.35</mp>
-            <cp>1027.26</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1764.3</hp>
-            <mp>689.1</mp>
-            <cp>1058.58</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1816.86</hp>
-            <mp>711.0</mp>
-            <cp>1090.116</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1869.78</hp>
-            <mp>733.05</mp>
-            <cp>1121.868</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>1923.06</hp>
-            <mp>755.25</mp>
-            <cp>1153.836</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>1976.7</hp>
-            <mp>777.6</mp>
-            <cp>1186.02</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2030.7</hp>
-            <mp>800.1</mp>
-            <cp>1218.42</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2085.06</hp>
-            <mp>822.75</mp>
-            <cp>1251.036</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2139.78</hp>
-            <mp>845.55</mp>
-            <cp>1283.868</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2194.86</hp>
-            <mp>868.5</mp>
-            <cp>1316.916</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2250.3</hp>
-            <mp>891.6</mp>
-            <cp>1350.18</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2306.1</hp>
-            <mp>914.85</mp>
-            <cp>1383.66</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2362.26</hp>
-            <mp>938.25</mp>
-            <cp>1417.356</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2418.78</hp>
-            <mp>961.8</mp>
-            <cp>1451.268</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2475.66</hp>
-            <mp>985.5</mp>
-            <cp>1485.396</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2532.9</hp>
-            <mp>1009.35</mp>
-            <cp>1519.74</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2590.5</hp>
-            <mp>1033.35</mp>
-            <cp>1554.3</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2648.46</hp>
-            <mp>1057.5</mp>
-            <cp>1589.076</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2706.78</hp>
-            <mp>1081.8</mp>
-            <cp>1624.068</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2765.46</hp>
-            <mp>1106.25</mp>
-            <cp>1659.276</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2824.5</hp>
-            <mp>1130.85</mp>
-            <cp>1694.7</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>2883.9</hp>
-            <mp>1155.6</mp>
-            <cp>1730.34</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>2943.66</hp>
-            <mp>1180.5</mp>
-            <cp>1766.196</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3003.78</hp>
-            <mp>1205.55</mp>
-            <cp>1802.268</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3064.26</hp>
-            <mp>1230.75</mp>
-            <cp>1838.556</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3125.1</hp>
-            <mp>1256.1</mp>
-            <cp>1875.06</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3186.3</hp>
-            <mp>1281.6</mp>
-            <cp>1911.78</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3247.86</hp>
-            <mp>1307.25</mp>
-            <cp>1948.716</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3309.78</hp>
-            <mp>1333.05</mp>
-            <cp>1985.868</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3372.06</hp>
-            <mp>1359.0</mp>
-            <cp>2023.236</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3434.7</hp>
-            <mp>1385.1</mp>
-            <cp>2060.82</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3497.7</hp>
-            <mp>1411.35</mp>
-            <cp>2098.62</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3561.06</hp>
-            <mp>1437.75</mp>
-            <cp>2136.636</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3624.78</hp>
-            <mp>1464.3</mp>
-            <cp>2174.868</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3688.86</hp>
-            <mp>1491.0</mp>
-            <cp>2213.316</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3753.3</hp>
-            <mp>1517.85</mp>
-            <cp>2251.98</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>3818.1</hp>
-            <mp>1544.85</mp>
-            <cp>2290.86</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>91</classId>
+	<staticData>
+		<baseINT>21</baseINT>
+		<baseSTR>40</baseSTR>
+		<baseCON>43</baseCON>
+		<baseMEN>25</baseMEN>
+		<baseDEX>30</baseDEX>
+		<baseWIT>11</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-71338" y="258271" z="-3104" />
+			<node x="-71417" y="258270" z="-3104" />
+			<node x="-71453" y="258305" z="-3104" />
+			<node x="-71467" y="258378" z="-3104" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>80</walk>
+			<run>132</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>250</baseSafeFall>
+		<collisionMale>
+			<radius>9.0</radius>
+			<height>23</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>8.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>80.0</hp>
+			<mp>30.0</mp>
+			<cp>48.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>91.83</hp>
+			<mp>35.46</mp>
+			<cp>55.098</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>103.79</hp>
+			<mp>40.98</mp>
+			<cp>62.274</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>115.88</hp>
+			<mp>46.56</mp>
+			<cp>69.528</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>128.1</hp>
+			<mp>52.2</mp>
+			<cp>76.86</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>140.45</hp>
+			<mp>57.9</mp>
+			<cp>84.27</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>152.93</hp>
+			<mp>63.66</mp>
+			<cp>91.758</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>165.54</hp>
+			<mp>69.48</mp>
+			<cp>99.324</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>178.28</hp>
+			<mp>75.36</mp>
+			<cp>106.968</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>191.15</hp>
+			<mp>81.3</mp>
+			<cp>114.69</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>204.15</hp>
+			<mp>87.3</mp>
+			<cp>122.49</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>217.28</hp>
+			<mp>93.36</mp>
+			<cp>130.368</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>230.54</hp>
+			<mp>99.48</mp>
+			<cp>138.324</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>243.93</hp>
+			<mp>105.66</mp>
+			<cp>146.358</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>257.45</hp>
+			<mp>111.9</mp>
+			<cp>154.47</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>271.1</hp>
+			<mp>118.2</mp>
+			<cp>162.66</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>284.88</hp>
+			<mp>124.56</mp>
+			<cp>170.928</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>298.79</hp>
+			<mp>130.98</mp>
+			<cp>179.274</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>312.83</hp>
+			<mp>137.46</mp>
+			<cp>187.698</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>327.0</hp>
+			<mp>144.0</mp>
+			<cp>196.2</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>356.7</hp>
+			<mp>153.9</mp>
+			<cp>214.02</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>386.67</hp>
+			<mp>163.89</mp>
+			<cp>232.002</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>416.91</hp>
+			<mp>173.97</mp>
+			<cp>250.146</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>447.42</hp>
+			<mp>184.14</mp>
+			<cp>268.452</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>478.2</hp>
+			<mp>194.4</mp>
+			<cp>286.92</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>509.25</hp>
+			<mp>204.75</mp>
+			<cp>305.55</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>540.57</hp>
+			<mp>215.19</mp>
+			<cp>324.342</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>572.16</hp>
+			<mp>225.72</mp>
+			<cp>343.296</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>604.02</hp>
+			<mp>236.34</mp>
+			<cp>362.412</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>636.15</hp>
+			<mp>247.05</mp>
+			<cp>381.69</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>668.55</hp>
+			<mp>257.85</mp>
+			<cp>401.13</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>701.22</hp>
+			<mp>268.74</mp>
+			<cp>420.732</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>734.16</hp>
+			<mp>279.72</mp>
+			<cp>440.496</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>767.37</hp>
+			<mp>290.79</mp>
+			<cp>460.422</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>800.85</hp>
+			<mp>301.95</mp>
+			<cp>480.51</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>834.6</hp>
+			<mp>313.2</mp>
+			<cp>500.76</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>868.62</hp>
+			<mp>324.54</mp>
+			<cp>521.172</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>902.91</hp>
+			<mp>335.97</mp>
+			<cp>541.746</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>937.47</hp>
+			<mp>347.49</mp>
+			<cp>562.482</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>972.3</hp>
+			<mp>359.1</mp>
+			<cp>583.38</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1019.1</hp>
+			<mp>378.6</mp>
+			<cp>611.46</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1066.26</hp>
+			<mp>398.25</mp>
+			<cp>639.756</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1113.78</hp>
+			<mp>418.05</mp>
+			<cp>668.268</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1161.66</hp>
+			<mp>438.0</mp>
+			<cp>696.996</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1209.9</hp>
+			<mp>458.1</mp>
+			<cp>725.94</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1258.5</hp>
+			<mp>478.35</mp>
+			<cp>755.1</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1307.46</hp>
+			<mp>498.75</mp>
+			<cp>784.476</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1356.78</hp>
+			<mp>519.3</mp>
+			<cp>814.068</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1406.46</hp>
+			<mp>540.0</mp>
+			<cp>843.876</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1456.5</hp>
+			<mp>560.85</mp>
+			<cp>873.9</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1506.9</hp>
+			<mp>581.85</mp>
+			<cp>904.14</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1557.66</hp>
+			<mp>603.0</mp>
+			<cp>934.596</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1608.78</hp>
+			<mp>624.3</mp>
+			<cp>965.268</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1660.26</hp>
+			<mp>645.75</mp>
+			<cp>996.156</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1712.1</hp>
+			<mp>667.35</mp>
+			<cp>1027.26</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1764.3</hp>
+			<mp>689.1</mp>
+			<cp>1058.58</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1816.86</hp>
+			<mp>711.0</mp>
+			<cp>1090.116</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1869.78</hp>
+			<mp>733.05</mp>
+			<cp>1121.868</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1923.06</hp>
+			<mp>755.25</mp>
+			<cp>1153.836</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1976.7</hp>
+			<mp>777.6</mp>
+			<cp>1186.02</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2030.7</hp>
+			<mp>800.1</mp>
+			<cp>1218.42</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2085.06</hp>
+			<mp>822.75</mp>
+			<cp>1251.036</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2139.78</hp>
+			<mp>845.55</mp>
+			<cp>1283.868</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2194.86</hp>
+			<mp>868.5</mp>
+			<cp>1316.916</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2250.3</hp>
+			<mp>891.6</mp>
+			<cp>1350.18</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2306.1</hp>
+			<mp>914.85</mp>
+			<cp>1383.66</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2362.26</hp>
+			<mp>938.25</mp>
+			<cp>1417.356</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2418.78</hp>
+			<mp>961.8</mp>
+			<cp>1451.268</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2475.66</hp>
+			<mp>985.5</mp>
+			<cp>1485.396</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2532.9</hp>
+			<mp>1009.35</mp>
+			<cp>1519.74</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2590.5</hp>
+			<mp>1033.35</mp>
+			<cp>1554.3</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2648.46</hp>
+			<mp>1057.5</mp>
+			<cp>1589.076</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2706.78</hp>
+			<mp>1081.8</mp>
+			<cp>1624.068</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2765.46</hp>
+			<mp>1106.25</mp>
+			<cp>1659.276</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2824.5</hp>
+			<mp>1130.85</mp>
+			<cp>1694.7</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>2883.9</hp>
+			<mp>1155.6</mp>
+			<cp>1730.34</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>2943.66</hp>
+			<mp>1180.5</mp>
+			<cp>1766.196</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3003.78</hp>
+			<mp>1205.55</mp>
+			<cp>1802.268</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3064.26</hp>
+			<mp>1230.75</mp>
+			<cp>1838.556</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3125.1</hp>
+			<mp>1256.1</mp>
+			<cp>1875.06</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3186.3</hp>
+			<mp>1281.6</mp>
+			<cp>1911.78</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3247.86</hp>
+			<mp>1307.25</mp>
+			<cp>1948.716</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3309.78</hp>
+			<mp>1333.05</mp>
+			<cp>1985.868</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3372.06</hp>
+			<mp>1359.0</mp>
+			<cp>2023.236</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3434.7</hp>
+			<mp>1385.1</mp>
+			<cp>2060.82</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3497.7</hp>
+			<mp>1411.35</mp>
+			<cp>2098.62</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3561.06</hp>
+			<mp>1437.75</mp>
+			<cp>2136.636</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3624.78</hp>
+			<mp>1464.3</mp>
+			<cp>2174.868</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3688.86</hp>
+			<mp>1491.0</mp>
+			<cp>2213.316</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3753.3</hp>
+			<mp>1517.85</mp>
+			<cp>2251.98</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3818.1</hp>
+			<mp>1544.85</mp>
+			<cp>2290.86</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>3883.26</hp>
+			<mp>1572.0</mp>
+			<cp>2329.956</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>3948.78</hp>
+			<mp>1599.3</mp>
+			<cp>2369.268</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4014.66</hp>
+			<mp>1626.75</mp>
+			<cp>2408.796</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4080.9</hp>
+			<mp>1654.35</mp>
+			<cp>2448.54</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4147.5</hp>
+			<mp>1682.1</mp>
+			<cp>2488.5</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4214.46</hp>
+			<mp>1710.0</mp>
+			<cp>2528.676</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4281.78</hp>
+			<mp>1738.05</mp>
+			<cp>2569.068</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4349.46</hp>
+			<mp>1766.25</mp>
+			<cp>2609.676</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4417.5</hp>
+			<mp>1794.6</mp>
+			<cp>2650.5</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4485.9</hp>
+			<mp>1823.1</mp>
+			<cp>2691.55</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4554.66</hp>
+			<mp>1851.75</mp>
+			<cp>2732.82</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4623.78</hp>
+			<mp>1880.55</mp>
+			<cp>2774.31</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4693.26</hp>
+			<mp>1909.5</mp>
+			<cp>2816.02</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>4763.1</hp>
+			<mp>1938.6</mp>
+			<cp>2857.94</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>4833.3</hp>
+			<mp>1967.85</mp>
+			<cp>2900.09</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>4903.86</hp>
+			<mp>1997.25</mp>
+			<cp>2942.316</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Hierophant.xml
+++ b/data/stats/chars/baseStats/Hierophant.xml
@@ -1,798 +1,926 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>98</classId>
-    <staticData>
-        <baseINT>41</baseINT>
-        <baseSTR>22</baseSTR>
-        <baseCON>27</baseCON>
-        <baseMEN>39</baseMEN>
-        <baseDEX>21</baseDEX>
-        <baseWIT>20</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-90875" y="248162" z="-3570"/>
-            <node x="-90954" y="248118" z="-3570"/>
-            <node x="-90918" y="248070" z="-3570"/>
-            <node x="-90890" y="248027" z="-3570"/>
-        </creationPoints>
-        <basePAtk>3</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>15</chest>
-            <legs>8</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>78</walk>
-            <run>124</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>100</baseBreath>
-        <baseSafeFall>200</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>22.8</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>6.5</radius>
-            <height>22.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>101.0</hp>
-            <mp>40.0</mp>
-            <cp>50.5</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>116.47</hp>
-            <mp>47.28</mp>
-            <cp>58.235</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>132.11</hp>
-            <mp>54.64</mp>
-            <cp>66.055</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>147.92</hp>
-            <mp>62.08</mp>
-            <cp>73.96</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>163.9</hp>
-            <mp>69.6</mp>
-            <cp>81.95</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>180.05</hp>
-            <mp>77.2</mp>
-            <cp>90.025</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>196.37</hp>
-            <mp>84.88</mp>
-            <cp>98.185</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>212.86</hp>
-            <mp>92.64</mp>
-            <cp>106.43</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>229.52</hp>
-            <mp>100.48</mp>
-            <cp>114.76</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>246.35</hp>
-            <mp>108.4</mp>
-            <cp>123.175</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>263.35</hp>
-            <mp>116.4</mp>
-            <cp>131.675</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>280.52</hp>
-            <mp>124.48</mp>
-            <cp>140.26</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>297.86</hp>
-            <mp>132.64</mp>
-            <cp>148.93</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>315.37</hp>
-            <mp>140.88</mp>
-            <cp>157.685</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>333.05</hp>
-            <mp>149.2</mp>
-            <cp>166.525</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>350.9</hp>
-            <mp>157.6</mp>
-            <cp>175.45</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>368.92</hp>
-            <mp>166.08</mp>
-            <cp>184.46</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>387.11</hp>
-            <mp>174.64</mp>
-            <cp>193.555</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>405.47</hp>
-            <mp>183.28</mp>
-            <cp>202.735</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>424.0</hp>
-            <mp>192.0</mp>
-            <cp>212.0</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>458.1</hp>
-            <mp>205.2</mp>
-            <cp>229.05</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>492.51</hp>
-            <mp>218.52</mp>
-            <cp>246.255</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>527.23</hp>
-            <mp>231.96</mp>
-            <cp>263.615</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>562.26</hp>
-            <mp>245.52</mp>
-            <cp>281.13</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>597.6</hp>
-            <mp>259.2</mp>
-            <cp>298.8</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>633.25</hp>
-            <mp>273.0</mp>
-            <cp>316.625</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>669.21</hp>
-            <mp>286.92</mp>
-            <cp>334.605</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>705.48</hp>
-            <mp>300.96</mp>
-            <cp>352.74</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>742.06</hp>
-            <mp>315.12</mp>
-            <cp>371.03</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>778.95</hp>
-            <mp>329.4</mp>
-            <cp>389.475</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>816.15</hp>
-            <mp>343.8</mp>
-            <cp>408.075</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>853.66</hp>
-            <mp>358.32</mp>
-            <cp>426.83</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>891.48</hp>
-            <mp>372.96</mp>
-            <cp>445.74</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>929.61</hp>
-            <mp>387.72</mp>
-            <cp>464.805</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>968.05</hp>
-            <mp>402.6</mp>
-            <cp>484.025</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>1006.8</hp>
-            <mp>417.6</mp>
-            <cp>503.4</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>1045.86</hp>
-            <mp>432.72</mp>
-            <cp>522.93</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1085.23</hp>
-            <mp>447.96</mp>
-            <cp>542.615</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1124.91</hp>
-            <mp>463.32</mp>
-            <cp>562.455</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1164.9</hp>
-            <mp>478.8</mp>
-            <cp>582.45</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1218.2</hp>
-            <mp>504.8</mp>
-            <cp>609.1</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1271.91</hp>
-            <mp>531.0</mp>
-            <cp>635.955</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1326.03</hp>
-            <mp>557.4</mp>
-            <cp>663.015</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1380.56</hp>
-            <mp>584.0</mp>
-            <cp>690.28</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1435.5</hp>
-            <mp>610.8</mp>
-            <cp>717.75</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1490.85</hp>
-            <mp>637.8</mp>
-            <cp>745.425</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1546.61</hp>
-            <mp>665.0</mp>
-            <cp>773.305</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1602.78</hp>
-            <mp>692.4</mp>
-            <cp>801.39</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1659.36</hp>
-            <mp>720.0</mp>
-            <cp>829.68</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1716.35</hp>
-            <mp>747.8</mp>
-            <cp>858.175</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1773.75</hp>
-            <mp>775.8</mp>
-            <cp>886.875</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1831.56</hp>
-            <mp>804.0</mp>
-            <cp>915.78</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1889.78</hp>
-            <mp>832.4</mp>
-            <cp>944.89</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1948.41</hp>
-            <mp>861.0</mp>
-            <cp>974.205</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>2007.45</hp>
-            <mp>889.8</mp>
-            <cp>1003.725</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>2066.9</hp>
-            <mp>918.8</mp>
-            <cp>1033.45</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>2126.76</hp>
-            <mp>948.0</mp>
-            <cp>1063.38</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2187.03</hp>
-            <mp>977.4</mp>
-            <cp>1093.515</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2247.71</hp>
-            <mp>1007.0</mp>
-            <cp>1123.855</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2308.8</hp>
-            <mp>1036.8</mp>
-            <cp>1154.4</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2370.3</hp>
-            <mp>1066.8</mp>
-            <cp>1185.15</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2432.21</hp>
-            <mp>1097.0</mp>
-            <cp>1216.105</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2494.53</hp>
-            <mp>1127.4</mp>
-            <cp>1247.265</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2557.26</hp>
-            <mp>1158.0</mp>
-            <cp>1278.63</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2620.4</hp>
-            <mp>1188.8</mp>
-            <cp>1310.2</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2683.95</hp>
-            <mp>1219.8</mp>
-            <cp>1341.975</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2747.91</hp>
-            <mp>1251.0</mp>
-            <cp>1373.955</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2812.28</hp>
-            <mp>1282.4</mp>
-            <cp>1406.14</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2877.06</hp>
-            <mp>1314.0</mp>
-            <cp>1438.53</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2942.25</hp>
-            <mp>1345.8</mp>
-            <cp>1471.125</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>3007.85</hp>
-            <mp>1377.8</mp>
-            <cp>1503.925</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>3073.86</hp>
-            <mp>1410.0</mp>
-            <cp>1536.93</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>3140.28</hp>
-            <mp>1442.4</mp>
-            <cp>1570.14</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>3207.11</hp>
-            <mp>1475.0</mp>
-            <cp>1603.555</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3274.35</hp>
-            <mp>1507.8</mp>
-            <cp>1637.175</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3342.0</hp>
-            <mp>1540.8</mp>
-            <cp>1671.0</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3410.06</hp>
-            <mp>1574.0</mp>
-            <cp>1705.03</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3478.53</hp>
-            <mp>1607.4</mp>
-            <cp>1739.265</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3547.41</hp>
-            <mp>1641.0</mp>
-            <cp>1773.705</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3616.7</hp>
-            <mp>1674.8</mp>
-            <cp>1808.35</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3686.4</hp>
-            <mp>1708.8</mp>
-            <cp>1843.2</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3756.51</hp>
-            <mp>1743.0</mp>
-            <cp>1878.255</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3827.03</hp>
-            <mp>1777.4</mp>
-            <cp>1913.515</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3897.96</hp>
-            <mp>1812.0</mp>
-            <cp>1948.98</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3969.3</hp>
-            <mp>1846.8</mp>
-            <cp>1984.65</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>4041.05</hp>
-            <mp>1881.8</mp>
-            <cp>2020.525</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>4113.21</hp>
-            <mp>1917.0</mp>
-            <cp>2056.605</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>4185.78</hp>
-            <mp>1952.4</mp>
-            <cp>2092.89</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>4258.76</hp>
-            <mp>1988.0</mp>
-            <cp>2129.38</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4332.15</hp>
-            <mp>2023.8</mp>
-            <cp>2166.075</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4405.95</hp>
-            <mp>2059.8</mp>
-            <cp>2202.975</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>98</classId>
+	<staticData>
+		<baseINT>41</baseINT>
+		<baseSTR>22</baseSTR>
+		<baseCON>27</baseCON>
+		<baseMEN>39</baseMEN>
+		<baseDEX>21</baseDEX>
+		<baseWIT>20</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-90875" y="248162" z="-3570" />
+			<node x="-90954" y="248118" z="-3570" />
+			<node x="-90918" y="248070" z="-3570" />
+			<node x="-90890" y="248027" z="-3570" />
+		</creationPoints>
+		<basePAtk>3</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>15</chest>
+			<legs>8</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>78</walk>
+			<run>124</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>200</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>22.8</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>6.5</radius>
+			<height>22.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>101.0</hp>
+			<mp>40.0</mp>
+			<cp>50.5</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>116.47</hp>
+			<mp>47.28</mp>
+			<cp>58.235</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>132.11</hp>
+			<mp>54.64</mp>
+			<cp>66.055</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>147.92</hp>
+			<mp>62.08</mp>
+			<cp>73.96</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>163.9</hp>
+			<mp>69.6</mp>
+			<cp>81.95</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>180.05</hp>
+			<mp>77.2</mp>
+			<cp>90.025</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>196.37</hp>
+			<mp>84.88</mp>
+			<cp>98.185</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>212.86</hp>
+			<mp>92.64</mp>
+			<cp>106.43</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>229.52</hp>
+			<mp>100.48</mp>
+			<cp>114.76</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>246.35</hp>
+			<mp>108.4</mp>
+			<cp>123.175</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>263.35</hp>
+			<mp>116.4</mp>
+			<cp>131.675</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>280.52</hp>
+			<mp>124.48</mp>
+			<cp>140.26</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>297.86</hp>
+			<mp>132.64</mp>
+			<cp>148.93</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>315.37</hp>
+			<mp>140.88</mp>
+			<cp>157.685</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>333.05</hp>
+			<mp>149.2</mp>
+			<cp>166.525</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>350.9</hp>
+			<mp>157.6</mp>
+			<cp>175.45</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>368.92</hp>
+			<mp>166.08</mp>
+			<cp>184.46</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>387.11</hp>
+			<mp>174.64</mp>
+			<cp>193.555</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>405.47</hp>
+			<mp>183.28</mp>
+			<cp>202.735</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>424.0</hp>
+			<mp>192.0</mp>
+			<cp>212.0</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>458.1</hp>
+			<mp>205.2</mp>
+			<cp>229.05</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>492.51</hp>
+			<mp>218.52</mp>
+			<cp>246.255</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>527.23</hp>
+			<mp>231.96</mp>
+			<cp>263.615</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>562.26</hp>
+			<mp>245.52</mp>
+			<cp>281.13</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>597.6</hp>
+			<mp>259.2</mp>
+			<cp>298.8</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>633.25</hp>
+			<mp>273.0</mp>
+			<cp>316.625</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>669.21</hp>
+			<mp>286.92</mp>
+			<cp>334.605</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>705.48</hp>
+			<mp>300.96</mp>
+			<cp>352.74</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>742.06</hp>
+			<mp>315.12</mp>
+			<cp>371.03</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>778.95</hp>
+			<mp>329.4</mp>
+			<cp>389.475</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>816.15</hp>
+			<mp>343.8</mp>
+			<cp>408.075</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>853.66</hp>
+			<mp>358.32</mp>
+			<cp>426.83</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>891.48</hp>
+			<mp>372.96</mp>
+			<cp>445.74</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>929.61</hp>
+			<mp>387.72</mp>
+			<cp>464.805</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>968.05</hp>
+			<mp>402.6</mp>
+			<cp>484.025</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>1006.8</hp>
+			<mp>417.6</mp>
+			<cp>503.4</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>1045.86</hp>
+			<mp>432.72</mp>
+			<cp>522.93</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1085.23</hp>
+			<mp>447.96</mp>
+			<cp>542.615</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1124.91</hp>
+			<mp>463.32</mp>
+			<cp>562.455</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1164.9</hp>
+			<mp>478.8</mp>
+			<cp>582.45</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1218.2</hp>
+			<mp>504.8</mp>
+			<cp>609.1</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1271.91</hp>
+			<mp>531.0</mp>
+			<cp>635.955</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1326.03</hp>
+			<mp>557.4</mp>
+			<cp>663.015</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1380.56</hp>
+			<mp>584.0</mp>
+			<cp>690.28</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1435.5</hp>
+			<mp>610.8</mp>
+			<cp>717.75</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1490.85</hp>
+			<mp>637.8</mp>
+			<cp>745.425</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1546.61</hp>
+			<mp>665.0</mp>
+			<cp>773.305</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1602.78</hp>
+			<mp>692.4</mp>
+			<cp>801.39</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1659.36</hp>
+			<mp>720.0</mp>
+			<cp>829.68</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1716.35</hp>
+			<mp>747.8</mp>
+			<cp>858.175</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1773.75</hp>
+			<mp>775.8</mp>
+			<cp>886.875</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1831.56</hp>
+			<mp>804.0</mp>
+			<cp>915.78</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1889.78</hp>
+			<mp>832.4</mp>
+			<cp>944.89</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1948.41</hp>
+			<mp>861.0</mp>
+			<cp>974.205</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>2007.45</hp>
+			<mp>889.8</mp>
+			<cp>1003.725</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>2066.9</hp>
+			<mp>918.8</mp>
+			<cp>1033.45</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2126.76</hp>
+			<mp>948.0</mp>
+			<cp>1063.38</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2187.03</hp>
+			<mp>977.4</mp>
+			<cp>1093.515</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2247.71</hp>
+			<mp>1007.0</mp>
+			<cp>1123.855</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2308.8</hp>
+			<mp>1036.8</mp>
+			<cp>1154.4</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2370.3</hp>
+			<mp>1066.8</mp>
+			<cp>1185.15</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2432.21</hp>
+			<mp>1097.0</mp>
+			<cp>1216.105</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2494.53</hp>
+			<mp>1127.4</mp>
+			<cp>1247.265</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2557.26</hp>
+			<mp>1158.0</mp>
+			<cp>1278.63</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2620.4</hp>
+			<mp>1188.8</mp>
+			<cp>1310.2</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2683.95</hp>
+			<mp>1219.8</mp>
+			<cp>1341.975</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2747.91</hp>
+			<mp>1251.0</mp>
+			<cp>1373.955</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2812.28</hp>
+			<mp>1282.4</mp>
+			<cp>1406.14</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2877.06</hp>
+			<mp>1314.0</mp>
+			<cp>1438.53</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2942.25</hp>
+			<mp>1345.8</mp>
+			<cp>1471.125</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>3007.85</hp>
+			<mp>1377.8</mp>
+			<cp>1503.925</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>3073.86</hp>
+			<mp>1410.0</mp>
+			<cp>1536.93</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>3140.28</hp>
+			<mp>1442.4</mp>
+			<cp>1570.14</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3207.11</hp>
+			<mp>1475.0</mp>
+			<cp>1603.555</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3274.35</hp>
+			<mp>1507.8</mp>
+			<cp>1637.175</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3342.0</hp>
+			<mp>1540.8</mp>
+			<cp>1671.0</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3410.06</hp>
+			<mp>1574.0</mp>
+			<cp>1705.03</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3478.53</hp>
+			<mp>1607.4</mp>
+			<cp>1739.265</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3547.41</hp>
+			<mp>1641.0</mp>
+			<cp>1773.705</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3616.7</hp>
+			<mp>1674.8</mp>
+			<cp>1808.35</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3686.4</hp>
+			<mp>1708.8</mp>
+			<cp>1843.2</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3756.51</hp>
+			<mp>1743.0</mp>
+			<cp>1878.255</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3827.03</hp>
+			<mp>1777.4</mp>
+			<cp>1913.515</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3897.96</hp>
+			<mp>1812.0</mp>
+			<cp>1948.98</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3969.3</hp>
+			<mp>1846.8</mp>
+			<cp>1984.65</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>4041.05</hp>
+			<mp>1881.8</mp>
+			<cp>2020.525</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>4113.21</hp>
+			<mp>1917.0</mp>
+			<cp>2056.605</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4185.78</hp>
+			<mp>1952.4</mp>
+			<cp>2092.89</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4258.76</hp>
+			<mp>1988.0</mp>
+			<cp>2129.38</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4332.15</hp>
+			<mp>2023.8</mp>
+			<cp>2166.075</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4405.95</hp>
+			<mp>2059.8</mp>
+			<cp>2202.975</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4480.16</hp>
+			<mp>2096.0</mp>
+			<cp>2240.08</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4554.78</hp>
+			<mp>2132.4</mp>
+			<cp>2277.39</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4629.81</hp>
+			<mp>2169.0</mp>
+			<cp>2314.905</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4705.25</hp>
+			<mp>2205.8</mp>
+			<cp>2352.625</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4781.1</hp>
+			<mp>2242.8</mp>
+			<cp>2390.55</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4857.36</hp>
+			<mp>2280.0</mp>
+			<cp>2428.68</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4934.03</hp>
+			<mp>2317.4</mp>
+			<cp>2467.015</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>5011.11</hp>
+			<mp>2355.0</mp>
+			<cp>2505.555</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>5088.6</hp>
+			<mp>2392.8</mp>
+			<cp>2544.3</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>5166.5</hp>
+			<mp>2430.8</mp>
+			<cp>2583.24</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5244.81</hp>
+			<mp>2469</mp>
+			<cp>2622.38</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5323.53</hp>
+			<mp>2507.4</mp>
+			<cp>2661.72</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5402.66</hp>
+			<mp>2546</mp>
+			<cp>2701.26</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5482.2</hp>
+			<mp>2584.8</mp>
+			<cp>2741</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5562.15</hp>
+			<mp>2623.8</mp>
+			<cp>2780.94</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5642.51</hp>
+			<mp>2663</mp>
+			<cp>2821.255</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/HumanDeathBlader.xml
+++ b/data/stats/chars/baseStats/HumanDeathBlader.xml
@@ -1,0 +1,923 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
+	<classId>197</classId>
+	<staticData>
+		<baseINT>20</baseINT>
+		<baseSTR>40</baseSTR>
+		<baseCON>41</baseCON>
+		<baseMEN>25</baseMEN>
+		<baseDEX>34</baseDEX>
+		<baseWIT>10</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="47417" y="153541" z="-2728" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>80</walk>
+			<run>132</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>250</baseSafeFall>
+		<collisionMale>
+			<radius>9.0</radius>
+			<height>23</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>8.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>80.0</hp>
+			<mp>30.0</mp>
+			<cp>48.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>91.83</hp>
+			<mp>35.46</mp>
+			<cp>55.098</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>103.79</hp>
+			<mp>40.98</mp>
+			<cp>62.274</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>115.88</hp>
+			<mp>46.56</mp>
+			<cp>69.528</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>128.1</hp>
+			<mp>52.2</mp>
+			<cp>76.86</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>140.45</hp>
+			<mp>57.9</mp>
+			<cp>84.27</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>152.93</hp>
+			<mp>63.66</mp>
+			<cp>91.758</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>165.54</hp>
+			<mp>69.48</mp>
+			<cp>99.324</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>178.28</hp>
+			<mp>75.36</mp>
+			<cp>106.968</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>191.15</hp>
+			<mp>81.3</mp>
+			<cp>114.69</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>204.15</hp>
+			<mp>87.3</mp>
+			<cp>122.49</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>217.28</hp>
+			<mp>93.36</mp>
+			<cp>130.368</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>230.54</hp>
+			<mp>99.48</mp>
+			<cp>138.324</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>243.93</hp>
+			<mp>105.66</mp>
+			<cp>146.358</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>257.45</hp>
+			<mp>111.9</mp>
+			<cp>154.47</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>271.1</hp>
+			<mp>118.2</mp>
+			<cp>162.66</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>284.88</hp>
+			<mp>124.56</mp>
+			<cp>170.928</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>298.79</hp>
+			<mp>130.98</mp>
+			<cp>179.274</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>312.83</hp>
+			<mp>137.46</mp>
+			<cp>187.698</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>327.0</hp>
+			<mp>144.0</mp>
+			<cp>196.2</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>356.7</hp>
+			<mp>153.9</mp>
+			<cp>214.02</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>386.67</hp>
+			<mp>163.89</mp>
+			<cp>232.002</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>416.91</hp>
+			<mp>173.97</mp>
+			<cp>250.146</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>447.42</hp>
+			<mp>184.14</mp>
+			<cp>268.452</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>478.2</hp>
+			<mp>194.4</mp>
+			<cp>286.92</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>509.25</hp>
+			<mp>204.75</mp>
+			<cp>305.55</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>540.57</hp>
+			<mp>215.19</mp>
+			<cp>324.342</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>572.16</hp>
+			<mp>225.72</mp>
+			<cp>343.296</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>604.02</hp>
+			<mp>236.34</mp>
+			<cp>362.412</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>636.15</hp>
+			<mp>247.05</mp>
+			<cp>381.69</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>668.55</hp>
+			<mp>257.85</mp>
+			<cp>401.13</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>701.22</hp>
+			<mp>268.74</mp>
+			<cp>420.732</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>734.16</hp>
+			<mp>279.72</mp>
+			<cp>440.496</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>767.37</hp>
+			<mp>290.79</mp>
+			<cp>460.422</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>800.85</hp>
+			<mp>301.95</mp>
+			<cp>480.51</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>834.6</hp>
+			<mp>313.2</mp>
+			<cp>500.76</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>868.62</hp>
+			<mp>324.54</mp>
+			<cp>521.172</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>902.91</hp>
+			<mp>335.97</mp>
+			<cp>541.746</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>937.47</hp>
+			<mp>347.49</mp>
+			<cp>562.482</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>972.3</hp>
+			<mp>359.1</mp>
+			<cp>583.38</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1007.4</hp>
+			<mp>370.8</mp>
+			<cp>604.44</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1042.77</hp>
+			<mp>382.59</mp>
+			<cp>625.662</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1078.41</hp>
+			<mp>394.47</mp>
+			<cp>647.046</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1114.32</hp>
+			<mp>406.44</mp>
+			<cp>668.592</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1150.5</hp>
+			<mp>418.5</mp>
+			<cp>690.3</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1186.95</hp>
+			<mp>430.65</mp>
+			<cp>712.17</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1223.67</hp>
+			<mp>442.89</mp>
+			<cp>734.202</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1260.66</hp>
+			<mp>455.22</mp>
+			<cp>756.396</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1297.92</hp>
+			<mp>467.64</mp>
+			<cp>778.752</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1335.45</hp>
+			<mp>480.15</mp>
+			<cp>801.27</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1373.25</hp>
+			<mp>492.75</mp>
+			<cp>823.95</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1411.32</hp>
+			<mp>505.44</mp>
+			<cp>846.792</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1449.66</hp>
+			<mp>518.22</mp>
+			<cp>869.796</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1488.27</hp>
+			<mp>531.09</mp>
+			<cp>892.962</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1527.15</hp>
+			<mp>544.05</mp>
+			<cp>916.29</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1566.3</hp>
+			<mp>557.1</mp>
+			<cp>939.78</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1605.72</hp>
+			<mp>570.24</mp>
+			<cp>963.432</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1645.41</hp>
+			<mp>583.47</mp>
+			<cp>987.246</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1685.37</hp>
+			<mp>596.79</mp>
+			<cp>1011.222</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1725.6</hp>
+			<mp>610.2</mp>
+			<cp>1035.36</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>1766.1</hp>
+			<mp>623.7</mp>
+			<cp>1059.66</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>1806.87</hp>
+			<mp>637.29</mp>
+			<cp>1084.122</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>1847.91</hp>
+			<mp>650.97</mp>
+			<cp>1108.746</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>1889.22</hp>
+			<mp>664.74</mp>
+			<cp>1133.532</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>1930.8</hp>
+			<mp>678.6</mp>
+			<cp>1158.48</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>1972.65</hp>
+			<mp>692.55</mp>
+			<cp>1183.59</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2014.77</hp>
+			<mp>706.59</mp>
+			<cp>1208.862</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2057.16</hp>
+			<mp>720.72</mp>
+			<cp>1234.296</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2099.82</hp>
+			<mp>734.94</mp>
+			<cp>1259.892</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2142.75</hp>
+			<mp>749.25</mp>
+			<cp>1285.65</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2185.95</hp>
+			<mp>763.65</mp>
+			<cp>1311.57</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2229.42</hp>
+			<mp>778.14</mp>
+			<cp>1337.652</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2273.16</hp>
+			<mp>792.72</mp>
+			<cp>1363.896</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2317.17</hp>
+			<mp>807.39</mp>
+			<cp>1390.302</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2361.45</hp>
+			<mp>822.15</mp>
+			<cp>1416.87</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>2406.0</hp>
+			<mp>837.0</mp>
+			<cp>1443.6</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>2450.82</hp>
+			<mp>851.94</mp>
+			<cp>1470.492</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>2495.91</hp>
+			<mp>866.97</mp>
+			<cp>1497.546</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>2541.27</hp>
+			<mp>882.09</mp>
+			<cp>1524.762</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>2586.9</hp>
+			<mp>897.3</mp>
+			<cp>1552.14</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>2632.8</hp>
+			<mp>912.6</mp>
+			<cp>1579.68</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>2678.97</hp>
+			<mp>927.99</mp>
+			<cp>1607.382</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>2725.41</hp>
+			<mp>943.47</mp>
+			<cp>1635.246</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>2772.12</hp>
+			<mp>959.04</mp>
+			<cp>1663.272</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>2819.1</hp>
+			<mp>974.7</mp>
+			<cp>1691.46</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>2866.35</hp>
+			<mp>990.45</mp>
+			<cp>1719.81</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>2913.87</hp>
+			<mp>1006.29</mp>
+			<cp>1748.322</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>2961.66</hp>
+			<mp>1022.22</mp>
+			<cp>1776.996</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3009.72</hp>
+			<mp>1038.24</mp>
+			<cp>1805.832</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3058.05</hp>
+			<mp>1054.35</mp>
+			<cp>1834.83</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3106.65</hp>
+			<mp>1070.55</mp>
+			<cp>1863.99</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>3155.52</hp>
+			<mp>1086.84</mp>
+			<cp>1893.312</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>3204.66</hp>
+			<mp>1103.22</mp>
+			<cp>1922.796</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>3254.07</hp>
+			<mp>1119.69</mp>
+			<cp>1952.442</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>3303.75</hp>
+			<mp>1136.25</mp>
+			<cp>1982.25</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>3353.7</hp>
+			<mp>1152.9</mp>
+			<cp>2012.22</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>3403.92</hp>
+			<mp>1169.64</mp>
+			<cp>2042.352</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>3454.41</hp>
+			<mp>1186.47</mp>
+			<cp>2072.646</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>3505.17</hp>
+			<mp>1203.39</mp>
+			<cp>2103.102</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>3556.2</hp>
+			<mp>1220.4</mp>
+			<cp>2133.72</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>3607.5</hp>
+			<mp>1237.5</mp>
+			<cp>2164.49</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>3659.07</hp>
+			<mp>1254.69</mp>
+			<cp>2195.43</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>3710.91</hp>
+			<mp>1271.97</mp>
+			<cp>2226.53</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>3763.02</hp>
+			<mp>1289.34</mp>
+			<cp>2257.78</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>3815.4</hp>
+			<mp>1306.8</mp>
+			<cp>2289.2</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>3868.05</hp>
+			<mp>1324.35</mp>
+			<cp>2320.77</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>3920.97</hp>
+			<mp>1341.99</mp>
+			<cp>2352.582</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
+</list>

--- a/data/stats/chars/baseStats/HumanDeathKnight.xml
+++ b/data/stats/chars/baseStats/HumanDeathKnight.xml
@@ -1,0 +1,923 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
+	<classId>199</classId>
+	<staticData>
+		<baseINT>20</baseINT>
+		<baseSTR>40</baseSTR>
+		<baseCON>41</baseCON>
+		<baseMEN>25</baseMEN>
+		<baseDEX>34</baseDEX>
+		<baseWIT>10</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="47417" y="153541" z="-2728" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>80</walk>
+			<run>132</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>250</baseSafeFall>
+		<collisionMale>
+			<radius>9.0</radius>
+			<height>23</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>8.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>80.0</hp>
+			<mp>30.0</mp>
+			<cp>48.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>91.83</hp>
+			<mp>35.46</mp>
+			<cp>55.098</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>103.79</hp>
+			<mp>40.98</mp>
+			<cp>62.274</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>115.88</hp>
+			<mp>46.56</mp>
+			<cp>69.528</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>128.1</hp>
+			<mp>52.2</mp>
+			<cp>76.86</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>140.45</hp>
+			<mp>57.9</mp>
+			<cp>84.27</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>152.93</hp>
+			<mp>63.66</mp>
+			<cp>91.758</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>165.54</hp>
+			<mp>69.48</mp>
+			<cp>99.324</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>178.28</hp>
+			<mp>75.36</mp>
+			<cp>106.968</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>191.15</hp>
+			<mp>81.3</mp>
+			<cp>114.69</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>204.15</hp>
+			<mp>87.3</mp>
+			<cp>122.49</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>217.28</hp>
+			<mp>93.36</mp>
+			<cp>130.368</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>230.54</hp>
+			<mp>99.48</mp>
+			<cp>138.324</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>243.93</hp>
+			<mp>105.66</mp>
+			<cp>146.358</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>257.45</hp>
+			<mp>111.9</mp>
+			<cp>154.47</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>271.1</hp>
+			<mp>118.2</mp>
+			<cp>162.66</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>284.88</hp>
+			<mp>124.56</mp>
+			<cp>170.928</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>298.79</hp>
+			<mp>130.98</mp>
+			<cp>179.274</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>312.83</hp>
+			<mp>137.46</mp>
+			<cp>187.698</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>327.0</hp>
+			<mp>144.0</mp>
+			<cp>196.2</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>356.7</hp>
+			<mp>153.9</mp>
+			<cp>214.02</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>386.67</hp>
+			<mp>163.89</mp>
+			<cp>232.002</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>416.91</hp>
+			<mp>173.97</mp>
+			<cp>250.146</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>447.42</hp>
+			<mp>184.14</mp>
+			<cp>268.452</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>478.2</hp>
+			<mp>194.4</mp>
+			<cp>286.92</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>509.25</hp>
+			<mp>204.75</mp>
+			<cp>305.55</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>540.57</hp>
+			<mp>215.19</mp>
+			<cp>324.342</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>572.16</hp>
+			<mp>225.72</mp>
+			<cp>343.296</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>604.02</hp>
+			<mp>236.34</mp>
+			<cp>362.412</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>636.15</hp>
+			<mp>247.05</mp>
+			<cp>381.69</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>668.55</hp>
+			<mp>257.85</mp>
+			<cp>401.13</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>701.22</hp>
+			<mp>268.74</mp>
+			<cp>420.732</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>734.16</hp>
+			<mp>279.72</mp>
+			<cp>440.496</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>767.37</hp>
+			<mp>290.79</mp>
+			<cp>460.422</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>800.85</hp>
+			<mp>301.95</mp>
+			<cp>480.51</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>834.6</hp>
+			<mp>313.2</mp>
+			<cp>500.76</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>868.62</hp>
+			<mp>324.54</mp>
+			<cp>521.172</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>902.91</hp>
+			<mp>335.97</mp>
+			<cp>541.746</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>937.47</hp>
+			<mp>347.49</mp>
+			<cp>562.482</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>972.3</hp>
+			<mp>359.1</mp>
+			<cp>583.38</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1019.1</hp>
+			<mp>378.6</mp>
+			<cp>611.46</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1066.26</hp>
+			<mp>398.25</mp>
+			<cp>639.756</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1113.78</hp>
+			<mp>418.05</mp>
+			<cp>668.268</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1161.66</hp>
+			<mp>438.0</mp>
+			<cp>696.996</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1209.9</hp>
+			<mp>458.1</mp>
+			<cp>725.94</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1258.5</hp>
+			<mp>478.35</mp>
+			<cp>755.1</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1307.46</hp>
+			<mp>498.75</mp>
+			<cp>784.476</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1356.78</hp>
+			<mp>519.3</mp>
+			<cp>814.068</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1406.46</hp>
+			<mp>540.0</mp>
+			<cp>843.876</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1456.5</hp>
+			<mp>560.85</mp>
+			<cp>873.9</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1506.9</hp>
+			<mp>581.85</mp>
+			<cp>904.14</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1557.66</hp>
+			<mp>603.0</mp>
+			<cp>934.596</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1608.78</hp>
+			<mp>624.3</mp>
+			<cp>965.268</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1660.26</hp>
+			<mp>645.75</mp>
+			<cp>996.156</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1712.1</hp>
+			<mp>667.35</mp>
+			<cp>1027.26</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1764.3</hp>
+			<mp>689.1</mp>
+			<cp>1058.58</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1816.86</hp>
+			<mp>711.0</mp>
+			<cp>1090.116</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1869.78</hp>
+			<mp>733.05</mp>
+			<cp>1121.868</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1923.06</hp>
+			<mp>755.25</mp>
+			<cp>1153.836</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1976.7</hp>
+			<mp>777.6</mp>
+			<cp>1186.02</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2030.7</hp>
+			<mp>800.1</mp>
+			<cp>1218.42</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2085.06</hp>
+			<mp>822.75</mp>
+			<cp>1251.036</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2139.78</hp>
+			<mp>845.55</mp>
+			<cp>1283.868</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2194.86</hp>
+			<mp>868.5</mp>
+			<cp>1316.916</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2250.3</hp>
+			<mp>891.6</mp>
+			<cp>1350.18</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2306.1</hp>
+			<mp>914.85</mp>
+			<cp>1383.66</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2362.26</hp>
+			<mp>938.25</mp>
+			<cp>1417.356</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2418.78</hp>
+			<mp>961.8</mp>
+			<cp>1451.268</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2475.66</hp>
+			<mp>985.5</mp>
+			<cp>1485.396</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2532.9</hp>
+			<mp>1009.35</mp>
+			<cp>1519.74</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2590.5</hp>
+			<mp>1033.35</mp>
+			<cp>1554.3</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2648.46</hp>
+			<mp>1057.5</mp>
+			<cp>1589.076</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2706.78</hp>
+			<mp>1081.8</mp>
+			<cp>1624.068</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2765.46</hp>
+			<mp>1106.25</mp>
+			<cp>1659.276</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2824.5</hp>
+			<mp>1130.85</mp>
+			<cp>1694.7</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>2883.9</hp>
+			<mp>1155.6</mp>
+			<cp>1730.34</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>2943.66</hp>
+			<mp>1180.5</mp>
+			<cp>1766.196</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3003.78</hp>
+			<mp>1205.55</mp>
+			<cp>1802.268</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3064.26</hp>
+			<mp>1230.75</mp>
+			<cp>1838.556</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3125.1</hp>
+			<mp>1256.1</mp>
+			<cp>1875.06</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3186.3</hp>
+			<mp>1281.6</mp>
+			<cp>1911.78</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3247.86</hp>
+			<mp>1307.25</mp>
+			<cp>1948.716</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3309.78</hp>
+			<mp>1333.05</mp>
+			<cp>1985.868</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3372.06</hp>
+			<mp>1359.0</mp>
+			<cp>2023.236</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3434.7</hp>
+			<mp>1385.1</mp>
+			<cp>2060.82</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3497.7</hp>
+			<mp>1411.35</mp>
+			<cp>2098.62</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3561.06</hp>
+			<mp>1437.75</mp>
+			<cp>2136.636</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3624.78</hp>
+			<mp>1464.3</mp>
+			<cp>2174.868</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3688.86</hp>
+			<mp>1491.0</mp>
+			<cp>2213.316</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3753.3</hp>
+			<mp>1517.85</mp>
+			<cp>2251.98</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3818.1</hp>
+			<mp>1544.85</mp>
+			<cp>2290.86</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>3883.26</hp>
+			<mp>1572.0</mp>
+			<cp>2329.956</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>3948.78</hp>
+			<mp>1599.3</mp>
+			<cp>2369.268</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4014.66</hp>
+			<mp>1626.75</mp>
+			<cp>2408.796</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4080.9</hp>
+			<mp>1654.35</mp>
+			<cp>2448.54</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4147.5</hp>
+			<mp>1682.1</mp>
+			<cp>2488.5</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4214.46</hp>
+			<mp>1710.0</mp>
+			<cp>2528.676</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4281.78</hp>
+			<mp>1738.05</mp>
+			<cp>2569.068</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4349.46</hp>
+			<mp>1766.25</mp>
+			<cp>2609.676</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4417.5</hp>
+			<mp>1794.6</mp>
+			<cp>2650.5</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4485.9</hp>
+			<mp>1823.1</mp>
+			<cp>2691.55</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4554.66</hp>
+			<mp>1851.75</mp>
+			<cp>2732.82</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4623.78</hp>
+			<mp>1880.55</mp>
+			<cp>2774.31</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4693.26</hp>
+			<mp>1909.5</mp>
+			<cp>2816.02</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>4763.1</hp>
+			<mp>1938.6</mp>
+			<cp>2857.94</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>4833.3</hp>
+			<mp>1967.85</mp>
+			<cp>2900.09</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>4903.86</hp>
+			<mp>1997.25</mp>
+			<cp>2942.316</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
+</list>

--- a/data/stats/chars/baseStats/HumanDeathWalker.xml
+++ b/data/stats/chars/baseStats/HumanDeathWalker.xml
@@ -1,0 +1,923 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
+	<classId>196</classId>
+	<staticData>
+		<baseINT>20</baseINT>
+		<baseSTR>40</baseSTR>
+		<baseCON>41</baseCON>
+		<baseMEN>25</baseMEN>
+		<baseDEX>34</baseDEX>
+		<baseWIT>10</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="47417" y="153541" z="-2728" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>80</walk>
+			<run>132</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>250</baseSafeFall>
+		<collisionMale>
+			<radius>9.0</radius>
+			<height>23</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>8.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>80.0</hp>
+			<mp>30.0</mp>
+			<cp>32.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>91.83</hp>
+			<mp>35.46</mp>
+			<cp>36.732</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>103.79</hp>
+			<mp>40.98</mp>
+			<cp>41.516</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>115.88</hp>
+			<mp>46.56</mp>
+			<cp>46.352</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>128.1</hp>
+			<mp>52.2</mp>
+			<cp>51.24</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>140.45</hp>
+			<mp>57.9</mp>
+			<cp>56.18</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>152.93</hp>
+			<mp>63.66</mp>
+			<cp>61.172</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>165.54</hp>
+			<mp>69.48</mp>
+			<cp>66.216</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>178.28</hp>
+			<mp>75.36</mp>
+			<cp>71.312</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>191.15</hp>
+			<mp>81.3</mp>
+			<cp>76.46</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>204.15</hp>
+			<mp>87.3</mp>
+			<cp>81.66</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>217.28</hp>
+			<mp>93.36</mp>
+			<cp>86.912</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>230.54</hp>
+			<mp>99.48</mp>
+			<cp>92.216</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>243.93</hp>
+			<mp>105.66</mp>
+			<cp>97.572</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>257.45</hp>
+			<mp>111.9</mp>
+			<cp>102.98</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>271.1</hp>
+			<mp>118.2</mp>
+			<cp>108.44</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>284.88</hp>
+			<mp>124.56</mp>
+			<cp>113.952</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>298.79</hp>
+			<mp>130.98</mp>
+			<cp>119.516</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>312.83</hp>
+			<mp>137.46</mp>
+			<cp>125.132</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>327.0</hp>
+			<mp>144.0</mp>
+			<cp>130.8</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>341.3</hp>
+			<mp>150.6</mp>
+			<cp>136.52</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>355.73</hp>
+			<mp>157.26</mp>
+			<cp>142.292</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>370.29</hp>
+			<mp>163.98</mp>
+			<cp>148.116</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>384.98</hp>
+			<mp>170.76</mp>
+			<cp>153.992</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>399.8</hp>
+			<mp>177.6</mp>
+			<cp>159.92</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>414.75</hp>
+			<mp>184.5</mp>
+			<cp>165.9</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>429.83</hp>
+			<mp>191.46</mp>
+			<cp>171.932</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>445.04</hp>
+			<mp>198.48</mp>
+			<cp>178.016</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>460.38</hp>
+			<mp>205.56</mp>
+			<cp>184.152</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>475.85</hp>
+			<mp>212.7</mp>
+			<cp>190.34</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>491.45</hp>
+			<mp>219.9</mp>
+			<cp>196.58</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>507.18</hp>
+			<mp>227.16</mp>
+			<cp>202.872</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>523.04</hp>
+			<mp>234.48</mp>
+			<cp>209.216</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>539.03</hp>
+			<mp>241.86</mp>
+			<cp>215.612</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>555.15</hp>
+			<mp>249.3</mp>
+			<cp>222.06</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>571.4</hp>
+			<mp>256.8</mp>
+			<cp>228.56</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>587.78</hp>
+			<mp>264.36</mp>
+			<cp>235.112</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>604.29</hp>
+			<mp>271.98</mp>
+			<cp>241.716</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>620.93</hp>
+			<mp>279.66</mp>
+			<cp>248.372</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>637.7</hp>
+			<mp>287.4</mp>
+			<cp>255.08</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>654.6</hp>
+			<mp>295.2</mp>
+			<cp>261.84</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>671.63</hp>
+			<mp>303.06</mp>
+			<cp>268.652</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>688.79</hp>
+			<mp>310.98</mp>
+			<cp>275.516</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>706.08</hp>
+			<mp>318.96</mp>
+			<cp>282.432</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>723.5</hp>
+			<mp>327.0</mp>
+			<cp>289.4</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>741.05</hp>
+			<mp>335.1</mp>
+			<cp>296.42</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>758.73</hp>
+			<mp>343.26</mp>
+			<cp>303.492</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>776.54</hp>
+			<mp>351.48</mp>
+			<cp>310.616</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>794.48</hp>
+			<mp>359.76</mp>
+			<cp>317.792</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>812.55</hp>
+			<mp>368.1</mp>
+			<cp>325.02</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>830.75</hp>
+			<mp>376.5</mp>
+			<cp>332.3</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>849.08</hp>
+			<mp>384.96</mp>
+			<cp>339.632</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>867.54</hp>
+			<mp>393.48</mp>
+			<cp>347.016</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>886.13</hp>
+			<mp>402.06</mp>
+			<cp>354.452</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>904.85</hp>
+			<mp>410.7</mp>
+			<cp>361.94</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>923.7</hp>
+			<mp>419.4</mp>
+			<cp>369.48</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>942.68</hp>
+			<mp>428.16</mp>
+			<cp>377.072</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>961.79</hp>
+			<mp>436.98</mp>
+			<cp>384.716</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>981.03</hp>
+			<mp>445.86</mp>
+			<cp>392.412</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1000.4</hp>
+			<mp>454.8</mp>
+			<cp>400.16</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>1019.9</hp>
+			<mp>463.8</mp>
+			<cp>407.96</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>1039.53</hp>
+			<mp>472.86</mp>
+			<cp>415.812</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>1059.29</hp>
+			<mp>481.98</mp>
+			<cp>423.716</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>1079.18</hp>
+			<mp>491.16</mp>
+			<cp>431.672</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>1099.2</hp>
+			<mp>500.4</mp>
+			<cp>439.68</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>1119.35</hp>
+			<mp>509.7</mp>
+			<cp>447.74</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>1139.63</hp>
+			<mp>519.06</mp>
+			<cp>455.852</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>1160.04</hp>
+			<mp>528.48</mp>
+			<cp>464.016</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>1180.58</hp>
+			<mp>537.96</mp>
+			<cp>472.232</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>1201.25</hp>
+			<mp>547.5</mp>
+			<cp>480.5</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>1222.05</hp>
+			<mp>557.1</mp>
+			<cp>488.82</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>1242.98</hp>
+			<mp>566.76</mp>
+			<cp>497.192</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>1264.04</hp>
+			<mp>576.48</mp>
+			<cp>505.616</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>1285.23</hp>
+			<mp>586.26</mp>
+			<cp>514.092</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>1306.55</hp>
+			<mp>596.1</mp>
+			<cp>522.62</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>1328.0</hp>
+			<mp>606.0</mp>
+			<cp>531.2</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>1349.58</hp>
+			<mp>615.96</mp>
+			<cp>539.832</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>1371.29</hp>
+			<mp>625.98</mp>
+			<cp>548.516</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>1393.13</hp>
+			<mp>636.06</mp>
+			<cp>557.252</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>1415.1</hp>
+			<mp>646.2</mp>
+			<cp>566.04</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>1437.2</hp>
+			<mp>656.4</mp>
+			<cp>574.88</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>1459.43</hp>
+			<mp>666.66</mp>
+			<cp>583.772</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>1481.79</hp>
+			<mp>676.98</mp>
+			<cp>592.716</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>1504.28</hp>
+			<mp>687.36</mp>
+			<cp>601.712</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>1526.9</hp>
+			<mp>697.8</mp>
+			<cp>610.76</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>1549.65</hp>
+			<mp>708.3</mp>
+			<cp>619.86</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>1572.53</hp>
+			<mp>718.86</mp>
+			<cp>629.012</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>1595.54</hp>
+			<mp>729.48</mp>
+			<cp>638.216</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>1618.68</hp>
+			<mp>740.16</mp>
+			<cp>647.472</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>1641.95</hp>
+			<mp>750.9</mp>
+			<cp>656.78</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>1665.35</hp>
+			<mp>761.7</mp>
+			<cp>666.14</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>1688.88</hp>
+			<mp>772.56</mp>
+			<cp>675.552</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>1712.54</hp>
+			<mp>783.48</mp>
+			<cp>685.016</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>1736.33</hp>
+			<mp>794.46</mp>
+			<cp>694.532</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>1760.25</hp>
+			<mp>805.5</mp>
+			<cp>704.1</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>1784.3</hp>
+			<mp>816.6</mp>
+			<cp>713.72</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>1808.48</hp>
+			<mp>827.76</mp>
+			<cp>723.392</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>1832.79</hp>
+			<mp>838.98</mp>
+			<cp>733.116</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>1857.23</hp>
+			<mp>850.26</mp>
+			<cp>742.892</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>1881.8</hp>
+			<mp>861.6</mp>
+			<cp>752.72</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>1906.5</hp>
+			<mp>873</mp>
+			<cp>762.59</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>1931.33</hp>
+			<mp>884.46</mp>
+			<cp>772.52</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>1956.29</hp>
+			<mp>895.98</mp>
+			<cp>782.5</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>1981.38</hp>
+			<mp>907.56</mp>
+			<cp>792.52</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>2006.6</hp>
+			<mp>919.2</mp>
+			<cp>802.6</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>2031.95</hp>
+			<mp>930.9</mp>
+			<cp>812.72</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>2057.43</hp>
+			<mp>942.66</mp>
+			<cp>822.972</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
+</list>

--- a/data/stats/chars/baseStats/HumanFighter.xml
+++ b/data/stats/chars/baseStats/HumanFighter.xml
@@ -1,798 +1,926 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>0</classId>
-    <staticData>
-        <baseINT>21</baseINT>
-        <baseSTR>40</baseSTR>
-        <baseCON>43</baseCON>
-        <baseMEN>25</baseMEN>
-        <baseDEX>30</baseDEX>
-        <baseWIT>11</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-71338" y="258271" z="-3104"/>
-            <node x="-71417" y="258270" z="-3104"/>
-            <node x="-71453" y="258305" z="-3104"/>
-            <node x="-71467" y="258378" z="-3104"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>80</walk>
-            <run>132</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>100</baseBreath>
-        <baseSafeFall>250</baseSafeFall>
-        <collisionMale>
-            <radius>9.0</radius>
-            <height>23</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>8.0</radius>
-            <height>23.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>80.0</hp>
-            <mp>30.0</mp>
-            <cp>32.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>91.83</hp>
-            <mp>35.46</mp>
-            <cp>36.732</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>103.79</hp>
-            <mp>40.98</mp>
-            <cp>41.516</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>115.88</hp>
-            <mp>46.56</mp>
-            <cp>46.352</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>128.1</hp>
-            <mp>52.2</mp>
-            <cp>51.24</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>140.45</hp>
-            <mp>57.9</mp>
-            <cp>56.18</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>152.93</hp>
-            <mp>63.66</mp>
-            <cp>61.172</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>165.54</hp>
-            <mp>69.48</mp>
-            <cp>66.216</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>178.28</hp>
-            <mp>75.36</mp>
-            <cp>71.312</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>191.15</hp>
-            <mp>81.3</mp>
-            <cp>76.46</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>204.15</hp>
-            <mp>87.3</mp>
-            <cp>81.66</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>217.28</hp>
-            <mp>93.36</mp>
-            <cp>86.912</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>230.54</hp>
-            <mp>99.48</mp>
-            <cp>92.216</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>243.93</hp>
-            <mp>105.66</mp>
-            <cp>97.572</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>257.45</hp>
-            <mp>111.9</mp>
-            <cp>102.98</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>271.1</hp>
-            <mp>118.2</mp>
-            <cp>108.44</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>284.88</hp>
-            <mp>124.56</mp>
-            <cp>113.952</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>298.79</hp>
-            <mp>130.98</mp>
-            <cp>119.516</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>312.83</hp>
-            <mp>137.46</mp>
-            <cp>125.132</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>327.0</hp>
-            <mp>144.0</mp>
-            <cp>130.8</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>341.3</hp>
-            <mp>150.6</mp>
-            <cp>136.52</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>355.73</hp>
-            <mp>157.26</mp>
-            <cp>142.292</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>370.29</hp>
-            <mp>163.98</mp>
-            <cp>148.116</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>384.98</hp>
-            <mp>170.76</mp>
-            <cp>153.992</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>399.8</hp>
-            <mp>177.6</mp>
-            <cp>159.92</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>414.75</hp>
-            <mp>184.5</mp>
-            <cp>165.9</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>429.83</hp>
-            <mp>191.46</mp>
-            <cp>171.932</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>445.04</hp>
-            <mp>198.48</mp>
-            <cp>178.016</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>460.38</hp>
-            <mp>205.56</mp>
-            <cp>184.152</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>475.85</hp>
-            <mp>212.7</mp>
-            <cp>190.34</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>491.45</hp>
-            <mp>219.9</mp>
-            <cp>196.58</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>507.18</hp>
-            <mp>227.16</mp>
-            <cp>202.872</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>523.04</hp>
-            <mp>234.48</mp>
-            <cp>209.216</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>539.03</hp>
-            <mp>241.86</mp>
-            <cp>215.612</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>555.15</hp>
-            <mp>249.3</mp>
-            <cp>222.06</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>571.4</hp>
-            <mp>256.8</mp>
-            <cp>228.56</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>587.78</hp>
-            <mp>264.36</mp>
-            <cp>235.112</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>604.29</hp>
-            <mp>271.98</mp>
-            <cp>241.716</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>620.93</hp>
-            <mp>279.66</mp>
-            <cp>248.372</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>637.7</hp>
-            <mp>287.4</mp>
-            <cp>255.08</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>654.6</hp>
-            <mp>295.2</mp>
-            <cp>261.84</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>671.63</hp>
-            <mp>303.06</mp>
-            <cp>268.652</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>688.79</hp>
-            <mp>310.98</mp>
-            <cp>275.516</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>706.08</hp>
-            <mp>318.96</mp>
-            <cp>282.432</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>723.5</hp>
-            <mp>327.0</mp>
-            <cp>289.4</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>741.05</hp>
-            <mp>335.1</mp>
-            <cp>296.42</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>758.73</hp>
-            <mp>343.26</mp>
-            <cp>303.492</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>776.54</hp>
-            <mp>351.48</mp>
-            <cp>310.616</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>794.48</hp>
-            <mp>359.76</mp>
-            <cp>317.792</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>812.55</hp>
-            <mp>368.1</mp>
-            <cp>325.02</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>830.75</hp>
-            <mp>376.5</mp>
-            <cp>332.3</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>849.08</hp>
-            <mp>384.96</mp>
-            <cp>339.632</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>867.54</hp>
-            <mp>393.48</mp>
-            <cp>347.016</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>886.13</hp>
-            <mp>402.06</mp>
-            <cp>354.452</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>904.85</hp>
-            <mp>410.7</mp>
-            <cp>361.94</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>923.7</hp>
-            <mp>419.4</mp>
-            <cp>369.48</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>942.68</hp>
-            <mp>428.16</mp>
-            <cp>377.072</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>961.79</hp>
-            <mp>436.98</mp>
-            <cp>384.716</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>981.03</hp>
-            <mp>445.86</mp>
-            <cp>392.412</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>1000.4</hp>
-            <mp>454.8</mp>
-            <cp>400.16</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>1019.9</hp>
-            <mp>463.8</mp>
-            <cp>407.96</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>1039.53</hp>
-            <mp>472.86</mp>
-            <cp>415.812</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>1059.29</hp>
-            <mp>481.98</mp>
-            <cp>423.716</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>1079.18</hp>
-            <mp>491.16</mp>
-            <cp>431.672</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>1099.2</hp>
-            <mp>500.4</mp>
-            <cp>439.68</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>1119.35</hp>
-            <mp>509.7</mp>
-            <cp>447.74</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>1139.63</hp>
-            <mp>519.06</mp>
-            <cp>455.852</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>1160.04</hp>
-            <mp>528.48</mp>
-            <cp>464.016</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>1180.58</hp>
-            <mp>537.96</mp>
-            <cp>472.232</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>1201.25</hp>
-            <mp>547.5</mp>
-            <cp>480.5</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>1222.05</hp>
-            <mp>557.1</mp>
-            <cp>488.82</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>1242.98</hp>
-            <mp>566.76</mp>
-            <cp>497.192</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>1264.04</hp>
-            <mp>576.48</mp>
-            <cp>505.616</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>1285.23</hp>
-            <mp>586.26</mp>
-            <cp>514.092</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>1306.55</hp>
-            <mp>596.1</mp>
-            <cp>522.62</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>1328.0</hp>
-            <mp>606.0</mp>
-            <cp>531.2</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>1349.58</hp>
-            <mp>615.96</mp>
-            <cp>539.832</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>1371.29</hp>
-            <mp>625.98</mp>
-            <cp>548.516</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>1393.13</hp>
-            <mp>636.06</mp>
-            <cp>557.252</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>1415.1</hp>
-            <mp>646.2</mp>
-            <cp>566.04</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>1437.2</hp>
-            <mp>656.4</mp>
-            <cp>574.88</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>1459.43</hp>
-            <mp>666.66</mp>
-            <cp>583.772</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>1481.79</hp>
-            <mp>676.98</mp>
-            <cp>592.716</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>1504.28</hp>
-            <mp>687.36</mp>
-            <cp>601.712</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>1526.9</hp>
-            <mp>697.8</mp>
-            <cp>610.76</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>1549.65</hp>
-            <mp>708.3</mp>
-            <cp>619.86</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>1572.53</hp>
-            <mp>718.86</mp>
-            <cp>629.012</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>1595.54</hp>
-            <mp>729.48</mp>
-            <cp>638.216</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>1618.68</hp>
-            <mp>740.16</mp>
-            <cp>647.472</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>1641.95</hp>
-            <mp>750.9</mp>
-            <cp>656.78</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>1665.35</hp>
-            <mp>761.7</mp>
-            <cp>666.14</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>0</classId>
+	<staticData>
+		<baseINT>21</baseINT>
+		<baseSTR>40</baseSTR>
+		<baseCON>43</baseCON>
+		<baseMEN>25</baseMEN>
+		<baseDEX>30</baseDEX>
+		<baseWIT>11</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-71315" y="257165" z="-3112" />
+			<node x="-71657" y="256818" z="-3112" />
+			<node x="-71562" y="256785" z="-3112" />
+			<node x="-71281" y="257016" z="-3112" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>80</walk>
+			<run>132</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>250</baseSafeFall>
+		<collisionMale>
+			<radius>9.0</radius>
+			<height>23</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>8.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>80.0</hp>
+			<mp>30.0</mp>
+			<cp>32.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>91.83</hp>
+			<mp>35.46</mp>
+			<cp>36.732</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>103.79</hp>
+			<mp>40.98</mp>
+			<cp>41.516</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>115.88</hp>
+			<mp>46.56</mp>
+			<cp>46.352</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>128.1</hp>
+			<mp>52.2</mp>
+			<cp>51.24</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>140.45</hp>
+			<mp>57.9</mp>
+			<cp>56.18</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>152.93</hp>
+			<mp>63.66</mp>
+			<cp>61.172</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>165.54</hp>
+			<mp>69.48</mp>
+			<cp>66.216</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>178.28</hp>
+			<mp>75.36</mp>
+			<cp>71.312</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>191.15</hp>
+			<mp>81.3</mp>
+			<cp>76.46</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>204.15</hp>
+			<mp>87.3</mp>
+			<cp>81.66</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>217.28</hp>
+			<mp>93.36</mp>
+			<cp>86.912</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>230.54</hp>
+			<mp>99.48</mp>
+			<cp>92.216</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>243.93</hp>
+			<mp>105.66</mp>
+			<cp>97.572</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>257.45</hp>
+			<mp>111.9</mp>
+			<cp>102.98</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>271.1</hp>
+			<mp>118.2</mp>
+			<cp>108.44</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>284.88</hp>
+			<mp>124.56</mp>
+			<cp>113.952</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>298.79</hp>
+			<mp>130.98</mp>
+			<cp>119.516</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>312.83</hp>
+			<mp>137.46</mp>
+			<cp>125.132</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>327.0</hp>
+			<mp>144.0</mp>
+			<cp>130.8</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>341.3</hp>
+			<mp>150.6</mp>
+			<cp>136.52</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>355.73</hp>
+			<mp>157.26</mp>
+			<cp>142.292</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>370.29</hp>
+			<mp>163.98</mp>
+			<cp>148.116</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>384.98</hp>
+			<mp>170.76</mp>
+			<cp>153.992</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>399.8</hp>
+			<mp>177.6</mp>
+			<cp>159.92</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>414.75</hp>
+			<mp>184.5</mp>
+			<cp>165.9</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>429.83</hp>
+			<mp>191.46</mp>
+			<cp>171.932</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>445.04</hp>
+			<mp>198.48</mp>
+			<cp>178.016</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>460.38</hp>
+			<mp>205.56</mp>
+			<cp>184.152</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>475.85</hp>
+			<mp>212.7</mp>
+			<cp>190.34</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>491.45</hp>
+			<mp>219.9</mp>
+			<cp>196.58</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>507.18</hp>
+			<mp>227.16</mp>
+			<cp>202.872</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>523.04</hp>
+			<mp>234.48</mp>
+			<cp>209.216</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>539.03</hp>
+			<mp>241.86</mp>
+			<cp>215.612</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>555.15</hp>
+			<mp>249.3</mp>
+			<cp>222.06</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>571.4</hp>
+			<mp>256.8</mp>
+			<cp>228.56</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>587.78</hp>
+			<mp>264.36</mp>
+			<cp>235.112</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>604.29</hp>
+			<mp>271.98</mp>
+			<cp>241.716</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>620.93</hp>
+			<mp>279.66</mp>
+			<cp>248.372</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>637.7</hp>
+			<mp>287.4</mp>
+			<cp>255.08</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>654.6</hp>
+			<mp>295.2</mp>
+			<cp>261.84</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>671.63</hp>
+			<mp>303.06</mp>
+			<cp>268.652</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>688.79</hp>
+			<mp>310.98</mp>
+			<cp>275.516</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>706.08</hp>
+			<mp>318.96</mp>
+			<cp>282.432</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>723.5</hp>
+			<mp>327.0</mp>
+			<cp>289.4</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>741.05</hp>
+			<mp>335.1</mp>
+			<cp>296.42</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>758.73</hp>
+			<mp>343.26</mp>
+			<cp>303.492</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>776.54</hp>
+			<mp>351.48</mp>
+			<cp>310.616</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>794.48</hp>
+			<mp>359.76</mp>
+			<cp>317.792</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>812.55</hp>
+			<mp>368.1</mp>
+			<cp>325.02</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>830.75</hp>
+			<mp>376.5</mp>
+			<cp>332.3</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>849.08</hp>
+			<mp>384.96</mp>
+			<cp>339.632</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>867.54</hp>
+			<mp>393.48</mp>
+			<cp>347.016</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>886.13</hp>
+			<mp>402.06</mp>
+			<cp>354.452</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>904.85</hp>
+			<mp>410.7</mp>
+			<cp>361.94</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>923.7</hp>
+			<mp>419.4</mp>
+			<cp>369.48</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>942.68</hp>
+			<mp>428.16</mp>
+			<cp>377.072</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>961.79</hp>
+			<mp>436.98</mp>
+			<cp>384.716</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>981.03</hp>
+			<mp>445.86</mp>
+			<cp>392.412</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1000.4</hp>
+			<mp>454.8</mp>
+			<cp>400.16</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>1019.9</hp>
+			<mp>463.8</mp>
+			<cp>407.96</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>1039.53</hp>
+			<mp>472.86</mp>
+			<cp>415.812</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>1059.29</hp>
+			<mp>481.98</mp>
+			<cp>423.716</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>1079.18</hp>
+			<mp>491.16</mp>
+			<cp>431.672</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>1099.2</hp>
+			<mp>500.4</mp>
+			<cp>439.68</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>1119.35</hp>
+			<mp>509.7</mp>
+			<cp>447.74</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>1139.63</hp>
+			<mp>519.06</mp>
+			<cp>455.852</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>1160.04</hp>
+			<mp>528.48</mp>
+			<cp>464.016</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>1180.58</hp>
+			<mp>537.96</mp>
+			<cp>472.232</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>1201.25</hp>
+			<mp>547.5</mp>
+			<cp>480.5</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>1222.05</hp>
+			<mp>557.1</mp>
+			<cp>488.82</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>1242.98</hp>
+			<mp>566.76</mp>
+			<cp>497.192</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>1264.04</hp>
+			<mp>576.48</mp>
+			<cp>505.616</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>1285.23</hp>
+			<mp>586.26</mp>
+			<cp>514.092</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>1306.55</hp>
+			<mp>596.1</mp>
+			<cp>522.62</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>1328.0</hp>
+			<mp>606.0</mp>
+			<cp>531.2</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>1349.58</hp>
+			<mp>615.96</mp>
+			<cp>539.832</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>1371.29</hp>
+			<mp>625.98</mp>
+			<cp>548.516</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>1393.13</hp>
+			<mp>636.06</mp>
+			<cp>557.252</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>1415.1</hp>
+			<mp>646.2</mp>
+			<cp>566.04</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>1437.2</hp>
+			<mp>656.4</mp>
+			<cp>574.88</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>1459.43</hp>
+			<mp>666.66</mp>
+			<cp>583.772</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>1481.79</hp>
+			<mp>676.98</mp>
+			<cp>592.716</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>1504.28</hp>
+			<mp>687.36</mp>
+			<cp>601.712</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>1526.9</hp>
+			<mp>697.8</mp>
+			<cp>610.76</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>1549.65</hp>
+			<mp>708.3</mp>
+			<cp>619.86</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>1572.53</hp>
+			<mp>718.86</mp>
+			<cp>629.012</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>1595.54</hp>
+			<mp>729.48</mp>
+			<cp>638.216</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>1618.68</hp>
+			<mp>740.16</mp>
+			<cp>647.472</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>1641.95</hp>
+			<mp>750.9</mp>
+			<cp>656.78</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>1665.35</hp>
+			<mp>761.7</mp>
+			<cp>666.14</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>1688.88</hp>
+			<mp>772.56</mp>
+			<cp>675.552</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>1712.54</hp>
+			<mp>783.48</mp>
+			<cp>685.016</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>1736.33</hp>
+			<mp>794.46</mp>
+			<cp>694.532</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>1760.25</hp>
+			<mp>805.5</mp>
+			<cp>704.1</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>1784.3</hp>
+			<mp>816.6</mp>
+			<cp>713.72</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>1808.48</hp>
+			<mp>827.76</mp>
+			<cp>723.392</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>1832.79</hp>
+			<mp>838.98</mp>
+			<cp>733.116</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>1857.23</hp>
+			<mp>850.26</mp>
+			<cp>742.892</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>1881.8</hp>
+			<mp>861.6</mp>
+			<cp>752.72</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>1906.5</hp>
+			<mp>873</mp>
+			<cp>762.59</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>1931.33</hp>
+			<mp>884.46</mp>
+			<cp>772.52</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>1956.29</hp>
+			<mp>895.98</mp>
+			<cp>782.5</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>1981.38</hp>
+			<mp>907.56</mp>
+			<cp>792.52</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>2006.6</hp>
+			<mp>919.2</mp>
+			<cp>802.6</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>2031.95</hp>
+			<mp>930.9</mp>
+			<cp>812.72</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>2057.43</hp>
+			<mp>942.66</mp>
+			<cp>822.972</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/HumanKnight.xml
+++ b/data/stats/chars/baseStats/HumanKnight.xml
@@ -1,798 +1,926 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>4</classId>
-    <staticData>
-        <baseINT>21</baseINT>
-        <baseSTR>40</baseSTR>
-        <baseCON>43</baseCON>
-        <baseMEN>25</baseMEN>
-        <baseDEX>30</baseDEX>
-        <baseWIT>11</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-71338" y="258271" z="-3104"/>
-            <node x="-71417" y="258270" z="-3104"/>
-            <node x="-71453" y="258305" z="-3104"/>
-            <node x="-71467" y="258378" z="-3104"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>80</walk>
-            <run>132</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>100</baseBreath>
-        <baseSafeFall>250</baseSafeFall>
-        <collisionMale>
-            <radius>9.0</radius>
-            <height>23</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>8.0</radius>
-            <height>23.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>80.0</hp>
-            <mp>30.0</mp>
-            <cp>48.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>91.83</hp>
-            <mp>35.46</mp>
-            <cp>55.098</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>103.79</hp>
-            <mp>40.98</mp>
-            <cp>62.274</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>115.88</hp>
-            <mp>46.56</mp>
-            <cp>69.528</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>128.1</hp>
-            <mp>52.2</mp>
-            <cp>76.86</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>140.45</hp>
-            <mp>57.9</mp>
-            <cp>84.27</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>152.93</hp>
-            <mp>63.66</mp>
-            <cp>91.758</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>165.54</hp>
-            <mp>69.48</mp>
-            <cp>99.324</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>178.28</hp>
-            <mp>75.36</mp>
-            <cp>106.968</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>191.15</hp>
-            <mp>81.3</mp>
-            <cp>114.69</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>204.15</hp>
-            <mp>87.3</mp>
-            <cp>122.49</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>217.28</hp>
-            <mp>93.36</mp>
-            <cp>130.368</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>230.54</hp>
-            <mp>99.48</mp>
-            <cp>138.324</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>243.93</hp>
-            <mp>105.66</mp>
-            <cp>146.358</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>257.45</hp>
-            <mp>111.9</mp>
-            <cp>154.47</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>271.1</hp>
-            <mp>118.2</mp>
-            <cp>162.66</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>284.88</hp>
-            <mp>124.56</mp>
-            <cp>170.928</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>298.79</hp>
-            <mp>130.98</mp>
-            <cp>179.274</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>312.83</hp>
-            <mp>137.46</mp>
-            <cp>187.698</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>327.0</hp>
-            <mp>144.0</mp>
-            <cp>196.2</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>356.7</hp>
-            <mp>153.9</mp>
-            <cp>214.02</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>386.67</hp>
-            <mp>163.89</mp>
-            <cp>232.002</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>416.91</hp>
-            <mp>173.97</mp>
-            <cp>250.146</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>447.42</hp>
-            <mp>184.14</mp>
-            <cp>268.452</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>478.2</hp>
-            <mp>194.4</mp>
-            <cp>286.92</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>509.25</hp>
-            <mp>204.75</mp>
-            <cp>305.55</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>540.57</hp>
-            <mp>215.19</mp>
-            <cp>324.342</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>572.16</hp>
-            <mp>225.72</mp>
-            <cp>343.296</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>604.02</hp>
-            <mp>236.34</mp>
-            <cp>362.412</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>636.15</hp>
-            <mp>247.05</mp>
-            <cp>381.69</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>668.55</hp>
-            <mp>257.85</mp>
-            <cp>401.13</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>701.22</hp>
-            <mp>268.74</mp>
-            <cp>420.732</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>734.16</hp>
-            <mp>279.72</mp>
-            <cp>440.496</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>767.37</hp>
-            <mp>290.79</mp>
-            <cp>460.422</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>800.85</hp>
-            <mp>301.95</mp>
-            <cp>480.51</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>834.6</hp>
-            <mp>313.2</mp>
-            <cp>500.76</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>868.62</hp>
-            <mp>324.54</mp>
-            <cp>521.172</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>902.91</hp>
-            <mp>335.97</mp>
-            <cp>541.746</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>937.47</hp>
-            <mp>347.49</mp>
-            <cp>562.482</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>972.3</hp>
-            <mp>359.1</mp>
-            <cp>583.38</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1007.4</hp>
-            <mp>370.8</mp>
-            <cp>604.44</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1042.77</hp>
-            <mp>382.59</mp>
-            <cp>625.662</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1078.41</hp>
-            <mp>394.47</mp>
-            <cp>647.046</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1114.32</hp>
-            <mp>406.44</mp>
-            <cp>668.592</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1150.5</hp>
-            <mp>418.5</mp>
-            <cp>690.3</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1186.95</hp>
-            <mp>430.65</mp>
-            <cp>712.17</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1223.67</hp>
-            <mp>442.89</mp>
-            <cp>734.202</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1260.66</hp>
-            <mp>455.22</mp>
-            <cp>756.396</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1297.92</hp>
-            <mp>467.64</mp>
-            <cp>778.752</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1335.45</hp>
-            <mp>480.15</mp>
-            <cp>801.27</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1373.25</hp>
-            <mp>492.75</mp>
-            <cp>823.95</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1411.32</hp>
-            <mp>505.44</mp>
-            <cp>846.792</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1449.66</hp>
-            <mp>518.22</mp>
-            <cp>869.796</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1488.27</hp>
-            <mp>531.09</mp>
-            <cp>892.962</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1527.15</hp>
-            <mp>544.05</mp>
-            <cp>916.29</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1566.3</hp>
-            <mp>557.1</mp>
-            <cp>939.78</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1605.72</hp>
-            <mp>570.24</mp>
-            <cp>963.432</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1645.41</hp>
-            <mp>583.47</mp>
-            <cp>987.246</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>1685.37</hp>
-            <mp>596.79</mp>
-            <cp>1011.222</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>1725.6</hp>
-            <mp>610.2</mp>
-            <cp>1035.36</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>1766.1</hp>
-            <mp>623.7</mp>
-            <cp>1059.66</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>1806.87</hp>
-            <mp>637.29</mp>
-            <cp>1084.122</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>1847.91</hp>
-            <mp>650.97</mp>
-            <cp>1108.746</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>1889.22</hp>
-            <mp>664.74</mp>
-            <cp>1133.532</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>1930.8</hp>
-            <mp>678.6</mp>
-            <cp>1158.48</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>1972.65</hp>
-            <mp>692.55</mp>
-            <cp>1183.59</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2014.77</hp>
-            <mp>706.59</mp>
-            <cp>1208.862</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2057.16</hp>
-            <mp>720.72</mp>
-            <cp>1234.296</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2099.82</hp>
-            <mp>734.94</mp>
-            <cp>1259.892</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2142.75</hp>
-            <mp>749.25</mp>
-            <cp>1285.65</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2185.95</hp>
-            <mp>763.65</mp>
-            <cp>1311.57</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2229.42</hp>
-            <mp>778.14</mp>
-            <cp>1337.652</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2273.16</hp>
-            <mp>792.72</mp>
-            <cp>1363.896</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2317.17</hp>
-            <mp>807.39</mp>
-            <cp>1390.302</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2361.45</hp>
-            <mp>822.15</mp>
-            <cp>1416.87</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>2406.0</hp>
-            <mp>837.0</mp>
-            <cp>1443.6</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>2450.82</hp>
-            <mp>851.94</mp>
-            <cp>1470.492</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>2495.91</hp>
-            <mp>866.97</mp>
-            <cp>1497.546</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>2541.27</hp>
-            <mp>882.09</mp>
-            <cp>1524.762</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>2586.9</hp>
-            <mp>897.3</mp>
-            <cp>1552.14</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>2632.8</hp>
-            <mp>912.6</mp>
-            <cp>1579.68</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>2678.97</hp>
-            <mp>927.99</mp>
-            <cp>1607.382</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>2725.41</hp>
-            <mp>943.47</mp>
-            <cp>1635.246</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>2772.12</hp>
-            <mp>959.04</mp>
-            <cp>1663.272</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>2819.1</hp>
-            <mp>974.7</mp>
-            <cp>1691.46</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>2866.35</hp>
-            <mp>990.45</mp>
-            <cp>1719.81</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>2913.87</hp>
-            <mp>1006.29</mp>
-            <cp>1748.322</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>2961.66</hp>
-            <mp>1022.22</mp>
-            <cp>1776.996</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3009.72</hp>
-            <mp>1038.24</mp>
-            <cp>1805.832</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3058.05</hp>
-            <mp>1054.35</mp>
-            <cp>1834.83</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>3106.65</hp>
-            <mp>1070.55</mp>
-            <cp>1863.99</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>4</classId>
+	<staticData>
+		<baseINT>21</baseINT>
+		<baseSTR>40</baseSTR>
+		<baseCON>43</baseCON>
+		<baseMEN>25</baseMEN>
+		<baseDEX>30</baseDEX>
+		<baseWIT>11</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-71338" y="258271" z="-3104" />
+			<node x="-71417" y="258270" z="-3104" />
+			<node x="-71453" y="258305" z="-3104" />
+			<node x="-71467" y="258378" z="-3104" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>80</walk>
+			<run>132</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>250</baseSafeFall>
+		<collisionMale>
+			<radius>9.0</radius>
+			<height>23</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>8.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>80.0</hp>
+			<mp>30.0</mp>
+			<cp>48.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>91.83</hp>
+			<mp>35.46</mp>
+			<cp>55.098</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>103.79</hp>
+			<mp>40.98</mp>
+			<cp>62.274</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>115.88</hp>
+			<mp>46.56</mp>
+			<cp>69.528</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>128.1</hp>
+			<mp>52.2</mp>
+			<cp>76.86</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>140.45</hp>
+			<mp>57.9</mp>
+			<cp>84.27</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>152.93</hp>
+			<mp>63.66</mp>
+			<cp>91.758</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>165.54</hp>
+			<mp>69.48</mp>
+			<cp>99.324</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>178.28</hp>
+			<mp>75.36</mp>
+			<cp>106.968</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>191.15</hp>
+			<mp>81.3</mp>
+			<cp>114.69</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>204.15</hp>
+			<mp>87.3</mp>
+			<cp>122.49</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>217.28</hp>
+			<mp>93.36</mp>
+			<cp>130.368</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>230.54</hp>
+			<mp>99.48</mp>
+			<cp>138.324</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>243.93</hp>
+			<mp>105.66</mp>
+			<cp>146.358</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>257.45</hp>
+			<mp>111.9</mp>
+			<cp>154.47</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>271.1</hp>
+			<mp>118.2</mp>
+			<cp>162.66</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>284.88</hp>
+			<mp>124.56</mp>
+			<cp>170.928</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>298.79</hp>
+			<mp>130.98</mp>
+			<cp>179.274</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>312.83</hp>
+			<mp>137.46</mp>
+			<cp>187.698</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>327.0</hp>
+			<mp>144.0</mp>
+			<cp>196.2</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>356.7</hp>
+			<mp>153.9</mp>
+			<cp>214.02</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>386.67</hp>
+			<mp>163.89</mp>
+			<cp>232.002</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>416.91</hp>
+			<mp>173.97</mp>
+			<cp>250.146</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>447.42</hp>
+			<mp>184.14</mp>
+			<cp>268.452</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>478.2</hp>
+			<mp>194.4</mp>
+			<cp>286.92</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>509.25</hp>
+			<mp>204.75</mp>
+			<cp>305.55</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>540.57</hp>
+			<mp>215.19</mp>
+			<cp>324.342</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>572.16</hp>
+			<mp>225.72</mp>
+			<cp>343.296</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>604.02</hp>
+			<mp>236.34</mp>
+			<cp>362.412</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>636.15</hp>
+			<mp>247.05</mp>
+			<cp>381.69</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>668.55</hp>
+			<mp>257.85</mp>
+			<cp>401.13</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>701.22</hp>
+			<mp>268.74</mp>
+			<cp>420.732</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>734.16</hp>
+			<mp>279.72</mp>
+			<cp>440.496</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>767.37</hp>
+			<mp>290.79</mp>
+			<cp>460.422</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>800.85</hp>
+			<mp>301.95</mp>
+			<cp>480.51</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>834.6</hp>
+			<mp>313.2</mp>
+			<cp>500.76</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>868.62</hp>
+			<mp>324.54</mp>
+			<cp>521.172</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>902.91</hp>
+			<mp>335.97</mp>
+			<cp>541.746</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>937.47</hp>
+			<mp>347.49</mp>
+			<cp>562.482</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>972.3</hp>
+			<mp>359.1</mp>
+			<cp>583.38</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1007.4</hp>
+			<mp>370.8</mp>
+			<cp>604.44</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1042.77</hp>
+			<mp>382.59</mp>
+			<cp>625.662</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1078.41</hp>
+			<mp>394.47</mp>
+			<cp>647.046</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1114.32</hp>
+			<mp>406.44</mp>
+			<cp>668.592</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1150.5</hp>
+			<mp>418.5</mp>
+			<cp>690.3</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1186.95</hp>
+			<mp>430.65</mp>
+			<cp>712.17</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1223.67</hp>
+			<mp>442.89</mp>
+			<cp>734.202</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1260.66</hp>
+			<mp>455.22</mp>
+			<cp>756.396</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1297.92</hp>
+			<mp>467.64</mp>
+			<cp>778.752</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1335.45</hp>
+			<mp>480.15</mp>
+			<cp>801.27</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1373.25</hp>
+			<mp>492.75</mp>
+			<cp>823.95</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1411.32</hp>
+			<mp>505.44</mp>
+			<cp>846.792</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1449.66</hp>
+			<mp>518.22</mp>
+			<cp>869.796</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1488.27</hp>
+			<mp>531.09</mp>
+			<cp>892.962</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1527.15</hp>
+			<mp>544.05</mp>
+			<cp>916.29</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1566.3</hp>
+			<mp>557.1</mp>
+			<cp>939.78</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1605.72</hp>
+			<mp>570.24</mp>
+			<cp>963.432</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1645.41</hp>
+			<mp>583.47</mp>
+			<cp>987.246</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1685.37</hp>
+			<mp>596.79</mp>
+			<cp>1011.222</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1725.6</hp>
+			<mp>610.2</mp>
+			<cp>1035.36</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>1766.1</hp>
+			<mp>623.7</mp>
+			<cp>1059.66</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>1806.87</hp>
+			<mp>637.29</mp>
+			<cp>1084.122</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>1847.91</hp>
+			<mp>650.97</mp>
+			<cp>1108.746</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>1889.22</hp>
+			<mp>664.74</mp>
+			<cp>1133.532</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>1930.8</hp>
+			<mp>678.6</mp>
+			<cp>1158.48</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>1972.65</hp>
+			<mp>692.55</mp>
+			<cp>1183.59</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2014.77</hp>
+			<mp>706.59</mp>
+			<cp>1208.862</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2057.16</hp>
+			<mp>720.72</mp>
+			<cp>1234.296</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2099.82</hp>
+			<mp>734.94</mp>
+			<cp>1259.892</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2142.75</hp>
+			<mp>749.25</mp>
+			<cp>1285.65</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2185.95</hp>
+			<mp>763.65</mp>
+			<cp>1311.57</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2229.42</hp>
+			<mp>778.14</mp>
+			<cp>1337.652</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2273.16</hp>
+			<mp>792.72</mp>
+			<cp>1363.896</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2317.17</hp>
+			<mp>807.39</mp>
+			<cp>1390.302</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2361.45</hp>
+			<mp>822.15</mp>
+			<cp>1416.87</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>2406.0</hp>
+			<mp>837.0</mp>
+			<cp>1443.6</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>2450.82</hp>
+			<mp>851.94</mp>
+			<cp>1470.492</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>2495.91</hp>
+			<mp>866.97</mp>
+			<cp>1497.546</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>2541.27</hp>
+			<mp>882.09</mp>
+			<cp>1524.762</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>2586.9</hp>
+			<mp>897.3</mp>
+			<cp>1552.14</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>2632.8</hp>
+			<mp>912.6</mp>
+			<cp>1579.68</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>2678.97</hp>
+			<mp>927.99</mp>
+			<cp>1607.382</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>2725.41</hp>
+			<mp>943.47</mp>
+			<cp>1635.246</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>2772.12</hp>
+			<mp>959.04</mp>
+			<cp>1663.272</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>2819.1</hp>
+			<mp>974.7</mp>
+			<cp>1691.46</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>2866.35</hp>
+			<mp>990.45</mp>
+			<cp>1719.81</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>2913.87</hp>
+			<mp>1006.29</mp>
+			<cp>1748.322</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>2961.66</hp>
+			<mp>1022.22</mp>
+			<cp>1776.996</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3009.72</hp>
+			<mp>1038.24</mp>
+			<cp>1805.832</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3058.05</hp>
+			<mp>1054.35</mp>
+			<cp>1834.83</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3106.65</hp>
+			<mp>1070.55</mp>
+			<cp>1863.99</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>3155.52</hp>
+			<mp>1086.84</mp>
+			<cp>1893.312</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>3204.66</hp>
+			<mp>1103.22</mp>
+			<cp>1922.796</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>3254.07</hp>
+			<mp>1119.69</mp>
+			<cp>1952.442</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>3303.75</hp>
+			<mp>1136.25</mp>
+			<cp>1982.25</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>3353.7</hp>
+			<mp>1152.9</mp>
+			<cp>2012.22</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>3403.92</hp>
+			<mp>1169.64</mp>
+			<cp>2042.352</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>3454.41</hp>
+			<mp>1186.47</mp>
+			<cp>2072.646</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>3505.17</hp>
+			<mp>1203.39</mp>
+			<cp>2103.102</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>3556.2</hp>
+			<mp>1220.4</mp>
+			<cp>2133.72</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>3607.5</hp>
+			<mp>1237.5</mp>
+			<cp>2164.49</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>3659.07</hp>
+			<mp>1254.69</mp>
+			<cp>2195.43</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>3710.91</hp>
+			<mp>1271.97</mp>
+			<cp>2226.53</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>3763.02</hp>
+			<mp>1289.34</mp>
+			<cp>2257.78</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>3815.4</hp>
+			<mp>1306.8</mp>
+			<cp>2289.2</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>3868.05</hp>
+			<mp>1324.35</mp>
+			<cp>2320.77</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>3920.97</hp>
+			<mp>1341.99</mp>
+			<cp>2352.582</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/HumanMystic.xml
+++ b/data/stats/chars/baseStats/HumanMystic.xml
@@ -1,798 +1,926 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>10</classId>
-    <staticData>
-        <baseINT>41</baseINT>
-        <baseSTR>22</baseSTR>
-        <baseCON>27</baseCON>
-        <baseMEN>39</baseMEN>
-        <baseDEX>21</baseDEX>
-        <baseWIT>20</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-90875" y="248162" z="-3570"/>
-            <node x="-90954" y="248118" z="-3570"/>
-            <node x="-90918" y="248070" z="-3570"/>
-            <node x="-90890" y="248027" z="-3570"/>
-        </creationPoints>
-        <basePAtk>3</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>15</chest>
-            <legs>8</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>78</walk>
-            <run>124</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>100</baseBreath>
-        <baseSafeFall>200</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>22.8</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>6.5</radius>
-            <height>22.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>101.0</hp>
-            <mp>40.0</mp>
-            <cp>50.5</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>116.47</hp>
-            <mp>47.28</mp>
-            <cp>58.235</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>132.11</hp>
-            <mp>54.64</mp>
-            <cp>66.055</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>147.92</hp>
-            <mp>62.08</mp>
-            <cp>73.96</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>163.9</hp>
-            <mp>69.6</mp>
-            <cp>81.95</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>180.05</hp>
-            <mp>77.2</mp>
-            <cp>90.025</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>196.37</hp>
-            <mp>84.88</mp>
-            <cp>98.185</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>212.86</hp>
-            <mp>92.64</mp>
-            <cp>106.43</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>229.52</hp>
-            <mp>100.48</mp>
-            <cp>114.76</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>246.35</hp>
-            <mp>108.4</mp>
-            <cp>123.175</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>263.35</hp>
-            <mp>116.4</mp>
-            <cp>131.675</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>280.52</hp>
-            <mp>124.48</mp>
-            <cp>140.26</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>297.86</hp>
-            <mp>132.64</mp>
-            <cp>148.93</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>315.37</hp>
-            <mp>140.88</mp>
-            <cp>157.685</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>333.05</hp>
-            <mp>149.2</mp>
-            <cp>166.525</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>350.9</hp>
-            <mp>157.6</mp>
-            <cp>175.45</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>368.92</hp>
-            <mp>166.08</mp>
-            <cp>184.46</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>387.11</hp>
-            <mp>174.64</mp>
-            <cp>193.555</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>405.47</hp>
-            <mp>183.28</mp>
-            <cp>202.735</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>424.0</hp>
-            <mp>192.0</mp>
-            <cp>212.0</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>442.7</hp>
-            <mp>200.8</mp>
-            <cp>221.35</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>461.57</hp>
-            <mp>209.68</mp>
-            <cp>230.785</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>480.61</hp>
-            <mp>218.64</mp>
-            <cp>240.305</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>499.82</hp>
-            <mp>227.68</mp>
-            <cp>249.91</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>519.2</hp>
-            <mp>236.8</mp>
-            <cp>259.6</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>538.75</hp>
-            <mp>246.0</mp>
-            <cp>269.375</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>558.47</hp>
-            <mp>255.28</mp>
-            <cp>279.235</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>578.36</hp>
-            <mp>264.64</mp>
-            <cp>289.18</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>598.42</hp>
-            <mp>274.08</mp>
-            <cp>299.21</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>618.65</hp>
-            <mp>283.6</mp>
-            <cp>309.325</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>639.05</hp>
-            <mp>293.2</mp>
-            <cp>319.525</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>659.62</hp>
-            <mp>302.88</mp>
-            <cp>329.81</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>680.36</hp>
-            <mp>312.64</mp>
-            <cp>340.18</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>701.27</hp>
-            <mp>322.48</mp>
-            <cp>350.635</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>722.35</hp>
-            <mp>332.4</mp>
-            <cp>361.175</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>743.6</hp>
-            <mp>342.4</mp>
-            <cp>371.8</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>765.02</hp>
-            <mp>352.48</mp>
-            <cp>382.51</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>786.61</hp>
-            <mp>362.64</mp>
-            <cp>393.305</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>808.37</hp>
-            <mp>372.88</mp>
-            <cp>404.185</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>830.3</hp>
-            <mp>383.2</mp>
-            <cp>415.15</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>852.4</hp>
-            <mp>393.6</mp>
-            <cp>426.2</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>874.67</hp>
-            <mp>404.08</mp>
-            <cp>437.335</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>897.11</hp>
-            <mp>414.64</mp>
-            <cp>448.555</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>919.72</hp>
-            <mp>425.28</mp>
-            <cp>459.86</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>942.5</hp>
-            <mp>436.0</mp>
-            <cp>471.25</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>965.45</hp>
-            <mp>446.8</mp>
-            <cp>482.725</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>988.57</hp>
-            <mp>457.68</mp>
-            <cp>494.285</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1011.86</hp>
-            <mp>468.64</mp>
-            <cp>505.93</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1035.32</hp>
-            <mp>479.68</mp>
-            <cp>517.66</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1058.95</hp>
-            <mp>490.8</mp>
-            <cp>529.475</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1082.75</hp>
-            <mp>502.0</mp>
-            <cp>541.375</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1106.72</hp>
-            <mp>513.28</mp>
-            <cp>553.36</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1130.86</hp>
-            <mp>524.64</mp>
-            <cp>565.43</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1155.17</hp>
-            <mp>536.08</mp>
-            <cp>577.585</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1179.65</hp>
-            <mp>547.6</mp>
-            <cp>589.825</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1204.3</hp>
-            <mp>559.2</mp>
-            <cp>602.15</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1229.12</hp>
-            <mp>570.88</mp>
-            <cp>614.56</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1254.11</hp>
-            <mp>582.64</mp>
-            <cp>627.055</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>1279.27</hp>
-            <mp>594.48</mp>
-            <cp>639.635</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>1304.6</hp>
-            <mp>606.4</mp>
-            <cp>652.3</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>1330.1</hp>
-            <mp>618.4</mp>
-            <cp>665.05</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>1355.77</hp>
-            <mp>630.48</mp>
-            <cp>677.885</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>1381.61</hp>
-            <mp>642.64</mp>
-            <cp>690.805</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>1407.62</hp>
-            <mp>654.88</mp>
-            <cp>703.81</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>1433.8</hp>
-            <mp>667.2</mp>
-            <cp>716.9</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>1460.15</hp>
-            <mp>679.6</mp>
-            <cp>730.075</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>1486.67</hp>
-            <mp>692.08</mp>
-            <cp>743.335</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>1513.36</hp>
-            <mp>704.64</mp>
-            <cp>756.68</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>1540.22</hp>
-            <mp>717.28</mp>
-            <cp>770.11</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>1567.25</hp>
-            <mp>730.0</mp>
-            <cp>783.625</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>1594.45</hp>
-            <mp>742.8</mp>
-            <cp>797.225</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>1621.82</hp>
-            <mp>755.68</mp>
-            <cp>810.91</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>1649.36</hp>
-            <mp>768.64</mp>
-            <cp>824.68</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>1677.07</hp>
-            <mp>781.68</mp>
-            <cp>838.535</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>1704.95</hp>
-            <mp>794.8</mp>
-            <cp>852.475</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>1733.0</hp>
-            <mp>808.0</mp>
-            <cp>866.5</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>1761.22</hp>
-            <mp>821.28</mp>
-            <cp>880.61</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>1789.61</hp>
-            <mp>834.64</mp>
-            <cp>894.805</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>1818.17</hp>
-            <mp>848.08</mp>
-            <cp>909.085</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>1846.9</hp>
-            <mp>861.6</mp>
-            <cp>923.45</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>1875.8</hp>
-            <mp>875.2</mp>
-            <cp>937.9</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>1904.87</hp>
-            <mp>888.88</mp>
-            <cp>952.435</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>1934.11</hp>
-            <mp>902.64</mp>
-            <cp>967.055</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>1963.52</hp>
-            <mp>916.48</mp>
-            <cp>981.76</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>1993.1</hp>
-            <mp>930.4</mp>
-            <cp>996.55</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>2022.85</hp>
-            <mp>944.4</mp>
-            <cp>1011.425</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>2052.77</hp>
-            <mp>958.48</mp>
-            <cp>1026.385</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>2082.86</hp>
-            <mp>972.64</mp>
-            <cp>1041.43</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>2113.12</hp>
-            <mp>986.88</mp>
-            <cp>1056.56</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>2143.55</hp>
-            <mp>1001.2</mp>
-            <cp>1071.775</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>2174.15</hp>
-            <mp>1015.6</mp>
-            <cp>1087.075</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>10</classId>
+	<staticData>
+		<baseINT>41</baseINT>
+		<baseSTR>22</baseSTR>
+		<baseCON>27</baseCON>
+		<baseMEN>39</baseMEN>
+		<baseDEX>21</baseDEX>
+		<baseWIT>20</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-90271" y="249081" z="-3568" />
+			<node x="-90170" y="248965" z="-3568" />
+			<node x="-90074" y="249156" z="-3568" />
+			<node x="-90293" y="249194" z="-3568" />
+		</creationPoints>
+		<basePAtk>3</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>15</chest>
+			<legs>8</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>78</walk>
+			<run>124</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>200</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>22.8</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>6.5</radius>
+			<height>22.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>101.0</hp>
+			<mp>40.0</mp>
+			<cp>50.5</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>116.47</hp>
+			<mp>47.28</mp>
+			<cp>58.235</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>132.11</hp>
+			<mp>54.64</mp>
+			<cp>66.055</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>147.92</hp>
+			<mp>62.08</mp>
+			<cp>73.96</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>163.9</hp>
+			<mp>69.6</mp>
+			<cp>81.95</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>180.05</hp>
+			<mp>77.2</mp>
+			<cp>90.025</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>196.37</hp>
+			<mp>84.88</mp>
+			<cp>98.185</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>212.86</hp>
+			<mp>92.64</mp>
+			<cp>106.43</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>229.52</hp>
+			<mp>100.48</mp>
+			<cp>114.76</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>246.35</hp>
+			<mp>108.4</mp>
+			<cp>123.175</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>263.35</hp>
+			<mp>116.4</mp>
+			<cp>131.675</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>280.52</hp>
+			<mp>124.48</mp>
+			<cp>140.26</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>297.86</hp>
+			<mp>132.64</mp>
+			<cp>148.93</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>315.37</hp>
+			<mp>140.88</mp>
+			<cp>157.685</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>333.05</hp>
+			<mp>149.2</mp>
+			<cp>166.525</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>350.9</hp>
+			<mp>157.6</mp>
+			<cp>175.45</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>368.92</hp>
+			<mp>166.08</mp>
+			<cp>184.46</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>387.11</hp>
+			<mp>174.64</mp>
+			<cp>193.555</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>405.47</hp>
+			<mp>183.28</mp>
+			<cp>202.735</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>424.0</hp>
+			<mp>192.0</mp>
+			<cp>212.0</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>442.7</hp>
+			<mp>200.8</mp>
+			<cp>221.35</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>461.57</hp>
+			<mp>209.68</mp>
+			<cp>230.785</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>480.61</hp>
+			<mp>218.64</mp>
+			<cp>240.305</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>499.82</hp>
+			<mp>227.68</mp>
+			<cp>249.91</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>519.2</hp>
+			<mp>236.8</mp>
+			<cp>259.6</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>538.75</hp>
+			<mp>246.0</mp>
+			<cp>269.375</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>558.47</hp>
+			<mp>255.28</mp>
+			<cp>279.235</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>578.36</hp>
+			<mp>264.64</mp>
+			<cp>289.18</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>598.42</hp>
+			<mp>274.08</mp>
+			<cp>299.21</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>618.65</hp>
+			<mp>283.6</mp>
+			<cp>309.325</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>639.05</hp>
+			<mp>293.2</mp>
+			<cp>319.525</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>659.62</hp>
+			<mp>302.88</mp>
+			<cp>329.81</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>680.36</hp>
+			<mp>312.64</mp>
+			<cp>340.18</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>701.27</hp>
+			<mp>322.48</mp>
+			<cp>350.635</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>722.35</hp>
+			<mp>332.4</mp>
+			<cp>361.175</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>743.6</hp>
+			<mp>342.4</mp>
+			<cp>371.8</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>765.02</hp>
+			<mp>352.48</mp>
+			<cp>382.51</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>786.61</hp>
+			<mp>362.64</mp>
+			<cp>393.305</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>808.37</hp>
+			<mp>372.88</mp>
+			<cp>404.185</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>830.3</hp>
+			<mp>383.2</mp>
+			<cp>415.15</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>852.4</hp>
+			<mp>393.6</mp>
+			<cp>426.2</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>874.67</hp>
+			<mp>404.08</mp>
+			<cp>437.335</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>897.11</hp>
+			<mp>414.64</mp>
+			<cp>448.555</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>919.72</hp>
+			<mp>425.28</mp>
+			<cp>459.86</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>942.5</hp>
+			<mp>436.0</mp>
+			<cp>471.25</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>965.45</hp>
+			<mp>446.8</mp>
+			<cp>482.725</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>988.57</hp>
+			<mp>457.68</mp>
+			<cp>494.285</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1011.86</hp>
+			<mp>468.64</mp>
+			<cp>505.93</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1035.32</hp>
+			<mp>479.68</mp>
+			<cp>517.66</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1058.95</hp>
+			<mp>490.8</mp>
+			<cp>529.475</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1082.75</hp>
+			<mp>502.0</mp>
+			<cp>541.375</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1106.72</hp>
+			<mp>513.28</mp>
+			<cp>553.36</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1130.86</hp>
+			<mp>524.64</mp>
+			<cp>565.43</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1155.17</hp>
+			<mp>536.08</mp>
+			<cp>577.585</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1179.65</hp>
+			<mp>547.6</mp>
+			<cp>589.825</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1204.3</hp>
+			<mp>559.2</mp>
+			<cp>602.15</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1229.12</hp>
+			<mp>570.88</mp>
+			<cp>614.56</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1254.11</hp>
+			<mp>582.64</mp>
+			<cp>627.055</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1279.27</hp>
+			<mp>594.48</mp>
+			<cp>639.635</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1304.6</hp>
+			<mp>606.4</mp>
+			<cp>652.3</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>1330.1</hp>
+			<mp>618.4</mp>
+			<cp>665.05</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>1355.77</hp>
+			<mp>630.48</mp>
+			<cp>677.885</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>1381.61</hp>
+			<mp>642.64</mp>
+			<cp>690.805</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>1407.62</hp>
+			<mp>654.88</mp>
+			<cp>703.81</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>1433.8</hp>
+			<mp>667.2</mp>
+			<cp>716.9</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>1460.15</hp>
+			<mp>679.6</mp>
+			<cp>730.075</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>1486.67</hp>
+			<mp>692.08</mp>
+			<cp>743.335</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>1513.36</hp>
+			<mp>704.64</mp>
+			<cp>756.68</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>1540.22</hp>
+			<mp>717.28</mp>
+			<cp>770.11</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>1567.25</hp>
+			<mp>730.0</mp>
+			<cp>783.625</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>1594.45</hp>
+			<mp>742.8</mp>
+			<cp>797.225</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>1621.82</hp>
+			<mp>755.68</mp>
+			<cp>810.91</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>1649.36</hp>
+			<mp>768.64</mp>
+			<cp>824.68</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>1677.07</hp>
+			<mp>781.68</mp>
+			<cp>838.535</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>1704.95</hp>
+			<mp>794.8</mp>
+			<cp>852.475</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>1733.0</hp>
+			<mp>808.0</mp>
+			<cp>866.5</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>1761.22</hp>
+			<mp>821.28</mp>
+			<cp>880.61</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>1789.61</hp>
+			<mp>834.64</mp>
+			<cp>894.805</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>1818.17</hp>
+			<mp>848.08</mp>
+			<cp>909.085</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>1846.9</hp>
+			<mp>861.6</mp>
+			<cp>923.45</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>1875.8</hp>
+			<mp>875.2</mp>
+			<cp>937.9</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>1904.87</hp>
+			<mp>888.88</mp>
+			<cp>952.435</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>1934.11</hp>
+			<mp>902.64</mp>
+			<cp>967.055</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>1963.52</hp>
+			<mp>916.48</mp>
+			<cp>981.76</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>1993.1</hp>
+			<mp>930.4</mp>
+			<cp>996.55</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>2022.85</hp>
+			<mp>944.4</mp>
+			<cp>1011.425</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>2052.77</hp>
+			<mp>958.48</mp>
+			<cp>1026.385</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>2082.86</hp>
+			<mp>972.64</mp>
+			<cp>1041.43</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>2113.12</hp>
+			<mp>986.88</mp>
+			<cp>1056.56</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>2143.55</hp>
+			<mp>1001.2</mp>
+			<cp>1071.775</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>2174.15</hp>
+			<mp>1015.6</mp>
+			<cp>1087.075</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>2204.92</hp>
+			<mp>1030.08</mp>
+			<cp>1102.46</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>2235.86</hp>
+			<mp>1044.64</mp>
+			<cp>1117.93</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>2266.97</hp>
+			<mp>1059.28</mp>
+			<cp>1133.485</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>2298.25</hp>
+			<mp>1074.0</mp>
+			<cp>1149.125</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>2329.7</hp>
+			<mp>1088.8</mp>
+			<cp>1164.85</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>2361.32</hp>
+			<mp>1103.68</mp>
+			<cp>1180.66</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>2393.11</hp>
+			<mp>1118.64</mp>
+			<cp>1196.555</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>2425.07</hp>
+			<mp>1133.68</mp>
+			<cp>1212.535</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>2457.2</hp>
+			<mp>1148.8</mp>
+			<cp>1228.61</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>2489.5</hp>
+			<mp>1164</mp>
+			<cp>1244.77</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>2521.97</hp>
+			<mp>1179.28</mp>
+			<cp>1261.02</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>2554.61</hp>
+			<mp>1194.64</mp>
+			<cp>1277.36</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>2587.42</hp>
+			<mp>1210.08</mp>
+			<cp>1293.79</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>2620.4</hp>
+			<mp>1225.6</mp>
+			<cp>1310.31</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>2653.55</hp>
+			<mp>1241.2</mp>
+			<cp>1326.92</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>2686.87</hp>
+			<mp>1256.88</mp>
+			<cp>1343.435</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/HumanUndertaker.xml
+++ b/data/stats/chars/baseStats/HumanUndertaker.xml
@@ -1,0 +1,923 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
+	<classId>198</classId>
+	<staticData>
+		<baseINT>20</baseINT>
+		<baseSTR>40</baseSTR>
+		<baseCON>41</baseCON>
+		<baseMEN>25</baseMEN>
+		<baseDEX>34</baseDEX>
+		<baseWIT>10</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="47417" y="153541" z="-2728" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>80</walk>
+			<run>132</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>250</baseSafeFall>
+		<collisionMale>
+			<radius>9.0</radius>
+			<height>23</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>8.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>80.0</hp>
+			<mp>30.0</mp>
+			<cp>48.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>91.83</hp>
+			<mp>35.46</mp>
+			<cp>55.098</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>103.79</hp>
+			<mp>40.98</mp>
+			<cp>62.274</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>115.88</hp>
+			<mp>46.56</mp>
+			<cp>69.528</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>128.1</hp>
+			<mp>52.2</mp>
+			<cp>76.86</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>140.45</hp>
+			<mp>57.9</mp>
+			<cp>84.27</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>152.93</hp>
+			<mp>63.66</mp>
+			<cp>91.758</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>165.54</hp>
+			<mp>69.48</mp>
+			<cp>99.324</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>178.28</hp>
+			<mp>75.36</mp>
+			<cp>106.968</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>191.15</hp>
+			<mp>81.3</mp>
+			<cp>114.69</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>204.15</hp>
+			<mp>87.3</mp>
+			<cp>122.49</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>217.28</hp>
+			<mp>93.36</mp>
+			<cp>130.368</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>230.54</hp>
+			<mp>99.48</mp>
+			<cp>138.324</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>243.93</hp>
+			<mp>105.66</mp>
+			<cp>146.358</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>257.45</hp>
+			<mp>111.9</mp>
+			<cp>154.47</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>271.1</hp>
+			<mp>118.2</mp>
+			<cp>162.66</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>284.88</hp>
+			<mp>124.56</mp>
+			<cp>170.928</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>298.79</hp>
+			<mp>130.98</mp>
+			<cp>179.274</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>312.83</hp>
+			<mp>137.46</mp>
+			<cp>187.698</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>327.0</hp>
+			<mp>144.0</mp>
+			<cp>196.2</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>356.7</hp>
+			<mp>153.9</mp>
+			<cp>214.02</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>386.67</hp>
+			<mp>163.89</mp>
+			<cp>232.002</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>416.91</hp>
+			<mp>173.97</mp>
+			<cp>250.146</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>447.42</hp>
+			<mp>184.14</mp>
+			<cp>268.452</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>478.2</hp>
+			<mp>194.4</mp>
+			<cp>286.92</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>509.25</hp>
+			<mp>204.75</mp>
+			<cp>305.55</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>540.57</hp>
+			<mp>215.19</mp>
+			<cp>324.342</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>572.16</hp>
+			<mp>225.72</mp>
+			<cp>343.296</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>604.02</hp>
+			<mp>236.34</mp>
+			<cp>362.412</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>636.15</hp>
+			<mp>247.05</mp>
+			<cp>381.69</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>668.55</hp>
+			<mp>257.85</mp>
+			<cp>401.13</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>701.22</hp>
+			<mp>268.74</mp>
+			<cp>420.732</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>734.16</hp>
+			<mp>279.72</mp>
+			<cp>440.496</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>767.37</hp>
+			<mp>290.79</mp>
+			<cp>460.422</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>800.85</hp>
+			<mp>301.95</mp>
+			<cp>480.51</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>834.6</hp>
+			<mp>313.2</mp>
+			<cp>500.76</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>868.62</hp>
+			<mp>324.54</mp>
+			<cp>521.172</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>902.91</hp>
+			<mp>335.97</mp>
+			<cp>541.746</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>937.47</hp>
+			<mp>347.49</mp>
+			<cp>562.482</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>972.3</hp>
+			<mp>359.1</mp>
+			<cp>583.38</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1019.1</hp>
+			<mp>378.6</mp>
+			<cp>611.46</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1066.26</hp>
+			<mp>398.25</mp>
+			<cp>639.756</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1113.78</hp>
+			<mp>418.05</mp>
+			<cp>668.268</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1161.66</hp>
+			<mp>438.0</mp>
+			<cp>696.996</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1209.9</hp>
+			<mp>458.1</mp>
+			<cp>725.94</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1258.5</hp>
+			<mp>478.35</mp>
+			<cp>755.1</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1307.46</hp>
+			<mp>498.75</mp>
+			<cp>784.476</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1356.78</hp>
+			<mp>519.3</mp>
+			<cp>814.068</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1406.46</hp>
+			<mp>540.0</mp>
+			<cp>843.876</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1456.5</hp>
+			<mp>560.85</mp>
+			<cp>873.9</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1506.9</hp>
+			<mp>581.85</mp>
+			<cp>904.14</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1557.66</hp>
+			<mp>603.0</mp>
+			<cp>934.596</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1608.78</hp>
+			<mp>624.3</mp>
+			<cp>965.268</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1660.26</hp>
+			<mp>645.75</mp>
+			<cp>996.156</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1712.1</hp>
+			<mp>667.35</mp>
+			<cp>1027.26</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1764.3</hp>
+			<mp>689.1</mp>
+			<cp>1058.58</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1816.86</hp>
+			<mp>711.0</mp>
+			<cp>1090.116</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1869.78</hp>
+			<mp>733.05</mp>
+			<cp>1121.868</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1923.06</hp>
+			<mp>755.25</mp>
+			<cp>1153.836</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1976.7</hp>
+			<mp>777.6</mp>
+			<cp>1186.02</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2030.7</hp>
+			<mp>800.1</mp>
+			<cp>1218.42</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2085.06</hp>
+			<mp>822.75</mp>
+			<cp>1251.036</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2139.78</hp>
+			<mp>845.55</mp>
+			<cp>1283.868</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2194.86</hp>
+			<mp>868.5</mp>
+			<cp>1316.916</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2250.3</hp>
+			<mp>891.6</mp>
+			<cp>1350.18</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2306.1</hp>
+			<mp>914.85</mp>
+			<cp>1383.66</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2362.26</hp>
+			<mp>938.25</mp>
+			<cp>1417.356</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2418.78</hp>
+			<mp>961.8</mp>
+			<cp>1451.268</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2475.66</hp>
+			<mp>985.5</mp>
+			<cp>1485.396</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2532.9</hp>
+			<mp>1009.35</mp>
+			<cp>1519.74</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2590.5</hp>
+			<mp>1033.35</mp>
+			<cp>1554.3</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2648.46</hp>
+			<mp>1057.5</mp>
+			<cp>1589.076</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2706.78</hp>
+			<mp>1081.8</mp>
+			<cp>1624.068</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2765.46</hp>
+			<mp>1106.25</mp>
+			<cp>1659.276</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2824.5</hp>
+			<mp>1130.85</mp>
+			<cp>1694.7</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>2883.9</hp>
+			<mp>1155.6</mp>
+			<cp>1730.34</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>2943.66</hp>
+			<mp>1180.5</mp>
+			<cp>1766.196</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3003.78</hp>
+			<mp>1205.55</mp>
+			<cp>1802.268</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3064.26</hp>
+			<mp>1230.75</mp>
+			<cp>1838.556</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3125.1</hp>
+			<mp>1256.1</mp>
+			<cp>1875.06</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3186.3</hp>
+			<mp>1281.6</mp>
+			<cp>1911.78</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3247.86</hp>
+			<mp>1307.25</mp>
+			<cp>1948.716</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3309.78</hp>
+			<mp>1333.05</mp>
+			<cp>1985.868</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3372.06</hp>
+			<mp>1359.0</mp>
+			<cp>2023.236</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3434.7</hp>
+			<mp>1385.1</mp>
+			<cp>2060.82</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3497.7</hp>
+			<mp>1411.35</mp>
+			<cp>2098.62</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3561.06</hp>
+			<mp>1437.75</mp>
+			<cp>2136.636</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3624.78</hp>
+			<mp>1464.3</mp>
+			<cp>2174.868</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3688.86</hp>
+			<mp>1491.0</mp>
+			<cp>2213.316</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3753.3</hp>
+			<mp>1517.85</mp>
+			<cp>2251.98</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3818.1</hp>
+			<mp>1544.85</mp>
+			<cp>2290.86</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>3883.26</hp>
+			<mp>1572.0</mp>
+			<cp>2329.956</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>3948.78</hp>
+			<mp>1599.3</mp>
+			<cp>2369.268</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4014.66</hp>
+			<mp>1626.75</mp>
+			<cp>2408.796</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4080.9</hp>
+			<mp>1654.35</mp>
+			<cp>2448.54</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4147.5</hp>
+			<mp>1682.1</mp>
+			<cp>2488.5</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4214.46</hp>
+			<mp>1710.0</mp>
+			<cp>2528.676</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4281.78</hp>
+			<mp>1738.05</mp>
+			<cp>2569.068</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4349.46</hp>
+			<mp>1766.25</mp>
+			<cp>2609.676</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4417.5</hp>
+			<mp>1794.6</mp>
+			<cp>2650.5</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4485.9</hp>
+			<mp>1823.1</mp>
+			<cp>2691.55</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4554.66</hp>
+			<mp>1851.75</mp>
+			<cp>2732.82</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4623.78</hp>
+			<mp>1880.55</mp>
+			<cp>2774.31</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4693.26</hp>
+			<mp>1909.5</mp>
+			<cp>2816.02</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>4763.1</hp>
+			<mp>1938.6</mp>
+			<cp>2857.94</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>4833.3</hp>
+			<mp>1967.85</mp>
+			<cp>2900.09</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>4903.86</hp>
+			<mp>1997.25</mp>
+			<cp>2942.316</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
+</list>

--- a/data/stats/chars/baseStats/HumanWizard.xml
+++ b/data/stats/chars/baseStats/HumanWizard.xml
@@ -1,799 +1,927 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>11</classId>
-    <staticData>
-        <baseINT>41</baseINT>
-        <baseSTR>22</baseSTR>
-        <baseCON>27</baseCON>
-        <baseMEN>39</baseMEN>
-        <baseDEX>21</baseDEX>
-        <baseWIT>20</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-90875" y="248162" z="-3570"/>
-            <node x="-90954" y="248118" z="-3570"/>
-            <node x="-90918" y="248070" z="-3570"/>
-            <node x="-90890" y="248027" z="-3570"/>
-        </creationPoints>
-        <basePAtk>3</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>15</chest>
-            <legs>8</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>78</walk>
-            <run>124</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>100</baseBreath>
-        <baseSafeFall>200</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>22.8</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>6.5</radius>
-            <height>22.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <!-- Level 1 confirmed, data are equals to Human Wizard -->
-        <level val="1">
-            <hp>101.0</hp>
-            <mp>40.0</mp>
-            <cp>50.5</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>116.47</hp>
-            <mp>47.28</mp>
-            <cp>58.235</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>132.11</hp>
-            <mp>54.64</mp>
-            <cp>66.055</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>147.92</hp>
-            <mp>62.08</mp>
-            <cp>73.96</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>163.9</hp>
-            <mp>69.6</mp>
-            <cp>81.95</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>180.05</hp>
-            <mp>77.2</mp>
-            <cp>90.025</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>196.37</hp>
-            <mp>84.88</mp>
-            <cp>98.185</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>212.86</hp>
-            <mp>92.64</mp>
-            <cp>106.43</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>229.52</hp>
-            <mp>100.48</mp>
-            <cp>114.76</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>246.35</hp>
-            <mp>108.4</mp>
-            <cp>123.175</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>263.35</hp>
-            <mp>116.4</mp>
-            <cp>131.675</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>280.52</hp>
-            <mp>124.48</mp>
-            <cp>140.26</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>297.86</hp>
-            <mp>132.64</mp>
-            <cp>148.93</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>315.37</hp>
-            <mp>140.88</mp>
-            <cp>157.685</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>333.05</hp>
-            <mp>149.2</mp>
-            <cp>166.525</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>350.9</hp>
-            <mp>157.6</mp>
-            <cp>175.45</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>368.92</hp>
-            <mp>166.08</mp>
-            <cp>184.46</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>387.11</hp>
-            <mp>174.64</mp>
-            <cp>193.555</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>405.47</hp>
-            <mp>183.28</mp>
-            <cp>202.735</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>424.0</hp>
-            <mp>192.0</mp>
-            <cp>212.0</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>451.5</hp>
-            <mp>205.2</mp>
-            <cp>225.75</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>479.25</hp>
-            <mp>218.52</mp>
-            <cp>239.625</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>507.25</hp>
-            <mp>231.96</mp>
-            <cp>253.625</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>535.5</hp>
-            <mp>245.52</mp>
-            <cp>267.75</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>564.0</hp>
-            <mp>259.2</mp>
-            <cp>282.0</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>592.75</hp>
-            <mp>273.0</mp>
-            <cp>296.375</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>621.75</hp>
-            <mp>286.92</mp>
-            <cp>310.875</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>651.0</hp>
-            <mp>300.96</mp>
-            <cp>325.5</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>680.5</hp>
-            <mp>315.12</mp>
-            <cp>340.25</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>710.25</hp>
-            <mp>329.4</mp>
-            <cp>355.125</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>740.25</hp>
-            <mp>343.8</mp>
-            <cp>370.125</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>770.5</hp>
-            <mp>358.32</mp>
-            <cp>385.25</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>801.0</hp>
-            <mp>372.96</mp>
-            <cp>400.5</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>831.75</hp>
-            <mp>387.72</mp>
-            <cp>415.875</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>862.75</hp>
-            <mp>402.6</mp>
-            <cp>431.375</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>894.0</hp>
-            <mp>417.6</mp>
-            <cp>447.0</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>925.5</hp>
-            <mp>432.72</mp>
-            <cp>462.75</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>957.25</hp>
-            <mp>447.96</mp>
-            <cp>478.625</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>989.25</hp>
-            <mp>463.32</mp>
-            <cp>494.625</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1021.5</hp>
-            <mp>478.8</mp>
-            <cp>510.75</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1054.0</hp>
-            <mp>494.4</mp>
-            <cp>527.0</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1086.75</hp>
-            <mp>510.12</mp>
-            <cp>543.375</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1119.75</hp>
-            <mp>525.96</mp>
-            <cp>559.875</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1153.0</hp>
-            <mp>541.92</mp>
-            <cp>576.5</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1186.5</hp>
-            <mp>558.0</mp>
-            <cp>593.25</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1220.25</hp>
-            <mp>574.2</mp>
-            <cp>610.125</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1254.25</hp>
-            <mp>590.52</mp>
-            <cp>627.125</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1288.5</hp>
-            <mp>606.96</mp>
-            <cp>644.25</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1323.0</hp>
-            <mp>623.52</mp>
-            <cp>661.5</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1357.75</hp>
-            <mp>640.2</mp>
-            <cp>678.875</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1392.75</hp>
-            <mp>657.0</mp>
-            <cp>696.375</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1428.0</hp>
-            <mp>673.92</mp>
-            <cp>714.0</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1463.5</hp>
-            <mp>690.96</mp>
-            <cp>731.75</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1499.25</hp>
-            <mp>708.12</mp>
-            <cp>749.625</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1535.25</hp>
-            <mp>725.4</mp>
-            <cp>767.625</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1571.5</hp>
-            <mp>742.8</mp>
-            <cp>785.75</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1608.0</hp>
-            <mp>760.32</mp>
-            <cp>804.0</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1644.75</hp>
-            <mp>777.96</mp>
-            <cp>822.375</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>1681.75</hp>
-            <mp>795.72</mp>
-            <cp>840.875</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>1719.0</hp>
-            <mp>813.6</mp>
-            <cp>859.5</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>1756.5</hp>
-            <mp>831.6</mp>
-            <cp>878.25</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>1794.25</hp>
-            <mp>849.72</mp>
-            <cp>897.125</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>1832.25</hp>
-            <mp>867.96</mp>
-            <cp>916.125</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>1870.5</hp>
-            <mp>886.32</mp>
-            <cp>935.25</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>1909.0</hp>
-            <mp>904.8</mp>
-            <cp>954.5</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>1947.75</hp>
-            <mp>923.4</mp>
-            <cp>973.875</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>1986.75</hp>
-            <mp>942.12</mp>
-            <cp>993.375</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2026.0</hp>
-            <mp>960.96</mp>
-            <cp>1013.0</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2065.5</hp>
-            <mp>979.92</mp>
-            <cp>1032.75</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2105.25</hp>
-            <mp>999.0</mp>
-            <cp>1052.625</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2145.25</hp>
-            <mp>1018.2</mp>
-            <cp>1072.625</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2185.5</hp>
-            <mp>1037.52</mp>
-            <cp>1092.75</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2226.0</hp>
-            <mp>1056.96</mp>
-            <cp>1113.0</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2266.75</hp>
-            <mp>1076.52</mp>
-            <cp>1133.375</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2307.75</hp>
-            <mp>1096.2</mp>
-            <cp>1153.875</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>2349.0</hp>
-            <mp>1116.0</mp>
-            <cp>1174.5</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>2390.5</hp>
-            <mp>1135.92</mp>
-            <cp>1195.25</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>2432.25</hp>
-            <mp>1155.96</mp>
-            <cp>1216.125</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>2474.25</hp>
-            <mp>1176.12</mp>
-            <cp>1237.125</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>2516.5</hp>
-            <mp>1196.4</mp>
-            <cp>1258.25</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>2559.0</hp>
-            <mp>1216.8</mp>
-            <cp>1279.5</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>2601.75</hp>
-            <mp>1237.32</mp>
-            <cp>1300.875</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>2644.75</hp>
-            <mp>1257.96</mp>
-            <cp>1322.375</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>2688.0</hp>
-            <mp>1278.72</mp>
-            <cp>1344.0</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>2731.5</hp>
-            <mp>1299.6</mp>
-            <cp>1365.75</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>2775.25</hp>
-            <mp>1320.6</mp>
-            <cp>1387.625</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>2819.25</hp>
-            <mp>1341.72</mp>
-            <cp>1409.625</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>2863.5</hp>
-            <mp>1362.96</mp>
-            <cp>1431.75</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>2908.0</hp>
-            <mp>1384.32</mp>
-            <cp>1454.0</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>2952.75</hp>
-            <mp>1405.8</mp>
-            <cp>1476.375</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>2997.75</hp>
-            <mp>1427.4</mp>
-            <cp>1498.875</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>11</classId>
+	<staticData>
+		<baseINT>41</baseINT>
+		<baseSTR>22</baseSTR>
+		<baseCON>27</baseCON>
+		<baseMEN>39</baseMEN>
+		<baseDEX>21</baseDEX>
+		<baseWIT>20</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-90875" y="248162" z="-3570" />
+			<node x="-90954" y="248118" z="-3570" />
+			<node x="-90918" y="248070" z="-3570" />
+			<node x="-90890" y="248027" z="-3570" />
+		</creationPoints>
+		<basePAtk>3</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>15</chest>
+			<legs>8</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>78</walk>
+			<run>124</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>200</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>22.8</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>6.5</radius>
+			<height>22.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<!-- Level 1 confirmed, data are equals to Human Wizard -->
+		<level val="1">
+			<hp>101.0</hp>
+			<mp>40.0</mp>
+			<cp>50.5</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>116.47</hp>
+			<mp>47.28</mp>
+			<cp>58.235</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>132.11</hp>
+			<mp>54.64</mp>
+			<cp>66.055</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>147.92</hp>
+			<mp>62.08</mp>
+			<cp>73.96</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>163.9</hp>
+			<mp>69.6</mp>
+			<cp>81.95</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>180.05</hp>
+			<mp>77.2</mp>
+			<cp>90.025</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>196.37</hp>
+			<mp>84.88</mp>
+			<cp>98.185</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>212.86</hp>
+			<mp>92.64</mp>
+			<cp>106.43</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>229.52</hp>
+			<mp>100.48</mp>
+			<cp>114.76</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>246.35</hp>
+			<mp>108.4</mp>
+			<cp>123.175</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>263.35</hp>
+			<mp>116.4</mp>
+			<cp>131.675</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>280.52</hp>
+			<mp>124.48</mp>
+			<cp>140.26</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>297.86</hp>
+			<mp>132.64</mp>
+			<cp>148.93</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>315.37</hp>
+			<mp>140.88</mp>
+			<cp>157.685</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>333.05</hp>
+			<mp>149.2</mp>
+			<cp>166.525</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>350.9</hp>
+			<mp>157.6</mp>
+			<cp>175.45</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>368.92</hp>
+			<mp>166.08</mp>
+			<cp>184.46</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>387.11</hp>
+			<mp>174.64</mp>
+			<cp>193.555</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>405.47</hp>
+			<mp>183.28</mp>
+			<cp>202.735</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>424.0</hp>
+			<mp>192.0</mp>
+			<cp>212.0</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>451.5</hp>
+			<mp>205.2</mp>
+			<cp>225.75</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>479.25</hp>
+			<mp>218.52</mp>
+			<cp>239.625</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>507.25</hp>
+			<mp>231.96</mp>
+			<cp>253.625</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>535.5</hp>
+			<mp>245.52</mp>
+			<cp>267.75</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>564.0</hp>
+			<mp>259.2</mp>
+			<cp>282.0</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>592.75</hp>
+			<mp>273.0</mp>
+			<cp>296.375</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>621.75</hp>
+			<mp>286.92</mp>
+			<cp>310.875</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>651.0</hp>
+			<mp>300.96</mp>
+			<cp>325.5</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>680.5</hp>
+			<mp>315.12</mp>
+			<cp>340.25</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>710.25</hp>
+			<mp>329.4</mp>
+			<cp>355.125</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>740.25</hp>
+			<mp>343.8</mp>
+			<cp>370.125</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>770.5</hp>
+			<mp>358.32</mp>
+			<cp>385.25</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>801.0</hp>
+			<mp>372.96</mp>
+			<cp>400.5</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>831.75</hp>
+			<mp>387.72</mp>
+			<cp>415.875</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>862.75</hp>
+			<mp>402.6</mp>
+			<cp>431.375</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>894.0</hp>
+			<mp>417.6</mp>
+			<cp>447.0</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>925.5</hp>
+			<mp>432.72</mp>
+			<cp>462.75</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>957.25</hp>
+			<mp>447.96</mp>
+			<cp>478.625</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>989.25</hp>
+			<mp>463.32</mp>
+			<cp>494.625</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1021.5</hp>
+			<mp>478.8</mp>
+			<cp>510.75</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1054.0</hp>
+			<mp>494.4</mp>
+			<cp>527.0</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1086.75</hp>
+			<mp>510.12</mp>
+			<cp>543.375</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1119.75</hp>
+			<mp>525.96</mp>
+			<cp>559.875</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1153.0</hp>
+			<mp>541.92</mp>
+			<cp>576.5</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1186.5</hp>
+			<mp>558.0</mp>
+			<cp>593.25</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1220.25</hp>
+			<mp>574.2</mp>
+			<cp>610.125</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1254.25</hp>
+			<mp>590.52</mp>
+			<cp>627.125</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1288.5</hp>
+			<mp>606.96</mp>
+			<cp>644.25</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1323.0</hp>
+			<mp>623.52</mp>
+			<cp>661.5</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1357.75</hp>
+			<mp>640.2</mp>
+			<cp>678.875</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1392.75</hp>
+			<mp>657.0</mp>
+			<cp>696.375</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1428.0</hp>
+			<mp>673.92</mp>
+			<cp>714.0</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1463.5</hp>
+			<mp>690.96</mp>
+			<cp>731.75</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1499.25</hp>
+			<mp>708.12</mp>
+			<cp>749.625</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1535.25</hp>
+			<mp>725.4</mp>
+			<cp>767.625</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1571.5</hp>
+			<mp>742.8</mp>
+			<cp>785.75</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1608.0</hp>
+			<mp>760.32</mp>
+			<cp>804.0</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1644.75</hp>
+			<mp>777.96</mp>
+			<cp>822.375</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1681.75</hp>
+			<mp>795.72</mp>
+			<cp>840.875</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1719.0</hp>
+			<mp>813.6</mp>
+			<cp>859.5</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>1756.5</hp>
+			<mp>831.6</mp>
+			<cp>878.25</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>1794.25</hp>
+			<mp>849.72</mp>
+			<cp>897.125</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>1832.25</hp>
+			<mp>867.96</mp>
+			<cp>916.125</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>1870.5</hp>
+			<mp>886.32</mp>
+			<cp>935.25</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>1909.0</hp>
+			<mp>904.8</mp>
+			<cp>954.5</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>1947.75</hp>
+			<mp>923.4</mp>
+			<cp>973.875</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>1986.75</hp>
+			<mp>942.12</mp>
+			<cp>993.375</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2026.0</hp>
+			<mp>960.96</mp>
+			<cp>1013.0</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2065.5</hp>
+			<mp>979.92</mp>
+			<cp>1032.75</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2105.25</hp>
+			<mp>999.0</mp>
+			<cp>1052.625</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2145.25</hp>
+			<mp>1018.2</mp>
+			<cp>1072.625</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2185.5</hp>
+			<mp>1037.52</mp>
+			<cp>1092.75</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2226.0</hp>
+			<mp>1056.96</mp>
+			<cp>1113.0</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2266.75</hp>
+			<mp>1076.52</mp>
+			<cp>1133.375</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2307.75</hp>
+			<mp>1096.2</mp>
+			<cp>1153.875</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>2349.0</hp>
+			<mp>1116.0</mp>
+			<cp>1174.5</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>2390.5</hp>
+			<mp>1135.92</mp>
+			<cp>1195.25</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>2432.25</hp>
+			<mp>1155.96</mp>
+			<cp>1216.125</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>2474.25</hp>
+			<mp>1176.12</mp>
+			<cp>1237.125</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>2516.5</hp>
+			<mp>1196.4</mp>
+			<cp>1258.25</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>2559.0</hp>
+			<mp>1216.8</mp>
+			<cp>1279.5</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>2601.75</hp>
+			<mp>1237.32</mp>
+			<cp>1300.875</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>2644.75</hp>
+			<mp>1257.96</mp>
+			<cp>1322.375</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>2688.0</hp>
+			<mp>1278.72</mp>
+			<cp>1344.0</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>2731.5</hp>
+			<mp>1299.6</mp>
+			<cp>1365.75</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>2775.25</hp>
+			<mp>1320.6</mp>
+			<cp>1387.625</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>2819.25</hp>
+			<mp>1341.72</mp>
+			<cp>1409.625</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>2863.5</hp>
+			<mp>1362.96</mp>
+			<cp>1431.75</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>2908.0</hp>
+			<mp>1384.32</mp>
+			<cp>1454.0</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>2952.75</hp>
+			<mp>1405.8</mp>
+			<cp>1476.375</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>2997.75</hp>
+			<mp>1427.4</mp>
+			<cp>1498.875</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>3043.0</hp>
+			<mp>1449.12</mp>
+			<cp>1521.5</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>3088.5</hp>
+			<mp>1470.96</mp>
+			<cp>1544.25</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>3134.25</hp>
+			<mp>1492.92</mp>
+			<cp>1567.125</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>3180.25</hp>
+			<mp>1515.0</mp>
+			<cp>1590.125</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>3226.5</hp>
+			<mp>1537.2</mp>
+			<cp>1613.25</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>3273.0</hp>
+			<mp>1559.52</mp>
+			<cp>1636.5</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>3319.75</hp>
+			<mp>1581.96</mp>
+			<cp>1659.875</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>3366.75</hp>
+			<mp>1604.52</mp>
+			<cp>1683.375</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>3414</hp>
+			<mp>1627.2</mp>
+			<cp>1707.01</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>3461.5</hp>
+			<mp>1650</mp>
+			<cp>1730.77</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>3509.25</hp>
+			<mp>1672.92</mp>
+			<cp>1754.66</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>3557.25</hp>
+			<mp>1695.96</mp>
+			<cp>1778.68</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>3605.5</hp>
+			<mp>1719.12</mp>
+			<cp>1802.83</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>3654</hp>
+			<mp>1742.4</mp>
+			<cp>1827.11</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>3702.75</hp>
+			<mp>1765.8</mp>
+			<cp>1851.52</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>3751.75</hp>
+			<mp>1789.32</mp>
+			<cp>1875.875</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/JinKamaelSoldier.xml
+++ b/data/stats/chars/baseStats/JinKamaelSoldier.xml
@@ -11,12 +11,12 @@
         <physicalAbnormalResist>10</physicalAbnormalResist>
         <magicAbnormalResist>10</magicAbnormalResist>
         <creationPoints>
-            <node x="-125607" y="38452" z="1152"/>
-            <node x="-125472" y="38450" z="1152"/>
-            <node x="-125615" y="37771" z="1152"/>
-            <node x="-125464" y="37776" z="1152"/>
-            <node x="-125517" y="38267" z="1155"/>
-            <node x="-125531" y="37944" z="1155"/>
+            <node x="-125607" y="38452" z="1152" />
+            <node x="-125472" y="38450" z="1152" />
+            <node x="-125615" y="37771" z="1152" />
+            <node x="-125464" y="37776" z="1152" />
+            <node x="-125517" y="38267" z="1155" />
+            <node x="-125531" y="37944" z="1155" />
         </creationPoints>
         <basePAtk>4</basePAtk>
         <baseCritRate>4</baseCritRate>
@@ -793,6 +793,134 @@
             <mp>1015.6</mp>
             <cp>1146.05</cp>
             <hpRegen>10.5</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="92">
+            <hp>1951.4</hp>
+            <mp>772.56</mp>
+            <cp>975.7</cp>
+            <hpRegen>10.6</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="93">
+            <hp>1978.7</hp>
+            <mp>783.48</mp>
+            <cp>989.35</cp>
+            <hpRegen>10.7</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="94">
+            <hp>2006.15</hp>
+            <mp>794.46</mp>
+            <cp>1003.075</cp>
+            <hpRegen>10.8</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="95">
+            <hp>2033.75</hp>
+            <mp>805.5</mp>
+            <cp>1016.875</cp>
+            <hpRegen>10.9</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="96">
+            <hp>2061.5</hp>
+            <mp>816.6</mp>
+            <cp>1030.75</cp>
+            <hpRegen>11</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="97">
+            <hp>2089.4</hp>
+            <mp>827.76</mp>
+            <cp>1044.7</cp>
+            <hpRegen>11.1</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="98">
+            <hp>2117.45</hp>
+            <mp>838.98</mp>
+            <cp>1058.725</cp>
+            <hpRegen>11.2</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="99">
+            <hp>2145.65</hp>
+            <mp>850.26</mp>
+            <cp>1072.825</cp>
+            <hpRegen>11.3</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="100">
+            <hp>2174</hp>
+            <mp>861.6</mp>
+            <cp>1087.01</cp>
+            <hpRegen>11.4</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="101">
+            <hp>2202.5</hp>
+            <mp>873</mp>
+            <cp>1101.27</cp>
+            <hpRegen>11.5</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="102">
+            <hp>2231.15</hp>
+            <mp>884.46</mp>
+            <cp>1115.61</cp>
+            <hpRegen>11.6</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="103">
+            <hp>2259.95</hp>
+            <mp>895.98</mp>
+            <cp>1130.03</cp>
+            <hpRegen>11.7</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="104">
+            <hp>2288.9</hp>
+            <mp>907.56</mp>
+            <cp>1144.53</cp>
+            <hpRegen>11.8</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="105">
+            <hp>2318</hp>
+            <mp>919.2</mp>
+            <cp>1159.11</cp>
+            <hpRegen>11.9</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="106">
+            <hp>2347.25</hp>
+            <mp>930.9</mp>
+            <cp>1173.77</cp>
+            <hpRegen>12</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="107">
+            <hp>2376.65</hp>
+            <mp>942.66</mp>
+            <cp>1188.51</cp>
+            <hpRegen>12.1</hpRegen>
             <mpRegen>3.0</mpRegen>
             <cpRegen>8.5</cpRegen>
         </level>

--- a/data/stats/chars/baseStats/Maestro.xml
+++ b/data/stats/chars/baseStats/Maestro.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>118</classId>
-    <staticData>
-        <baseINT>20</baseINT>
-        <baseSTR>39</baseSTR>
-        <baseCON>45</baseCON>
-        <baseMEN>27</baseMEN>
-        <baseDEX>29</baseDEX>
-        <baseWIT>10</baseWIT>
-        <physicalAbnormalResist>15</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="108644" y="-173947" z="-400"/>
-            <node x="108678" y="-174002" z="-400"/>
-            <node x="108505" y="-173964" z="-400"/>
-            <node x="108512" y="-174026" z="-400"/>
-            <node x="108549" y="-174075" z="-400"/>
-            <node x="108576" y="-174122" z="-400"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>80</walk>
-            <run>131</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>80</baseBreath>
-        <baseSafeFall>180</baseSafeFall>
-        <collisionMale>
-            <radius>9.0</radius>
-            <height>18.0</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>5.0</radius>
-            <height>19.0</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>80.0</hp>
-            <mp>30.0</mp>
-            <cp>64.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>92.74</hp>
-            <mp>35.46</mp>
-            <cp>74.192</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>105.62</hp>
-            <mp>40.98</mp>
-            <cp>84.496</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>118.64</hp>
-            <mp>46.56</mp>
-            <cp>94.912</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>131.8</hp>
-            <mp>52.2</mp>
-            <cp>105.44</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>145.1</hp>
-            <mp>57.9</mp>
-            <cp>116.08</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>158.54</hp>
-            <mp>63.66</mp>
-            <cp>126.832</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>172.12</hp>
-            <mp>69.48</mp>
-            <cp>137.696</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>185.84</hp>
-            <mp>75.36</mp>
-            <cp>148.672</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>199.7</hp>
-            <mp>81.3</mp>
-            <cp>159.76</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>213.7</hp>
-            <mp>87.3</mp>
-            <cp>170.96</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>227.84</hp>
-            <mp>93.36</mp>
-            <cp>182.272</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>242.12</hp>
-            <mp>99.48</mp>
-            <cp>193.696</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>256.54</hp>
-            <mp>105.66</mp>
-            <cp>205.232</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>271.1</hp>
-            <mp>111.9</mp>
-            <cp>216.88</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>285.8</hp>
-            <mp>118.2</mp>
-            <cp>228.64</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>300.64</hp>
-            <mp>124.56</mp>
-            <cp>240.512</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>315.62</hp>
-            <mp>130.98</mp>
-            <cp>252.496</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>330.74</hp>
-            <mp>137.46</mp>
-            <cp>264.592</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>346.0</hp>
-            <mp>144.0</mp>
-            <cp>276.8</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>379.0</hp>
-            <mp>153.9</mp>
-            <cp>303.2</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>412.3</hp>
-            <mp>163.89</mp>
-            <cp>329.84</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>445.9</hp>
-            <mp>173.97</mp>
-            <cp>356.72</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>479.8</hp>
-            <mp>184.14</mp>
-            <cp>383.84</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>514.0</hp>
-            <mp>194.4</mp>
-            <cp>411.2</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>548.5</hp>
-            <mp>204.75</mp>
-            <cp>438.8</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>583.3</hp>
-            <mp>215.19</mp>
-            <cp>466.64</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>618.4</hp>
-            <mp>225.72</mp>
-            <cp>494.72</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>653.8</hp>
-            <mp>236.34</mp>
-            <cp>523.04</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>689.5</hp>
-            <mp>247.05</mp>
-            <cp>551.6</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>725.5</hp>
-            <mp>257.85</mp>
-            <cp>580.4</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>761.8</hp>
-            <mp>268.74</mp>
-            <cp>609.44</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>798.4</hp>
-            <mp>279.72</mp>
-            <cp>638.72</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>835.3</hp>
-            <mp>290.79</mp>
-            <cp>668.24</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>872.5</hp>
-            <mp>301.95</mp>
-            <cp>698.0</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>910.0</hp>
-            <mp>313.2</mp>
-            <cp>728.0</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>947.8</hp>
-            <mp>324.54</mp>
-            <cp>758.24</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>985.9</hp>
-            <mp>335.97</mp>
-            <cp>788.72</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1024.3</hp>
-            <mp>347.49</mp>
-            <cp>819.44</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1063.0</hp>
-            <mp>359.1</mp>
-            <cp>850.4</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1117.6</hp>
-            <mp>378.6</mp>
-            <cp>894.08</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1172.62</hp>
-            <mp>398.25</mp>
-            <cp>938.096</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1228.06</hp>
-            <mp>418.05</mp>
-            <cp>982.448</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1283.92</hp>
-            <mp>438.0</mp>
-            <cp>1027.136</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1340.2</hp>
-            <mp>458.1</mp>
-            <cp>1072.16</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1396.9</hp>
-            <mp>478.35</mp>
-            <cp>1117.52</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1454.02</hp>
-            <mp>498.75</mp>
-            <cp>1163.216</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1511.56</hp>
-            <mp>519.3</mp>
-            <cp>1209.248</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1569.52</hp>
-            <mp>540.0</mp>
-            <cp>1255.616</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1627.9</hp>
-            <mp>560.85</mp>
-            <cp>1302.32</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1686.7</hp>
-            <mp>581.85</mp>
-            <cp>1349.36</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1745.92</hp>
-            <mp>603.0</mp>
-            <cp>1396.736</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1805.56</hp>
-            <mp>624.3</mp>
-            <cp>1444.448</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1865.62</hp>
-            <mp>645.75</mp>
-            <cp>1492.496</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1926.1</hp>
-            <mp>667.35</mp>
-            <cp>1540.88</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1987.0</hp>
-            <mp>689.1</mp>
-            <cp>1589.6</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>2048.32</hp>
-            <mp>711.0</mp>
-            <cp>1638.656</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2110.06</hp>
-            <mp>733.05</mp>
-            <cp>1688.048</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2172.22</hp>
-            <mp>755.25</mp>
-            <cp>1737.776</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2234.8</hp>
-            <mp>777.6</mp>
-            <cp>1787.84</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2297.8</hp>
-            <mp>800.1</mp>
-            <cp>1838.24</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2361.22</hp>
-            <mp>822.75</mp>
-            <cp>1888.976</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2425.06</hp>
-            <mp>845.55</mp>
-            <cp>1940.048</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2489.32</hp>
-            <mp>868.5</mp>
-            <cp>1991.456</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2554.0</hp>
-            <mp>891.6</mp>
-            <cp>2043.2</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2619.1</hp>
-            <mp>914.85</mp>
-            <cp>2095.28</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2684.62</hp>
-            <mp>938.25</mp>
-            <cp>2147.696</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2750.56</hp>
-            <mp>961.8</mp>
-            <cp>2200.448</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2816.92</hp>
-            <mp>985.5</mp>
-            <cp>2253.536</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2883.7</hp>
-            <mp>1009.35</mp>
-            <cp>2306.96</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2950.9</hp>
-            <mp>1033.35</mp>
-            <cp>2360.72</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>3018.52</hp>
-            <mp>1057.5</mp>
-            <cp>2414.816</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>3086.56</hp>
-            <mp>1081.8</mp>
-            <cp>2469.248</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>3155.02</hp>
-            <mp>1106.25</mp>
-            <cp>2524.016</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3223.9</hp>
-            <mp>1130.85</mp>
-            <cp>2579.12</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3293.2</hp>
-            <mp>1155.6</mp>
-            <cp>2634.56</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3362.92</hp>
-            <mp>1180.5</mp>
-            <cp>2690.336</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3433.06</hp>
-            <mp>1205.55</mp>
-            <cp>2746.448</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3503.62</hp>
-            <mp>1230.75</mp>
-            <cp>2802.896</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3574.6</hp>
-            <mp>1256.1</mp>
-            <cp>2859.68</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3646.0</hp>
-            <mp>1281.6</mp>
-            <cp>2916.8</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3717.82</hp>
-            <mp>1307.25</mp>
-            <cp>2974.256</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3790.06</hp>
-            <mp>1333.05</mp>
-            <cp>3032.048</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3862.72</hp>
-            <mp>1359.0</mp>
-            <cp>3090.176</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3935.8</hp>
-            <mp>1385.1</mp>
-            <cp>3148.64</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>4009.3</hp>
-            <mp>1411.35</mp>
-            <cp>3207.44</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>4083.22</hp>
-            <mp>1437.75</mp>
-            <cp>3266.576</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>4157.56</hp>
-            <mp>1464.3</mp>
-            <cp>3326.048</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>4232.32</hp>
-            <mp>1491.0</mp>
-            <cp>3385.856</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4307.5</hp>
-            <mp>1517.85</mp>
-            <cp>3446.0</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4383.1</hp>
-            <mp>1544.85</mp>
-            <cp>3506.48</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>118</classId>
+	<staticData>
+		<baseINT>20</baseINT>
+		<baseSTR>39</baseSTR>
+		<baseCON>45</baseCON>
+		<baseMEN>27</baseMEN>
+		<baseDEX>29</baseDEX>
+		<baseWIT>10</baseWIT>
+		<physicalAbnormalResist>15</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="108644" y="-173947" z="-400" />
+			<node x="108678" y="-174002" z="-400" />
+			<node x="108505" y="-173964" z="-400" />
+			<node x="108512" y="-174026" z="-400" />
+			<node x="108549" y="-174075" z="-400" />
+			<node x="108576" y="-174122" z="-400" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>80</walk>
+			<run>131</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>80</baseBreath>
+		<baseSafeFall>180</baseSafeFall>
+		<collisionMale>
+			<radius>9.0</radius>
+			<height>18.0</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>5.0</radius>
+			<height>19.0</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>80.0</hp>
+			<mp>30.0</mp>
+			<cp>64.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>92.74</hp>
+			<mp>35.46</mp>
+			<cp>74.192</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>105.62</hp>
+			<mp>40.98</mp>
+			<cp>84.496</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>118.64</hp>
+			<mp>46.56</mp>
+			<cp>94.912</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>131.8</hp>
+			<mp>52.2</mp>
+			<cp>105.44</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>145.1</hp>
+			<mp>57.9</mp>
+			<cp>116.08</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>158.54</hp>
+			<mp>63.66</mp>
+			<cp>126.832</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>172.12</hp>
+			<mp>69.48</mp>
+			<cp>137.696</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>185.84</hp>
+			<mp>75.36</mp>
+			<cp>148.672</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>199.7</hp>
+			<mp>81.3</mp>
+			<cp>159.76</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>213.7</hp>
+			<mp>87.3</mp>
+			<cp>170.96</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>227.84</hp>
+			<mp>93.36</mp>
+			<cp>182.272</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>242.12</hp>
+			<mp>99.48</mp>
+			<cp>193.696</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>256.54</hp>
+			<mp>105.66</mp>
+			<cp>205.232</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>271.1</hp>
+			<mp>111.9</mp>
+			<cp>216.88</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>285.8</hp>
+			<mp>118.2</mp>
+			<cp>228.64</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>300.64</hp>
+			<mp>124.56</mp>
+			<cp>240.512</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>315.62</hp>
+			<mp>130.98</mp>
+			<cp>252.496</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>330.74</hp>
+			<mp>137.46</mp>
+			<cp>264.592</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>346.0</hp>
+			<mp>144.0</mp>
+			<cp>276.8</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>379.0</hp>
+			<mp>153.9</mp>
+			<cp>303.2</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>412.3</hp>
+			<mp>163.89</mp>
+			<cp>329.84</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>445.9</hp>
+			<mp>173.97</mp>
+			<cp>356.72</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>479.8</hp>
+			<mp>184.14</mp>
+			<cp>383.84</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>514.0</hp>
+			<mp>194.4</mp>
+			<cp>411.2</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>548.5</hp>
+			<mp>204.75</mp>
+			<cp>438.8</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>583.3</hp>
+			<mp>215.19</mp>
+			<cp>466.64</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>618.4</hp>
+			<mp>225.72</mp>
+			<cp>494.72</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>653.8</hp>
+			<mp>236.34</mp>
+			<cp>523.04</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>689.5</hp>
+			<mp>247.05</mp>
+			<cp>551.6</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>725.5</hp>
+			<mp>257.85</mp>
+			<cp>580.4</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>761.8</hp>
+			<mp>268.74</mp>
+			<cp>609.44</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>798.4</hp>
+			<mp>279.72</mp>
+			<cp>638.72</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>835.3</hp>
+			<mp>290.79</mp>
+			<cp>668.24</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>872.5</hp>
+			<mp>301.95</mp>
+			<cp>698.0</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>910.0</hp>
+			<mp>313.2</mp>
+			<cp>728.0</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>947.8</hp>
+			<mp>324.54</mp>
+			<cp>758.24</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>985.9</hp>
+			<mp>335.97</mp>
+			<cp>788.72</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1024.3</hp>
+			<mp>347.49</mp>
+			<cp>819.44</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1063.0</hp>
+			<mp>359.1</mp>
+			<cp>850.4</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1117.6</hp>
+			<mp>378.6</mp>
+			<cp>894.08</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1172.62</hp>
+			<mp>398.25</mp>
+			<cp>938.096</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1228.06</hp>
+			<mp>418.05</mp>
+			<cp>982.448</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1283.92</hp>
+			<mp>438.0</mp>
+			<cp>1027.136</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1340.2</hp>
+			<mp>458.1</mp>
+			<cp>1072.16</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1396.9</hp>
+			<mp>478.35</mp>
+			<cp>1117.52</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1454.02</hp>
+			<mp>498.75</mp>
+			<cp>1163.216</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1511.56</hp>
+			<mp>519.3</mp>
+			<cp>1209.248</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1569.52</hp>
+			<mp>540.0</mp>
+			<cp>1255.616</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1627.9</hp>
+			<mp>560.85</mp>
+			<cp>1302.32</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1686.7</hp>
+			<mp>581.85</mp>
+			<cp>1349.36</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1745.92</hp>
+			<mp>603.0</mp>
+			<cp>1396.736</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1805.56</hp>
+			<mp>624.3</mp>
+			<cp>1444.448</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1865.62</hp>
+			<mp>645.75</mp>
+			<cp>1492.496</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1926.1</hp>
+			<mp>667.35</mp>
+			<cp>1540.88</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1987.0</hp>
+			<mp>689.1</mp>
+			<cp>1589.6</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2048.32</hp>
+			<mp>711.0</mp>
+			<cp>1638.656</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2110.06</hp>
+			<mp>733.05</mp>
+			<cp>1688.048</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2172.22</hp>
+			<mp>755.25</mp>
+			<cp>1737.776</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2234.8</hp>
+			<mp>777.6</mp>
+			<cp>1787.84</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2297.8</hp>
+			<mp>800.1</mp>
+			<cp>1838.24</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2361.22</hp>
+			<mp>822.75</mp>
+			<cp>1888.976</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2425.06</hp>
+			<mp>845.55</mp>
+			<cp>1940.048</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2489.32</hp>
+			<mp>868.5</mp>
+			<cp>1991.456</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2554.0</hp>
+			<mp>891.6</mp>
+			<cp>2043.2</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2619.1</hp>
+			<mp>914.85</mp>
+			<cp>2095.28</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2684.62</hp>
+			<mp>938.25</mp>
+			<cp>2147.696</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2750.56</hp>
+			<mp>961.8</mp>
+			<cp>2200.448</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2816.92</hp>
+			<mp>985.5</mp>
+			<cp>2253.536</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2883.7</hp>
+			<mp>1009.35</mp>
+			<cp>2306.96</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2950.9</hp>
+			<mp>1033.35</mp>
+			<cp>2360.72</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>3018.52</hp>
+			<mp>1057.5</mp>
+			<cp>2414.816</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>3086.56</hp>
+			<mp>1081.8</mp>
+			<cp>2469.248</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3155.02</hp>
+			<mp>1106.25</mp>
+			<cp>2524.016</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3223.9</hp>
+			<mp>1130.85</mp>
+			<cp>2579.12</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3293.2</hp>
+			<mp>1155.6</mp>
+			<cp>2634.56</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3362.92</hp>
+			<mp>1180.5</mp>
+			<cp>2690.336</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3433.06</hp>
+			<mp>1205.55</mp>
+			<cp>2746.448</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3503.62</hp>
+			<mp>1230.75</mp>
+			<cp>2802.896</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3574.6</hp>
+			<mp>1256.1</mp>
+			<cp>2859.68</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3646.0</hp>
+			<mp>1281.6</mp>
+			<cp>2916.8</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3717.82</hp>
+			<mp>1307.25</mp>
+			<cp>2974.256</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3790.06</hp>
+			<mp>1333.05</mp>
+			<cp>3032.048</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3862.72</hp>
+			<mp>1359.0</mp>
+			<cp>3090.176</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3935.8</hp>
+			<mp>1385.1</mp>
+			<cp>3148.64</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>4009.3</hp>
+			<mp>1411.35</mp>
+			<cp>3207.44</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>4083.22</hp>
+			<mp>1437.75</mp>
+			<cp>3266.576</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4157.56</hp>
+			<mp>1464.3</mp>
+			<cp>3326.048</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4232.32</hp>
+			<mp>1491.0</mp>
+			<cp>3385.856</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4307.5</hp>
+			<mp>1517.85</mp>
+			<cp>3446.0</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4383.1</hp>
+			<mp>1544.85</mp>
+			<cp>3506.48</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4459.12</hp>
+			<mp>1572.0</mp>
+			<cp>3567.296</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4535.56</hp>
+			<mp>1599.3</mp>
+			<cp>3628.448</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4612.42</hp>
+			<mp>1626.75</mp>
+			<cp>3689.936</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4689.7</hp>
+			<mp>1654.35</mp>
+			<cp>3751.76</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4767.4</hp>
+			<mp>1682.1</mp>
+			<cp>3813.92</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4845.52</hp>
+			<mp>1710.0</mp>
+			<cp>3876.416</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4924.06</hp>
+			<mp>1738.05</mp>
+			<cp>3939.248</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>5003.02</hp>
+			<mp>1766.25</mp>
+			<cp>4002.416</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>5082.4</hp>
+			<mp>1794.6</mp>
+			<cp>4065.92</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>5162.2</hp>
+			<mp>1823.1</mp>
+			<cp>4129.77</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5242.42</hp>
+			<mp>1851.75</mp>
+			<cp>4193.96</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5323.06</hp>
+			<mp>1880.55</mp>
+			<cp>4258.49</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5404.12</hp>
+			<mp>1909.5</mp>
+			<cp>4323.36</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5485.6</hp>
+			<mp>1938.6</mp>
+			<cp>4388.56</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5567.5</hp>
+			<mp>1967.85</mp>
+			<cp>4454.11</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5649.82</hp>
+			<mp>1997.25</mp>
+			<cp>4519.856</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Monk.xml
+++ b/data/stats/chars/baseStats/Monk.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>47</classId>
-    <staticData>
-        <baseINT>18</baseINT>
-        <baseSTR>40</baseSTR>
-        <baseCON>47</baseCON>
-        <baseMEN>27</baseMEN>
-        <baseDEX>26</baseDEX>
-        <baseWIT>12</baseWIT>
-        <physicalAbnormalResist>15</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-56733" y="-113459" z="-690"/>
-            <node x="-56686" y="-113470" z="-690"/>
-            <node x="-56728" y="-113610" z="-690"/>
-            <node x="-56693" y="-113610" z="-690"/>
-            <node x="-56743" y="-113757" z="-690"/>
-            <node x="-56682" y="-113730" z="-690"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>25</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>70</walk>
-            <run>130</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>90</baseBreath>
-        <baseSafeFall>200</baseSafeFall>
-        <collisionMale>
-            <radius>11</radius>
-            <height>28.0</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7</radius>
-            <height>27.0</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>80.0</hp>
-            <mp>30.0</mp>
-            <cp>40.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>92.74</hp>
-            <mp>35.46</mp>
-            <cp>46.37</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>105.62</hp>
-            <mp>40.98</mp>
-            <cp>52.81</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>118.64</hp>
-            <mp>46.56</mp>
-            <cp>59.32</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>131.8</hp>
-            <mp>52.2</mp>
-            <cp>65.9</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>145.1</hp>
-            <mp>57.9</mp>
-            <cp>72.55</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>158.54</hp>
-            <mp>63.66</mp>
-            <cp>79.27</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>172.12</hp>
-            <mp>69.48</mp>
-            <cp>86.06</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>185.84</hp>
-            <mp>75.36</mp>
-            <cp>92.92</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>199.7</hp>
-            <mp>81.3</mp>
-            <cp>99.85</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>213.7</hp>
-            <mp>87.3</mp>
-            <cp>106.85</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>227.84</hp>
-            <mp>93.36</mp>
-            <cp>113.92</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>242.12</hp>
-            <mp>99.48</mp>
-            <cp>121.06</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>256.54</hp>
-            <mp>105.66</mp>
-            <cp>128.27</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>271.1</hp>
-            <mp>111.9</mp>
-            <cp>135.55</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>285.8</hp>
-            <mp>118.2</mp>
-            <cp>142.9</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>300.64</hp>
-            <mp>124.56</mp>
-            <cp>150.32</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>315.62</hp>
-            <mp>130.98</mp>
-            <cp>157.81</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>330.74</hp>
-            <mp>137.46</mp>
-            <cp>165.37</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>346.0</hp>
-            <mp>144.0</mp>
-            <cp>173.0</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>379.0</hp>
-            <mp>153.9</mp>
-            <cp>189.5</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>412.3</hp>
-            <mp>163.89</mp>
-            <cp>206.15</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>445.9</hp>
-            <mp>173.97</mp>
-            <cp>222.95</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>479.8</hp>
-            <mp>184.14</mp>
-            <cp>239.9</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>514.0</hp>
-            <mp>194.4</mp>
-            <cp>257.0</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>548.5</hp>
-            <mp>204.75</mp>
-            <cp>274.25</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>583.3</hp>
-            <mp>215.19</mp>
-            <cp>291.65</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>618.4</hp>
-            <mp>225.72</mp>
-            <cp>309.2</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>653.8</hp>
-            <mp>236.34</mp>
-            <cp>326.9</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>689.5</hp>
-            <mp>247.05</mp>
-            <cp>344.75</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>725.5</hp>
-            <mp>257.85</mp>
-            <cp>362.75</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>761.8</hp>
-            <mp>268.74</mp>
-            <cp>380.9</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>798.4</hp>
-            <mp>279.72</mp>
-            <cp>399.2</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>835.3</hp>
-            <mp>290.79</mp>
-            <cp>417.65</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>872.5</hp>
-            <mp>301.95</mp>
-            <cp>436.25</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>910.0</hp>
-            <mp>313.2</mp>
-            <cp>455.0</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>947.8</hp>
-            <mp>324.54</mp>
-            <cp>473.9</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>985.9</hp>
-            <mp>335.97</mp>
-            <cp>492.95</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1024.3</hp>
-            <mp>347.49</mp>
-            <cp>512.15</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1063.0</hp>
-            <mp>359.1</mp>
-            <cp>531.5</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1102.0</hp>
-            <mp>370.8</mp>
-            <cp>551.0</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1141.3</hp>
-            <mp>382.59</mp>
-            <cp>570.65</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1180.9</hp>
-            <mp>394.47</mp>
-            <cp>590.45</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1220.8</hp>
-            <mp>406.44</mp>
-            <cp>610.4</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1261.0</hp>
-            <mp>418.5</mp>
-            <cp>630.5</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1301.5</hp>
-            <mp>430.65</mp>
-            <cp>650.75</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1342.3</hp>
-            <mp>442.89</mp>
-            <cp>671.15</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1383.4</hp>
-            <mp>455.22</mp>
-            <cp>691.7</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1424.8</hp>
-            <mp>467.64</mp>
-            <cp>712.4</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1466.5</hp>
-            <mp>480.15</mp>
-            <cp>733.25</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1508.5</hp>
-            <mp>492.75</mp>
-            <cp>754.25</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1550.8</hp>
-            <mp>505.44</mp>
-            <cp>775.4</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1593.4</hp>
-            <mp>518.22</mp>
-            <cp>796.7</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1636.3</hp>
-            <mp>531.09</mp>
-            <cp>818.15</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1679.5</hp>
-            <mp>544.05</mp>
-            <cp>839.75</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1723.0</hp>
-            <mp>557.1</mp>
-            <cp>861.5</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1766.8</hp>
-            <mp>570.24</mp>
-            <cp>883.4</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1810.9</hp>
-            <mp>583.47</mp>
-            <cp>905.45</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>1855.3</hp>
-            <mp>596.79</mp>
-            <cp>927.65</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>1900.0</hp>
-            <mp>610.2</mp>
-            <cp>950.0</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>1945.0</hp>
-            <mp>623.7</mp>
-            <cp>972.5</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>1990.3</hp>
-            <mp>637.29</mp>
-            <cp>995.15</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2035.9</hp>
-            <mp>650.97</mp>
-            <cp>1017.95</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2081.8</hp>
-            <mp>664.74</mp>
-            <cp>1040.9</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2128.0</hp>
-            <mp>678.6</mp>
-            <cp>1064.0</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2174.5</hp>
-            <mp>692.55</mp>
-            <cp>1087.25</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2221.3</hp>
-            <mp>706.59</mp>
-            <cp>1110.65</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2268.4</hp>
-            <mp>720.72</mp>
-            <cp>1134.2</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2315.8</hp>
-            <mp>734.94</mp>
-            <cp>1157.9</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2363.5</hp>
-            <mp>749.25</mp>
-            <cp>1181.75</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2411.5</hp>
-            <mp>763.65</mp>
-            <cp>1205.75</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2459.8</hp>
-            <mp>778.14</mp>
-            <cp>1229.9</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2508.4</hp>
-            <mp>792.72</mp>
-            <cp>1254.2</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2557.3</hp>
-            <mp>807.39</mp>
-            <cp>1278.65</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2606.5</hp>
-            <mp>822.15</mp>
-            <cp>1303.25</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>2656.0</hp>
-            <mp>837.0</mp>
-            <cp>1328.0</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>2705.8</hp>
-            <mp>851.94</mp>
-            <cp>1352.9</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>2755.9</hp>
-            <mp>866.97</mp>
-            <cp>1377.95</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>2806.3</hp>
-            <mp>882.09</mp>
-            <cp>1403.15</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>2857.0</hp>
-            <mp>897.3</mp>
-            <cp>1428.5</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>2908.0</hp>
-            <mp>912.6</mp>
-            <cp>1454.0</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>2959.3</hp>
-            <mp>927.99</mp>
-            <cp>1479.65</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3010.9</hp>
-            <mp>943.47</mp>
-            <cp>1505.45</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3062.8</hp>
-            <mp>959.04</mp>
-            <cp>1531.4</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3115.0</hp>
-            <mp>974.7</mp>
-            <cp>1557.5</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3167.5</hp>
-            <mp>990.45</mp>
-            <cp>1583.75</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3220.3</hp>
-            <mp>1006.29</mp>
-            <cp>1610.15</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3273.4</hp>
-            <mp>1022.22</mp>
-            <cp>1636.7</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3326.8</hp>
-            <mp>1038.24</mp>
-            <cp>1663.4</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3380.5</hp>
-            <mp>1054.35</mp>
-            <cp>1690.25</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>3434.5</hp>
-            <mp>1070.55</mp>
-            <cp>1717.25</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>47</classId>
+	<staticData>
+		<baseINT>18</baseINT>
+		<baseSTR>40</baseSTR>
+		<baseCON>47</baseCON>
+		<baseMEN>27</baseMEN>
+		<baseDEX>26</baseDEX>
+		<baseWIT>12</baseWIT>
+		<physicalAbnormalResist>15</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-56733" y="-113459" z="-690" />
+			<node x="-56686" y="-113470" z="-690" />
+			<node x="-56728" y="-113610" z="-690" />
+			<node x="-56693" y="-113610" z="-690" />
+			<node x="-56743" y="-113757" z="-690" />
+			<node x="-56682" y="-113730" z="-690" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>25</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>70</walk>
+			<run>130</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>90</baseBreath>
+		<baseSafeFall>200</baseSafeFall>
+		<collisionMale>
+			<radius>11</radius>
+			<height>28.0</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7</radius>
+			<height>27.0</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>80.0</hp>
+			<mp>30.0</mp>
+			<cp>40.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>92.74</hp>
+			<mp>35.46</mp>
+			<cp>46.37</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>105.62</hp>
+			<mp>40.98</mp>
+			<cp>52.81</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>118.64</hp>
+			<mp>46.56</mp>
+			<cp>59.32</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>131.8</hp>
+			<mp>52.2</mp>
+			<cp>65.9</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>145.1</hp>
+			<mp>57.9</mp>
+			<cp>72.55</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>158.54</hp>
+			<mp>63.66</mp>
+			<cp>79.27</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>172.12</hp>
+			<mp>69.48</mp>
+			<cp>86.06</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>185.84</hp>
+			<mp>75.36</mp>
+			<cp>92.92</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>199.7</hp>
+			<mp>81.3</mp>
+			<cp>99.85</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>213.7</hp>
+			<mp>87.3</mp>
+			<cp>106.85</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>227.84</hp>
+			<mp>93.36</mp>
+			<cp>113.92</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>242.12</hp>
+			<mp>99.48</mp>
+			<cp>121.06</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>256.54</hp>
+			<mp>105.66</mp>
+			<cp>128.27</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>271.1</hp>
+			<mp>111.9</mp>
+			<cp>135.55</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>285.8</hp>
+			<mp>118.2</mp>
+			<cp>142.9</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>300.64</hp>
+			<mp>124.56</mp>
+			<cp>150.32</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>315.62</hp>
+			<mp>130.98</mp>
+			<cp>157.81</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>330.74</hp>
+			<mp>137.46</mp>
+			<cp>165.37</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>346.0</hp>
+			<mp>144.0</mp>
+			<cp>173.0</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>379.0</hp>
+			<mp>153.9</mp>
+			<cp>189.5</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>412.3</hp>
+			<mp>163.89</mp>
+			<cp>206.15</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>445.9</hp>
+			<mp>173.97</mp>
+			<cp>222.95</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>479.8</hp>
+			<mp>184.14</mp>
+			<cp>239.9</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>514.0</hp>
+			<mp>194.4</mp>
+			<cp>257.0</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>548.5</hp>
+			<mp>204.75</mp>
+			<cp>274.25</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>583.3</hp>
+			<mp>215.19</mp>
+			<cp>291.65</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>618.4</hp>
+			<mp>225.72</mp>
+			<cp>309.2</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>653.8</hp>
+			<mp>236.34</mp>
+			<cp>326.9</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>689.5</hp>
+			<mp>247.05</mp>
+			<cp>344.75</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>725.5</hp>
+			<mp>257.85</mp>
+			<cp>362.75</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>761.8</hp>
+			<mp>268.74</mp>
+			<cp>380.9</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>798.4</hp>
+			<mp>279.72</mp>
+			<cp>399.2</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>835.3</hp>
+			<mp>290.79</mp>
+			<cp>417.65</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>872.5</hp>
+			<mp>301.95</mp>
+			<cp>436.25</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>910.0</hp>
+			<mp>313.2</mp>
+			<cp>455.0</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>947.8</hp>
+			<mp>324.54</mp>
+			<cp>473.9</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>985.9</hp>
+			<mp>335.97</mp>
+			<cp>492.95</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1024.3</hp>
+			<mp>347.49</mp>
+			<cp>512.15</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1063.0</hp>
+			<mp>359.1</mp>
+			<cp>531.5</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1102.0</hp>
+			<mp>370.8</mp>
+			<cp>551.0</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1141.3</hp>
+			<mp>382.59</mp>
+			<cp>570.65</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1180.9</hp>
+			<mp>394.47</mp>
+			<cp>590.45</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1220.8</hp>
+			<mp>406.44</mp>
+			<cp>610.4</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1261.0</hp>
+			<mp>418.5</mp>
+			<cp>630.5</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1301.5</hp>
+			<mp>430.65</mp>
+			<cp>650.75</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1342.3</hp>
+			<mp>442.89</mp>
+			<cp>671.15</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1383.4</hp>
+			<mp>455.22</mp>
+			<cp>691.7</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1424.8</hp>
+			<mp>467.64</mp>
+			<cp>712.4</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1466.5</hp>
+			<mp>480.15</mp>
+			<cp>733.25</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1508.5</hp>
+			<mp>492.75</mp>
+			<cp>754.25</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1550.8</hp>
+			<mp>505.44</mp>
+			<cp>775.4</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1593.4</hp>
+			<mp>518.22</mp>
+			<cp>796.7</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1636.3</hp>
+			<mp>531.09</mp>
+			<cp>818.15</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1679.5</hp>
+			<mp>544.05</mp>
+			<cp>839.75</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1723.0</hp>
+			<mp>557.1</mp>
+			<cp>861.5</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1766.8</hp>
+			<mp>570.24</mp>
+			<cp>883.4</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1810.9</hp>
+			<mp>583.47</mp>
+			<cp>905.45</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1855.3</hp>
+			<mp>596.79</mp>
+			<cp>927.65</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1900.0</hp>
+			<mp>610.2</mp>
+			<cp>950.0</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>1945.0</hp>
+			<mp>623.7</mp>
+			<cp>972.5</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>1990.3</hp>
+			<mp>637.29</mp>
+			<cp>995.15</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2035.9</hp>
+			<mp>650.97</mp>
+			<cp>1017.95</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2081.8</hp>
+			<mp>664.74</mp>
+			<cp>1040.9</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2128.0</hp>
+			<mp>678.6</mp>
+			<cp>1064.0</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2174.5</hp>
+			<mp>692.55</mp>
+			<cp>1087.25</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2221.3</hp>
+			<mp>706.59</mp>
+			<cp>1110.65</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2268.4</hp>
+			<mp>720.72</mp>
+			<cp>1134.2</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2315.8</hp>
+			<mp>734.94</mp>
+			<cp>1157.9</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2363.5</hp>
+			<mp>749.25</mp>
+			<cp>1181.75</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2411.5</hp>
+			<mp>763.65</mp>
+			<cp>1205.75</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2459.8</hp>
+			<mp>778.14</mp>
+			<cp>1229.9</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2508.4</hp>
+			<mp>792.72</mp>
+			<cp>1254.2</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2557.3</hp>
+			<mp>807.39</mp>
+			<cp>1278.65</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2606.5</hp>
+			<mp>822.15</mp>
+			<cp>1303.25</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>2656.0</hp>
+			<mp>837.0</mp>
+			<cp>1328.0</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>2705.8</hp>
+			<mp>851.94</mp>
+			<cp>1352.9</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>2755.9</hp>
+			<mp>866.97</mp>
+			<cp>1377.95</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>2806.3</hp>
+			<mp>882.09</mp>
+			<cp>1403.15</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>2857.0</hp>
+			<mp>897.3</mp>
+			<cp>1428.5</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>2908.0</hp>
+			<mp>912.6</mp>
+			<cp>1454.0</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>2959.3</hp>
+			<mp>927.99</mp>
+			<cp>1479.65</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3010.9</hp>
+			<mp>943.47</mp>
+			<cp>1505.45</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3062.8</hp>
+			<mp>959.04</mp>
+			<cp>1531.4</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3115.0</hp>
+			<mp>974.7</mp>
+			<cp>1557.5</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3167.5</hp>
+			<mp>990.45</mp>
+			<cp>1583.75</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3220.3</hp>
+			<mp>1006.29</mp>
+			<cp>1610.15</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3273.4</hp>
+			<mp>1022.22</mp>
+			<cp>1636.7</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3326.8</hp>
+			<mp>1038.24</mp>
+			<cp>1663.4</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3380.5</hp>
+			<mp>1054.35</mp>
+			<cp>1690.25</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3434.5</hp>
+			<mp>1070.55</mp>
+			<cp>1717.25</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>3488.8</hp>
+			<mp>1086.84</mp>
+			<cp>1744.4</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>3543.4</hp>
+			<mp>1103.22</mp>
+			<cp>1771.7</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>3598.3</hp>
+			<mp>1119.69</mp>
+			<cp>1799.15</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>3653.5</hp>
+			<mp>1136.25</mp>
+			<cp>1826.75</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>3709.0</hp>
+			<mp>1152.9</mp>
+			<cp>1854.5</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>3764.8</hp>
+			<mp>1169.64</mp>
+			<cp>1882.4</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>3820.9</hp>
+			<mp>1186.47</mp>
+			<cp>1910.45</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>3877.3</hp>
+			<mp>1203.39</mp>
+			<cp>1938.65</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>3934</hp>
+			<mp>1220.4</mp>
+			<cp>1967</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>3991</hp>
+			<mp>1237.5</mp>
+			<cp>1995.5</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4048.3</hp>
+			<mp>1254.69</mp>
+			<cp>2024.15</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4105.9</hp>
+			<mp>1271.97</mp>
+			<cp>2052.95</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4163.8</hp>
+			<mp>1289.34</mp>
+			<cp>2081.9</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>4222</hp>
+			<mp>1306.8</mp>
+			<cp>2111</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>4280.5</hp>
+			<mp>1324.35</mp>
+			<cp>2140.25</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>4339.3</hp>
+			<mp>1341.99</mp>
+			<cp>2169.65</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/MoonlightSentinel.xml
+++ b/data/stats/chars/baseStats/MoonlightSentinel.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>102</classId>
-    <staticData>
-        <baseINT>23</baseINT>
-        <baseSTR>36</baseSTR>
-        <baseCON>36</baseCON>
-        <baseMEN>26</baseMEN>
-        <baseDEX>35</baseDEX>
-        <baseWIT>14</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>15</magicAbnormalResist>
-        <creationPoints>
-            <node x="46045" y="41251" z="-3440"/>
-            <node x="46117" y="41247" z="-3440"/>
-            <node x="46182" y="41198" z="-3440"/>
-            <node x="46115" y="41141" z="-3440"/>
-            <node x="46048" y="41141" z="-3440"/>
-            <node x="45978" y="41196" z="-3440"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>90</walk>
-            <run>143</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>150</baseBreath>
-        <baseSafeFall>350</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>24</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.5</radius>
-            <height>23</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>89.0</hp>
-            <mp>30.0</mp>
-            <cp>44.5</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>101.74</hp>
-            <mp>35.46</mp>
-            <cp>50.87</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>114.62</hp>
-            <mp>40.98</mp>
-            <cp>57.31</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>127.64</hp>
-            <mp>46.56</mp>
-            <cp>63.82</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>140.8</hp>
-            <mp>52.2</mp>
-            <cp>70.4</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>154.1</hp>
-            <mp>57.9</mp>
-            <cp>77.05</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>167.54</hp>
-            <mp>63.66</mp>
-            <cp>83.77</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>181.12</hp>
-            <mp>69.48</mp>
-            <cp>90.56</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>194.84</hp>
-            <mp>75.36</mp>
-            <cp>97.42</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>208.7</hp>
-            <mp>81.3</mp>
-            <cp>104.35</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>222.7</hp>
-            <mp>87.3</mp>
-            <cp>111.35</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>236.84</hp>
-            <mp>93.36</mp>
-            <cp>118.42</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>251.12</hp>
-            <mp>99.48</mp>
-            <cp>125.56</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>265.54</hp>
-            <mp>105.66</mp>
-            <cp>132.77</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>280.1</hp>
-            <mp>111.9</mp>
-            <cp>140.05</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>294.8</hp>
-            <mp>118.2</mp>
-            <cp>147.4</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>309.64</hp>
-            <mp>124.56</mp>
-            <cp>154.82</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>324.62</hp>
-            <mp>130.98</mp>
-            <cp>162.31</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>339.74</hp>
-            <mp>137.46</mp>
-            <cp>169.87</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>355.0</hp>
-            <mp>144.0</mp>
-            <cp>177.5</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>385.8</hp>
-            <mp>153.9</mp>
-            <cp>192.9</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>416.88</hp>
-            <mp>163.89</mp>
-            <cp>208.44</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>448.24</hp>
-            <mp>173.97</mp>
-            <cp>224.12</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>479.88</hp>
-            <mp>184.14</mp>
-            <cp>239.94</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>511.8</hp>
-            <mp>194.4</mp>
-            <cp>255.9</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>544.0</hp>
-            <mp>204.75</mp>
-            <cp>272.0</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>576.48</hp>
-            <mp>215.19</mp>
-            <cp>288.24</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>609.24</hp>
-            <mp>225.72</mp>
-            <cp>304.62</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>642.28</hp>
-            <mp>236.34</mp>
-            <cp>321.14</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>675.6</hp>
-            <mp>247.05</mp>
-            <cp>337.8</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>709.2</hp>
-            <mp>257.85</mp>
-            <cp>354.6</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>743.08</hp>
-            <mp>268.74</mp>
-            <cp>371.54</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>777.24</hp>
-            <mp>279.72</mp>
-            <cp>388.62</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>811.68</hp>
-            <mp>290.79</mp>
-            <cp>405.84</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>846.4</hp>
-            <mp>301.95</mp>
-            <cp>423.2</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>881.4</hp>
-            <mp>313.2</mp>
-            <cp>440.7</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>916.68</hp>
-            <mp>324.54</mp>
-            <cp>458.34</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>952.24</hp>
-            <mp>335.97</mp>
-            <cp>476.12</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>988.08</hp>
-            <mp>347.49</mp>
-            <cp>494.04</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1024.2</hp>
-            <mp>359.1</mp>
-            <cp>512.1</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1073.6</hp>
-            <mp>378.6</mp>
-            <cp>536.8</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1123.38</hp>
-            <mp>398.25</mp>
-            <cp>561.69</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1173.54</hp>
-            <mp>418.05</mp>
-            <cp>586.77</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1224.08</hp>
-            <mp>438.0</mp>
-            <cp>612.04</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1275.0</hp>
-            <mp>458.1</mp>
-            <cp>637.5</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1326.3</hp>
-            <mp>478.35</mp>
-            <cp>663.15</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1377.98</hp>
-            <mp>498.75</mp>
-            <cp>688.99</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1430.04</hp>
-            <mp>519.3</mp>
-            <cp>715.02</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1482.48</hp>
-            <mp>540.0</mp>
-            <cp>741.24</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1535.3</hp>
-            <mp>560.85</mp>
-            <cp>767.65</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1588.5</hp>
-            <mp>581.85</mp>
-            <cp>794.25</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1642.08</hp>
-            <mp>603.0</mp>
-            <cp>821.04</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1696.04</hp>
-            <mp>624.3</mp>
-            <cp>848.02</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1750.38</hp>
-            <mp>645.75</mp>
-            <cp>875.19</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1805.1</hp>
-            <mp>667.35</mp>
-            <cp>902.55</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1860.2</hp>
-            <mp>689.1</mp>
-            <cp>930.1</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1915.68</hp>
-            <mp>711.0</mp>
-            <cp>957.84</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1971.54</hp>
-            <mp>733.05</mp>
-            <cp>985.77</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2027.78</hp>
-            <mp>755.25</mp>
-            <cp>1013.89</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2084.4</hp>
-            <mp>777.6</mp>
-            <cp>1042.2</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2141.4</hp>
-            <mp>800.1</mp>
-            <cp>1070.7</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2198.78</hp>
-            <mp>822.75</mp>
-            <cp>1099.39</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2256.54</hp>
-            <mp>845.55</mp>
-            <cp>1128.27</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2314.68</hp>
-            <mp>868.5</mp>
-            <cp>1157.34</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2373.2</hp>
-            <mp>891.6</mp>
-            <cp>1186.6</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2432.1</hp>
-            <mp>914.85</mp>
-            <cp>1216.05</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2491.38</hp>
-            <mp>938.25</mp>
-            <cp>1245.69</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2551.04</hp>
-            <mp>961.8</mp>
-            <cp>1275.52</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2611.08</hp>
-            <mp>985.5</mp>
-            <cp>1305.54</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2671.5</hp>
-            <mp>1009.35</mp>
-            <cp>1335.75</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2732.3</hp>
-            <mp>1033.35</mp>
-            <cp>1366.15</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2793.48</hp>
-            <mp>1057.5</mp>
-            <cp>1396.74</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2855.04</hp>
-            <mp>1081.8</mp>
-            <cp>1427.52</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2916.98</hp>
-            <mp>1106.25</mp>
-            <cp>1458.49</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2979.3</hp>
-            <mp>1130.85</mp>
-            <cp>1489.65</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3042.0</hp>
-            <mp>1155.6</mp>
-            <cp>1521.0</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3105.08</hp>
-            <mp>1180.5</mp>
-            <cp>1552.54</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3168.54</hp>
-            <mp>1205.55</mp>
-            <cp>1584.27</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3232.38</hp>
-            <mp>1230.75</mp>
-            <cp>1616.19</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3296.6</hp>
-            <mp>1256.1</mp>
-            <cp>1648.3</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3361.2</hp>
-            <mp>1281.6</mp>
-            <cp>1680.6</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3426.18</hp>
-            <mp>1307.25</mp>
-            <cp>1713.09</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3491.54</hp>
-            <mp>1333.05</mp>
-            <cp>1745.77</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3557.28</hp>
-            <mp>1359.0</mp>
-            <cp>1778.64</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3623.4</hp>
-            <mp>1385.1</mp>
-            <cp>1811.7</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3689.9</hp>
-            <mp>1411.35</mp>
-            <cp>1844.95</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3756.78</hp>
-            <mp>1437.75</mp>
-            <cp>1878.39</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3824.04</hp>
-            <mp>1464.3</mp>
-            <cp>1912.02</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3891.68</hp>
-            <mp>1491.0</mp>
-            <cp>1945.84</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3959.7</hp>
-            <mp>1517.85</mp>
-            <cp>1979.85</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4028.1</hp>
-            <mp>1544.85</mp>
-            <cp>2014.05</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>102</classId>
+	<staticData>
+		<baseINT>23</baseINT>
+		<baseSTR>36</baseSTR>
+		<baseCON>36</baseCON>
+		<baseMEN>26</baseMEN>
+		<baseDEX>35</baseDEX>
+		<baseWIT>14</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="46045" y="41251" z="-3440" />
+			<node x="46117" y="41247" z="-3440" />
+			<node x="46182" y="41198" z="-3440" />
+			<node x="46115" y="41141" z="-3440" />
+			<node x="46048" y="41141" z="-3440" />
+			<node x="45978" y="41196" z="-3440" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>90</walk>
+			<run>143</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>350</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.5</radius>
+			<height>23</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>89.0</hp>
+			<mp>30.0</mp>
+			<cp>44.5</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>101.74</hp>
+			<mp>35.46</mp>
+			<cp>50.87</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>114.62</hp>
+			<mp>40.98</mp>
+			<cp>57.31</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>127.64</hp>
+			<mp>46.56</mp>
+			<cp>63.82</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>140.8</hp>
+			<mp>52.2</mp>
+			<cp>70.4</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>154.1</hp>
+			<mp>57.9</mp>
+			<cp>77.05</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>167.54</hp>
+			<mp>63.66</mp>
+			<cp>83.77</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>181.12</hp>
+			<mp>69.48</mp>
+			<cp>90.56</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>194.84</hp>
+			<mp>75.36</mp>
+			<cp>97.42</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>208.7</hp>
+			<mp>81.3</mp>
+			<cp>104.35</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>222.7</hp>
+			<mp>87.3</mp>
+			<cp>111.35</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>236.84</hp>
+			<mp>93.36</mp>
+			<cp>118.42</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>251.12</hp>
+			<mp>99.48</mp>
+			<cp>125.56</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>265.54</hp>
+			<mp>105.66</mp>
+			<cp>132.77</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>280.1</hp>
+			<mp>111.9</mp>
+			<cp>140.05</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>294.8</hp>
+			<mp>118.2</mp>
+			<cp>147.4</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>309.64</hp>
+			<mp>124.56</mp>
+			<cp>154.82</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>324.62</hp>
+			<mp>130.98</mp>
+			<cp>162.31</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>339.74</hp>
+			<mp>137.46</mp>
+			<cp>169.87</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>355.0</hp>
+			<mp>144.0</mp>
+			<cp>177.5</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>385.8</hp>
+			<mp>153.9</mp>
+			<cp>192.9</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>416.88</hp>
+			<mp>163.89</mp>
+			<cp>208.44</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>448.24</hp>
+			<mp>173.97</mp>
+			<cp>224.12</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>479.88</hp>
+			<mp>184.14</mp>
+			<cp>239.94</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>511.8</hp>
+			<mp>194.4</mp>
+			<cp>255.9</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>544.0</hp>
+			<mp>204.75</mp>
+			<cp>272.0</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>576.48</hp>
+			<mp>215.19</mp>
+			<cp>288.24</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>609.24</hp>
+			<mp>225.72</mp>
+			<cp>304.62</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>642.28</hp>
+			<mp>236.34</mp>
+			<cp>321.14</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>675.6</hp>
+			<mp>247.05</mp>
+			<cp>337.8</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>709.2</hp>
+			<mp>257.85</mp>
+			<cp>354.6</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>743.08</hp>
+			<mp>268.74</mp>
+			<cp>371.54</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>777.24</hp>
+			<mp>279.72</mp>
+			<cp>388.62</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>811.68</hp>
+			<mp>290.79</mp>
+			<cp>405.84</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>846.4</hp>
+			<mp>301.95</mp>
+			<cp>423.2</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>881.4</hp>
+			<mp>313.2</mp>
+			<cp>440.7</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>916.68</hp>
+			<mp>324.54</mp>
+			<cp>458.34</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>952.24</hp>
+			<mp>335.97</mp>
+			<cp>476.12</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>988.08</hp>
+			<mp>347.49</mp>
+			<cp>494.04</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1024.2</hp>
+			<mp>359.1</mp>
+			<cp>512.1</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1073.6</hp>
+			<mp>378.6</mp>
+			<cp>536.8</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1123.38</hp>
+			<mp>398.25</mp>
+			<cp>561.69</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1173.54</hp>
+			<mp>418.05</mp>
+			<cp>586.77</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1224.08</hp>
+			<mp>438.0</mp>
+			<cp>612.04</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1275.0</hp>
+			<mp>458.1</mp>
+			<cp>637.5</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1326.3</hp>
+			<mp>478.35</mp>
+			<cp>663.15</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1377.98</hp>
+			<mp>498.75</mp>
+			<cp>688.99</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1430.04</hp>
+			<mp>519.3</mp>
+			<cp>715.02</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1482.48</hp>
+			<mp>540.0</mp>
+			<cp>741.24</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1535.3</hp>
+			<mp>560.85</mp>
+			<cp>767.65</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1588.5</hp>
+			<mp>581.85</mp>
+			<cp>794.25</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1642.08</hp>
+			<mp>603.0</mp>
+			<cp>821.04</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1696.04</hp>
+			<mp>624.3</mp>
+			<cp>848.02</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1750.38</hp>
+			<mp>645.75</mp>
+			<cp>875.19</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1805.1</hp>
+			<mp>667.35</mp>
+			<cp>902.55</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1860.2</hp>
+			<mp>689.1</mp>
+			<cp>930.1</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1915.68</hp>
+			<mp>711.0</mp>
+			<cp>957.84</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1971.54</hp>
+			<mp>733.05</mp>
+			<cp>985.77</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2027.78</hp>
+			<mp>755.25</mp>
+			<cp>1013.89</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2084.4</hp>
+			<mp>777.6</mp>
+			<cp>1042.2</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2141.4</hp>
+			<mp>800.1</mp>
+			<cp>1070.7</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2198.78</hp>
+			<mp>822.75</mp>
+			<cp>1099.39</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2256.54</hp>
+			<mp>845.55</mp>
+			<cp>1128.27</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2314.68</hp>
+			<mp>868.5</mp>
+			<cp>1157.34</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2373.2</hp>
+			<mp>891.6</mp>
+			<cp>1186.6</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2432.1</hp>
+			<mp>914.85</mp>
+			<cp>1216.05</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2491.38</hp>
+			<mp>938.25</mp>
+			<cp>1245.69</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2551.04</hp>
+			<mp>961.8</mp>
+			<cp>1275.52</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2611.08</hp>
+			<mp>985.5</mp>
+			<cp>1305.54</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2671.5</hp>
+			<mp>1009.35</mp>
+			<cp>1335.75</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2732.3</hp>
+			<mp>1033.35</mp>
+			<cp>1366.15</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2793.48</hp>
+			<mp>1057.5</mp>
+			<cp>1396.74</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2855.04</hp>
+			<mp>1081.8</mp>
+			<cp>1427.52</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2916.98</hp>
+			<mp>1106.25</mp>
+			<cp>1458.49</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2979.3</hp>
+			<mp>1130.85</mp>
+			<cp>1489.65</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3042.0</hp>
+			<mp>1155.6</mp>
+			<cp>1521.0</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3105.08</hp>
+			<mp>1180.5</mp>
+			<cp>1552.54</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3168.54</hp>
+			<mp>1205.55</mp>
+			<cp>1584.27</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3232.38</hp>
+			<mp>1230.75</mp>
+			<cp>1616.19</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3296.6</hp>
+			<mp>1256.1</mp>
+			<cp>1648.3</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3361.2</hp>
+			<mp>1281.6</mp>
+			<cp>1680.6</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3426.18</hp>
+			<mp>1307.25</mp>
+			<cp>1713.09</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3491.54</hp>
+			<mp>1333.05</mp>
+			<cp>1745.77</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3557.28</hp>
+			<mp>1359.0</mp>
+			<cp>1778.64</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3623.4</hp>
+			<mp>1385.1</mp>
+			<cp>1811.7</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3689.9</hp>
+			<mp>1411.35</mp>
+			<cp>1844.95</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3756.78</hp>
+			<mp>1437.75</mp>
+			<cp>1878.39</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3824.04</hp>
+			<mp>1464.3</mp>
+			<cp>1912.02</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3891.68</hp>
+			<mp>1491.0</mp>
+			<cp>1945.84</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3959.7</hp>
+			<mp>1517.85</mp>
+			<cp>1979.85</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4028.1</hp>
+			<mp>1544.85</mp>
+			<cp>2014.05</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4096.88</hp>
+			<mp>1572.0</mp>
+			<cp>2048.44</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4166.04</hp>
+			<mp>1599.3</mp>
+			<cp>2083.02</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4235.58</hp>
+			<mp>1626.75</mp>
+			<cp>2117.79</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4305.5</hp>
+			<mp>1654.35</mp>
+			<cp>2152.75</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4375.8</hp>
+			<mp>1682.1</mp>
+			<cp>2187.9</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4446.48</hp>
+			<mp>1710.0</mp>
+			<cp>2223.24</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4517.54</hp>
+			<mp>1738.05</mp>
+			<cp>2258.77</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4588.98</hp>
+			<mp>1766.25</mp>
+			<cp>2294.49</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4660.8</hp>
+			<mp>1794.6</mp>
+			<cp>2330.4</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4733</hp>
+			<mp>1823.1</mp>
+			<cp>2366.5</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4805.58</hp>
+			<mp>1851.75</mp>
+			<cp>2402.79</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4878.54</hp>
+			<mp>1880.55</mp>
+			<cp>2439.27</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4951.88</hp>
+			<mp>1909.5</mp>
+			<cp>2475.94</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5025.6</hp>
+			<mp>1938.6</mp>
+			<cp>2512.8</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5099.7</hp>
+			<mp>1967.85</mp>
+			<cp>2549.85</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5174.18</hp>
+			<mp>1997.25</mp>
+			<cp>2587.09</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/MysticMuse.xml
+++ b/data/stats/chars/baseStats/MysticMuse.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>103</classId>
-    <staticData>
-        <baseINT>37</baseINT>
-        <baseSTR>21</baseSTR>
-        <baseCON>25</baseCON>
-        <baseMEN>40</baseMEN>
-        <baseDEX>24</baseDEX>
-        <baseWIT>23</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>15</magicAbnormalResist>
-        <creationPoints>
-            <node x="46045" y="41251" z="-3440"/>
-            <node x="46117" y="41247" z="-3440"/>
-            <node x="46182" y="41198" z="-3440"/>
-            <node x="46115" y="41141" z="-3440"/>
-            <node x="46048" y="41141" z="-3440"/>
-            <node x="45978" y="41196" z="-3440"/>
-        </creationPoints>
-        <basePAtk>3</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>15</chest>
-            <legs>8</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>85</walk>
-            <run>128</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>150</baseBreath>
-        <baseSafeFall>300</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>24</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.5</radius>
-            <height>23</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>104.0</hp>
-            <mp>40.0</mp>
-            <cp>62.4</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>119.47</hp>
-            <mp>47.28</mp>
-            <cp>71.682</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>135.11</hp>
-            <mp>54.64</mp>
-            <cp>81.066</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>150.92</hp>
-            <mp>62.08</mp>
-            <cp>90.552</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>166.9</hp>
-            <mp>69.6</mp>
-            <cp>100.14</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>183.05</hp>
-            <mp>77.2</mp>
-            <cp>109.83</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>199.37</hp>
-            <mp>84.88</mp>
-            <cp>119.622</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>215.86</hp>
-            <mp>92.64</mp>
-            <cp>129.516</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>232.52</hp>
-            <mp>100.48</mp>
-            <cp>139.512</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>249.35</hp>
-            <mp>108.4</mp>
-            <cp>149.61</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>266.35</hp>
-            <mp>116.4</mp>
-            <cp>159.81</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>283.52</hp>
-            <mp>124.48</mp>
-            <cp>170.112</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>300.86</hp>
-            <mp>132.64</mp>
-            <cp>180.516</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>318.37</hp>
-            <mp>140.88</mp>
-            <cp>191.022</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>336.05</hp>
-            <mp>149.2</mp>
-            <cp>201.63</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>353.9</hp>
-            <mp>157.6</mp>
-            <cp>212.34</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>371.92</hp>
-            <mp>166.08</mp>
-            <cp>223.152</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>390.11</hp>
-            <mp>174.64</mp>
-            <cp>234.066</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>408.47</hp>
-            <mp>183.28</mp>
-            <cp>245.082</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>427.0</hp>
-            <mp>192.0</mp>
-            <cp>256.2</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>455.6</hp>
-            <mp>205.2</mp>
-            <cp>273.36</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>484.46</hp>
-            <mp>218.52</mp>
-            <cp>290.676</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>513.58</hp>
-            <mp>231.96</mp>
-            <cp>308.148</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>542.96</hp>
-            <mp>245.52</mp>
-            <cp>325.776</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>572.6</hp>
-            <mp>259.2</mp>
-            <cp>343.56</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>602.5</hp>
-            <mp>273.0</mp>
-            <cp>361.5</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>632.66</hp>
-            <mp>286.92</mp>
-            <cp>379.596</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>663.08</hp>
-            <mp>300.96</mp>
-            <cp>397.848</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>693.76</hp>
-            <mp>315.12</mp>
-            <cp>416.256</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>724.7</hp>
-            <mp>329.4</mp>
-            <cp>434.82</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>755.9</hp>
-            <mp>343.8</mp>
-            <cp>453.54</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>787.36</hp>
-            <mp>358.32</mp>
-            <cp>472.416</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>819.08</hp>
-            <mp>372.96</mp>
-            <cp>491.448</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>851.06</hp>
-            <mp>387.72</mp>
-            <cp>510.636</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>883.3</hp>
-            <mp>402.6</mp>
-            <cp>529.98</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>915.8</hp>
-            <mp>417.6</mp>
-            <cp>549.48</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>948.56</hp>
-            <mp>432.72</mp>
-            <cp>569.136</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>981.58</hp>
-            <mp>447.96</mp>
-            <cp>588.948</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1014.86</hp>
-            <mp>463.32</mp>
-            <cp>608.916</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1048.4</hp>
-            <mp>478.8</mp>
-            <cp>629.04</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1096.5</hp>
-            <mp>504.8</mp>
-            <cp>657.9</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1144.97</hp>
-            <mp>531.0</mp>
-            <cp>686.982</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1193.81</hp>
-            <mp>557.4</mp>
-            <cp>716.286</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1243.02</hp>
-            <mp>584.0</mp>
-            <cp>745.812</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1292.6</hp>
-            <mp>610.8</mp>
-            <cp>775.56</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1342.55</hp>
-            <mp>637.8</mp>
-            <cp>805.53</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1392.87</hp>
-            <mp>665.0</mp>
-            <cp>835.722</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1443.56</hp>
-            <mp>692.4</mp>
-            <cp>866.136</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1494.62</hp>
-            <mp>720.0</mp>
-            <cp>896.772</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1546.05</hp>
-            <mp>747.8</mp>
-            <cp>927.63</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1597.85</hp>
-            <mp>775.8</mp>
-            <cp>958.71</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1650.02</hp>
-            <mp>804.0</mp>
-            <cp>990.012</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1702.56</hp>
-            <mp>832.4</mp>
-            <cp>1021.536</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1755.47</hp>
-            <mp>861.0</mp>
-            <cp>1053.282</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1808.75</hp>
-            <mp>889.8</mp>
-            <cp>1085.25</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1862.4</hp>
-            <mp>918.8</mp>
-            <cp>1117.44</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1916.42</hp>
-            <mp>948.0</mp>
-            <cp>1149.852</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1970.81</hp>
-            <mp>977.4</mp>
-            <cp>1182.486</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2025.57</hp>
-            <mp>1007.0</mp>
-            <cp>1215.342</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2080.7</hp>
-            <mp>1036.8</mp>
-            <cp>1248.42</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2136.2</hp>
-            <mp>1066.8</mp>
-            <cp>1281.72</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2192.07</hp>
-            <mp>1097.0</mp>
-            <cp>1315.242</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2248.31</hp>
-            <mp>1127.4</mp>
-            <cp>1348.986</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2304.92</hp>
-            <mp>1158.0</mp>
-            <cp>1382.952</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2361.9</hp>
-            <mp>1188.8</mp>
-            <cp>1417.14</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2419.25</hp>
-            <mp>1219.8</mp>
-            <cp>1451.55</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2476.97</hp>
-            <mp>1251.0</mp>
-            <cp>1486.182</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2535.06</hp>
-            <mp>1282.4</mp>
-            <cp>1521.036</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2593.52</hp>
-            <mp>1314.0</mp>
-            <cp>1556.112</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2652.35</hp>
-            <mp>1345.8</mp>
-            <cp>1591.41</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2711.55</hp>
-            <mp>1377.8</mp>
-            <cp>1626.93</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2771.12</hp>
-            <mp>1410.0</mp>
-            <cp>1662.672</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2831.06</hp>
-            <mp>1442.4</mp>
-            <cp>1698.636</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2891.37</hp>
-            <mp>1475.0</mp>
-            <cp>1734.822</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2952.05</hp>
-            <mp>1507.8</mp>
-            <cp>1771.23</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3013.1</hp>
-            <mp>1540.8</mp>
-            <cp>1807.86</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3074.52</hp>
-            <mp>1574.0</mp>
-            <cp>1844.712</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3136.31</hp>
-            <mp>1607.4</mp>
-            <cp>1881.786</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3198.47</hp>
-            <mp>1641.0</mp>
-            <cp>1919.082</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3261.0</hp>
-            <mp>1674.8</mp>
-            <cp>1956.6</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3323.9</hp>
-            <mp>1708.8</mp>
-            <cp>1994.34</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3387.17</hp>
-            <mp>1743.0</mp>
-            <cp>2032.302</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3450.81</hp>
-            <mp>1777.4</mp>
-            <cp>2070.486</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3514.82</hp>
-            <mp>1812.0</mp>
-            <cp>2108.892</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3579.2</hp>
-            <mp>1846.8</mp>
-            <cp>2147.52</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3643.95</hp>
-            <mp>1881.8</mp>
-            <cp>2186.37</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3709.07</hp>
-            <mp>1917.0</mp>
-            <cp>2225.442</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3774.56</hp>
-            <mp>1952.4</mp>
-            <cp>2264.736</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3840.42</hp>
-            <mp>1988.0</mp>
-            <cp>2304.252</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3906.65</hp>
-            <mp>2023.8</mp>
-            <cp>2343.99</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>3973.25</hp>
-            <mp>2059.8</mp>
-            <cp>2383.95</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>103</classId>
+	<staticData>
+		<baseINT>37</baseINT>
+		<baseSTR>21</baseSTR>
+		<baseCON>25</baseCON>
+		<baseMEN>40</baseMEN>
+		<baseDEX>24</baseDEX>
+		<baseWIT>23</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="46045" y="41251" z="-3440" />
+			<node x="46117" y="41247" z="-3440" />
+			<node x="46182" y="41198" z="-3440" />
+			<node x="46115" y="41141" z="-3440" />
+			<node x="46048" y="41141" z="-3440" />
+			<node x="45978" y="41196" z="-3440" />
+		</creationPoints>
+		<basePAtk>3</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>15</chest>
+			<legs>8</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>85</walk>
+			<run>128</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>300</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.5</radius>
+			<height>23</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>104.0</hp>
+			<mp>40.0</mp>
+			<cp>62.4</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>119.47</hp>
+			<mp>47.28</mp>
+			<cp>71.682</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>135.11</hp>
+			<mp>54.64</mp>
+			<cp>81.066</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>150.92</hp>
+			<mp>62.08</mp>
+			<cp>90.552</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>166.9</hp>
+			<mp>69.6</mp>
+			<cp>100.14</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>183.05</hp>
+			<mp>77.2</mp>
+			<cp>109.83</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>199.37</hp>
+			<mp>84.88</mp>
+			<cp>119.622</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>215.86</hp>
+			<mp>92.64</mp>
+			<cp>129.516</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>232.52</hp>
+			<mp>100.48</mp>
+			<cp>139.512</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>249.35</hp>
+			<mp>108.4</mp>
+			<cp>149.61</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>266.35</hp>
+			<mp>116.4</mp>
+			<cp>159.81</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>283.52</hp>
+			<mp>124.48</mp>
+			<cp>170.112</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>300.86</hp>
+			<mp>132.64</mp>
+			<cp>180.516</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>318.37</hp>
+			<mp>140.88</mp>
+			<cp>191.022</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>336.05</hp>
+			<mp>149.2</mp>
+			<cp>201.63</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>353.9</hp>
+			<mp>157.6</mp>
+			<cp>212.34</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>371.92</hp>
+			<mp>166.08</mp>
+			<cp>223.152</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>390.11</hp>
+			<mp>174.64</mp>
+			<cp>234.066</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>408.47</hp>
+			<mp>183.28</mp>
+			<cp>245.082</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>427.0</hp>
+			<mp>192.0</mp>
+			<cp>256.2</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>455.6</hp>
+			<mp>205.2</mp>
+			<cp>273.36</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>484.46</hp>
+			<mp>218.52</mp>
+			<cp>290.676</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>513.58</hp>
+			<mp>231.96</mp>
+			<cp>308.148</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>542.96</hp>
+			<mp>245.52</mp>
+			<cp>325.776</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>572.6</hp>
+			<mp>259.2</mp>
+			<cp>343.56</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>602.5</hp>
+			<mp>273.0</mp>
+			<cp>361.5</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>632.66</hp>
+			<mp>286.92</mp>
+			<cp>379.596</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>663.08</hp>
+			<mp>300.96</mp>
+			<cp>397.848</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>693.76</hp>
+			<mp>315.12</mp>
+			<cp>416.256</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>724.7</hp>
+			<mp>329.4</mp>
+			<cp>434.82</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>755.9</hp>
+			<mp>343.8</mp>
+			<cp>453.54</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>787.36</hp>
+			<mp>358.32</mp>
+			<cp>472.416</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>819.08</hp>
+			<mp>372.96</mp>
+			<cp>491.448</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>851.06</hp>
+			<mp>387.72</mp>
+			<cp>510.636</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>883.3</hp>
+			<mp>402.6</mp>
+			<cp>529.98</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>915.8</hp>
+			<mp>417.6</mp>
+			<cp>549.48</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>948.56</hp>
+			<mp>432.72</mp>
+			<cp>569.136</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>981.58</hp>
+			<mp>447.96</mp>
+			<cp>588.948</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1014.86</hp>
+			<mp>463.32</mp>
+			<cp>608.916</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1048.4</hp>
+			<mp>478.8</mp>
+			<cp>629.04</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1096.5</hp>
+			<mp>504.8</mp>
+			<cp>657.9</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1144.97</hp>
+			<mp>531.0</mp>
+			<cp>686.982</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1193.81</hp>
+			<mp>557.4</mp>
+			<cp>716.286</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1243.02</hp>
+			<mp>584.0</mp>
+			<cp>745.812</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1292.6</hp>
+			<mp>610.8</mp>
+			<cp>775.56</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1342.55</hp>
+			<mp>637.8</mp>
+			<cp>805.53</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1392.87</hp>
+			<mp>665.0</mp>
+			<cp>835.722</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1443.56</hp>
+			<mp>692.4</mp>
+			<cp>866.136</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1494.62</hp>
+			<mp>720.0</mp>
+			<cp>896.772</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1546.05</hp>
+			<mp>747.8</mp>
+			<cp>927.63</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1597.85</hp>
+			<mp>775.8</mp>
+			<cp>958.71</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1650.02</hp>
+			<mp>804.0</mp>
+			<cp>990.012</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1702.56</hp>
+			<mp>832.4</mp>
+			<cp>1021.536</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1755.47</hp>
+			<mp>861.0</mp>
+			<cp>1053.282</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1808.75</hp>
+			<mp>889.8</mp>
+			<cp>1085.25</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1862.4</hp>
+			<mp>918.8</mp>
+			<cp>1117.44</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1916.42</hp>
+			<mp>948.0</mp>
+			<cp>1149.852</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1970.81</hp>
+			<mp>977.4</mp>
+			<cp>1182.486</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2025.57</hp>
+			<mp>1007.0</mp>
+			<cp>1215.342</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2080.7</hp>
+			<mp>1036.8</mp>
+			<cp>1248.42</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2136.2</hp>
+			<mp>1066.8</mp>
+			<cp>1281.72</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2192.07</hp>
+			<mp>1097.0</mp>
+			<cp>1315.242</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2248.31</hp>
+			<mp>1127.4</mp>
+			<cp>1348.986</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2304.92</hp>
+			<mp>1158.0</mp>
+			<cp>1382.952</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2361.9</hp>
+			<mp>1188.8</mp>
+			<cp>1417.14</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2419.25</hp>
+			<mp>1219.8</mp>
+			<cp>1451.55</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2476.97</hp>
+			<mp>1251.0</mp>
+			<cp>1486.182</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2535.06</hp>
+			<mp>1282.4</mp>
+			<cp>1521.036</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2593.52</hp>
+			<mp>1314.0</mp>
+			<cp>1556.112</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2652.35</hp>
+			<mp>1345.8</mp>
+			<cp>1591.41</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2711.55</hp>
+			<mp>1377.8</mp>
+			<cp>1626.93</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2771.12</hp>
+			<mp>1410.0</mp>
+			<cp>1662.672</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2831.06</hp>
+			<mp>1442.4</mp>
+			<cp>1698.636</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2891.37</hp>
+			<mp>1475.0</mp>
+			<cp>1734.822</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2952.05</hp>
+			<mp>1507.8</mp>
+			<cp>1771.23</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3013.1</hp>
+			<mp>1540.8</mp>
+			<cp>1807.86</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3074.52</hp>
+			<mp>1574.0</mp>
+			<cp>1844.712</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3136.31</hp>
+			<mp>1607.4</mp>
+			<cp>1881.786</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3198.47</hp>
+			<mp>1641.0</mp>
+			<cp>1919.082</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3261.0</hp>
+			<mp>1674.8</mp>
+			<cp>1956.6</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3323.9</hp>
+			<mp>1708.8</mp>
+			<cp>1994.34</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3387.17</hp>
+			<mp>1743.0</mp>
+			<cp>2032.302</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3450.81</hp>
+			<mp>1777.4</mp>
+			<cp>2070.486</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3514.82</hp>
+			<mp>1812.0</mp>
+			<cp>2108.892</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3579.2</hp>
+			<mp>1846.8</mp>
+			<cp>2147.52</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3643.95</hp>
+			<mp>1881.8</mp>
+			<cp>2186.37</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3709.07</hp>
+			<mp>1917.0</mp>
+			<cp>2225.442</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3774.56</hp>
+			<mp>1952.4</mp>
+			<cp>2264.736</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3840.42</hp>
+			<mp>1988.0</mp>
+			<cp>2304.252</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3906.65</hp>
+			<mp>2023.8</mp>
+			<cp>2343.99</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3973.25</hp>
+			<mp>2059.8</mp>
+			<cp>2383.95</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4040.22</hp>
+			<mp>2096.0</mp>
+			<cp>2424.132</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4107.56</hp>
+			<mp>2132.4</mp>
+			<cp>2464.536</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4175.27</hp>
+			<mp>2169.0</mp>
+			<cp>2505.162</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4243.35</hp>
+			<mp>2205.8</mp>
+			<cp>2546.01</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4311.8</hp>
+			<mp>2242.8</mp>
+			<cp>2587.08</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4380.62</hp>
+			<mp>2280.0</mp>
+			<cp>2628.372</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4449.81</hp>
+			<mp>2317.4</mp>
+			<cp>2669.886</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4519.37</hp>
+			<mp>2355.0</mp>
+			<cp>2711.622</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4589.3</hp>
+			<mp>2392.8</mp>
+			<cp>2753.58</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4659.6</hp>
+			<mp>2430.8</mp>
+			<cp>2795.75</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4730.27</hp>
+			<mp>2469</mp>
+			<cp>2838.15</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4801.31</hp>
+			<mp>2507.4</mp>
+			<cp>2880.77</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4872.72</hp>
+			<mp>2546</mp>
+			<cp>2923.6</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>4944.5</hp>
+			<mp>2584.8</mp>
+			<cp>2966.66</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5016.65</hp>
+			<mp>2623.8</mp>
+			<cp>3009.93</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5089.17</hp>
+			<mp>2663</mp>
+			<cp>3053.502</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Necromancer.xml
+++ b/data/stats/chars/baseStats/Necromancer.xml
@@ -1,798 +1,926 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>13</classId>
-    <staticData>
-        <baseINT>41</baseINT>
-        <baseSTR>22</baseSTR>
-        <baseCON>27</baseCON>
-        <baseMEN>39</baseMEN>
-        <baseDEX>21</baseDEX>
-        <baseWIT>20</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-90875" y="248162" z="-3570"/>
-            <node x="-90954" y="248118" z="-3570"/>
-            <node x="-90918" y="248070" z="-3570"/>
-            <node x="-90890" y="248027" z="-3570"/>
-        </creationPoints>
-        <basePAtk>3</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>15</chest>
-            <legs>8</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>78</walk>
-            <run>124</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>100</baseBreath>
-        <baseSafeFall>200</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>22.8</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>6.5</radius>
-            <height>22.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>101.0</hp>
-            <mp>40.0</mp>
-            <cp>50.5</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>116.47</hp>
-            <mp>47.28</mp>
-            <cp>58.235</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>132.11</hp>
-            <mp>54.64</mp>
-            <cp>66.055</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>147.92</hp>
-            <mp>62.08</mp>
-            <cp>73.96</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>163.9</hp>
-            <mp>69.6</mp>
-            <cp>81.95</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>180.05</hp>
-            <mp>77.2</mp>
-            <cp>90.025</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>196.37</hp>
-            <mp>84.88</mp>
-            <cp>98.185</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>212.86</hp>
-            <mp>92.64</mp>
-            <cp>106.43</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>229.52</hp>
-            <mp>100.48</mp>
-            <cp>114.76</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>246.35</hp>
-            <mp>108.4</mp>
-            <cp>123.175</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>263.35</hp>
-            <mp>116.4</mp>
-            <cp>131.675</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>280.52</hp>
-            <mp>124.48</mp>
-            <cp>140.26</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>297.86</hp>
-            <mp>132.64</mp>
-            <cp>148.93</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>315.37</hp>
-            <mp>140.88</mp>
-            <cp>157.685</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>333.05</hp>
-            <mp>149.2</mp>
-            <cp>166.525</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>350.9</hp>
-            <mp>157.6</mp>
-            <cp>175.45</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>368.92</hp>
-            <mp>166.08</mp>
-            <cp>184.46</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>387.11</hp>
-            <mp>174.64</mp>
-            <cp>193.555</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>405.47</hp>
-            <mp>183.28</mp>
-            <cp>202.735</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>424.0</hp>
-            <mp>192.0</mp>
-            <cp>212.0</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>451.5</hp>
-            <mp>205.2</mp>
-            <cp>225.75</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>479.25</hp>
-            <mp>218.52</mp>
-            <cp>239.625</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>507.25</hp>
-            <mp>231.96</mp>
-            <cp>253.625</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>535.5</hp>
-            <mp>245.52</mp>
-            <cp>267.75</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>564.0</hp>
-            <mp>259.2</mp>
-            <cp>282.0</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>592.75</hp>
-            <mp>273.0</mp>
-            <cp>296.375</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>621.75</hp>
-            <mp>286.92</mp>
-            <cp>310.875</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>651.0</hp>
-            <mp>300.96</mp>
-            <cp>325.5</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>680.5</hp>
-            <mp>315.12</mp>
-            <cp>340.25</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>710.25</hp>
-            <mp>329.4</mp>
-            <cp>355.125</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>740.25</hp>
-            <mp>343.8</mp>
-            <cp>370.125</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>770.5</hp>
-            <mp>358.32</mp>
-            <cp>385.25</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>801.0</hp>
-            <mp>372.96</mp>
-            <cp>400.5</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>831.75</hp>
-            <mp>387.72</mp>
-            <cp>415.875</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>862.75</hp>
-            <mp>402.6</mp>
-            <cp>431.375</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>894.0</hp>
-            <mp>417.6</mp>
-            <cp>447.0</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>925.5</hp>
-            <mp>432.72</mp>
-            <cp>462.75</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>957.25</hp>
-            <mp>447.96</mp>
-            <cp>478.625</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>989.25</hp>
-            <mp>463.32</mp>
-            <cp>494.625</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1021.5</hp>
-            <mp>478.8</mp>
-            <cp>510.75</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1067.0</hp>
-            <mp>504.8</mp>
-            <cp>533.5</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1112.85</hp>
-            <mp>531.0</mp>
-            <cp>556.425</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1159.05</hp>
-            <mp>557.4</mp>
-            <cp>579.525</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1205.6</hp>
-            <mp>584.0</mp>
-            <cp>602.8</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1252.5</hp>
-            <mp>610.8</mp>
-            <cp>626.25</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1299.75</hp>
-            <mp>637.8</mp>
-            <cp>649.875</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1347.35</hp>
-            <mp>665.0</mp>
-            <cp>673.675</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1395.3</hp>
-            <mp>692.4</mp>
-            <cp>697.65</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1443.6</hp>
-            <mp>720.0</mp>
-            <cp>721.8</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1492.25</hp>
-            <mp>747.8</mp>
-            <cp>746.125</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1541.25</hp>
-            <mp>775.8</mp>
-            <cp>770.625</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1590.6</hp>
-            <mp>804.0</mp>
-            <cp>795.3</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1640.3</hp>
-            <mp>832.4</mp>
-            <cp>820.15</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1690.35</hp>
-            <mp>861.0</mp>
-            <cp>845.175</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1740.75</hp>
-            <mp>889.8</mp>
-            <cp>870.375</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1791.5</hp>
-            <mp>918.8</mp>
-            <cp>895.75</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1842.6</hp>
-            <mp>948.0</mp>
-            <cp>921.3</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1894.05</hp>
-            <mp>977.4</mp>
-            <cp>947.025</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>1945.85</hp>
-            <mp>1007.0</mp>
-            <cp>972.925</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>1998.0</hp>
-            <mp>1036.8</mp>
-            <cp>999.0</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2050.5</hp>
-            <mp>1066.8</mp>
-            <cp>1025.25</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2103.35</hp>
-            <mp>1097.0</mp>
-            <cp>1051.675</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2156.55</hp>
-            <mp>1127.4</mp>
-            <cp>1078.275</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2210.1</hp>
-            <mp>1158.0</mp>
-            <cp>1105.05</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2264.0</hp>
-            <mp>1188.8</mp>
-            <cp>1132.0</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2318.25</hp>
-            <mp>1219.8</mp>
-            <cp>1159.125</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2372.85</hp>
-            <mp>1251.0</mp>
-            <cp>1186.425</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2427.8</hp>
-            <mp>1282.4</mp>
-            <cp>1213.9</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2483.1</hp>
-            <mp>1314.0</mp>
-            <cp>1241.55</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2538.75</hp>
-            <mp>1345.8</mp>
-            <cp>1269.375</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2594.75</hp>
-            <mp>1377.8</mp>
-            <cp>1297.375</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2651.1</hp>
-            <mp>1410.0</mp>
-            <cp>1325.55</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2707.8</hp>
-            <mp>1442.4</mp>
-            <cp>1353.9</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2764.85</hp>
-            <mp>1475.0</mp>
-            <cp>1382.425</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2822.25</hp>
-            <mp>1507.8</mp>
-            <cp>1411.125</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>2880.0</hp>
-            <mp>1540.8</mp>
-            <cp>1440.0</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>2938.1</hp>
-            <mp>1574.0</mp>
-            <cp>1469.05</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>2996.55</hp>
-            <mp>1607.4</mp>
-            <cp>1498.275</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3055.35</hp>
-            <mp>1641.0</mp>
-            <cp>1527.675</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3114.5</hp>
-            <mp>1674.8</mp>
-            <cp>1557.25</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3174.0</hp>
-            <mp>1708.8</mp>
-            <cp>1587.0</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3233.85</hp>
-            <mp>1743.0</mp>
-            <cp>1616.925</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3294.05</hp>
-            <mp>1777.4</mp>
-            <cp>1647.025</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3354.6</hp>
-            <mp>1812.0</mp>
-            <cp>1677.3</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3415.5</hp>
-            <mp>1846.8</mp>
-            <cp>1707.75</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3476.75</hp>
-            <mp>1881.8</mp>
-            <cp>1738.375</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3538.35</hp>
-            <mp>1917.0</mp>
-            <cp>1769.175</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3600.3</hp>
-            <mp>1952.4</mp>
-            <cp>1800.15</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3662.6</hp>
-            <mp>1988.0</mp>
-            <cp>1831.3</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3725.25</hp>
-            <mp>2023.8</mp>
-            <cp>1862.625</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>3788.25</hp>
-            <mp>2059.8</mp>
-            <cp>1894.125</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>13</classId>
+	<staticData>
+		<baseINT>41</baseINT>
+		<baseSTR>22</baseSTR>
+		<baseCON>27</baseCON>
+		<baseMEN>39</baseMEN>
+		<baseDEX>21</baseDEX>
+		<baseWIT>20</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-90875" y="248162" z="-3570" />
+			<node x="-90954" y="248118" z="-3570" />
+			<node x="-90918" y="248070" z="-3570" />
+			<node x="-90890" y="248027" z="-3570" />
+		</creationPoints>
+		<basePAtk>3</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>15</chest>
+			<legs>8</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>78</walk>
+			<run>124</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>200</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>22.8</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>6.5</radius>
+			<height>22.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>101.0</hp>
+			<mp>40.0</mp>
+			<cp>50.5</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>116.47</hp>
+			<mp>47.28</mp>
+			<cp>58.235</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>132.11</hp>
+			<mp>54.64</mp>
+			<cp>66.055</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>147.92</hp>
+			<mp>62.08</mp>
+			<cp>73.96</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>163.9</hp>
+			<mp>69.6</mp>
+			<cp>81.95</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>180.05</hp>
+			<mp>77.2</mp>
+			<cp>90.025</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>196.37</hp>
+			<mp>84.88</mp>
+			<cp>98.185</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>212.86</hp>
+			<mp>92.64</mp>
+			<cp>106.43</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>229.52</hp>
+			<mp>100.48</mp>
+			<cp>114.76</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>246.35</hp>
+			<mp>108.4</mp>
+			<cp>123.175</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>263.35</hp>
+			<mp>116.4</mp>
+			<cp>131.675</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>280.52</hp>
+			<mp>124.48</mp>
+			<cp>140.26</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>297.86</hp>
+			<mp>132.64</mp>
+			<cp>148.93</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>315.37</hp>
+			<mp>140.88</mp>
+			<cp>157.685</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>333.05</hp>
+			<mp>149.2</mp>
+			<cp>166.525</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>350.9</hp>
+			<mp>157.6</mp>
+			<cp>175.45</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>368.92</hp>
+			<mp>166.08</mp>
+			<cp>184.46</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>387.11</hp>
+			<mp>174.64</mp>
+			<cp>193.555</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>405.47</hp>
+			<mp>183.28</mp>
+			<cp>202.735</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>424.0</hp>
+			<mp>192.0</mp>
+			<cp>212.0</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>451.5</hp>
+			<mp>205.2</mp>
+			<cp>225.75</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>479.25</hp>
+			<mp>218.52</mp>
+			<cp>239.625</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>507.25</hp>
+			<mp>231.96</mp>
+			<cp>253.625</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>535.5</hp>
+			<mp>245.52</mp>
+			<cp>267.75</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>564.0</hp>
+			<mp>259.2</mp>
+			<cp>282.0</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>592.75</hp>
+			<mp>273.0</mp>
+			<cp>296.375</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>621.75</hp>
+			<mp>286.92</mp>
+			<cp>310.875</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>651.0</hp>
+			<mp>300.96</mp>
+			<cp>325.5</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>680.5</hp>
+			<mp>315.12</mp>
+			<cp>340.25</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>710.25</hp>
+			<mp>329.4</mp>
+			<cp>355.125</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>740.25</hp>
+			<mp>343.8</mp>
+			<cp>370.125</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>770.5</hp>
+			<mp>358.32</mp>
+			<cp>385.25</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>801.0</hp>
+			<mp>372.96</mp>
+			<cp>400.5</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>831.75</hp>
+			<mp>387.72</mp>
+			<cp>415.875</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>862.75</hp>
+			<mp>402.6</mp>
+			<cp>431.375</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>894.0</hp>
+			<mp>417.6</mp>
+			<cp>447.0</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>925.5</hp>
+			<mp>432.72</mp>
+			<cp>462.75</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>957.25</hp>
+			<mp>447.96</mp>
+			<cp>478.625</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>989.25</hp>
+			<mp>463.32</mp>
+			<cp>494.625</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1021.5</hp>
+			<mp>478.8</mp>
+			<cp>510.75</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1067.0</hp>
+			<mp>504.8</mp>
+			<cp>533.5</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1112.85</hp>
+			<mp>531.0</mp>
+			<cp>556.425</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1159.05</hp>
+			<mp>557.4</mp>
+			<cp>579.525</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1205.6</hp>
+			<mp>584.0</mp>
+			<cp>602.8</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1252.5</hp>
+			<mp>610.8</mp>
+			<cp>626.25</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1299.75</hp>
+			<mp>637.8</mp>
+			<cp>649.875</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1347.35</hp>
+			<mp>665.0</mp>
+			<cp>673.675</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1395.3</hp>
+			<mp>692.4</mp>
+			<cp>697.65</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1443.6</hp>
+			<mp>720.0</mp>
+			<cp>721.8</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1492.25</hp>
+			<mp>747.8</mp>
+			<cp>746.125</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1541.25</hp>
+			<mp>775.8</mp>
+			<cp>770.625</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1590.6</hp>
+			<mp>804.0</mp>
+			<cp>795.3</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1640.3</hp>
+			<mp>832.4</mp>
+			<cp>820.15</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1690.35</hp>
+			<mp>861.0</mp>
+			<cp>845.175</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1740.75</hp>
+			<mp>889.8</mp>
+			<cp>870.375</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1791.5</hp>
+			<mp>918.8</mp>
+			<cp>895.75</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1842.6</hp>
+			<mp>948.0</mp>
+			<cp>921.3</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1894.05</hp>
+			<mp>977.4</mp>
+			<cp>947.025</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1945.85</hp>
+			<mp>1007.0</mp>
+			<cp>972.925</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1998.0</hp>
+			<mp>1036.8</mp>
+			<cp>999.0</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2050.5</hp>
+			<mp>1066.8</mp>
+			<cp>1025.25</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2103.35</hp>
+			<mp>1097.0</mp>
+			<cp>1051.675</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2156.55</hp>
+			<mp>1127.4</mp>
+			<cp>1078.275</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2210.1</hp>
+			<mp>1158.0</mp>
+			<cp>1105.05</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2264.0</hp>
+			<mp>1188.8</mp>
+			<cp>1132.0</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2318.25</hp>
+			<mp>1219.8</mp>
+			<cp>1159.125</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2372.85</hp>
+			<mp>1251.0</mp>
+			<cp>1186.425</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2427.8</hp>
+			<mp>1282.4</mp>
+			<cp>1213.9</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2483.1</hp>
+			<mp>1314.0</mp>
+			<cp>1241.55</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2538.75</hp>
+			<mp>1345.8</mp>
+			<cp>1269.375</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2594.75</hp>
+			<mp>1377.8</mp>
+			<cp>1297.375</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2651.1</hp>
+			<mp>1410.0</mp>
+			<cp>1325.55</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2707.8</hp>
+			<mp>1442.4</mp>
+			<cp>1353.9</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2764.85</hp>
+			<mp>1475.0</mp>
+			<cp>1382.425</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2822.25</hp>
+			<mp>1507.8</mp>
+			<cp>1411.125</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>2880.0</hp>
+			<mp>1540.8</mp>
+			<cp>1440.0</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>2938.1</hp>
+			<mp>1574.0</mp>
+			<cp>1469.05</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>2996.55</hp>
+			<mp>1607.4</mp>
+			<cp>1498.275</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3055.35</hp>
+			<mp>1641.0</mp>
+			<cp>1527.675</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3114.5</hp>
+			<mp>1674.8</mp>
+			<cp>1557.25</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3174.0</hp>
+			<mp>1708.8</mp>
+			<cp>1587.0</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3233.85</hp>
+			<mp>1743.0</mp>
+			<cp>1616.925</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3294.05</hp>
+			<mp>1777.4</mp>
+			<cp>1647.025</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3354.6</hp>
+			<mp>1812.0</mp>
+			<cp>1677.3</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3415.5</hp>
+			<mp>1846.8</mp>
+			<cp>1707.75</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3476.75</hp>
+			<mp>1881.8</mp>
+			<cp>1738.375</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3538.35</hp>
+			<mp>1917.0</mp>
+			<cp>1769.175</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3600.3</hp>
+			<mp>1952.4</mp>
+			<cp>1800.15</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3662.6</hp>
+			<mp>1988.0</mp>
+			<cp>1831.3</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3725.25</hp>
+			<mp>2023.8</mp>
+			<cp>1862.625</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3788.25</hp>
+			<mp>2059.8</mp>
+			<cp>1894.125</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>3851.6</hp>
+			<mp>2096.0</mp>
+			<cp>1925.8</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>3915.3</hp>
+			<mp>2132.4</mp>
+			<cp>1957.65</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>3979.35</hp>
+			<mp>2169.0</mp>
+			<cp>1989.675</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4043.75</hp>
+			<mp>2205.8</mp>
+			<cp>2021.875</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4108.5</hp>
+			<mp>2242.8</mp>
+			<cp>2054.25</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4173.6</hp>
+			<mp>2280.0</mp>
+			<cp>2086.8</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4239.05</hp>
+			<mp>2317.4</mp>
+			<cp>2119.525</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4304.85</hp>
+			<mp>2355.0</mp>
+			<cp>2152.425</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4371</hp>
+			<mp>2392.8</mp>
+			<cp>2185.51</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4437.5</hp>
+			<mp>2430.8</mp>
+			<cp>2218.77</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4504.35</hp>
+			<mp>2469</mp>
+			<cp>2252.21</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4571.55</hp>
+			<mp>2507.4</mp>
+			<cp>2285.83</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4639.1</hp>
+			<mp>2546</mp>
+			<cp>2319.63</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>4707</hp>
+			<mp>2584.8</mp>
+			<cp>2353.61</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>4775.25</hp>
+			<mp>2623.8</mp>
+			<cp>2387.77</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>4843.85</hp>
+			<mp>2663</mp>
+			<cp>2421.925</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/OrcFighter.xml
+++ b/data/stats/chars/baseStats/OrcFighter.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>44</classId>
-    <staticData>
-        <baseINT>18</baseINT>
-        <baseSTR>40</baseSTR>
-        <baseCON>47</baseCON>
-        <baseMEN>27</baseMEN>
-        <baseDEX>26</baseDEX>
-        <baseWIT>12</baseWIT>
-        <physicalAbnormalResist>15</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-56733" y="-113459" z="-690"/>
-            <node x="-56686" y="-113470" z="-690"/>
-            <node x="-56728" y="-113610" z="-690"/>
-            <node x="-56693" y="-113610" z="-690"/>
-            <node x="-56743" y="-113757" z="-690"/>
-            <node x="-56682" y="-113730" z="-690"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>25</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>70</walk>
-            <run>130</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>90</baseBreath>
-        <baseSafeFall>200</baseSafeFall>
-        <collisionMale>
-            <radius>11</radius>
-            <height>28.0</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7</radius>
-            <height>27.0</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>80.0</hp>
-            <mp>30.0</mp>
-            <cp>40.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>92.74</hp>
-            <mp>35.46</mp>
-            <cp>46.37</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>105.62</hp>
-            <mp>40.98</mp>
-            <cp>52.81</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>118.64</hp>
-            <mp>46.56</mp>
-            <cp>59.32</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>131.8</hp>
-            <mp>52.2</mp>
-            <cp>65.9</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>145.1</hp>
-            <mp>57.9</mp>
-            <cp>72.55</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>158.54</hp>
-            <mp>63.66</mp>
-            <cp>79.27</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>172.12</hp>
-            <mp>69.48</mp>
-            <cp>86.06</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>185.84</hp>
-            <mp>75.36</mp>
-            <cp>92.92</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>199.7</hp>
-            <mp>81.3</mp>
-            <cp>99.85</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>213.7</hp>
-            <mp>87.3</mp>
-            <cp>106.85</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>227.84</hp>
-            <mp>93.36</mp>
-            <cp>113.92</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>242.12</hp>
-            <mp>99.48</mp>
-            <cp>121.06</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>256.54</hp>
-            <mp>105.66</mp>
-            <cp>128.27</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>271.1</hp>
-            <mp>111.9</mp>
-            <cp>135.55</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>285.8</hp>
-            <mp>118.2</mp>
-            <cp>142.9</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>300.64</hp>
-            <mp>124.56</mp>
-            <cp>150.32</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>315.62</hp>
-            <mp>130.98</mp>
-            <cp>157.81</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>330.74</hp>
-            <mp>137.46</mp>
-            <cp>165.37</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>346.0</hp>
-            <mp>144.0</mp>
-            <cp>173.0</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>361.4</hp>
-            <mp>150.6</mp>
-            <cp>180.7</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>376.94</hp>
-            <mp>157.26</mp>
-            <cp>188.47</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>392.62</hp>
-            <mp>163.98</mp>
-            <cp>196.31</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>408.44</hp>
-            <mp>170.76</mp>
-            <cp>204.22</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>424.4</hp>
-            <mp>177.6</mp>
-            <cp>212.2</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>440.5</hp>
-            <mp>184.5</mp>
-            <cp>220.25</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>456.74</hp>
-            <mp>191.46</mp>
-            <cp>228.37</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>473.12</hp>
-            <mp>198.48</mp>
-            <cp>236.56</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>489.64</hp>
-            <mp>205.56</mp>
-            <cp>244.82</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>506.3</hp>
-            <mp>212.7</mp>
-            <cp>253.15</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>523.1</hp>
-            <mp>219.9</mp>
-            <cp>261.55</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>540.04</hp>
-            <mp>227.16</mp>
-            <cp>270.02</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>557.12</hp>
-            <mp>234.48</mp>
-            <cp>278.56</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>574.34</hp>
-            <mp>241.86</mp>
-            <cp>287.17</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>591.7</hp>
-            <mp>249.3</mp>
-            <cp>295.85</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>609.2</hp>
-            <mp>256.8</mp>
-            <cp>304.6</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>626.84</hp>
-            <mp>264.36</mp>
-            <cp>313.42</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>644.62</hp>
-            <mp>271.98</mp>
-            <cp>322.31</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>662.54</hp>
-            <mp>279.66</mp>
-            <cp>331.27</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>680.6</hp>
-            <mp>287.4</mp>
-            <cp>340.3</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>698.8</hp>
-            <mp>295.2</mp>
-            <cp>349.4</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>717.14</hp>
-            <mp>303.06</mp>
-            <cp>358.57</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>735.62</hp>
-            <mp>310.98</mp>
-            <cp>367.81</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>754.24</hp>
-            <mp>318.96</mp>
-            <cp>377.12</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>773.0</hp>
-            <mp>327.0</mp>
-            <cp>386.5</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>791.9</hp>
-            <mp>335.1</mp>
-            <cp>395.95</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>810.94</hp>
-            <mp>343.26</mp>
-            <cp>405.47</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>830.12</hp>
-            <mp>351.48</mp>
-            <cp>415.06</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>849.44</hp>
-            <mp>359.76</mp>
-            <cp>424.72</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>868.9</hp>
-            <mp>368.1</mp>
-            <cp>434.45</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>888.5</hp>
-            <mp>376.5</mp>
-            <cp>444.25</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>908.24</hp>
-            <mp>384.96</mp>
-            <cp>454.12</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>928.12</hp>
-            <mp>393.48</mp>
-            <cp>464.06</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>948.14</hp>
-            <mp>402.06</mp>
-            <cp>474.07</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>968.3</hp>
-            <mp>410.7</mp>
-            <cp>484.15</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>988.6</hp>
-            <mp>419.4</mp>
-            <cp>494.3</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1009.04</hp>
-            <mp>428.16</mp>
-            <cp>504.52</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1029.62</hp>
-            <mp>436.98</mp>
-            <cp>514.81</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>1050.34</hp>
-            <mp>445.86</mp>
-            <cp>525.17</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>1071.2</hp>
-            <mp>454.8</mp>
-            <cp>535.6</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>1092.2</hp>
-            <mp>463.8</mp>
-            <cp>546.1</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>1113.34</hp>
-            <mp>472.86</mp>
-            <cp>556.67</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>1134.62</hp>
-            <mp>481.98</mp>
-            <cp>567.31</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>1156.04</hp>
-            <mp>491.16</mp>
-            <cp>578.02</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>1177.6</hp>
-            <mp>500.4</mp>
-            <cp>588.8</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>1199.3</hp>
-            <mp>509.7</mp>
-            <cp>599.65</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>1221.14</hp>
-            <mp>519.06</mp>
-            <cp>610.57</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>1243.12</hp>
-            <mp>528.48</mp>
-            <cp>621.56</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>1265.24</hp>
-            <mp>537.96</mp>
-            <cp>632.62</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>1287.5</hp>
-            <mp>547.5</mp>
-            <cp>643.75</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>1309.9</hp>
-            <mp>557.1</mp>
-            <cp>654.95</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>1332.44</hp>
-            <mp>566.76</mp>
-            <cp>666.22</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>1355.12</hp>
-            <mp>576.48</mp>
-            <cp>677.56</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>1377.94</hp>
-            <mp>586.26</mp>
-            <cp>688.97</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>1400.9</hp>
-            <mp>596.1</mp>
-            <cp>700.45</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>1424.0</hp>
-            <mp>606.0</mp>
-            <cp>712.0</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>1447.24</hp>
-            <mp>615.96</mp>
-            <cp>723.62</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>1470.62</hp>
-            <mp>625.98</mp>
-            <cp>735.31</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>1494.14</hp>
-            <mp>636.06</mp>
-            <cp>747.07</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>1517.8</hp>
-            <mp>646.2</mp>
-            <cp>758.9</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>1541.6</hp>
-            <mp>656.4</mp>
-            <cp>770.8</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>1565.54</hp>
-            <mp>666.66</mp>
-            <cp>782.77</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>1589.62</hp>
-            <mp>676.98</mp>
-            <cp>794.81</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>1613.84</hp>
-            <mp>687.36</mp>
-            <cp>806.92</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>1638.2</hp>
-            <mp>697.8</mp>
-            <cp>819.1</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>1662.7</hp>
-            <mp>708.3</mp>
-            <cp>831.35</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>1687.34</hp>
-            <mp>718.86</mp>
-            <cp>843.67</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>1712.12</hp>
-            <mp>729.48</mp>
-            <cp>856.06</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>1737.04</hp>
-            <mp>740.16</mp>
-            <cp>868.52</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>1762.1</hp>
-            <mp>750.9</mp>
-            <cp>881.05</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>1787.3</hp>
-            <mp>761.7</mp>
-            <cp>893.65</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>44</classId>
+	<staticData>
+		<baseINT>18</baseINT>
+		<baseSTR>40</baseSTR>
+		<baseCON>47</baseCON>
+		<baseMEN>27</baseMEN>
+		<baseDEX>26</baseDEX>
+		<baseWIT>12</baseWIT>
+		<physicalAbnormalResist>15</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-56733" y="-113459" z="-690" />
+			<node x="-56686" y="-113470" z="-690" />
+			<node x="-56728" y="-113610" z="-690" />
+			<node x="-56693" y="-113610" z="-690" />
+			<node x="-56743" y="-113757" z="-690" />
+			<node x="-56682" y="-113730" z="-690" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>25</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>70</walk>
+			<run>130</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>90</baseBreath>
+		<baseSafeFall>200</baseSafeFall>
+		<collisionMale>
+			<radius>11</radius>
+			<height>28.0</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7</radius>
+			<height>27.0</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>80.0</hp>
+			<mp>30.0</mp>
+			<cp>40.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>92.74</hp>
+			<mp>35.46</mp>
+			<cp>46.37</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>105.62</hp>
+			<mp>40.98</mp>
+			<cp>52.81</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>118.64</hp>
+			<mp>46.56</mp>
+			<cp>59.32</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>131.8</hp>
+			<mp>52.2</mp>
+			<cp>65.9</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>145.1</hp>
+			<mp>57.9</mp>
+			<cp>72.55</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>158.54</hp>
+			<mp>63.66</mp>
+			<cp>79.27</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>172.12</hp>
+			<mp>69.48</mp>
+			<cp>86.06</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>185.84</hp>
+			<mp>75.36</mp>
+			<cp>92.92</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>199.7</hp>
+			<mp>81.3</mp>
+			<cp>99.85</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>213.7</hp>
+			<mp>87.3</mp>
+			<cp>106.85</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>227.84</hp>
+			<mp>93.36</mp>
+			<cp>113.92</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>242.12</hp>
+			<mp>99.48</mp>
+			<cp>121.06</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>256.54</hp>
+			<mp>105.66</mp>
+			<cp>128.27</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>271.1</hp>
+			<mp>111.9</mp>
+			<cp>135.55</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>285.8</hp>
+			<mp>118.2</mp>
+			<cp>142.9</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>300.64</hp>
+			<mp>124.56</mp>
+			<cp>150.32</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>315.62</hp>
+			<mp>130.98</mp>
+			<cp>157.81</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>330.74</hp>
+			<mp>137.46</mp>
+			<cp>165.37</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>346.0</hp>
+			<mp>144.0</mp>
+			<cp>173.0</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>361.4</hp>
+			<mp>150.6</mp>
+			<cp>180.7</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>376.94</hp>
+			<mp>157.26</mp>
+			<cp>188.47</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>392.62</hp>
+			<mp>163.98</mp>
+			<cp>196.31</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>408.44</hp>
+			<mp>170.76</mp>
+			<cp>204.22</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>424.4</hp>
+			<mp>177.6</mp>
+			<cp>212.2</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>440.5</hp>
+			<mp>184.5</mp>
+			<cp>220.25</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>456.74</hp>
+			<mp>191.46</mp>
+			<cp>228.37</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>473.12</hp>
+			<mp>198.48</mp>
+			<cp>236.56</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>489.64</hp>
+			<mp>205.56</mp>
+			<cp>244.82</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>506.3</hp>
+			<mp>212.7</mp>
+			<cp>253.15</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>523.1</hp>
+			<mp>219.9</mp>
+			<cp>261.55</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>540.04</hp>
+			<mp>227.16</mp>
+			<cp>270.02</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>557.12</hp>
+			<mp>234.48</mp>
+			<cp>278.56</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>574.34</hp>
+			<mp>241.86</mp>
+			<cp>287.17</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>591.7</hp>
+			<mp>249.3</mp>
+			<cp>295.85</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>609.2</hp>
+			<mp>256.8</mp>
+			<cp>304.6</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>626.84</hp>
+			<mp>264.36</mp>
+			<cp>313.42</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>644.62</hp>
+			<mp>271.98</mp>
+			<cp>322.31</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>662.54</hp>
+			<mp>279.66</mp>
+			<cp>331.27</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>680.6</hp>
+			<mp>287.4</mp>
+			<cp>340.3</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>698.8</hp>
+			<mp>295.2</mp>
+			<cp>349.4</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>717.14</hp>
+			<mp>303.06</mp>
+			<cp>358.57</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>735.62</hp>
+			<mp>310.98</mp>
+			<cp>367.81</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>754.24</hp>
+			<mp>318.96</mp>
+			<cp>377.12</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>773.0</hp>
+			<mp>327.0</mp>
+			<cp>386.5</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>791.9</hp>
+			<mp>335.1</mp>
+			<cp>395.95</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>810.94</hp>
+			<mp>343.26</mp>
+			<cp>405.47</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>830.12</hp>
+			<mp>351.48</mp>
+			<cp>415.06</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>849.44</hp>
+			<mp>359.76</mp>
+			<cp>424.72</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>868.9</hp>
+			<mp>368.1</mp>
+			<cp>434.45</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>888.5</hp>
+			<mp>376.5</mp>
+			<cp>444.25</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>908.24</hp>
+			<mp>384.96</mp>
+			<cp>454.12</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>928.12</hp>
+			<mp>393.48</mp>
+			<cp>464.06</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>948.14</hp>
+			<mp>402.06</mp>
+			<cp>474.07</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>968.3</hp>
+			<mp>410.7</mp>
+			<cp>484.15</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>988.6</hp>
+			<mp>419.4</mp>
+			<cp>494.3</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1009.04</hp>
+			<mp>428.16</mp>
+			<cp>504.52</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1029.62</hp>
+			<mp>436.98</mp>
+			<cp>514.81</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1050.34</hp>
+			<mp>445.86</mp>
+			<cp>525.17</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1071.2</hp>
+			<mp>454.8</mp>
+			<cp>535.6</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>1092.2</hp>
+			<mp>463.8</mp>
+			<cp>546.1</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>1113.34</hp>
+			<mp>472.86</mp>
+			<cp>556.67</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>1134.62</hp>
+			<mp>481.98</mp>
+			<cp>567.31</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>1156.04</hp>
+			<mp>491.16</mp>
+			<cp>578.02</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>1177.6</hp>
+			<mp>500.4</mp>
+			<cp>588.8</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>1199.3</hp>
+			<mp>509.7</mp>
+			<cp>599.65</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>1221.14</hp>
+			<mp>519.06</mp>
+			<cp>610.57</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>1243.12</hp>
+			<mp>528.48</mp>
+			<cp>621.56</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>1265.24</hp>
+			<mp>537.96</mp>
+			<cp>632.62</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>1287.5</hp>
+			<mp>547.5</mp>
+			<cp>643.75</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>1309.9</hp>
+			<mp>557.1</mp>
+			<cp>654.95</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>1332.44</hp>
+			<mp>566.76</mp>
+			<cp>666.22</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>1355.12</hp>
+			<mp>576.48</mp>
+			<cp>677.56</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>1377.94</hp>
+			<mp>586.26</mp>
+			<cp>688.97</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>1400.9</hp>
+			<mp>596.1</mp>
+			<cp>700.45</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>1424.0</hp>
+			<mp>606.0</mp>
+			<cp>712.0</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>1447.24</hp>
+			<mp>615.96</mp>
+			<cp>723.62</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>1470.62</hp>
+			<mp>625.98</mp>
+			<cp>735.31</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>1494.14</hp>
+			<mp>636.06</mp>
+			<cp>747.07</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>1517.8</hp>
+			<mp>646.2</mp>
+			<cp>758.9</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>1541.6</hp>
+			<mp>656.4</mp>
+			<cp>770.8</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>1565.54</hp>
+			<mp>666.66</mp>
+			<cp>782.77</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>1589.62</hp>
+			<mp>676.98</mp>
+			<cp>794.81</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>1613.84</hp>
+			<mp>687.36</mp>
+			<cp>806.92</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>1638.2</hp>
+			<mp>697.8</mp>
+			<cp>819.1</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>1662.7</hp>
+			<mp>708.3</mp>
+			<cp>831.35</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>1687.34</hp>
+			<mp>718.86</mp>
+			<cp>843.67</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>1712.12</hp>
+			<mp>729.48</mp>
+			<cp>856.06</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>1737.04</hp>
+			<mp>740.16</mp>
+			<cp>868.52</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>1762.1</hp>
+			<mp>750.9</mp>
+			<cp>881.05</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>1787.3</hp>
+			<mp>761.7</mp>
+			<cp>893.65</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>1812.64</hp>
+			<mp>772.56</mp>
+			<cp>906.32</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>1838.12</hp>
+			<mp>783.48</mp>
+			<cp>919.06</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>1863.74</hp>
+			<mp>794.46</mp>
+			<cp>931.87</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>1889.5</hp>
+			<mp>805.5</mp>
+			<cp>944.75</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>1915.4</hp>
+			<mp>816.6</mp>
+			<cp>957.7</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>1941.44</hp>
+			<mp>827.76</mp>
+			<cp>970.72</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>1967.62</hp>
+			<mp>838.98</mp>
+			<cp>983.81</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>1993.94</hp>
+			<mp>850.26</mp>
+			<cp>996.97</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>2020.4</hp>
+			<mp>861.6</mp>
+			<cp>1010.2</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>2047</hp>
+			<mp>873</mp>
+			<cp>1023.5</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>2073.74</hp>
+			<mp>884.46</mp>
+			<cp>1036.87</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>2100.62</hp>
+			<mp>895.98</mp>
+			<cp>1050.31</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>2127.64</hp>
+			<mp>907.56</mp>
+			<cp>1063.82</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>2154.8</hp>
+			<mp>919.2</mp>
+			<cp>1077.4</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>2182.1</hp>
+			<mp>930.9</mp>
+			<cp>1091.05</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>2209.54</hp>
+			<mp>942.66</mp>
+			<cp>1104.77</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/OrcMystic.xml
+++ b/data/stats/chars/baseStats/OrcMystic.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>49</classId>
-    <staticData>
-        <baseINT>31</baseINT>
-        <baseSTR>27</baseSTR>
-        <baseCON>31</baseCON>
-        <baseMEN>42</baseMEN>
-        <baseDEX>24</baseDEX>
-        <baseWIT>15</baseWIT>
-        <physicalAbnormalResist>15</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-56733" y="-113459" z="-690"/>
-            <node x="-56686" y="-113470" z="-690"/>
-            <node x="-56728" y="-113610" z="-690"/>
-            <node x="-56693" y="-113610" z="-690"/>
-            <node x="-56743" y="-113757" z="-690"/>
-            <node x="-56682" y="-113730" z="-690"/>
-        </creationPoints>
-        <basePAtk>3</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>15</chest>
-            <legs>8</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>25</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>70</walk>
-            <run>128</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>90</baseBreath>
-        <baseSafeFall>250</baseSafeFall>
-        <collisionMale>
-            <radius>7.0</radius>
-            <height>27.5</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>8.0</radius>
-            <height>25.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>95.0</hp>
-            <mp>40.0</mp>
-            <cp>47.5</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>110.47</hp>
-            <mp>47.28</mp>
-            <cp>55.235</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>126.11</hp>
-            <mp>54.64</mp>
-            <cp>63.055</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>141.92</hp>
-            <mp>62.08</mp>
-            <cp>70.96</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>157.9</hp>
-            <mp>69.6</mp>
-            <cp>78.95</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>174.05</hp>
-            <mp>77.2</mp>
-            <cp>87.025</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>190.37</hp>
-            <mp>84.88</mp>
-            <cp>95.185</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>206.86</hp>
-            <mp>92.64</mp>
-            <cp>103.43</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>223.52</hp>
-            <mp>100.48</mp>
-            <cp>111.76</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>240.35</hp>
-            <mp>108.4</mp>
-            <cp>120.175</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>257.35</hp>
-            <mp>116.4</mp>
-            <cp>128.675</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>274.52</hp>
-            <mp>124.48</mp>
-            <cp>137.26</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>291.86</hp>
-            <mp>132.64</mp>
-            <cp>145.93</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>309.37</hp>
-            <mp>140.88</mp>
-            <cp>154.685</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>327.05</hp>
-            <mp>149.2</mp>
-            <cp>163.525</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>344.9</hp>
-            <mp>157.6</mp>
-            <cp>172.45</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>362.92</hp>
-            <mp>166.08</mp>
-            <cp>181.46</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>381.11</hp>
-            <mp>174.64</mp>
-            <cp>190.555</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>399.47</hp>
-            <mp>183.28</mp>
-            <cp>199.735</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>418.0</hp>
-            <mp>192.0</mp>
-            <cp>209.0</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>436.7</hp>
-            <mp>200.8</mp>
-            <cp>218.35</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>455.57</hp>
-            <mp>209.68</mp>
-            <cp>227.785</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>474.61</hp>
-            <mp>218.64</mp>
-            <cp>237.305</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>493.82</hp>
-            <mp>227.68</mp>
-            <cp>246.91</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>513.2</hp>
-            <mp>236.8</mp>
-            <cp>256.6</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>532.75</hp>
-            <mp>246.0</mp>
-            <cp>266.375</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>552.47</hp>
-            <mp>255.28</mp>
-            <cp>276.235</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>572.36</hp>
-            <mp>264.64</mp>
-            <cp>286.18</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>592.42</hp>
-            <mp>274.08</mp>
-            <cp>296.21</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>612.65</hp>
-            <mp>283.6</mp>
-            <cp>306.325</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>633.05</hp>
-            <mp>293.2</mp>
-            <cp>316.525</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>653.62</hp>
-            <mp>302.88</mp>
-            <cp>326.81</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>674.36</hp>
-            <mp>312.64</mp>
-            <cp>337.18</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>695.27</hp>
-            <mp>322.48</mp>
-            <cp>347.635</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>716.35</hp>
-            <mp>332.4</mp>
-            <cp>358.175</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>737.6</hp>
-            <mp>342.4</mp>
-            <cp>368.8</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>759.02</hp>
-            <mp>352.48</mp>
-            <cp>379.51</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>780.61</hp>
-            <mp>362.64</mp>
-            <cp>390.305</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>802.37</hp>
-            <mp>372.88</mp>
-            <cp>401.185</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>824.3</hp>
-            <mp>383.2</mp>
-            <cp>412.15</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>846.4</hp>
-            <mp>393.6</mp>
-            <cp>423.2</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>868.67</hp>
-            <mp>404.08</mp>
-            <cp>434.335</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>891.11</hp>
-            <mp>414.64</mp>
-            <cp>445.555</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>913.72</hp>
-            <mp>425.28</mp>
-            <cp>456.86</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>936.5</hp>
-            <mp>436.0</mp>
-            <cp>468.25</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>959.45</hp>
-            <mp>446.8</mp>
-            <cp>479.725</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>982.57</hp>
-            <mp>457.68</mp>
-            <cp>491.285</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1005.86</hp>
-            <mp>468.64</mp>
-            <cp>502.93</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1029.32</hp>
-            <mp>479.68</mp>
-            <cp>514.66</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1052.95</hp>
-            <mp>490.8</mp>
-            <cp>526.475</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1076.75</hp>
-            <mp>502.0</mp>
-            <cp>538.375</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1100.72</hp>
-            <mp>513.28</mp>
-            <cp>550.36</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1124.86</hp>
-            <mp>524.64</mp>
-            <cp>562.43</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1149.17</hp>
-            <mp>536.08</mp>
-            <cp>574.585</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1173.65</hp>
-            <mp>547.6</mp>
-            <cp>586.825</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1198.3</hp>
-            <mp>559.2</mp>
-            <cp>599.15</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1223.12</hp>
-            <mp>570.88</mp>
-            <cp>611.56</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1248.11</hp>
-            <mp>582.64</mp>
-            <cp>624.055</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>1273.27</hp>
-            <mp>594.48</mp>
-            <cp>636.635</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>1298.6</hp>
-            <mp>606.4</mp>
-            <cp>649.3</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>1324.1</hp>
-            <mp>618.4</mp>
-            <cp>662.05</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>1349.77</hp>
-            <mp>630.48</mp>
-            <cp>674.885</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>1375.61</hp>
-            <mp>642.64</mp>
-            <cp>687.805</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>1401.62</hp>
-            <mp>654.88</mp>
-            <cp>700.81</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>1427.8</hp>
-            <mp>667.2</mp>
-            <cp>713.9</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>1454.15</hp>
-            <mp>679.6</mp>
-            <cp>727.075</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>1480.67</hp>
-            <mp>692.08</mp>
-            <cp>740.335</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>1507.36</hp>
-            <mp>704.64</mp>
-            <cp>753.68</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>1534.22</hp>
-            <mp>717.28</mp>
-            <cp>767.11</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>1561.25</hp>
-            <mp>730.0</mp>
-            <cp>780.625</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>1588.45</hp>
-            <mp>742.8</mp>
-            <cp>794.225</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>1615.82</hp>
-            <mp>755.68</mp>
-            <cp>807.91</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>1643.36</hp>
-            <mp>768.64</mp>
-            <cp>821.68</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>1671.07</hp>
-            <mp>781.68</mp>
-            <cp>835.535</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>1698.95</hp>
-            <mp>794.8</mp>
-            <cp>849.475</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>1727.0</hp>
-            <mp>808.0</mp>
-            <cp>863.5</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>1755.22</hp>
-            <mp>821.28</mp>
-            <cp>877.61</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>1783.61</hp>
-            <mp>834.64</mp>
-            <cp>891.805</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>1812.17</hp>
-            <mp>848.08</mp>
-            <cp>906.085</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>1840.9</hp>
-            <mp>861.6</mp>
-            <cp>920.45</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>1869.8</hp>
-            <mp>875.2</mp>
-            <cp>934.9</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>1898.87</hp>
-            <mp>888.88</mp>
-            <cp>949.435</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>1928.11</hp>
-            <mp>902.64</mp>
-            <cp>964.055</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>1957.52</hp>
-            <mp>916.48</mp>
-            <cp>978.76</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>1987.1</hp>
-            <mp>930.4</mp>
-            <cp>993.55</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>2016.85</hp>
-            <mp>944.4</mp>
-            <cp>1008.425</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>2046.77</hp>
-            <mp>958.48</mp>
-            <cp>1023.385</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>2076.86</hp>
-            <mp>972.64</mp>
-            <cp>1038.43</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>2107.12</hp>
-            <mp>986.88</mp>
-            <cp>1053.56</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>2137.55</hp>
-            <mp>1001.2</mp>
-            <cp>1068.775</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>2168.15</hp>
-            <mp>1015.6</mp>
-            <cp>1084.075</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>49</classId>
+	<staticData>
+		<baseINT>31</baseINT>
+		<baseSTR>27</baseSTR>
+		<baseCON>31</baseCON>
+		<baseMEN>42</baseMEN>
+		<baseDEX>24</baseDEX>
+		<baseWIT>15</baseWIT>
+		<physicalAbnormalResist>15</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-56733" y="-113459" z="-690" />
+			<node x="-56686" y="-113470" z="-690" />
+			<node x="-56728" y="-113610" z="-690" />
+			<node x="-56693" y="-113610" z="-690" />
+			<node x="-56743" y="-113757" z="-690" />
+			<node x="-56682" y="-113730" z="-690" />
+		</creationPoints>
+		<basePAtk>3</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>15</chest>
+			<legs>8</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>25</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>70</walk>
+			<run>128</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>90</baseBreath>
+		<baseSafeFall>250</baseSafeFall>
+		<collisionMale>
+			<radius>7.0</radius>
+			<height>27.5</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>8.0</radius>
+			<height>25.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>95.0</hp>
+			<mp>40.0</mp>
+			<cp>47.5</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>110.47</hp>
+			<mp>47.28</mp>
+			<cp>55.235</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>126.11</hp>
+			<mp>54.64</mp>
+			<cp>63.055</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>141.92</hp>
+			<mp>62.08</mp>
+			<cp>70.96</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>157.9</hp>
+			<mp>69.6</mp>
+			<cp>78.95</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>174.05</hp>
+			<mp>77.2</mp>
+			<cp>87.025</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>190.37</hp>
+			<mp>84.88</mp>
+			<cp>95.185</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>206.86</hp>
+			<mp>92.64</mp>
+			<cp>103.43</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>223.52</hp>
+			<mp>100.48</mp>
+			<cp>111.76</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>240.35</hp>
+			<mp>108.4</mp>
+			<cp>120.175</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>257.35</hp>
+			<mp>116.4</mp>
+			<cp>128.675</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>274.52</hp>
+			<mp>124.48</mp>
+			<cp>137.26</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>291.86</hp>
+			<mp>132.64</mp>
+			<cp>145.93</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>309.37</hp>
+			<mp>140.88</mp>
+			<cp>154.685</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>327.05</hp>
+			<mp>149.2</mp>
+			<cp>163.525</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>344.9</hp>
+			<mp>157.6</mp>
+			<cp>172.45</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>362.92</hp>
+			<mp>166.08</mp>
+			<cp>181.46</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>381.11</hp>
+			<mp>174.64</mp>
+			<cp>190.555</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>399.47</hp>
+			<mp>183.28</mp>
+			<cp>199.735</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>418.0</hp>
+			<mp>192.0</mp>
+			<cp>209.0</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>436.7</hp>
+			<mp>200.8</mp>
+			<cp>218.35</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>455.57</hp>
+			<mp>209.68</mp>
+			<cp>227.785</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>474.61</hp>
+			<mp>218.64</mp>
+			<cp>237.305</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>493.82</hp>
+			<mp>227.68</mp>
+			<cp>246.91</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>513.2</hp>
+			<mp>236.8</mp>
+			<cp>256.6</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>532.75</hp>
+			<mp>246.0</mp>
+			<cp>266.375</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>552.47</hp>
+			<mp>255.28</mp>
+			<cp>276.235</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>572.36</hp>
+			<mp>264.64</mp>
+			<cp>286.18</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>592.42</hp>
+			<mp>274.08</mp>
+			<cp>296.21</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>612.65</hp>
+			<mp>283.6</mp>
+			<cp>306.325</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>633.05</hp>
+			<mp>293.2</mp>
+			<cp>316.525</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>653.62</hp>
+			<mp>302.88</mp>
+			<cp>326.81</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>674.36</hp>
+			<mp>312.64</mp>
+			<cp>337.18</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>695.27</hp>
+			<mp>322.48</mp>
+			<cp>347.635</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>716.35</hp>
+			<mp>332.4</mp>
+			<cp>358.175</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>737.6</hp>
+			<mp>342.4</mp>
+			<cp>368.8</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>759.02</hp>
+			<mp>352.48</mp>
+			<cp>379.51</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>780.61</hp>
+			<mp>362.64</mp>
+			<cp>390.305</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>802.37</hp>
+			<mp>372.88</mp>
+			<cp>401.185</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>824.3</hp>
+			<mp>383.2</mp>
+			<cp>412.15</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>846.4</hp>
+			<mp>393.6</mp>
+			<cp>423.2</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>868.67</hp>
+			<mp>404.08</mp>
+			<cp>434.335</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>891.11</hp>
+			<mp>414.64</mp>
+			<cp>445.555</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>913.72</hp>
+			<mp>425.28</mp>
+			<cp>456.86</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>936.5</hp>
+			<mp>436.0</mp>
+			<cp>468.25</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>959.45</hp>
+			<mp>446.8</mp>
+			<cp>479.725</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>982.57</hp>
+			<mp>457.68</mp>
+			<cp>491.285</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1005.86</hp>
+			<mp>468.64</mp>
+			<cp>502.93</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1029.32</hp>
+			<mp>479.68</mp>
+			<cp>514.66</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1052.95</hp>
+			<mp>490.8</mp>
+			<cp>526.475</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1076.75</hp>
+			<mp>502.0</mp>
+			<cp>538.375</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1100.72</hp>
+			<mp>513.28</mp>
+			<cp>550.36</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1124.86</hp>
+			<mp>524.64</mp>
+			<cp>562.43</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1149.17</hp>
+			<mp>536.08</mp>
+			<cp>574.585</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1173.65</hp>
+			<mp>547.6</mp>
+			<cp>586.825</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1198.3</hp>
+			<mp>559.2</mp>
+			<cp>599.15</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1223.12</hp>
+			<mp>570.88</mp>
+			<cp>611.56</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1248.11</hp>
+			<mp>582.64</mp>
+			<cp>624.055</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1273.27</hp>
+			<mp>594.48</mp>
+			<cp>636.635</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1298.6</hp>
+			<mp>606.4</mp>
+			<cp>649.3</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>1324.1</hp>
+			<mp>618.4</mp>
+			<cp>662.05</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>1349.77</hp>
+			<mp>630.48</mp>
+			<cp>674.885</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>1375.61</hp>
+			<mp>642.64</mp>
+			<cp>687.805</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>1401.62</hp>
+			<mp>654.88</mp>
+			<cp>700.81</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>1427.8</hp>
+			<mp>667.2</mp>
+			<cp>713.9</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>1454.15</hp>
+			<mp>679.6</mp>
+			<cp>727.075</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>1480.67</hp>
+			<mp>692.08</mp>
+			<cp>740.335</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>1507.36</hp>
+			<mp>704.64</mp>
+			<cp>753.68</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>1534.22</hp>
+			<mp>717.28</mp>
+			<cp>767.11</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>1561.25</hp>
+			<mp>730.0</mp>
+			<cp>780.625</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>1588.45</hp>
+			<mp>742.8</mp>
+			<cp>794.225</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>1615.82</hp>
+			<mp>755.68</mp>
+			<cp>807.91</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>1643.36</hp>
+			<mp>768.64</mp>
+			<cp>821.68</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>1671.07</hp>
+			<mp>781.68</mp>
+			<cp>835.535</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>1698.95</hp>
+			<mp>794.8</mp>
+			<cp>849.475</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>1727.0</hp>
+			<mp>808.0</mp>
+			<cp>863.5</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>1755.22</hp>
+			<mp>821.28</mp>
+			<cp>877.61</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>1783.61</hp>
+			<mp>834.64</mp>
+			<cp>891.805</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>1812.17</hp>
+			<mp>848.08</mp>
+			<cp>906.085</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>1840.9</hp>
+			<mp>861.6</mp>
+			<cp>920.45</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>1869.8</hp>
+			<mp>875.2</mp>
+			<cp>934.9</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>1898.87</hp>
+			<mp>888.88</mp>
+			<cp>949.435</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>1928.11</hp>
+			<mp>902.64</mp>
+			<cp>964.055</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>1957.52</hp>
+			<mp>916.48</mp>
+			<cp>978.76</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>1987.1</hp>
+			<mp>930.4</mp>
+			<cp>993.55</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>2016.85</hp>
+			<mp>944.4</mp>
+			<cp>1008.425</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>2046.77</hp>
+			<mp>958.48</mp>
+			<cp>1023.385</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>2076.86</hp>
+			<mp>972.64</mp>
+			<cp>1038.43</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>2107.12</hp>
+			<mp>986.88</mp>
+			<cp>1053.56</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>2137.55</hp>
+			<mp>1001.2</mp>
+			<cp>1068.775</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>2168.15</hp>
+			<mp>1015.6</mp>
+			<cp>1084.075</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>2198.92</hp>
+			<mp>1030.08</mp>
+			<cp>1099.46</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>2229.86</hp>
+			<mp>1044.64</mp>
+			<cp>1114.93</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>2260.97</hp>
+			<mp>1059.28</mp>
+			<cp>1130.485</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>2292.25</hp>
+			<mp>1074.0</mp>
+			<cp>1146.125</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>2323.7</hp>
+			<mp>1088.8</mp>
+			<cp>1161.85</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>2355.32</hp>
+			<mp>1103.68</mp>
+			<cp>1177.66</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>2387.11</hp>
+			<mp>1118.64</mp>
+			<cp>1193.555</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>2419.07</hp>
+			<mp>1133.68</mp>
+			<cp>1209.535</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>2451.2</hp>
+			<mp>1148.8</mp>
+			<cp>1225.61</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>2483.5</hp>
+			<mp>1164</mp>
+			<cp>1241.77</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>2515.97</hp>
+			<mp>1179.28</mp>
+			<cp>1258.02</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>2548.61</hp>
+			<mp>1194.64</mp>
+			<cp>1274.36</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>2581.42</hp>
+			<mp>1210.08</mp>
+			<cp>1290.79</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>2614.4</hp>
+			<mp>1225.6</mp>
+			<cp>1307.31</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>2647.55</hp>
+			<mp>1241.2</mp>
+			<cp>1323.92</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>2680.87</hp>
+			<mp>1256.88</mp>
+			<cp>1340.435</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/OrcRaider.xml
+++ b/data/stats/chars/baseStats/OrcRaider.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>45</classId>
-    <staticData>
-        <baseINT>18</baseINT>
-        <baseSTR>40</baseSTR>
-        <baseCON>47</baseCON>
-        <baseMEN>27</baseMEN>
-        <baseDEX>26</baseDEX>
-        <baseWIT>12</baseWIT>
-        <physicalAbnormalResist>15</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-56733" y="-113459" z="-690"/>
-            <node x="-56686" y="-113470" z="-690"/>
-            <node x="-56728" y="-113610" z="-690"/>
-            <node x="-56693" y="-113610" z="-690"/>
-            <node x="-56743" y="-113757" z="-690"/>
-            <node x="-56682" y="-113730" z="-690"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>25</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>70</walk>
-            <run>130</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>90</baseBreath>
-        <baseSafeFall>200</baseSafeFall>
-        <collisionMale>
-            <radius>11</radius>
-            <height>28.0</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7</radius>
-            <height>27.0</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>80.0</hp>
-            <mp>30.0</mp>
-            <cp>56.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>92.74</hp>
-            <mp>35.46</mp>
-            <cp>64.918</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>105.62</hp>
-            <mp>40.98</mp>
-            <cp>73.934</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>118.64</hp>
-            <mp>46.56</mp>
-            <cp>83.048</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>131.8</hp>
-            <mp>52.2</mp>
-            <cp>92.26</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>145.1</hp>
-            <mp>57.9</mp>
-            <cp>101.57</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>158.54</hp>
-            <mp>63.66</mp>
-            <cp>110.978</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>172.12</hp>
-            <mp>69.48</mp>
-            <cp>120.484</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>185.84</hp>
-            <mp>75.36</mp>
-            <cp>130.088</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>199.7</hp>
-            <mp>81.3</mp>
-            <cp>139.79</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>213.7</hp>
-            <mp>87.3</mp>
-            <cp>149.59</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>227.84</hp>
-            <mp>93.36</mp>
-            <cp>159.488</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>242.12</hp>
-            <mp>99.48</mp>
-            <cp>169.484</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>256.54</hp>
-            <mp>105.66</mp>
-            <cp>179.578</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>271.1</hp>
-            <mp>111.9</mp>
-            <cp>189.77</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>285.8</hp>
-            <mp>118.2</mp>
-            <cp>200.06</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>300.64</hp>
-            <mp>124.56</mp>
-            <cp>210.448</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>315.62</hp>
-            <mp>130.98</mp>
-            <cp>220.934</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>330.74</hp>
-            <mp>137.46</mp>
-            <cp>231.518</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>346.0</hp>
-            <mp>144.0</mp>
-            <cp>242.2</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>381.2</hp>
-            <mp>153.9</mp>
-            <cp>266.84</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>416.72</hp>
-            <mp>163.89</mp>
-            <cp>291.704</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>452.56</hp>
-            <mp>173.97</mp>
-            <cp>316.792</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>488.72</hp>
-            <mp>184.14</mp>
-            <cp>342.104</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>525.2</hp>
-            <mp>194.4</mp>
-            <cp>367.64</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>562.0</hp>
-            <mp>204.75</mp>
-            <cp>393.4</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>599.12</hp>
-            <mp>215.19</mp>
-            <cp>419.384</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>636.56</hp>
-            <mp>225.72</mp>
-            <cp>445.592</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>674.32</hp>
-            <mp>236.34</mp>
-            <cp>472.024</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>712.4</hp>
-            <mp>247.05</mp>
-            <cp>498.68</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>750.8</hp>
-            <mp>257.85</mp>
-            <cp>525.56</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>789.52</hp>
-            <mp>268.74</mp>
-            <cp>552.664</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>828.56</hp>
-            <mp>279.72</mp>
-            <cp>579.992</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>867.92</hp>
-            <mp>290.79</mp>
-            <cp>607.544</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>907.6</hp>
-            <mp>301.95</mp>
-            <cp>635.32</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>947.6</hp>
-            <mp>313.2</mp>
-            <cp>663.32</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>987.92</hp>
-            <mp>324.54</mp>
-            <cp>691.544</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1028.56</hp>
-            <mp>335.97</mp>
-            <cp>719.992</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1069.52</hp>
-            <mp>347.49</mp>
-            <cp>748.664</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1110.8</hp>
-            <mp>359.1</mp>
-            <cp>777.56</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1152.4</hp>
-            <mp>370.8</mp>
-            <cp>806.68</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1194.32</hp>
-            <mp>382.59</mp>
-            <cp>836.024</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1236.56</hp>
-            <mp>394.47</mp>
-            <cp>865.592</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1279.12</hp>
-            <mp>406.44</mp>
-            <cp>895.384</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1322.0</hp>
-            <mp>418.5</mp>
-            <cp>925.4</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1365.2</hp>
-            <mp>430.65</mp>
-            <cp>955.64</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1408.72</hp>
-            <mp>442.89</mp>
-            <cp>986.104</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1452.56</hp>
-            <mp>455.22</mp>
-            <cp>1016.792</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1496.72</hp>
-            <mp>467.64</mp>
-            <cp>1047.704</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1541.2</hp>
-            <mp>480.15</mp>
-            <cp>1078.84</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1586.0</hp>
-            <mp>492.75</mp>
-            <cp>1110.2</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1631.12</hp>
-            <mp>505.44</mp>
-            <cp>1141.784</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1676.56</hp>
-            <mp>518.22</mp>
-            <cp>1173.592</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1722.32</hp>
-            <mp>531.09</mp>
-            <cp>1205.624</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1768.4</hp>
-            <mp>544.05</mp>
-            <cp>1237.88</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1814.8</hp>
-            <mp>557.1</mp>
-            <cp>1270.36</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1861.52</hp>
-            <mp>570.24</mp>
-            <cp>1303.064</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1908.56</hp>
-            <mp>583.47</mp>
-            <cp>1335.992</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>1955.92</hp>
-            <mp>596.79</mp>
-            <cp>1369.144</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2003.6</hp>
-            <mp>610.2</mp>
-            <cp>1402.52</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2051.6</hp>
-            <mp>623.7</mp>
-            <cp>1436.12</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2099.92</hp>
-            <mp>637.29</mp>
-            <cp>1469.944</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2148.56</hp>
-            <mp>650.97</mp>
-            <cp>1503.992</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2197.52</hp>
-            <mp>664.74</mp>
-            <cp>1538.264</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2246.8</hp>
-            <mp>678.6</mp>
-            <cp>1572.76</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2296.4</hp>
-            <mp>692.55</mp>
-            <cp>1607.48</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2346.32</hp>
-            <mp>706.59</mp>
-            <cp>1642.424</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2396.56</hp>
-            <mp>720.72</mp>
-            <cp>1677.592</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2447.12</hp>
-            <mp>734.94</mp>
-            <cp>1712.984</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2498.0</hp>
-            <mp>749.25</mp>
-            <cp>1748.6</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2549.2</hp>
-            <mp>763.65</mp>
-            <cp>1784.44</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2600.72</hp>
-            <mp>778.14</mp>
-            <cp>1820.504</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2652.56</hp>
-            <mp>792.72</mp>
-            <cp>1856.792</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2704.72</hp>
-            <mp>807.39</mp>
-            <cp>1893.304</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2757.2</hp>
-            <mp>822.15</mp>
-            <cp>1930.04</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>2810.0</hp>
-            <mp>837.0</mp>
-            <cp>1967.0</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>2863.12</hp>
-            <mp>851.94</mp>
-            <cp>2004.184</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>2916.56</hp>
-            <mp>866.97</mp>
-            <cp>2041.592</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>2970.32</hp>
-            <mp>882.09</mp>
-            <cp>2079.224</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3024.4</hp>
-            <mp>897.3</mp>
-            <cp>2117.08</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3078.8</hp>
-            <mp>912.6</mp>
-            <cp>2155.16</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3133.52</hp>
-            <mp>927.99</mp>
-            <cp>2193.464</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3188.56</hp>
-            <mp>943.47</mp>
-            <cp>2231.992</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3243.92</hp>
-            <mp>959.04</mp>
-            <cp>2270.744</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3299.6</hp>
-            <mp>974.7</mp>
-            <cp>2309.72</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3355.6</hp>
-            <mp>990.45</mp>
-            <cp>2348.92</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3411.92</hp>
-            <mp>1006.29</mp>
-            <cp>2388.344</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3468.56</hp>
-            <mp>1022.22</mp>
-            <cp>2427.992</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3525.52</hp>
-            <mp>1038.24</mp>
-            <cp>2467.864</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3582.8</hp>
-            <mp>1054.35</mp>
-            <cp>2507.96</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>3640.4</hp>
-            <mp>1070.55</mp>
-            <cp>2548.28</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>45</classId>
+	<staticData>
+		<baseINT>18</baseINT>
+		<baseSTR>40</baseSTR>
+		<baseCON>47</baseCON>
+		<baseMEN>27</baseMEN>
+		<baseDEX>26</baseDEX>
+		<baseWIT>12</baseWIT>
+		<physicalAbnormalResist>15</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-56733" y="-113459" z="-690" />
+			<node x="-56686" y="-113470" z="-690" />
+			<node x="-56728" y="-113610" z="-690" />
+			<node x="-56693" y="-113610" z="-690" />
+			<node x="-56743" y="-113757" z="-690" />
+			<node x="-56682" y="-113730" z="-690" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>25</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>70</walk>
+			<run>130</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>90</baseBreath>
+		<baseSafeFall>200</baseSafeFall>
+		<collisionMale>
+			<radius>11</radius>
+			<height>28.0</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7</radius>
+			<height>27.0</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>80.0</hp>
+			<mp>30.0</mp>
+			<cp>56.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>92.74</hp>
+			<mp>35.46</mp>
+			<cp>64.918</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>105.62</hp>
+			<mp>40.98</mp>
+			<cp>73.934</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>118.64</hp>
+			<mp>46.56</mp>
+			<cp>83.048</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>131.8</hp>
+			<mp>52.2</mp>
+			<cp>92.26</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>145.1</hp>
+			<mp>57.9</mp>
+			<cp>101.57</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>158.54</hp>
+			<mp>63.66</mp>
+			<cp>110.978</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>172.12</hp>
+			<mp>69.48</mp>
+			<cp>120.484</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>185.84</hp>
+			<mp>75.36</mp>
+			<cp>130.088</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>199.7</hp>
+			<mp>81.3</mp>
+			<cp>139.79</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>213.7</hp>
+			<mp>87.3</mp>
+			<cp>149.59</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>227.84</hp>
+			<mp>93.36</mp>
+			<cp>159.488</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>242.12</hp>
+			<mp>99.48</mp>
+			<cp>169.484</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>256.54</hp>
+			<mp>105.66</mp>
+			<cp>179.578</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>271.1</hp>
+			<mp>111.9</mp>
+			<cp>189.77</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>285.8</hp>
+			<mp>118.2</mp>
+			<cp>200.06</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>300.64</hp>
+			<mp>124.56</mp>
+			<cp>210.448</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>315.62</hp>
+			<mp>130.98</mp>
+			<cp>220.934</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>330.74</hp>
+			<mp>137.46</mp>
+			<cp>231.518</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>346.0</hp>
+			<mp>144.0</mp>
+			<cp>242.2</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>381.2</hp>
+			<mp>153.9</mp>
+			<cp>266.84</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>416.72</hp>
+			<mp>163.89</mp>
+			<cp>291.704</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>452.56</hp>
+			<mp>173.97</mp>
+			<cp>316.792</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>488.72</hp>
+			<mp>184.14</mp>
+			<cp>342.104</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>525.2</hp>
+			<mp>194.4</mp>
+			<cp>367.64</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>562.0</hp>
+			<mp>204.75</mp>
+			<cp>393.4</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>599.12</hp>
+			<mp>215.19</mp>
+			<cp>419.384</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>636.56</hp>
+			<mp>225.72</mp>
+			<cp>445.592</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>674.32</hp>
+			<mp>236.34</mp>
+			<cp>472.024</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>712.4</hp>
+			<mp>247.05</mp>
+			<cp>498.68</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>750.8</hp>
+			<mp>257.85</mp>
+			<cp>525.56</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>789.52</hp>
+			<mp>268.74</mp>
+			<cp>552.664</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>828.56</hp>
+			<mp>279.72</mp>
+			<cp>579.992</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>867.92</hp>
+			<mp>290.79</mp>
+			<cp>607.544</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>907.6</hp>
+			<mp>301.95</mp>
+			<cp>635.32</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>947.6</hp>
+			<mp>313.2</mp>
+			<cp>663.32</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>987.92</hp>
+			<mp>324.54</mp>
+			<cp>691.544</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1028.56</hp>
+			<mp>335.97</mp>
+			<cp>719.992</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1069.52</hp>
+			<mp>347.49</mp>
+			<cp>748.664</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1110.8</hp>
+			<mp>359.1</mp>
+			<cp>777.56</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1152.4</hp>
+			<mp>370.8</mp>
+			<cp>806.68</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1194.32</hp>
+			<mp>382.59</mp>
+			<cp>836.024</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1236.56</hp>
+			<mp>394.47</mp>
+			<cp>865.592</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1279.12</hp>
+			<mp>406.44</mp>
+			<cp>895.384</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1322.0</hp>
+			<mp>418.5</mp>
+			<cp>925.4</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1365.2</hp>
+			<mp>430.65</mp>
+			<cp>955.64</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1408.72</hp>
+			<mp>442.89</mp>
+			<cp>986.104</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1452.56</hp>
+			<mp>455.22</mp>
+			<cp>1016.792</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1496.72</hp>
+			<mp>467.64</mp>
+			<cp>1047.704</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1541.2</hp>
+			<mp>480.15</mp>
+			<cp>1078.84</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1586.0</hp>
+			<mp>492.75</mp>
+			<cp>1110.2</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1631.12</hp>
+			<mp>505.44</mp>
+			<cp>1141.784</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1676.56</hp>
+			<mp>518.22</mp>
+			<cp>1173.592</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1722.32</hp>
+			<mp>531.09</mp>
+			<cp>1205.624</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1768.4</hp>
+			<mp>544.05</mp>
+			<cp>1237.88</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1814.8</hp>
+			<mp>557.1</mp>
+			<cp>1270.36</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1861.52</hp>
+			<mp>570.24</mp>
+			<cp>1303.064</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1908.56</hp>
+			<mp>583.47</mp>
+			<cp>1335.992</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1955.92</hp>
+			<mp>596.79</mp>
+			<cp>1369.144</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2003.6</hp>
+			<mp>610.2</mp>
+			<cp>1402.52</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2051.6</hp>
+			<mp>623.7</mp>
+			<cp>1436.12</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2099.92</hp>
+			<mp>637.29</mp>
+			<cp>1469.944</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2148.56</hp>
+			<mp>650.97</mp>
+			<cp>1503.992</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2197.52</hp>
+			<mp>664.74</mp>
+			<cp>1538.264</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2246.8</hp>
+			<mp>678.6</mp>
+			<cp>1572.76</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2296.4</hp>
+			<mp>692.55</mp>
+			<cp>1607.48</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2346.32</hp>
+			<mp>706.59</mp>
+			<cp>1642.424</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2396.56</hp>
+			<mp>720.72</mp>
+			<cp>1677.592</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2447.12</hp>
+			<mp>734.94</mp>
+			<cp>1712.984</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2498.0</hp>
+			<mp>749.25</mp>
+			<cp>1748.6</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2549.2</hp>
+			<mp>763.65</mp>
+			<cp>1784.44</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2600.72</hp>
+			<mp>778.14</mp>
+			<cp>1820.504</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2652.56</hp>
+			<mp>792.72</mp>
+			<cp>1856.792</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2704.72</hp>
+			<mp>807.39</mp>
+			<cp>1893.304</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2757.2</hp>
+			<mp>822.15</mp>
+			<cp>1930.04</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>2810.0</hp>
+			<mp>837.0</mp>
+			<cp>1967.0</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>2863.12</hp>
+			<mp>851.94</mp>
+			<cp>2004.184</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>2916.56</hp>
+			<mp>866.97</mp>
+			<cp>2041.592</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>2970.32</hp>
+			<mp>882.09</mp>
+			<cp>2079.224</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3024.4</hp>
+			<mp>897.3</mp>
+			<cp>2117.08</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3078.8</hp>
+			<mp>912.6</mp>
+			<cp>2155.16</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3133.52</hp>
+			<mp>927.99</mp>
+			<cp>2193.464</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3188.56</hp>
+			<mp>943.47</mp>
+			<cp>2231.992</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3243.92</hp>
+			<mp>959.04</mp>
+			<cp>2270.744</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3299.6</hp>
+			<mp>974.7</mp>
+			<cp>2309.72</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3355.6</hp>
+			<mp>990.45</mp>
+			<cp>2348.92</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3411.92</hp>
+			<mp>1006.29</mp>
+			<cp>2388.344</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3468.56</hp>
+			<mp>1022.22</mp>
+			<cp>2427.992</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3525.52</hp>
+			<mp>1038.24</mp>
+			<cp>2467.864</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3582.8</hp>
+			<mp>1054.35</mp>
+			<cp>2507.96</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3640.4</hp>
+			<mp>1070.55</mp>
+			<cp>2548.28</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>3698.32</hp>
+			<mp>1086.84</mp>
+			<cp>2588.824</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>3756.56</hp>
+			<mp>1103.22</mp>
+			<cp>2629.592</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>3815.12</hp>
+			<mp>1119.69</mp>
+			<cp>2670.584</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>3874.0</hp>
+			<mp>1136.25</mp>
+			<cp>2711.8</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>3933.2</hp>
+			<mp>1152.9</mp>
+			<cp>2753.24</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>3992.72</hp>
+			<mp>1169.64</mp>
+			<cp>2794.904</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4052.56</hp>
+			<mp>1186.47</mp>
+			<cp>2836.792</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4112.72</hp>
+			<mp>1203.39</mp>
+			<cp>2878.904</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4173.2</hp>
+			<mp>1220.4</mp>
+			<cp>2921.24</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4234</hp>
+			<mp>1237.5</mp>
+			<cp>2963.79</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4295.12</hp>
+			<mp>1254.69</mp>
+			<cp>3006.56</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4356.56</hp>
+			<mp>1271.97</mp>
+			<cp>3049.55</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4418.32</hp>
+			<mp>1289.34</mp>
+			<cp>3092.76</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>4480.4</hp>
+			<mp>1306.8</mp>
+			<cp>3136.2</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>4542.8</hp>
+			<mp>1324.35</mp>
+			<cp>3179.85</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>4605.52</hp>
+			<mp>1341.99</mp>
+			<cp>3223.864</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/OrcShaman.xml
+++ b/data/stats/chars/baseStats/OrcShaman.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>50</classId>
-    <staticData>
-        <baseINT>31</baseINT>
-        <baseSTR>27</baseSTR>
-        <baseCON>31</baseCON>
-        <baseMEN>42</baseMEN>
-        <baseDEX>24</baseDEX>
-        <baseWIT>15</baseWIT>
-        <physicalAbnormalResist>15</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-56733" y="-113459" z="-690"/>
-            <node x="-56686" y="-113470" z="-690"/>
-            <node x="-56728" y="-113610" z="-690"/>
-            <node x="-56693" y="-113610" z="-690"/>
-            <node x="-56743" y="-113757" z="-690"/>
-            <node x="-56682" y="-113730" z="-690"/>
-        </creationPoints>
-        <basePAtk>3</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>15</chest>
-            <legs>8</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>25</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>70</walk>
-            <run>128</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>90</baseBreath>
-        <baseSafeFall>250</baseSafeFall>
-        <collisionMale>
-            <radius>7.0</radius>
-            <height>27.5</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>8.0</radius>
-            <height>25.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>95.0</hp>
-            <mp>40.0</mp>
-            <cp>47.5</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>110.47</hp>
-            <mp>47.28</mp>
-            <cp>55.235</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>126.11</hp>
-            <mp>54.64</mp>
-            <cp>63.055</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>141.92</hp>
-            <mp>62.08</mp>
-            <cp>70.96</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>157.9</hp>
-            <mp>69.6</mp>
-            <cp>78.95</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>174.05</hp>
-            <mp>77.2</mp>
-            <cp>87.025</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>190.37</hp>
-            <mp>84.88</mp>
-            <cp>95.185</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>206.86</hp>
-            <mp>92.64</mp>
-            <cp>103.43</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>223.52</hp>
-            <mp>100.48</mp>
-            <cp>111.76</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>240.35</hp>
-            <mp>108.4</mp>
-            <cp>120.175</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>257.35</hp>
-            <mp>116.4</mp>
-            <cp>128.675</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>274.52</hp>
-            <mp>124.48</mp>
-            <cp>137.26</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>291.86</hp>
-            <mp>132.64</mp>
-            <cp>145.93</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>309.37</hp>
-            <mp>140.88</mp>
-            <cp>154.685</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>327.05</hp>
-            <mp>149.2</mp>
-            <cp>163.525</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>344.9</hp>
-            <mp>157.6</mp>
-            <cp>172.45</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>362.92</hp>
-            <mp>166.08</mp>
-            <cp>181.46</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>381.11</hp>
-            <mp>174.64</mp>
-            <cp>190.555</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>399.47</hp>
-            <mp>183.28</mp>
-            <cp>199.735</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>418.0</hp>
-            <mp>192.0</mp>
-            <cp>209.0</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>453.2</hp>
-            <mp>205.2</mp>
-            <cp>226.6</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>488.72</hp>
-            <mp>218.52</mp>
-            <cp>244.36</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>524.56</hp>
-            <mp>231.96</mp>
-            <cp>262.28</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>560.72</hp>
-            <mp>245.52</mp>
-            <cp>280.36</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>597.2</hp>
-            <mp>259.2</mp>
-            <cp>298.6</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>634.0</hp>
-            <mp>273.0</mp>
-            <cp>317.0</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>671.12</hp>
-            <mp>286.92</mp>
-            <cp>335.56</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>708.56</hp>
-            <mp>300.96</mp>
-            <cp>354.28</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>746.32</hp>
-            <mp>315.12</mp>
-            <cp>373.16</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>784.4</hp>
-            <mp>329.4</mp>
-            <cp>392.2</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>822.8</hp>
-            <mp>343.8</mp>
-            <cp>411.4</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>861.52</hp>
-            <mp>358.32</mp>
-            <cp>430.76</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>900.56</hp>
-            <mp>372.96</mp>
-            <cp>450.28</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>939.92</hp>
-            <mp>387.72</mp>
-            <cp>469.96</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>979.6</hp>
-            <mp>402.6</mp>
-            <cp>489.8</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>1019.6</hp>
-            <mp>417.6</mp>
-            <cp>509.8</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>1059.92</hp>
-            <mp>432.72</mp>
-            <cp>529.96</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1100.56</hp>
-            <mp>447.96</mp>
-            <cp>550.28</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1141.52</hp>
-            <mp>463.32</mp>
-            <cp>570.76</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1182.8</hp>
-            <mp>478.8</mp>
-            <cp>591.4</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1224.4</hp>
-            <mp>494.4</mp>
-            <cp>612.2</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1266.32</hp>
-            <mp>510.12</mp>
-            <cp>633.16</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1308.56</hp>
-            <mp>525.96</mp>
-            <cp>654.28</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1351.12</hp>
-            <mp>541.92</mp>
-            <cp>675.56</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1394.0</hp>
-            <mp>558.0</mp>
-            <cp>697.0</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1437.2</hp>
-            <mp>574.2</mp>
-            <cp>718.6</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1480.72</hp>
-            <mp>590.52</mp>
-            <cp>740.36</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1524.56</hp>
-            <mp>606.96</mp>
-            <cp>762.28</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1568.72</hp>
-            <mp>623.52</mp>
-            <cp>784.36</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1613.2</hp>
-            <mp>640.2</mp>
-            <cp>806.6</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1658.0</hp>
-            <mp>657.0</mp>
-            <cp>829.0</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1703.12</hp>
-            <mp>673.92</mp>
-            <cp>851.56</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1748.56</hp>
-            <mp>690.96</mp>
-            <cp>874.28</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1794.32</hp>
-            <mp>708.12</mp>
-            <cp>897.16</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1840.4</hp>
-            <mp>725.4</mp>
-            <cp>920.2</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1886.8</hp>
-            <mp>742.8</mp>
-            <cp>943.4</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1933.52</hp>
-            <mp>760.32</mp>
-            <cp>966.76</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1980.56</hp>
-            <mp>777.96</mp>
-            <cp>990.28</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2027.92</hp>
-            <mp>795.72</mp>
-            <cp>1013.96</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2075.6</hp>
-            <mp>813.6</mp>
-            <cp>1037.8</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2123.6</hp>
-            <mp>831.6</mp>
-            <cp>1061.8</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2171.92</hp>
-            <mp>849.72</mp>
-            <cp>1085.96</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2220.56</hp>
-            <mp>867.96</mp>
-            <cp>1110.28</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2269.52</hp>
-            <mp>886.32</mp>
-            <cp>1134.76</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2318.8</hp>
-            <mp>904.8</mp>
-            <cp>1159.4</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2368.4</hp>
-            <mp>923.4</mp>
-            <cp>1184.2</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2418.32</hp>
-            <mp>942.12</mp>
-            <cp>1209.16</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2468.56</hp>
-            <mp>960.96</mp>
-            <cp>1234.28</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2519.12</hp>
-            <mp>979.92</mp>
-            <cp>1259.56</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2570.0</hp>
-            <mp>999.0</mp>
-            <cp>1285.0</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2621.2</hp>
-            <mp>1018.2</mp>
-            <cp>1310.6</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2672.72</hp>
-            <mp>1037.52</mp>
-            <cp>1336.36</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2724.56</hp>
-            <mp>1056.96</mp>
-            <cp>1362.28</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2776.72</hp>
-            <mp>1076.52</mp>
-            <cp>1388.36</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2829.2</hp>
-            <mp>1096.2</mp>
-            <cp>1414.6</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>2882.0</hp>
-            <mp>1116.0</mp>
-            <cp>1441.0</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>2935.12</hp>
-            <mp>1135.92</mp>
-            <cp>1467.56</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>2988.56</hp>
-            <mp>1155.96</mp>
-            <cp>1494.28</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3042.32</hp>
-            <mp>1176.12</mp>
-            <cp>1521.16</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3096.4</hp>
-            <mp>1196.4</mp>
-            <cp>1548.2</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3150.8</hp>
-            <mp>1216.8</mp>
-            <cp>1575.4</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3205.52</hp>
-            <mp>1237.32</mp>
-            <cp>1602.76</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3260.56</hp>
-            <mp>1257.96</mp>
-            <cp>1630.28</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3315.92</hp>
-            <mp>1278.72</mp>
-            <cp>1657.96</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3371.6</hp>
-            <mp>1299.6</mp>
-            <cp>1685.8</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3427.6</hp>
-            <mp>1320.6</mp>
-            <cp>1713.8</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3483.92</hp>
-            <mp>1341.72</mp>
-            <cp>1741.96</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3540.56</hp>
-            <mp>1362.96</mp>
-            <cp>1770.28</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3597.52</hp>
-            <mp>1384.32</mp>
-            <cp>1798.76</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3654.8</hp>
-            <mp>1405.8</mp>
-            <cp>1827.4</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>3712.4</hp>
-            <mp>1427.4</mp>
-            <cp>1856.2</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>50</classId>
+	<staticData>
+		<baseINT>31</baseINT>
+		<baseSTR>27</baseSTR>
+		<baseCON>31</baseCON>
+		<baseMEN>42</baseMEN>
+		<baseDEX>24</baseDEX>
+		<baseWIT>15</baseWIT>
+		<physicalAbnormalResist>15</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-56733" y="-113459" z="-690" />
+			<node x="-56686" y="-113470" z="-690" />
+			<node x="-56728" y="-113610" z="-690" />
+			<node x="-56693" y="-113610" z="-690" />
+			<node x="-56743" y="-113757" z="-690" />
+			<node x="-56682" y="-113730" z="-690" />
+		</creationPoints>
+		<basePAtk>3</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>15</chest>
+			<legs>8</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>25</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>70</walk>
+			<run>128</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>90</baseBreath>
+		<baseSafeFall>250</baseSafeFall>
+		<collisionMale>
+			<radius>7.0</radius>
+			<height>27.5</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>8.0</radius>
+			<height>25.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>95.0</hp>
+			<mp>40.0</mp>
+			<cp>47.5</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>110.47</hp>
+			<mp>47.28</mp>
+			<cp>55.235</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>126.11</hp>
+			<mp>54.64</mp>
+			<cp>63.055</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>141.92</hp>
+			<mp>62.08</mp>
+			<cp>70.96</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>157.9</hp>
+			<mp>69.6</mp>
+			<cp>78.95</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>174.05</hp>
+			<mp>77.2</mp>
+			<cp>87.025</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>190.37</hp>
+			<mp>84.88</mp>
+			<cp>95.185</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>206.86</hp>
+			<mp>92.64</mp>
+			<cp>103.43</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>223.52</hp>
+			<mp>100.48</mp>
+			<cp>111.76</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>240.35</hp>
+			<mp>108.4</mp>
+			<cp>120.175</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>257.35</hp>
+			<mp>116.4</mp>
+			<cp>128.675</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>274.52</hp>
+			<mp>124.48</mp>
+			<cp>137.26</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>291.86</hp>
+			<mp>132.64</mp>
+			<cp>145.93</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>309.37</hp>
+			<mp>140.88</mp>
+			<cp>154.685</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>327.05</hp>
+			<mp>149.2</mp>
+			<cp>163.525</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>344.9</hp>
+			<mp>157.6</mp>
+			<cp>172.45</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>362.92</hp>
+			<mp>166.08</mp>
+			<cp>181.46</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>381.11</hp>
+			<mp>174.64</mp>
+			<cp>190.555</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>399.47</hp>
+			<mp>183.28</mp>
+			<cp>199.735</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>418.0</hp>
+			<mp>192.0</mp>
+			<cp>209.0</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>453.2</hp>
+			<mp>205.2</mp>
+			<cp>226.6</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>488.72</hp>
+			<mp>218.52</mp>
+			<cp>244.36</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>524.56</hp>
+			<mp>231.96</mp>
+			<cp>262.28</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>560.72</hp>
+			<mp>245.52</mp>
+			<cp>280.36</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>597.2</hp>
+			<mp>259.2</mp>
+			<cp>298.6</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>634.0</hp>
+			<mp>273.0</mp>
+			<cp>317.0</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>671.12</hp>
+			<mp>286.92</mp>
+			<cp>335.56</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>708.56</hp>
+			<mp>300.96</mp>
+			<cp>354.28</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>746.32</hp>
+			<mp>315.12</mp>
+			<cp>373.16</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>784.4</hp>
+			<mp>329.4</mp>
+			<cp>392.2</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>822.8</hp>
+			<mp>343.8</mp>
+			<cp>411.4</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>861.52</hp>
+			<mp>358.32</mp>
+			<cp>430.76</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>900.56</hp>
+			<mp>372.96</mp>
+			<cp>450.28</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>939.92</hp>
+			<mp>387.72</mp>
+			<cp>469.96</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>979.6</hp>
+			<mp>402.6</mp>
+			<cp>489.8</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>1019.6</hp>
+			<mp>417.6</mp>
+			<cp>509.8</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>1059.92</hp>
+			<mp>432.72</mp>
+			<cp>529.96</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1100.56</hp>
+			<mp>447.96</mp>
+			<cp>550.28</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1141.52</hp>
+			<mp>463.32</mp>
+			<cp>570.76</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1182.8</hp>
+			<mp>478.8</mp>
+			<cp>591.4</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1224.4</hp>
+			<mp>494.4</mp>
+			<cp>612.2</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1266.32</hp>
+			<mp>510.12</mp>
+			<cp>633.16</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1308.56</hp>
+			<mp>525.96</mp>
+			<cp>654.28</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1351.12</hp>
+			<mp>541.92</mp>
+			<cp>675.56</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1394.0</hp>
+			<mp>558.0</mp>
+			<cp>697.0</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1437.2</hp>
+			<mp>574.2</mp>
+			<cp>718.6</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1480.72</hp>
+			<mp>590.52</mp>
+			<cp>740.36</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1524.56</hp>
+			<mp>606.96</mp>
+			<cp>762.28</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1568.72</hp>
+			<mp>623.52</mp>
+			<cp>784.36</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1613.2</hp>
+			<mp>640.2</mp>
+			<cp>806.6</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1658.0</hp>
+			<mp>657.0</mp>
+			<cp>829.0</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1703.12</hp>
+			<mp>673.92</mp>
+			<cp>851.56</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1748.56</hp>
+			<mp>690.96</mp>
+			<cp>874.28</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1794.32</hp>
+			<mp>708.12</mp>
+			<cp>897.16</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1840.4</hp>
+			<mp>725.4</mp>
+			<cp>920.2</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1886.8</hp>
+			<mp>742.8</mp>
+			<cp>943.4</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1933.52</hp>
+			<mp>760.32</mp>
+			<cp>966.76</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1980.56</hp>
+			<mp>777.96</mp>
+			<cp>990.28</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2027.92</hp>
+			<mp>795.72</mp>
+			<cp>1013.96</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2075.6</hp>
+			<mp>813.6</mp>
+			<cp>1037.8</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2123.6</hp>
+			<mp>831.6</mp>
+			<cp>1061.8</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2171.92</hp>
+			<mp>849.72</mp>
+			<cp>1085.96</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2220.56</hp>
+			<mp>867.96</mp>
+			<cp>1110.28</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2269.52</hp>
+			<mp>886.32</mp>
+			<cp>1134.76</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2318.8</hp>
+			<mp>904.8</mp>
+			<cp>1159.4</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2368.4</hp>
+			<mp>923.4</mp>
+			<cp>1184.2</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2418.32</hp>
+			<mp>942.12</mp>
+			<cp>1209.16</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2468.56</hp>
+			<mp>960.96</mp>
+			<cp>1234.28</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2519.12</hp>
+			<mp>979.92</mp>
+			<cp>1259.56</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2570.0</hp>
+			<mp>999.0</mp>
+			<cp>1285.0</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2621.2</hp>
+			<mp>1018.2</mp>
+			<cp>1310.6</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2672.72</hp>
+			<mp>1037.52</mp>
+			<cp>1336.36</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2724.56</hp>
+			<mp>1056.96</mp>
+			<cp>1362.28</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2776.72</hp>
+			<mp>1076.52</mp>
+			<cp>1388.36</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2829.2</hp>
+			<mp>1096.2</mp>
+			<cp>1414.6</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>2882.0</hp>
+			<mp>1116.0</mp>
+			<cp>1441.0</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>2935.12</hp>
+			<mp>1135.92</mp>
+			<cp>1467.56</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>2988.56</hp>
+			<mp>1155.96</mp>
+			<cp>1494.28</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3042.32</hp>
+			<mp>1176.12</mp>
+			<cp>1521.16</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3096.4</hp>
+			<mp>1196.4</mp>
+			<cp>1548.2</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3150.8</hp>
+			<mp>1216.8</mp>
+			<cp>1575.4</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3205.52</hp>
+			<mp>1237.32</mp>
+			<cp>1602.76</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3260.56</hp>
+			<mp>1257.96</mp>
+			<cp>1630.28</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3315.92</hp>
+			<mp>1278.72</mp>
+			<cp>1657.96</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3371.6</hp>
+			<mp>1299.6</mp>
+			<cp>1685.8</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3427.6</hp>
+			<mp>1320.6</mp>
+			<cp>1713.8</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3483.92</hp>
+			<mp>1341.72</mp>
+			<cp>1741.96</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3540.56</hp>
+			<mp>1362.96</mp>
+			<cp>1770.28</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3597.52</hp>
+			<mp>1384.32</mp>
+			<cp>1798.76</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3654.8</hp>
+			<mp>1405.8</mp>
+			<cp>1827.4</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3712.4</hp>
+			<mp>1427.4</mp>
+			<cp>1856.2</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>3770.32</hp>
+			<mp>1449.12</mp>
+			<cp>1885.16</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>3828.56</hp>
+			<mp>1470.96</mp>
+			<cp>1914.28</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>3887.12</hp>
+			<mp>1492.92</mp>
+			<cp>1943.56</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>3946.0</hp>
+			<mp>1515.0</mp>
+			<cp>1973.0</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4005.2</hp>
+			<mp>1537.2</mp>
+			<cp>2002.6</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4064.72</hp>
+			<mp>1559.52</mp>
+			<cp>2032.36</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4124.56</hp>
+			<mp>1581.96</mp>
+			<cp>2062.28</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4184.72</hp>
+			<mp>1604.52</mp>
+			<cp>2092.36</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4245.2</hp>
+			<mp>1627.2</mp>
+			<cp>2122.6</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4306</hp>
+			<mp>1650</mp>
+			<cp>2153</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4367.12</hp>
+			<mp>1672.92</mp>
+			<cp>2183.56</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4428.56</hp>
+			<mp>1695.96</mp>
+			<cp>2214.28</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4490.32</hp>
+			<mp>1719.12</mp>
+			<cp>2245.16</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>4552.4</hp>
+			<mp>1742.4</mp>
+			<cp>2276.2</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>4614.8</hp>
+			<mp>1765.8</mp>
+			<cp>2307.4</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>4677.52</hp>
+			<mp>1789.32</mp>
+			<cp>2338.76</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Overlord.xml
+++ b/data/stats/chars/baseStats/Overlord.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>51</classId>
-    <staticData>
-        <baseINT>31</baseINT>
-        <baseSTR>27</baseSTR>
-        <baseCON>31</baseCON>
-        <baseMEN>42</baseMEN>
-        <baseDEX>24</baseDEX>
-        <baseWIT>15</baseWIT>
-        <physicalAbnormalResist>15</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-56733" y="-113459" z="-690"/>
-            <node x="-56686" y="-113470" z="-690"/>
-            <node x="-56728" y="-113610" z="-690"/>
-            <node x="-56693" y="-113610" z="-690"/>
-            <node x="-56743" y="-113757" z="-690"/>
-            <node x="-56682" y="-113730" z="-690"/>
-        </creationPoints>
-        <basePAtk>3</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>15</chest>
-            <legs>8</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>25</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>70</walk>
-            <run>128</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>90</baseBreath>
-        <baseSafeFall>250</baseSafeFall>
-        <collisionMale>
-            <radius>7.0</radius>
-            <height>27.5</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>8.0</radius>
-            <height>25.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>95.0</hp>
-            <mp>40.0</mp>
-            <cp>85.5</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>110.47</hp>
-            <mp>47.28</mp>
-            <cp>99.423</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>126.11</hp>
-            <mp>54.64</mp>
-            <cp>113.499</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>141.92</hp>
-            <mp>62.08</mp>
-            <cp>127.728</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>157.9</hp>
-            <mp>69.6</mp>
-            <cp>142.11</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>174.05</hp>
-            <mp>77.2</mp>
-            <cp>156.645</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>190.37</hp>
-            <mp>84.88</mp>
-            <cp>171.333</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>206.86</hp>
-            <mp>92.64</mp>
-            <cp>186.174</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>223.52</hp>
-            <mp>100.48</mp>
-            <cp>201.168</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>240.35</hp>
-            <mp>108.4</mp>
-            <cp>216.315</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>257.35</hp>
-            <mp>116.4</mp>
-            <cp>231.615</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>274.52</hp>
-            <mp>124.48</mp>
-            <cp>247.068</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>291.86</hp>
-            <mp>132.64</mp>
-            <cp>262.674</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>309.37</hp>
-            <mp>140.88</mp>
-            <cp>278.433</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>327.05</hp>
-            <mp>149.2</mp>
-            <cp>294.345</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>344.9</hp>
-            <mp>157.6</mp>
-            <cp>310.41</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>362.92</hp>
-            <mp>166.08</mp>
-            <cp>326.628</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>381.11</hp>
-            <mp>174.64</mp>
-            <cp>342.999</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>399.47</hp>
-            <mp>183.28</mp>
-            <cp>359.523</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>418.0</hp>
-            <mp>192.0</mp>
-            <cp>376.2</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>453.2</hp>
-            <mp>205.2</mp>
-            <cp>407.88</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>488.72</hp>
-            <mp>218.52</mp>
-            <cp>439.848</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>524.56</hp>
-            <mp>231.96</mp>
-            <cp>472.104</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>560.72</hp>
-            <mp>245.52</mp>
-            <cp>504.648</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>597.2</hp>
-            <mp>259.2</mp>
-            <cp>537.48</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>634.0</hp>
-            <mp>273.0</mp>
-            <cp>570.6</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>671.12</hp>
-            <mp>286.92</mp>
-            <cp>604.008</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>708.56</hp>
-            <mp>300.96</mp>
-            <cp>637.704</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>746.32</hp>
-            <mp>315.12</mp>
-            <cp>671.688</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>784.4</hp>
-            <mp>329.4</mp>
-            <cp>705.96</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>822.8</hp>
-            <mp>343.8</mp>
-            <cp>740.52</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>861.52</hp>
-            <mp>358.32</mp>
-            <cp>775.368</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>900.56</hp>
-            <mp>372.96</mp>
-            <cp>810.504</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>939.92</hp>
-            <mp>387.72</mp>
-            <cp>845.928</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>979.6</hp>
-            <mp>402.6</mp>
-            <cp>881.64</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>1019.6</hp>
-            <mp>417.6</mp>
-            <cp>917.64</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>1059.92</hp>
-            <mp>432.72</mp>
-            <cp>953.928</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1100.56</hp>
-            <mp>447.96</mp>
-            <cp>990.504</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1141.52</hp>
-            <mp>463.32</mp>
-            <cp>1027.368</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1182.8</hp>
-            <mp>478.8</mp>
-            <cp>1064.52</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1236.1</hp>
-            <mp>504.8</mp>
-            <cp>1112.49</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1289.81</hp>
-            <mp>531.0</mp>
-            <cp>1160.829</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1343.93</hp>
-            <mp>557.4</mp>
-            <cp>1209.537</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1398.46</hp>
-            <mp>584.0</mp>
-            <cp>1258.614</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1453.4</hp>
-            <mp>610.8</mp>
-            <cp>1308.06</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1508.75</hp>
-            <mp>637.8</mp>
-            <cp>1357.875</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1564.51</hp>
-            <mp>665.0</mp>
-            <cp>1408.059</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1620.68</hp>
-            <mp>692.4</mp>
-            <cp>1458.612</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1677.26</hp>
-            <mp>720.0</mp>
-            <cp>1509.534</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1734.25</hp>
-            <mp>747.8</mp>
-            <cp>1560.825</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1791.65</hp>
-            <mp>775.8</mp>
-            <cp>1612.485</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1849.46</hp>
-            <mp>804.0</mp>
-            <cp>1664.514</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1907.68</hp>
-            <mp>832.4</mp>
-            <cp>1716.912</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1966.31</hp>
-            <mp>861.0</mp>
-            <cp>1769.679</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>2025.35</hp>
-            <mp>889.8</mp>
-            <cp>1822.815</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>2084.8</hp>
-            <mp>918.8</mp>
-            <cp>1876.32</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>2144.66</hp>
-            <mp>948.0</mp>
-            <cp>1930.194</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2204.93</hp>
-            <mp>977.4</mp>
-            <cp>1984.437</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2265.61</hp>
-            <mp>1007.0</mp>
-            <cp>2039.049</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2326.7</hp>
-            <mp>1036.8</mp>
-            <cp>2094.03</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2388.2</hp>
-            <mp>1066.8</mp>
-            <cp>2149.38</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2450.11</hp>
-            <mp>1097.0</mp>
-            <cp>2205.099</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2512.43</hp>
-            <mp>1127.4</mp>
-            <cp>2261.187</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2575.16</hp>
-            <mp>1158.0</mp>
-            <cp>2317.644</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2638.3</hp>
-            <mp>1188.8</mp>
-            <cp>2374.47</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2701.85</hp>
-            <mp>1219.8</mp>
-            <cp>2431.665</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2765.81</hp>
-            <mp>1251.0</mp>
-            <cp>2489.229</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2830.18</hp>
-            <mp>1282.4</mp>
-            <cp>2547.162</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2894.96</hp>
-            <mp>1314.0</mp>
-            <cp>2605.464</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2960.15</hp>
-            <mp>1345.8</mp>
-            <cp>2664.135</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>3025.75</hp>
-            <mp>1377.8</mp>
-            <cp>2723.175</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>3091.76</hp>
-            <mp>1410.0</mp>
-            <cp>2782.584</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>3158.18</hp>
-            <mp>1442.4</mp>
-            <cp>2842.362</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>3225.01</hp>
-            <mp>1475.0</mp>
-            <cp>2902.509</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3292.25</hp>
-            <mp>1507.8</mp>
-            <cp>2963.025</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3359.9</hp>
-            <mp>1540.8</mp>
-            <cp>3023.91</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3427.96</hp>
-            <mp>1574.0</mp>
-            <cp>3085.164</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3496.43</hp>
-            <mp>1607.4</mp>
-            <cp>3146.787</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3565.31</hp>
-            <mp>1641.0</mp>
-            <cp>3208.779</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3634.6</hp>
-            <mp>1674.8</mp>
-            <cp>3271.14</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3704.3</hp>
-            <mp>1708.8</mp>
-            <cp>3333.87</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3774.41</hp>
-            <mp>1743.0</mp>
-            <cp>3396.969</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3844.93</hp>
-            <mp>1777.4</mp>
-            <cp>3460.437</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3915.86</hp>
-            <mp>1812.0</mp>
-            <cp>3524.274</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3987.2</hp>
-            <mp>1846.8</mp>
-            <cp>3588.48</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>4058.95</hp>
-            <mp>1881.8</mp>
-            <cp>3653.055</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>4131.11</hp>
-            <mp>1917.0</mp>
-            <cp>3717.999</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>4203.68</hp>
-            <mp>1952.4</mp>
-            <cp>3783.312</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>4276.66</hp>
-            <mp>1988.0</mp>
-            <cp>3848.994</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4350.05</hp>
-            <mp>2023.8</mp>
-            <cp>3915.045</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4423.85</hp>
-            <mp>2059.8</mp>
-            <cp>3981.465</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>51</classId>
+	<staticData>
+		<baseINT>31</baseINT>
+		<baseSTR>27</baseSTR>
+		<baseCON>31</baseCON>
+		<baseMEN>42</baseMEN>
+		<baseDEX>24</baseDEX>
+		<baseWIT>15</baseWIT>
+		<physicalAbnormalResist>15</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-56733" y="-113459" z="-690" />
+			<node x="-56686" y="-113470" z="-690" />
+			<node x="-56728" y="-113610" z="-690" />
+			<node x="-56693" y="-113610" z="-690" />
+			<node x="-56743" y="-113757" z="-690" />
+			<node x="-56682" y="-113730" z="-690" />
+		</creationPoints>
+		<basePAtk>3</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>15</chest>
+			<legs>8</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>25</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>70</walk>
+			<run>128</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>90</baseBreath>
+		<baseSafeFall>250</baseSafeFall>
+		<collisionMale>
+			<radius>7.0</radius>
+			<height>27.5</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>8.0</radius>
+			<height>25.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>95.0</hp>
+			<mp>40.0</mp>
+			<cp>85.5</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>110.47</hp>
+			<mp>47.28</mp>
+			<cp>99.423</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>126.11</hp>
+			<mp>54.64</mp>
+			<cp>113.499</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>141.92</hp>
+			<mp>62.08</mp>
+			<cp>127.728</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>157.9</hp>
+			<mp>69.6</mp>
+			<cp>142.11</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>174.05</hp>
+			<mp>77.2</mp>
+			<cp>156.645</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>190.37</hp>
+			<mp>84.88</mp>
+			<cp>171.333</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>206.86</hp>
+			<mp>92.64</mp>
+			<cp>186.174</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>223.52</hp>
+			<mp>100.48</mp>
+			<cp>201.168</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>240.35</hp>
+			<mp>108.4</mp>
+			<cp>216.315</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>257.35</hp>
+			<mp>116.4</mp>
+			<cp>231.615</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>274.52</hp>
+			<mp>124.48</mp>
+			<cp>247.068</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>291.86</hp>
+			<mp>132.64</mp>
+			<cp>262.674</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>309.37</hp>
+			<mp>140.88</mp>
+			<cp>278.433</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>327.05</hp>
+			<mp>149.2</mp>
+			<cp>294.345</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>344.9</hp>
+			<mp>157.6</mp>
+			<cp>310.41</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>362.92</hp>
+			<mp>166.08</mp>
+			<cp>326.628</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>381.11</hp>
+			<mp>174.64</mp>
+			<cp>342.999</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>399.47</hp>
+			<mp>183.28</mp>
+			<cp>359.523</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>418.0</hp>
+			<mp>192.0</mp>
+			<cp>376.2</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>453.2</hp>
+			<mp>205.2</mp>
+			<cp>407.88</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>488.72</hp>
+			<mp>218.52</mp>
+			<cp>439.848</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>524.56</hp>
+			<mp>231.96</mp>
+			<cp>472.104</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>560.72</hp>
+			<mp>245.52</mp>
+			<cp>504.648</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>597.2</hp>
+			<mp>259.2</mp>
+			<cp>537.48</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>634.0</hp>
+			<mp>273.0</mp>
+			<cp>570.6</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>671.12</hp>
+			<mp>286.92</mp>
+			<cp>604.008</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>708.56</hp>
+			<mp>300.96</mp>
+			<cp>637.704</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>746.32</hp>
+			<mp>315.12</mp>
+			<cp>671.688</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>784.4</hp>
+			<mp>329.4</mp>
+			<cp>705.96</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>822.8</hp>
+			<mp>343.8</mp>
+			<cp>740.52</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>861.52</hp>
+			<mp>358.32</mp>
+			<cp>775.368</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>900.56</hp>
+			<mp>372.96</mp>
+			<cp>810.504</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>939.92</hp>
+			<mp>387.72</mp>
+			<cp>845.928</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>979.6</hp>
+			<mp>402.6</mp>
+			<cp>881.64</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>1019.6</hp>
+			<mp>417.6</mp>
+			<cp>917.64</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>1059.92</hp>
+			<mp>432.72</mp>
+			<cp>953.928</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1100.56</hp>
+			<mp>447.96</mp>
+			<cp>990.504</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1141.52</hp>
+			<mp>463.32</mp>
+			<cp>1027.368</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1182.8</hp>
+			<mp>478.8</mp>
+			<cp>1064.52</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1236.1</hp>
+			<mp>504.8</mp>
+			<cp>1112.49</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1289.81</hp>
+			<mp>531.0</mp>
+			<cp>1160.829</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1343.93</hp>
+			<mp>557.4</mp>
+			<cp>1209.537</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1398.46</hp>
+			<mp>584.0</mp>
+			<cp>1258.614</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1453.4</hp>
+			<mp>610.8</mp>
+			<cp>1308.06</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1508.75</hp>
+			<mp>637.8</mp>
+			<cp>1357.875</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1564.51</hp>
+			<mp>665.0</mp>
+			<cp>1408.059</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1620.68</hp>
+			<mp>692.4</mp>
+			<cp>1458.612</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1677.26</hp>
+			<mp>720.0</mp>
+			<cp>1509.534</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1734.25</hp>
+			<mp>747.8</mp>
+			<cp>1560.825</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1791.65</hp>
+			<mp>775.8</mp>
+			<cp>1612.485</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1849.46</hp>
+			<mp>804.0</mp>
+			<cp>1664.514</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1907.68</hp>
+			<mp>832.4</mp>
+			<cp>1716.912</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1966.31</hp>
+			<mp>861.0</mp>
+			<cp>1769.679</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>2025.35</hp>
+			<mp>889.8</mp>
+			<cp>1822.815</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>2084.8</hp>
+			<mp>918.8</mp>
+			<cp>1876.32</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2144.66</hp>
+			<mp>948.0</mp>
+			<cp>1930.194</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2204.93</hp>
+			<mp>977.4</mp>
+			<cp>1984.437</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2265.61</hp>
+			<mp>1007.0</mp>
+			<cp>2039.049</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2326.7</hp>
+			<mp>1036.8</mp>
+			<cp>2094.03</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2388.2</hp>
+			<mp>1066.8</mp>
+			<cp>2149.38</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2450.11</hp>
+			<mp>1097.0</mp>
+			<cp>2205.099</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2512.43</hp>
+			<mp>1127.4</mp>
+			<cp>2261.187</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2575.16</hp>
+			<mp>1158.0</mp>
+			<cp>2317.644</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2638.3</hp>
+			<mp>1188.8</mp>
+			<cp>2374.47</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2701.85</hp>
+			<mp>1219.8</mp>
+			<cp>2431.665</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2765.81</hp>
+			<mp>1251.0</mp>
+			<cp>2489.229</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2830.18</hp>
+			<mp>1282.4</mp>
+			<cp>2547.162</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2894.96</hp>
+			<mp>1314.0</mp>
+			<cp>2605.464</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2960.15</hp>
+			<mp>1345.8</mp>
+			<cp>2664.135</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>3025.75</hp>
+			<mp>1377.8</mp>
+			<cp>2723.175</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>3091.76</hp>
+			<mp>1410.0</mp>
+			<cp>2782.584</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>3158.18</hp>
+			<mp>1442.4</mp>
+			<cp>2842.362</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3225.01</hp>
+			<mp>1475.0</mp>
+			<cp>2902.509</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3292.25</hp>
+			<mp>1507.8</mp>
+			<cp>2963.025</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3359.9</hp>
+			<mp>1540.8</mp>
+			<cp>3023.91</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3427.96</hp>
+			<mp>1574.0</mp>
+			<cp>3085.164</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3496.43</hp>
+			<mp>1607.4</mp>
+			<cp>3146.787</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3565.31</hp>
+			<mp>1641.0</mp>
+			<cp>3208.779</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3634.6</hp>
+			<mp>1674.8</mp>
+			<cp>3271.14</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3704.3</hp>
+			<mp>1708.8</mp>
+			<cp>3333.87</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3774.41</hp>
+			<mp>1743.0</mp>
+			<cp>3396.969</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3844.93</hp>
+			<mp>1777.4</mp>
+			<cp>3460.437</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3915.86</hp>
+			<mp>1812.0</mp>
+			<cp>3524.274</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3987.2</hp>
+			<mp>1846.8</mp>
+			<cp>3588.48</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>4058.95</hp>
+			<mp>1881.8</mp>
+			<cp>3653.055</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>4131.11</hp>
+			<mp>1917.0</mp>
+			<cp>3717.999</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4203.68</hp>
+			<mp>1952.4</mp>
+			<cp>3783.312</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4276.66</hp>
+			<mp>1988.0</mp>
+			<cp>3848.994</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4350.05</hp>
+			<mp>2023.8</mp>
+			<cp>3915.045</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4423.85</hp>
+			<mp>2059.8</mp>
+			<cp>3981.465</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4498.06</hp>
+			<mp>2096.0</mp>
+			<cp>4048.254</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4572.68</hp>
+			<mp>2132.4</mp>
+			<cp>4115.412</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4647.71</hp>
+			<mp>2169.0</mp>
+			<cp>4182.939</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4723.15</hp>
+			<mp>2205.8</mp>
+			<cp>4250.835</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4799.0</hp>
+			<mp>2242.8</mp>
+			<cp>4319.1</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4875.26</hp>
+			<mp>2280.0</mp>
+			<cp>4387.734</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4951.93</hp>
+			<mp>2317.4</mp>
+			<cp>4456.737</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>5029.01</hp>
+			<mp>2355.0</mp>
+			<cp>4526.109</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>5106.5</hp>
+			<mp>2392.8</mp>
+			<cp>4595.85</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>5184.4</hp>
+			<mp>2430.8</mp>
+			<cp>4665.96</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5262.71</hp>
+			<mp>2469</mp>
+			<cp>4736.45</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5341.43</hp>
+			<mp>2507.4</mp>
+			<cp>4807.3</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5420.56</hp>
+			<mp>2546</mp>
+			<cp>4878.52</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5500.1</hp>
+			<mp>2584.8</mp>
+			<cp>4950.11</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5580.05</hp>
+			<mp>2623.8</mp>
+			<cp>5022.07</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5660.41</hp>
+			<mp>2663</mp>
+			<cp>5094.369</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Paladin.xml
+++ b/data/stats/chars/baseStats/Paladin.xml
@@ -1,798 +1,926 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>5</classId>
-    <staticData>
-        <baseINT>21</baseINT>
-        <baseSTR>40</baseSTR>
-        <baseCON>43</baseCON>
-        <baseMEN>25</baseMEN>
-        <baseDEX>30</baseDEX>
-        <baseWIT>11</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-71338" y="258271" z="-3104"/>
-            <node x="-71417" y="258270" z="-3104"/>
-            <node x="-71453" y="258305" z="-3104"/>
-            <node x="-71467" y="258378" z="-3104"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>80</walk>
-            <run>132</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>100</baseBreath>
-        <baseSafeFall>250</baseSafeFall>
-        <collisionMale>
-            <radius>9.0</radius>
-            <height>23</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>8.0</radius>
-            <height>23.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>80.0</hp>
-            <mp>30.0</mp>
-            <cp>48.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>91.83</hp>
-            <mp>35.46</mp>
-            <cp>55.098</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>103.79</hp>
-            <mp>40.98</mp>
-            <cp>62.274</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>115.88</hp>
-            <mp>46.56</mp>
-            <cp>69.528</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>128.1</hp>
-            <mp>52.2</mp>
-            <cp>76.86</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>140.45</hp>
-            <mp>57.9</mp>
-            <cp>84.27</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>152.93</hp>
-            <mp>63.66</mp>
-            <cp>91.758</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>165.54</hp>
-            <mp>69.48</mp>
-            <cp>99.324</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>178.28</hp>
-            <mp>75.36</mp>
-            <cp>106.968</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>191.15</hp>
-            <mp>81.3</mp>
-            <cp>114.69</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>204.15</hp>
-            <mp>87.3</mp>
-            <cp>122.49</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>217.28</hp>
-            <mp>93.36</mp>
-            <cp>130.368</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>230.54</hp>
-            <mp>99.48</mp>
-            <cp>138.324</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>243.93</hp>
-            <mp>105.66</mp>
-            <cp>146.358</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>257.45</hp>
-            <mp>111.9</mp>
-            <cp>154.47</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>271.1</hp>
-            <mp>118.2</mp>
-            <cp>162.66</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>284.88</hp>
-            <mp>124.56</mp>
-            <cp>170.928</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>298.79</hp>
-            <mp>130.98</mp>
-            <cp>179.274</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>312.83</hp>
-            <mp>137.46</mp>
-            <cp>187.698</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>327.0</hp>
-            <mp>144.0</mp>
-            <cp>196.2</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>356.7</hp>
-            <mp>153.9</mp>
-            <cp>214.02</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>386.67</hp>
-            <mp>163.89</mp>
-            <cp>232.002</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>416.91</hp>
-            <mp>173.97</mp>
-            <cp>250.146</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>447.42</hp>
-            <mp>184.14</mp>
-            <cp>268.452</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>478.2</hp>
-            <mp>194.4</mp>
-            <cp>286.92</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>509.25</hp>
-            <mp>204.75</mp>
-            <cp>305.55</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>540.57</hp>
-            <mp>215.19</mp>
-            <cp>324.342</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>572.16</hp>
-            <mp>225.72</mp>
-            <cp>343.296</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>604.02</hp>
-            <mp>236.34</mp>
-            <cp>362.412</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>636.15</hp>
-            <mp>247.05</mp>
-            <cp>381.69</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>668.55</hp>
-            <mp>257.85</mp>
-            <cp>401.13</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>701.22</hp>
-            <mp>268.74</mp>
-            <cp>420.732</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>734.16</hp>
-            <mp>279.72</mp>
-            <cp>440.496</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>767.37</hp>
-            <mp>290.79</mp>
-            <cp>460.422</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>800.85</hp>
-            <mp>301.95</mp>
-            <cp>480.51</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>834.6</hp>
-            <mp>313.2</mp>
-            <cp>500.76</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>868.62</hp>
-            <mp>324.54</mp>
-            <cp>521.172</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>902.91</hp>
-            <mp>335.97</mp>
-            <cp>541.746</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>937.47</hp>
-            <mp>347.49</mp>
-            <cp>562.482</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>972.3</hp>
-            <mp>359.1</mp>
-            <cp>583.38</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1019.1</hp>
-            <mp>378.6</mp>
-            <cp>611.46</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1066.26</hp>
-            <mp>398.25</mp>
-            <cp>639.756</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1113.78</hp>
-            <mp>418.05</mp>
-            <cp>668.268</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1161.66</hp>
-            <mp>438.0</mp>
-            <cp>696.996</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1209.9</hp>
-            <mp>458.1</mp>
-            <cp>725.94</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1258.5</hp>
-            <mp>478.35</mp>
-            <cp>755.1</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1307.46</hp>
-            <mp>498.75</mp>
-            <cp>784.476</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1356.78</hp>
-            <mp>519.3</mp>
-            <cp>814.068</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1406.46</hp>
-            <mp>540.0</mp>
-            <cp>843.876</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1456.5</hp>
-            <mp>560.85</mp>
-            <cp>873.9</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1506.9</hp>
-            <mp>581.85</mp>
-            <cp>904.14</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1557.66</hp>
-            <mp>603.0</mp>
-            <cp>934.596</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1608.78</hp>
-            <mp>624.3</mp>
-            <cp>965.268</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1660.26</hp>
-            <mp>645.75</mp>
-            <cp>996.156</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1712.1</hp>
-            <mp>667.35</mp>
-            <cp>1027.26</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1764.3</hp>
-            <mp>689.1</mp>
-            <cp>1058.58</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1816.86</hp>
-            <mp>711.0</mp>
-            <cp>1090.116</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1869.78</hp>
-            <mp>733.05</mp>
-            <cp>1121.868</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>1923.06</hp>
-            <mp>755.25</mp>
-            <cp>1153.836</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>1976.7</hp>
-            <mp>777.6</mp>
-            <cp>1186.02</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2030.7</hp>
-            <mp>800.1</mp>
-            <cp>1218.42</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2085.06</hp>
-            <mp>822.75</mp>
-            <cp>1251.036</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2139.78</hp>
-            <mp>845.55</mp>
-            <cp>1283.868</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2194.86</hp>
-            <mp>868.5</mp>
-            <cp>1316.916</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2250.3</hp>
-            <mp>891.6</mp>
-            <cp>1350.18</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2306.1</hp>
-            <mp>914.85</mp>
-            <cp>1383.66</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2362.26</hp>
-            <mp>938.25</mp>
-            <cp>1417.356</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2418.78</hp>
-            <mp>961.8</mp>
-            <cp>1451.268</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2475.66</hp>
-            <mp>985.5</mp>
-            <cp>1485.396</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2532.9</hp>
-            <mp>1009.35</mp>
-            <cp>1519.74</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2590.5</hp>
-            <mp>1033.35</mp>
-            <cp>1554.3</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2648.46</hp>
-            <mp>1057.5</mp>
-            <cp>1589.076</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2706.78</hp>
-            <mp>1081.8</mp>
-            <cp>1624.068</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2765.46</hp>
-            <mp>1106.25</mp>
-            <cp>1659.276</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2824.5</hp>
-            <mp>1130.85</mp>
-            <cp>1694.7</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>2883.9</hp>
-            <mp>1155.6</mp>
-            <cp>1730.34</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>2943.66</hp>
-            <mp>1180.5</mp>
-            <cp>1766.196</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3003.78</hp>
-            <mp>1205.55</mp>
-            <cp>1802.268</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3064.26</hp>
-            <mp>1230.75</mp>
-            <cp>1838.556</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3125.1</hp>
-            <mp>1256.1</mp>
-            <cp>1875.06</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3186.3</hp>
-            <mp>1281.6</mp>
-            <cp>1911.78</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3247.86</hp>
-            <mp>1307.25</mp>
-            <cp>1948.716</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3309.78</hp>
-            <mp>1333.05</mp>
-            <cp>1985.868</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3372.06</hp>
-            <mp>1359.0</mp>
-            <cp>2023.236</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3434.7</hp>
-            <mp>1385.1</mp>
-            <cp>2060.82</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3497.7</hp>
-            <mp>1411.35</mp>
-            <cp>2098.62</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3561.06</hp>
-            <mp>1437.75</mp>
-            <cp>2136.636</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3624.78</hp>
-            <mp>1464.3</mp>
-            <cp>2174.868</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3688.86</hp>
-            <mp>1491.0</mp>
-            <cp>2213.316</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3753.3</hp>
-            <mp>1517.85</mp>
-            <cp>2251.98</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>3818.1</hp>
-            <mp>1544.85</mp>
-            <cp>2290.86</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>5</classId>
+	<staticData>
+		<baseINT>21</baseINT>
+		<baseSTR>40</baseSTR>
+		<baseCON>43</baseCON>
+		<baseMEN>25</baseMEN>
+		<baseDEX>30</baseDEX>
+		<baseWIT>11</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-71338" y="258271" z="-3104" />
+			<node x="-71417" y="258270" z="-3104" />
+			<node x="-71453" y="258305" z="-3104" />
+			<node x="-71467" y="258378" z="-3104" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>80</walk>
+			<run>132</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>250</baseSafeFall>
+		<collisionMale>
+			<radius>9.0</radius>
+			<height>23</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>8.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>80.0</hp>
+			<mp>30.0</mp>
+			<cp>48.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>91.83</hp>
+			<mp>35.46</mp>
+			<cp>55.098</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>103.79</hp>
+			<mp>40.98</mp>
+			<cp>62.274</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>115.88</hp>
+			<mp>46.56</mp>
+			<cp>69.528</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>128.1</hp>
+			<mp>52.2</mp>
+			<cp>76.86</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>140.45</hp>
+			<mp>57.9</mp>
+			<cp>84.27</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>152.93</hp>
+			<mp>63.66</mp>
+			<cp>91.758</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>165.54</hp>
+			<mp>69.48</mp>
+			<cp>99.324</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>178.28</hp>
+			<mp>75.36</mp>
+			<cp>106.968</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>191.15</hp>
+			<mp>81.3</mp>
+			<cp>114.69</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>204.15</hp>
+			<mp>87.3</mp>
+			<cp>122.49</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>217.28</hp>
+			<mp>93.36</mp>
+			<cp>130.368</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>230.54</hp>
+			<mp>99.48</mp>
+			<cp>138.324</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>243.93</hp>
+			<mp>105.66</mp>
+			<cp>146.358</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>257.45</hp>
+			<mp>111.9</mp>
+			<cp>154.47</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>271.1</hp>
+			<mp>118.2</mp>
+			<cp>162.66</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>284.88</hp>
+			<mp>124.56</mp>
+			<cp>170.928</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>298.79</hp>
+			<mp>130.98</mp>
+			<cp>179.274</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>312.83</hp>
+			<mp>137.46</mp>
+			<cp>187.698</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>327.0</hp>
+			<mp>144.0</mp>
+			<cp>196.2</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>356.7</hp>
+			<mp>153.9</mp>
+			<cp>214.02</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>386.67</hp>
+			<mp>163.89</mp>
+			<cp>232.002</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>416.91</hp>
+			<mp>173.97</mp>
+			<cp>250.146</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>447.42</hp>
+			<mp>184.14</mp>
+			<cp>268.452</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>478.2</hp>
+			<mp>194.4</mp>
+			<cp>286.92</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>509.25</hp>
+			<mp>204.75</mp>
+			<cp>305.55</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>540.57</hp>
+			<mp>215.19</mp>
+			<cp>324.342</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>572.16</hp>
+			<mp>225.72</mp>
+			<cp>343.296</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>604.02</hp>
+			<mp>236.34</mp>
+			<cp>362.412</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>636.15</hp>
+			<mp>247.05</mp>
+			<cp>381.69</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>668.55</hp>
+			<mp>257.85</mp>
+			<cp>401.13</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>701.22</hp>
+			<mp>268.74</mp>
+			<cp>420.732</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>734.16</hp>
+			<mp>279.72</mp>
+			<cp>440.496</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>767.37</hp>
+			<mp>290.79</mp>
+			<cp>460.422</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>800.85</hp>
+			<mp>301.95</mp>
+			<cp>480.51</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>834.6</hp>
+			<mp>313.2</mp>
+			<cp>500.76</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>868.62</hp>
+			<mp>324.54</mp>
+			<cp>521.172</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>902.91</hp>
+			<mp>335.97</mp>
+			<cp>541.746</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>937.47</hp>
+			<mp>347.49</mp>
+			<cp>562.482</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>972.3</hp>
+			<mp>359.1</mp>
+			<cp>583.38</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1019.1</hp>
+			<mp>378.6</mp>
+			<cp>611.46</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1066.26</hp>
+			<mp>398.25</mp>
+			<cp>639.756</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1113.78</hp>
+			<mp>418.05</mp>
+			<cp>668.268</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1161.66</hp>
+			<mp>438.0</mp>
+			<cp>696.996</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1209.9</hp>
+			<mp>458.1</mp>
+			<cp>725.94</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1258.5</hp>
+			<mp>478.35</mp>
+			<cp>755.1</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1307.46</hp>
+			<mp>498.75</mp>
+			<cp>784.476</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1356.78</hp>
+			<mp>519.3</mp>
+			<cp>814.068</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1406.46</hp>
+			<mp>540.0</mp>
+			<cp>843.876</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1456.5</hp>
+			<mp>560.85</mp>
+			<cp>873.9</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1506.9</hp>
+			<mp>581.85</mp>
+			<cp>904.14</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1557.66</hp>
+			<mp>603.0</mp>
+			<cp>934.596</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1608.78</hp>
+			<mp>624.3</mp>
+			<cp>965.268</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1660.26</hp>
+			<mp>645.75</mp>
+			<cp>996.156</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1712.1</hp>
+			<mp>667.35</mp>
+			<cp>1027.26</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1764.3</hp>
+			<mp>689.1</mp>
+			<cp>1058.58</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1816.86</hp>
+			<mp>711.0</mp>
+			<cp>1090.116</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1869.78</hp>
+			<mp>733.05</mp>
+			<cp>1121.868</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1923.06</hp>
+			<mp>755.25</mp>
+			<cp>1153.836</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1976.7</hp>
+			<mp>777.6</mp>
+			<cp>1186.02</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2030.7</hp>
+			<mp>800.1</mp>
+			<cp>1218.42</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2085.06</hp>
+			<mp>822.75</mp>
+			<cp>1251.036</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2139.78</hp>
+			<mp>845.55</mp>
+			<cp>1283.868</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2194.86</hp>
+			<mp>868.5</mp>
+			<cp>1316.916</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2250.3</hp>
+			<mp>891.6</mp>
+			<cp>1350.18</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2306.1</hp>
+			<mp>914.85</mp>
+			<cp>1383.66</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2362.26</hp>
+			<mp>938.25</mp>
+			<cp>1417.356</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2418.78</hp>
+			<mp>961.8</mp>
+			<cp>1451.268</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2475.66</hp>
+			<mp>985.5</mp>
+			<cp>1485.396</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2532.9</hp>
+			<mp>1009.35</mp>
+			<cp>1519.74</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2590.5</hp>
+			<mp>1033.35</mp>
+			<cp>1554.3</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2648.46</hp>
+			<mp>1057.5</mp>
+			<cp>1589.076</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2706.78</hp>
+			<mp>1081.8</mp>
+			<cp>1624.068</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2765.46</hp>
+			<mp>1106.25</mp>
+			<cp>1659.276</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2824.5</hp>
+			<mp>1130.85</mp>
+			<cp>1694.7</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>2883.9</hp>
+			<mp>1155.6</mp>
+			<cp>1730.34</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>2943.66</hp>
+			<mp>1180.5</mp>
+			<cp>1766.196</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3003.78</hp>
+			<mp>1205.55</mp>
+			<cp>1802.268</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3064.26</hp>
+			<mp>1230.75</mp>
+			<cp>1838.556</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3125.1</hp>
+			<mp>1256.1</mp>
+			<cp>1875.06</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3186.3</hp>
+			<mp>1281.6</mp>
+			<cp>1911.78</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3247.86</hp>
+			<mp>1307.25</mp>
+			<cp>1948.716</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3309.78</hp>
+			<mp>1333.05</mp>
+			<cp>1985.868</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3372.06</hp>
+			<mp>1359.0</mp>
+			<cp>2023.236</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3434.7</hp>
+			<mp>1385.1</mp>
+			<cp>2060.82</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3497.7</hp>
+			<mp>1411.35</mp>
+			<cp>2098.62</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3561.06</hp>
+			<mp>1437.75</mp>
+			<cp>2136.636</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3624.78</hp>
+			<mp>1464.3</mp>
+			<cp>2174.868</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3688.86</hp>
+			<mp>1491.0</mp>
+			<cp>2213.316</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3753.3</hp>
+			<mp>1517.85</mp>
+			<cp>2251.98</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3818.1</hp>
+			<mp>1544.85</mp>
+			<cp>2290.86</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>3883.26</hp>
+			<mp>1572.0</mp>
+			<cp>2329.956</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>3948.78</hp>
+			<mp>1599.3</mp>
+			<cp>2369.268</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4014.66</hp>
+			<mp>1626.75</mp>
+			<cp>2408.796</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4080.9</hp>
+			<mp>1654.35</mp>
+			<cp>2448.54</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4147.5</hp>
+			<mp>1682.1</mp>
+			<cp>2488.5</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4214.46</hp>
+			<mp>1710.0</mp>
+			<cp>2528.676</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4281.78</hp>
+			<mp>1738.05</mp>
+			<cp>2569.068</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4349.46</hp>
+			<mp>1766.25</mp>
+			<cp>2609.676</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4417.5</hp>
+			<mp>1794.6</mp>
+			<cp>2650.5</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4485.9</hp>
+			<mp>1823.1</mp>
+			<cp>2691.55</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4554.66</hp>
+			<mp>1851.75</mp>
+			<cp>2732.82</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4623.78</hp>
+			<mp>1880.55</mp>
+			<cp>2774.31</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4693.26</hp>
+			<mp>1909.5</mp>
+			<cp>2816.02</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>4763.1</hp>
+			<mp>1938.6</mp>
+			<cp>2857.94</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>4833.3</hp>
+			<mp>1967.85</mp>
+			<cp>2900.09</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>4903.86</hp>
+			<mp>1997.25</mp>
+			<cp>2942.316</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/PalusKnight.xml
+++ b/data/stats/chars/baseStats/PalusKnight.xml
@@ -1,0 +1,928 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
+	<classId>32</classId>
+	<staticData>
+		<baseINT>25</baseINT>
+		<baseSTR>41</baseSTR>
+		<baseCON>32</baseCON>
+		<baseMEN>26</baseMEN>
+		<baseDEX>34</baseDEX>
+		<baseWIT>12</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="28295" y="11063" z="-4224" />
+			<node x="28302" y="11008" z="-4224" />
+			<node x="28377" y="10916" z="-4224" />
+			<node x="28456" y="10997" z="-4224" />
+			<node x="28461" y="11044" z="-4224" />
+			<node x="28395" y="11127" z="-4224" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>85</walk>
+			<run>139</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>350</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>94.0</hp>
+			<mp>30.0</mp>
+			<cp>47.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>107.65</hp>
+			<mp>35.46</mp>
+			<cp>53.825</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>121.45</hp>
+			<mp>40.98</mp>
+			<cp>60.725</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>135.4</hp>
+			<mp>46.56</mp>
+			<cp>67.7</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>149.5</hp>
+			<mp>52.2</mp>
+			<cp>74.75</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>163.75</hp>
+			<mp>57.9</mp>
+			<cp>81.875</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>178.15</hp>
+			<mp>63.66</mp>
+			<cp>89.075</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>192.7</hp>
+			<mp>69.48</mp>
+			<cp>96.35</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>207.4</hp>
+			<mp>75.36</mp>
+			<cp>103.7</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>222.25</hp>
+			<mp>81.3</mp>
+			<cp>111.125</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>237.25</hp>
+			<mp>87.3</mp>
+			<cp>118.625</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>252.4</hp>
+			<mp>93.36</mp>
+			<cp>126.2</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>267.7</hp>
+			<mp>99.48</mp>
+			<cp>133.85</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>283.15</hp>
+			<mp>105.66</mp>
+			<cp>141.575</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>298.75</hp>
+			<mp>111.9</mp>
+			<cp>149.375</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>314.5</hp>
+			<mp>118.2</mp>
+			<cp>157.25</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>330.4</hp>
+			<mp>124.56</mp>
+			<cp>165.2</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>346.45</hp>
+			<mp>130.98</mp>
+			<cp>173.225</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>362.65</hp>
+			<mp>137.46</mp>
+			<cp>181.325</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>379.0</hp>
+			<mp>144.0</mp>
+			<cp>189.5</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>414.2</hp>
+			<mp>153.9</mp>
+			<cp>207.1</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>449.72</hp>
+			<mp>163.89</mp>
+			<cp>224.86</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>485.56</hp>
+			<mp>173.97</mp>
+			<cp>242.78</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>521.72</hp>
+			<mp>184.14</mp>
+			<cp>260.86</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>558.2</hp>
+			<mp>194.4</mp>
+			<cp>279.1</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>595.0</hp>
+			<mp>204.75</mp>
+			<cp>297.5</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>632.12</hp>
+			<mp>215.19</mp>
+			<cp>316.06</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>669.56</hp>
+			<mp>225.72</mp>
+			<cp>334.78</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>707.32</hp>
+			<mp>236.34</mp>
+			<cp>353.66</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>745.4</hp>
+			<mp>247.05</mp>
+			<cp>372.7</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>783.8</hp>
+			<mp>257.85</mp>
+			<cp>391.9</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>822.52</hp>
+			<mp>268.74</mp>
+			<cp>411.26</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>861.56</hp>
+			<mp>279.72</mp>
+			<cp>430.78</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>900.92</hp>
+			<mp>290.79</mp>
+			<cp>450.46</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>940.6</hp>
+			<mp>301.95</mp>
+			<cp>470.3</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>980.6</hp>
+			<mp>313.2</mp>
+			<cp>490.3</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>1020.92</hp>
+			<mp>324.54</mp>
+			<cp>510.46</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1061.56</hp>
+			<mp>335.97</mp>
+			<cp>530.78</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1102.52</hp>
+			<mp>347.49</mp>
+			<cp>551.26</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1143.8</hp>
+			<mp>359.1</mp>
+			<cp>571.9</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1185.4</hp>
+			<mp>370.8</mp>
+			<cp>592.7</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1227.32</hp>
+			<mp>382.59</mp>
+			<cp>613.66</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1269.56</hp>
+			<mp>394.47</mp>
+			<cp>634.78</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1312.12</hp>
+			<mp>406.44</mp>
+			<cp>656.06</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1355.0</hp>
+			<mp>418.5</mp>
+			<cp>677.5</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1398.2</hp>
+			<mp>430.65</mp>
+			<cp>699.1</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1441.72</hp>
+			<mp>442.89</mp>
+			<cp>720.86</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1485.56</hp>
+			<mp>455.22</mp>
+			<cp>742.78</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1529.72</hp>
+			<mp>467.64</mp>
+			<cp>764.86</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1574.2</hp>
+			<mp>480.15</mp>
+			<cp>787.1</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1619.0</hp>
+			<mp>492.75</mp>
+			<cp>809.5</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1664.12</hp>
+			<mp>505.44</mp>
+			<cp>832.06</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1709.56</hp>
+			<mp>518.22</mp>
+			<cp>854.78</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1755.32</hp>
+			<mp>531.09</mp>
+			<cp>877.66</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1801.4</hp>
+			<mp>544.05</mp>
+			<cp>900.7</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1847.8</hp>
+			<mp>557.1</mp>
+			<cp>923.9</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1894.52</hp>
+			<mp>570.24</mp>
+			<cp>947.26</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1941.56</hp>
+			<mp>583.47</mp>
+			<cp>970.78</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1988.92</hp>
+			<mp>596.79</mp>
+			<cp>994.46</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2036.6</hp>
+			<mp>610.2</mp>
+			<cp>1018.3</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2084.6</hp>
+			<mp>623.7</mp>
+			<cp>1042.3</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2132.92</hp>
+			<mp>637.29</mp>
+			<cp>1066.46</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2181.56</hp>
+			<mp>650.97</mp>
+			<cp>1090.78</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2230.52</hp>
+			<mp>664.74</mp>
+			<cp>1115.26</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2279.8</hp>
+			<mp>678.6</mp>
+			<cp>1139.9</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2329.4</hp>
+			<mp>692.55</mp>
+			<cp>1164.7</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2379.32</hp>
+			<mp>706.59</mp>
+			<cp>1189.66</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2429.56</hp>
+			<mp>720.72</mp>
+			<cp>1214.78</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2480.12</hp>
+			<mp>734.94</mp>
+			<cp>1240.06</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2531.0</hp>
+			<mp>749.25</mp>
+			<cp>1265.5</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2582.2</hp>
+			<mp>763.65</mp>
+			<cp>1291.1</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2633.72</hp>
+			<mp>778.14</mp>
+			<cp>1316.86</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2685.56</hp>
+			<mp>792.72</mp>
+			<cp>1342.78</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2737.72</hp>
+			<mp>807.39</mp>
+			<cp>1368.86</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2790.2</hp>
+			<mp>822.15</mp>
+			<cp>1395.1</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>2843.0</hp>
+			<mp>837.0</mp>
+			<cp>1421.5</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>2896.12</hp>
+			<mp>851.94</mp>
+			<cp>1448.06</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>2949.56</hp>
+			<mp>866.97</mp>
+			<cp>1474.78</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3003.32</hp>
+			<mp>882.09</mp>
+			<cp>1501.66</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3057.4</hp>
+			<mp>897.3</mp>
+			<cp>1528.7</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3111.8</hp>
+			<mp>912.6</mp>
+			<cp>1555.9</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3166.52</hp>
+			<mp>927.99</mp>
+			<cp>1583.26</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3221.56</hp>
+			<mp>943.47</mp>
+			<cp>1610.78</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3276.92</hp>
+			<mp>959.04</mp>
+			<cp>1638.46</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3332.6</hp>
+			<mp>974.7</mp>
+			<cp>1666.3</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3388.6</hp>
+			<mp>990.45</mp>
+			<cp>1694.3</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3444.92</hp>
+			<mp>1006.29</mp>
+			<cp>1722.46</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3501.56</hp>
+			<mp>1022.22</mp>
+			<cp>1750.78</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3558.52</hp>
+			<mp>1038.24</mp>
+			<cp>1779.26</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3615.8</hp>
+			<mp>1054.35</mp>
+			<cp>1807.9</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3673.4</hp>
+			<mp>1070.55</mp>
+			<cp>1836.7</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>3731.32</hp>
+			<mp>1086.84</mp>
+			<cp>1865.66</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>3789.56</hp>
+			<mp>1103.22</mp>
+			<cp>1894.78</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>3848.12</hp>
+			<mp>1119.69</mp>
+			<cp>1924.06</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>3907.0</hp>
+			<mp>1136.25</mp>
+			<cp>1953.5</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>3966.2</hp>
+			<mp>1152.9</mp>
+			<cp>1983.1</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4025.72</hp>
+			<mp>1169.64</mp>
+			<cp>2012.86</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4085.56</hp>
+			<mp>1186.47</mp>
+			<cp>2042.78</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4145.72</hp>
+			<mp>1203.39</mp>
+			<cp>2072.86</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4206.2</hp>
+			<mp>1220.4</mp>
+			<cp>2103.1</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4267</hp>
+			<mp>1237.5</mp>
+			<cp>2133.5</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4328.12</hp>
+			<mp>1254.69</mp>
+			<cp>2164.06</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4389.56</hp>
+			<mp>1271.97</mp>
+			<cp>2194.78</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4451.32</hp>
+			<mp>1289.34</mp>
+			<cp>2225.66</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>4513.4</hp>
+			<mp>1306.8</mp>
+			<cp>2256.7</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>4575.8</hp>
+			<mp>1324.35</mp>
+			<cp>2287.9</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>4638.52</hp>
+			<mp>1341.99</mp>
+			<cp>2319.26</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
+</list>

--- a/data/stats/chars/baseStats/PhantomRanger.xml
+++ b/data/stats/chars/baseStats/PhantomRanger.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>37</classId>
-    <staticData>
-        <baseINT>25</baseINT>
-        <baseSTR>41</baseSTR>
-        <baseCON>32</baseCON>
-        <baseMEN>26</baseMEN>
-        <baseDEX>34</baseDEX>
-        <baseWIT>12</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>15</magicAbnormalResist>
-        <creationPoints>
-            <node x="28295" y="11063" z="-4224"/>
-            <node x="28302" y="11008" z="-4224"/>
-            <node x="28377" y="10916" z="-4224"/>
-            <node x="28456" y="10997" z="-4224"/>
-            <node x="28461" y="11044" z="-4224"/>
-            <node x="28395" y="11127" z="-4224"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>85</walk>
-            <run>139</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>150</baseBreath>
-        <baseSafeFall>350</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>24</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.0</radius>
-            <height>23.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>94.0</hp>
-            <mp>30.0</mp>
-            <cp>47.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>107.65</hp>
-            <mp>35.46</mp>
-            <cp>53.825</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>121.45</hp>
-            <mp>40.98</mp>
-            <cp>60.725</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>135.4</hp>
-            <mp>46.56</mp>
-            <cp>67.7</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>149.5</hp>
-            <mp>52.2</mp>
-            <cp>74.75</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>163.75</hp>
-            <mp>57.9</mp>
-            <cp>81.875</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>178.15</hp>
-            <mp>63.66</mp>
-            <cp>89.075</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>192.7</hp>
-            <mp>69.48</mp>
-            <cp>96.35</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>207.4</hp>
-            <mp>75.36</mp>
-            <cp>103.7</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>222.25</hp>
-            <mp>81.3</mp>
-            <cp>111.125</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>237.25</hp>
-            <mp>87.3</mp>
-            <cp>118.625</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>252.4</hp>
-            <mp>93.36</mp>
-            <cp>126.2</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>267.7</hp>
-            <mp>99.48</mp>
-            <cp>133.85</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>283.15</hp>
-            <mp>105.66</mp>
-            <cp>141.575</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>298.75</hp>
-            <mp>111.9</mp>
-            <cp>149.375</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>314.5</hp>
-            <mp>118.2</mp>
-            <cp>157.25</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>330.4</hp>
-            <mp>124.56</mp>
-            <cp>165.2</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>346.45</hp>
-            <mp>130.98</mp>
-            <cp>173.225</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>362.65</hp>
-            <mp>137.46</mp>
-            <cp>181.325</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>379.0</hp>
-            <mp>144.0</mp>
-            <cp>189.5</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>412.0</hp>
-            <mp>153.9</mp>
-            <cp>206.0</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>445.3</hp>
-            <mp>163.89</mp>
-            <cp>222.65</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>478.9</hp>
-            <mp>173.97</mp>
-            <cp>239.45</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>512.8</hp>
-            <mp>184.14</mp>
-            <cp>256.4</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>547.0</hp>
-            <mp>194.4</mp>
-            <cp>273.5</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>581.5</hp>
-            <mp>204.75</mp>
-            <cp>290.75</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>616.3</hp>
-            <mp>215.19</mp>
-            <cp>308.15</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>651.4</hp>
-            <mp>225.72</mp>
-            <cp>325.7</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>686.8</hp>
-            <mp>236.34</mp>
-            <cp>343.4</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>722.5</hp>
-            <mp>247.05</mp>
-            <cp>361.25</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>758.5</hp>
-            <mp>257.85</mp>
-            <cp>379.25</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>794.8</hp>
-            <mp>268.74</mp>
-            <cp>397.4</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>831.4</hp>
-            <mp>279.72</mp>
-            <cp>415.7</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>868.3</hp>
-            <mp>290.79</mp>
-            <cp>434.15</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>905.5</hp>
-            <mp>301.95</mp>
-            <cp>452.75</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>943.0</hp>
-            <mp>313.2</mp>
-            <cp>471.5</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>980.8</hp>
-            <mp>324.54</mp>
-            <cp>490.4</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1018.9</hp>
-            <mp>335.97</mp>
-            <cp>509.45</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1057.3</hp>
-            <mp>347.49</mp>
-            <cp>528.65</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1096.0</hp>
-            <mp>359.1</mp>
-            <cp>548.0</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1148.0</hp>
-            <mp>378.6</mp>
-            <cp>574.0</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1200.4</hp>
-            <mp>398.25</mp>
-            <cp>600.2</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1253.2</hp>
-            <mp>418.05</mp>
-            <cp>626.6</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1306.4</hp>
-            <mp>438.0</mp>
-            <cp>653.2</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1360.0</hp>
-            <mp>458.1</mp>
-            <cp>680.0</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1414.0</hp>
-            <mp>478.35</mp>
-            <cp>707.0</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1468.4</hp>
-            <mp>498.75</mp>
-            <cp>734.2</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1523.2</hp>
-            <mp>519.3</mp>
-            <cp>761.6</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1578.4</hp>
-            <mp>540.0</mp>
-            <cp>789.2</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1634.0</hp>
-            <mp>560.85</mp>
-            <cp>817.0</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1690.0</hp>
-            <mp>581.85</mp>
-            <cp>845.0</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1746.4</hp>
-            <mp>603.0</mp>
-            <cp>873.2</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1803.2</hp>
-            <mp>624.3</mp>
-            <cp>901.6</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1860.4</hp>
-            <mp>645.75</mp>
-            <cp>930.2</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1918.0</hp>
-            <mp>667.35</mp>
-            <cp>959.0</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1976.0</hp>
-            <mp>689.1</mp>
-            <cp>988.0</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>2034.4</hp>
-            <mp>711.0</mp>
-            <cp>1017.2</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2093.2</hp>
-            <mp>733.05</mp>
-            <cp>1046.6</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2152.4</hp>
-            <mp>755.25</mp>
-            <cp>1076.2</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2212.0</hp>
-            <mp>777.6</mp>
-            <cp>1106.0</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2272.0</hp>
-            <mp>800.1</mp>
-            <cp>1136.0</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2332.4</hp>
-            <mp>822.75</mp>
-            <cp>1166.2</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2393.2</hp>
-            <mp>845.55</mp>
-            <cp>1196.6</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2454.4</hp>
-            <mp>868.5</mp>
-            <cp>1227.2</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2516.0</hp>
-            <mp>891.6</mp>
-            <cp>1258.0</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2578.0</hp>
-            <mp>914.85</mp>
-            <cp>1289.0</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2640.4</hp>
-            <mp>938.25</mp>
-            <cp>1320.2</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2703.2</hp>
-            <mp>961.8</mp>
-            <cp>1351.6</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2766.4</hp>
-            <mp>985.5</mp>
-            <cp>1383.2</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2830.0</hp>
-            <mp>1009.35</mp>
-            <cp>1415.0</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2894.0</hp>
-            <mp>1033.35</mp>
-            <cp>1447.0</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2958.4</hp>
-            <mp>1057.5</mp>
-            <cp>1479.2</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>3023.2</hp>
-            <mp>1081.8</mp>
-            <cp>1511.6</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>3088.4</hp>
-            <mp>1106.25</mp>
-            <cp>1544.2</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3154.0</hp>
-            <mp>1130.85</mp>
-            <cp>1577.0</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3220.0</hp>
-            <mp>1155.6</mp>
-            <cp>1610.0</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3286.4</hp>
-            <mp>1180.5</mp>
-            <cp>1643.2</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3353.2</hp>
-            <mp>1205.55</mp>
-            <cp>1676.6</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3420.4</hp>
-            <mp>1230.75</mp>
-            <cp>1710.2</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3488.0</hp>
-            <mp>1256.1</mp>
-            <cp>1744.0</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3556.0</hp>
-            <mp>1281.6</mp>
-            <cp>1778.0</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3624.4</hp>
-            <mp>1307.25</mp>
-            <cp>1812.2</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3693.2</hp>
-            <mp>1333.05</mp>
-            <cp>1846.6</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3762.4</hp>
-            <mp>1359.0</mp>
-            <cp>1881.2</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3832.0</hp>
-            <mp>1385.1</mp>
-            <cp>1916.0</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3902.0</hp>
-            <mp>1411.35</mp>
-            <cp>1951.0</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3972.4</hp>
-            <mp>1437.75</mp>
-            <cp>1986.2</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>4043.2</hp>
-            <mp>1464.3</mp>
-            <cp>2021.6</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>4114.4</hp>
-            <mp>1491.0</mp>
-            <cp>2057.2</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4186.0</hp>
-            <mp>1517.85</mp>
-            <cp>2093.0</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4258.0</hp>
-            <mp>1544.85</mp>
-            <cp>2129.0</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>37</classId>
+	<staticData>
+		<baseINT>25</baseINT>
+		<baseSTR>41</baseSTR>
+		<baseCON>32</baseCON>
+		<baseMEN>26</baseMEN>
+		<baseDEX>34</baseDEX>
+		<baseWIT>12</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="28295" y="11063" z="-4224" />
+			<node x="28302" y="11008" z="-4224" />
+			<node x="28377" y="10916" z="-4224" />
+			<node x="28456" y="10997" z="-4224" />
+			<node x="28461" y="11044" z="-4224" />
+			<node x="28395" y="11127" z="-4224" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>85</walk>
+			<run>139</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>350</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>94.0</hp>
+			<mp>30.0</mp>
+			<cp>47.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>107.65</hp>
+			<mp>35.46</mp>
+			<cp>53.825</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>121.45</hp>
+			<mp>40.98</mp>
+			<cp>60.725</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>135.4</hp>
+			<mp>46.56</mp>
+			<cp>67.7</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>149.5</hp>
+			<mp>52.2</mp>
+			<cp>74.75</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>163.75</hp>
+			<mp>57.9</mp>
+			<cp>81.875</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>178.15</hp>
+			<mp>63.66</mp>
+			<cp>89.075</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>192.7</hp>
+			<mp>69.48</mp>
+			<cp>96.35</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>207.4</hp>
+			<mp>75.36</mp>
+			<cp>103.7</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>222.25</hp>
+			<mp>81.3</mp>
+			<cp>111.125</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>237.25</hp>
+			<mp>87.3</mp>
+			<cp>118.625</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>252.4</hp>
+			<mp>93.36</mp>
+			<cp>126.2</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>267.7</hp>
+			<mp>99.48</mp>
+			<cp>133.85</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>283.15</hp>
+			<mp>105.66</mp>
+			<cp>141.575</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>298.75</hp>
+			<mp>111.9</mp>
+			<cp>149.375</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>314.5</hp>
+			<mp>118.2</mp>
+			<cp>157.25</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>330.4</hp>
+			<mp>124.56</mp>
+			<cp>165.2</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>346.45</hp>
+			<mp>130.98</mp>
+			<cp>173.225</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>362.65</hp>
+			<mp>137.46</mp>
+			<cp>181.325</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>379.0</hp>
+			<mp>144.0</mp>
+			<cp>189.5</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>412.0</hp>
+			<mp>153.9</mp>
+			<cp>206.0</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>445.3</hp>
+			<mp>163.89</mp>
+			<cp>222.65</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>478.9</hp>
+			<mp>173.97</mp>
+			<cp>239.45</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>512.8</hp>
+			<mp>184.14</mp>
+			<cp>256.4</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>547.0</hp>
+			<mp>194.4</mp>
+			<cp>273.5</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>581.5</hp>
+			<mp>204.75</mp>
+			<cp>290.75</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>616.3</hp>
+			<mp>215.19</mp>
+			<cp>308.15</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>651.4</hp>
+			<mp>225.72</mp>
+			<cp>325.7</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>686.8</hp>
+			<mp>236.34</mp>
+			<cp>343.4</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>722.5</hp>
+			<mp>247.05</mp>
+			<cp>361.25</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>758.5</hp>
+			<mp>257.85</mp>
+			<cp>379.25</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>794.8</hp>
+			<mp>268.74</mp>
+			<cp>397.4</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>831.4</hp>
+			<mp>279.72</mp>
+			<cp>415.7</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>868.3</hp>
+			<mp>290.79</mp>
+			<cp>434.15</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>905.5</hp>
+			<mp>301.95</mp>
+			<cp>452.75</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>943.0</hp>
+			<mp>313.2</mp>
+			<cp>471.5</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>980.8</hp>
+			<mp>324.54</mp>
+			<cp>490.4</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1018.9</hp>
+			<mp>335.97</mp>
+			<cp>509.45</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1057.3</hp>
+			<mp>347.49</mp>
+			<cp>528.65</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1096.0</hp>
+			<mp>359.1</mp>
+			<cp>548.0</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1148.0</hp>
+			<mp>378.6</mp>
+			<cp>574.0</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1200.4</hp>
+			<mp>398.25</mp>
+			<cp>600.2</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1253.2</hp>
+			<mp>418.05</mp>
+			<cp>626.6</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1306.4</hp>
+			<mp>438.0</mp>
+			<cp>653.2</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1360.0</hp>
+			<mp>458.1</mp>
+			<cp>680.0</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1414.0</hp>
+			<mp>478.35</mp>
+			<cp>707.0</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1468.4</hp>
+			<mp>498.75</mp>
+			<cp>734.2</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1523.2</hp>
+			<mp>519.3</mp>
+			<cp>761.6</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1578.4</hp>
+			<mp>540.0</mp>
+			<cp>789.2</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1634.0</hp>
+			<mp>560.85</mp>
+			<cp>817.0</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1690.0</hp>
+			<mp>581.85</mp>
+			<cp>845.0</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1746.4</hp>
+			<mp>603.0</mp>
+			<cp>873.2</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1803.2</hp>
+			<mp>624.3</mp>
+			<cp>901.6</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1860.4</hp>
+			<mp>645.75</mp>
+			<cp>930.2</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1918.0</hp>
+			<mp>667.35</mp>
+			<cp>959.0</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1976.0</hp>
+			<mp>689.1</mp>
+			<cp>988.0</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2034.4</hp>
+			<mp>711.0</mp>
+			<cp>1017.2</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2093.2</hp>
+			<mp>733.05</mp>
+			<cp>1046.6</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2152.4</hp>
+			<mp>755.25</mp>
+			<cp>1076.2</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2212.0</hp>
+			<mp>777.6</mp>
+			<cp>1106.0</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2272.0</hp>
+			<mp>800.1</mp>
+			<cp>1136.0</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2332.4</hp>
+			<mp>822.75</mp>
+			<cp>1166.2</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2393.2</hp>
+			<mp>845.55</mp>
+			<cp>1196.6</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2454.4</hp>
+			<mp>868.5</mp>
+			<cp>1227.2</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2516.0</hp>
+			<mp>891.6</mp>
+			<cp>1258.0</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2578.0</hp>
+			<mp>914.85</mp>
+			<cp>1289.0</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2640.4</hp>
+			<mp>938.25</mp>
+			<cp>1320.2</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2703.2</hp>
+			<mp>961.8</mp>
+			<cp>1351.6</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2766.4</hp>
+			<mp>985.5</mp>
+			<cp>1383.2</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2830.0</hp>
+			<mp>1009.35</mp>
+			<cp>1415.0</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2894.0</hp>
+			<mp>1033.35</mp>
+			<cp>1447.0</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2958.4</hp>
+			<mp>1057.5</mp>
+			<cp>1479.2</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>3023.2</hp>
+			<mp>1081.8</mp>
+			<cp>1511.6</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3088.4</hp>
+			<mp>1106.25</mp>
+			<cp>1544.2</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3154.0</hp>
+			<mp>1130.85</mp>
+			<cp>1577.0</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3220.0</hp>
+			<mp>1155.6</mp>
+			<cp>1610.0</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3286.4</hp>
+			<mp>1180.5</mp>
+			<cp>1643.2</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3353.2</hp>
+			<mp>1205.55</mp>
+			<cp>1676.6</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3420.4</hp>
+			<mp>1230.75</mp>
+			<cp>1710.2</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3488.0</hp>
+			<mp>1256.1</mp>
+			<cp>1744.0</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3556.0</hp>
+			<mp>1281.6</mp>
+			<cp>1778.0</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3624.4</hp>
+			<mp>1307.25</mp>
+			<cp>1812.2</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3693.2</hp>
+			<mp>1333.05</mp>
+			<cp>1846.6</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3762.4</hp>
+			<mp>1359.0</mp>
+			<cp>1881.2</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3832.0</hp>
+			<mp>1385.1</mp>
+			<cp>1916.0</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3902.0</hp>
+			<mp>1411.35</mp>
+			<cp>1951.0</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3972.4</hp>
+			<mp>1437.75</mp>
+			<cp>1986.2</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4043.2</hp>
+			<mp>1464.3</mp>
+			<cp>2021.6</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4114.4</hp>
+			<mp>1491.0</mp>
+			<cp>2057.2</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4186.0</hp>
+			<mp>1517.85</mp>
+			<cp>2093.0</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4258.0</hp>
+			<mp>1544.85</mp>
+			<cp>2129.0</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4330.4</hp>
+			<mp>1572.0</mp>
+			<cp>2165.2</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4403.2</hp>
+			<mp>1599.3</mp>
+			<cp>2201.6</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4476.4</hp>
+			<mp>1626.75</mp>
+			<cp>2238.2</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4550.0</hp>
+			<mp>1654.35</mp>
+			<cp>2275.0</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4624.0</hp>
+			<mp>1682.1</mp>
+			<cp>2312.0</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4698.4</hp>
+			<mp>1710.0</mp>
+			<cp>2349.2</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4773.2</hp>
+			<mp>1738.05</mp>
+			<cp>2386.6</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4848.4</hp>
+			<mp>1766.25</mp>
+			<cp>2424.2</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4924</hp>
+			<mp>1794.6</mp>
+			<cp>2462</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>5000</hp>
+			<mp>1823.1</mp>
+			<cp>2500</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5076.4</hp>
+			<mp>1851.75</mp>
+			<cp>2538.2</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5153.2</hp>
+			<mp>1880.55</mp>
+			<cp>2576.6</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5230.4</hp>
+			<mp>1909.5</mp>
+			<cp>2615.2</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5308</hp>
+			<mp>1938.6</mp>
+			<cp>2654</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5386</hp>
+			<mp>1967.85</mp>
+			<cp>2693</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5464.4</hp>
+			<mp>1997.25</mp>
+			<cp>2732.2</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/PhantomSummoner.xml
+++ b/data/stats/chars/baseStats/PhantomSummoner.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>41</classId>
-    <staticData>
-        <baseINT>44</baseINT>
-        <baseSTR>23</baseSTR>
-        <baseCON>24</baseCON>
-        <baseMEN>37</baseMEN>
-        <baseDEX>23</baseDEX>
-        <baseWIT>19</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>15</magicAbnormalResist>
-        <creationPoints>
-            <node x="28295" y="11063" z="-4224"/>
-            <node x="28302" y="11008" z="-4224"/>
-            <node x="28377" y="10916" z="-4224"/>
-            <node x="28456" y="10997" z="-4224"/>
-            <node x="28461" y="11044" z="-4224"/>
-            <node x="28395" y="11127" z="-4224"/>
-        </creationPoints>
-        <basePAtk>3</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>15</chest>
-            <legs>8</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>85</walk>
-            <run>129</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>150</baseBreath>
-        <baseSafeFall>300</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>24</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.0</radius>
-            <height>23.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>106.0</hp>
-            <mp>40.0</mp>
-            <cp>63.6</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>121.47</hp>
-            <mp>47.28</mp>
-            <cp>72.882</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>137.11</hp>
-            <mp>54.64</mp>
-            <cp>82.266</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>152.92</hp>
-            <mp>62.08</mp>
-            <cp>91.752</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>168.9</hp>
-            <mp>69.6</mp>
-            <cp>101.34</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>185.05</hp>
-            <mp>77.2</mp>
-            <cp>111.03</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>201.37</hp>
-            <mp>84.88</mp>
-            <cp>120.822</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>217.86</hp>
-            <mp>92.64</mp>
-            <cp>130.716</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>234.52</hp>
-            <mp>100.48</mp>
-            <cp>140.712</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>251.35</hp>
-            <mp>108.4</mp>
-            <cp>150.81</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>268.35</hp>
-            <mp>116.4</mp>
-            <cp>161.01</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>285.52</hp>
-            <mp>124.48</mp>
-            <cp>171.312</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>302.86</hp>
-            <mp>132.64</mp>
-            <cp>181.716</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>320.37</hp>
-            <mp>140.88</mp>
-            <cp>192.222</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>338.05</hp>
-            <mp>149.2</mp>
-            <cp>202.83</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>355.9</hp>
-            <mp>157.6</mp>
-            <cp>213.54</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>373.92</hp>
-            <mp>166.08</mp>
-            <cp>224.352</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>392.11</hp>
-            <mp>174.64</mp>
-            <cp>235.266</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>410.47</hp>
-            <mp>183.28</mp>
-            <cp>246.282</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>429.0</hp>
-            <mp>192.0</mp>
-            <cp>257.4</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>458.7</hp>
-            <mp>205.2</mp>
-            <cp>275.22</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>488.67</hp>
-            <mp>218.52</mp>
-            <cp>293.202</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>518.91</hp>
-            <mp>231.96</mp>
-            <cp>311.346</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>549.42</hp>
-            <mp>245.52</mp>
-            <cp>329.652</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>580.2</hp>
-            <mp>259.2</mp>
-            <cp>348.12</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>611.25</hp>
-            <mp>273.0</mp>
-            <cp>366.75</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>642.57</hp>
-            <mp>286.92</mp>
-            <cp>385.542</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>674.16</hp>
-            <mp>300.96</mp>
-            <cp>404.496</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>706.02</hp>
-            <mp>315.12</mp>
-            <cp>423.612</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>738.15</hp>
-            <mp>329.4</mp>
-            <cp>442.89</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>770.55</hp>
-            <mp>343.8</mp>
-            <cp>462.33</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>803.22</hp>
-            <mp>358.32</mp>
-            <cp>481.932</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>836.16</hp>
-            <mp>372.96</mp>
-            <cp>501.696</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>869.37</hp>
-            <mp>387.72</mp>
-            <cp>521.622</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>902.85</hp>
-            <mp>402.6</mp>
-            <cp>541.71</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>936.6</hp>
-            <mp>417.6</mp>
-            <cp>561.96</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>970.62</hp>
-            <mp>432.72</mp>
-            <cp>582.372</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1004.91</hp>
-            <mp>447.96</mp>
-            <cp>602.946</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1039.47</hp>
-            <mp>463.32</mp>
-            <cp>623.682</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1074.3</hp>
-            <mp>478.8</mp>
-            <cp>644.58</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1126.3</hp>
-            <mp>504.8</mp>
-            <cp>675.78</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1178.7</hp>
-            <mp>531.0</mp>
-            <cp>707.22</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1231.5</hp>
-            <mp>557.4</mp>
-            <cp>738.9</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1284.7</hp>
-            <mp>584.0</mp>
-            <cp>770.82</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1338.3</hp>
-            <mp>610.8</mp>
-            <cp>802.98</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1392.3</hp>
-            <mp>637.8</mp>
-            <cp>835.38</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1446.7</hp>
-            <mp>665.0</mp>
-            <cp>868.02</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1501.5</hp>
-            <mp>692.4</mp>
-            <cp>900.9</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1556.7</hp>
-            <mp>720.0</mp>
-            <cp>934.02</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1612.3</hp>
-            <mp>747.8</mp>
-            <cp>967.38</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1668.3</hp>
-            <mp>775.8</mp>
-            <cp>1000.98</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1724.7</hp>
-            <mp>804.0</mp>
-            <cp>1034.82</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1781.5</hp>
-            <mp>832.4</mp>
-            <cp>1068.9</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1838.7</hp>
-            <mp>861.0</mp>
-            <cp>1103.22</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1896.3</hp>
-            <mp>889.8</mp>
-            <cp>1137.78</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1954.3</hp>
-            <mp>918.8</mp>
-            <cp>1172.58</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>2012.7</hp>
-            <mp>948.0</mp>
-            <cp>1207.62</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2071.5</hp>
-            <mp>977.4</mp>
-            <cp>1242.9</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2130.7</hp>
-            <mp>1007.0</mp>
-            <cp>1278.42</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2190.3</hp>
-            <mp>1036.8</mp>
-            <cp>1314.18</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2250.3</hp>
-            <mp>1066.8</mp>
-            <cp>1350.18</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2310.7</hp>
-            <mp>1097.0</mp>
-            <cp>1386.42</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2371.5</hp>
-            <mp>1127.4</mp>
-            <cp>1422.9</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2432.7</hp>
-            <mp>1158.0</mp>
-            <cp>1459.62</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2494.3</hp>
-            <mp>1188.8</mp>
-            <cp>1496.58</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2556.3</hp>
-            <mp>1219.8</mp>
-            <cp>1533.78</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2618.7</hp>
-            <mp>1251.0</mp>
-            <cp>1571.22</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2681.5</hp>
-            <mp>1282.4</mp>
-            <cp>1608.9</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2744.7</hp>
-            <mp>1314.0</mp>
-            <cp>1646.82</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2808.3</hp>
-            <mp>1345.8</mp>
-            <cp>1684.98</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2872.3</hp>
-            <mp>1377.8</mp>
-            <cp>1723.38</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2936.7</hp>
-            <mp>1410.0</mp>
-            <cp>1762.02</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>3001.5</hp>
-            <mp>1442.4</mp>
-            <cp>1800.9</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>3066.7</hp>
-            <mp>1475.0</mp>
-            <cp>1840.02</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3132.3</hp>
-            <mp>1507.8</mp>
-            <cp>1879.38</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3198.3</hp>
-            <mp>1540.8</mp>
-            <cp>1918.98</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3264.7</hp>
-            <mp>1574.0</mp>
-            <cp>1958.82</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3331.5</hp>
-            <mp>1607.4</mp>
-            <cp>1998.9</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3398.7</hp>
-            <mp>1641.0</mp>
-            <cp>2039.22</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3466.3</hp>
-            <mp>1674.8</mp>
-            <cp>2079.78</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3534.3</hp>
-            <mp>1708.8</mp>
-            <cp>2120.58</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3602.7</hp>
-            <mp>1743.0</mp>
-            <cp>2161.62</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3671.5</hp>
-            <mp>1777.4</mp>
-            <cp>2202.9</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3740.7</hp>
-            <mp>1812.0</mp>
-            <cp>2244.42</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3810.3</hp>
-            <mp>1846.8</mp>
-            <cp>2286.18</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3880.3</hp>
-            <mp>1881.8</mp>
-            <cp>2328.18</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3950.7</hp>
-            <mp>1917.0</mp>
-            <cp>2370.42</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>4021.5</hp>
-            <mp>1952.4</mp>
-            <cp>2412.9</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>4092.7</hp>
-            <mp>1988.0</mp>
-            <cp>2455.62</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4164.3</hp>
-            <mp>2023.8</mp>
-            <cp>2498.58</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4236.3</hp>
-            <mp>2059.8</mp>
-            <cp>2541.78</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>41</classId>
+	<staticData>
+		<baseINT>44</baseINT>
+		<baseSTR>23</baseSTR>
+		<baseCON>24</baseCON>
+		<baseMEN>37</baseMEN>
+		<baseDEX>23</baseDEX>
+		<baseWIT>19</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="28295" y="11063" z="-4224" />
+			<node x="28302" y="11008" z="-4224" />
+			<node x="28377" y="10916" z="-4224" />
+			<node x="28456" y="10997" z="-4224" />
+			<node x="28461" y="11044" z="-4224" />
+			<node x="28395" y="11127" z="-4224" />
+		</creationPoints>
+		<basePAtk>3</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>15</chest>
+			<legs>8</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>85</walk>
+			<run>129</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>300</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>106.0</hp>
+			<mp>40.0</mp>
+			<cp>63.6</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>121.47</hp>
+			<mp>47.28</mp>
+			<cp>72.882</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>137.11</hp>
+			<mp>54.64</mp>
+			<cp>82.266</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>152.92</hp>
+			<mp>62.08</mp>
+			<cp>91.752</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>168.9</hp>
+			<mp>69.6</mp>
+			<cp>101.34</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>185.05</hp>
+			<mp>77.2</mp>
+			<cp>111.03</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>201.37</hp>
+			<mp>84.88</mp>
+			<cp>120.822</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>217.86</hp>
+			<mp>92.64</mp>
+			<cp>130.716</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>234.52</hp>
+			<mp>100.48</mp>
+			<cp>140.712</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>251.35</hp>
+			<mp>108.4</mp>
+			<cp>150.81</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>268.35</hp>
+			<mp>116.4</mp>
+			<cp>161.01</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>285.52</hp>
+			<mp>124.48</mp>
+			<cp>171.312</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>302.86</hp>
+			<mp>132.64</mp>
+			<cp>181.716</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>320.37</hp>
+			<mp>140.88</mp>
+			<cp>192.222</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>338.05</hp>
+			<mp>149.2</mp>
+			<cp>202.83</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>355.9</hp>
+			<mp>157.6</mp>
+			<cp>213.54</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>373.92</hp>
+			<mp>166.08</mp>
+			<cp>224.352</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>392.11</hp>
+			<mp>174.64</mp>
+			<cp>235.266</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>410.47</hp>
+			<mp>183.28</mp>
+			<cp>246.282</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>429.0</hp>
+			<mp>192.0</mp>
+			<cp>257.4</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>458.7</hp>
+			<mp>205.2</mp>
+			<cp>275.22</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>488.67</hp>
+			<mp>218.52</mp>
+			<cp>293.202</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>518.91</hp>
+			<mp>231.96</mp>
+			<cp>311.346</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>549.42</hp>
+			<mp>245.52</mp>
+			<cp>329.652</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>580.2</hp>
+			<mp>259.2</mp>
+			<cp>348.12</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>611.25</hp>
+			<mp>273.0</mp>
+			<cp>366.75</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>642.57</hp>
+			<mp>286.92</mp>
+			<cp>385.542</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>674.16</hp>
+			<mp>300.96</mp>
+			<cp>404.496</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>706.02</hp>
+			<mp>315.12</mp>
+			<cp>423.612</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>738.15</hp>
+			<mp>329.4</mp>
+			<cp>442.89</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>770.55</hp>
+			<mp>343.8</mp>
+			<cp>462.33</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>803.22</hp>
+			<mp>358.32</mp>
+			<cp>481.932</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>836.16</hp>
+			<mp>372.96</mp>
+			<cp>501.696</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>869.37</hp>
+			<mp>387.72</mp>
+			<cp>521.622</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>902.85</hp>
+			<mp>402.6</mp>
+			<cp>541.71</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>936.6</hp>
+			<mp>417.6</mp>
+			<cp>561.96</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>970.62</hp>
+			<mp>432.72</mp>
+			<cp>582.372</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1004.91</hp>
+			<mp>447.96</mp>
+			<cp>602.946</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1039.47</hp>
+			<mp>463.32</mp>
+			<cp>623.682</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1074.3</hp>
+			<mp>478.8</mp>
+			<cp>644.58</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1126.3</hp>
+			<mp>504.8</mp>
+			<cp>675.78</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1178.7</hp>
+			<mp>531.0</mp>
+			<cp>707.22</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1231.5</hp>
+			<mp>557.4</mp>
+			<cp>738.9</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1284.7</hp>
+			<mp>584.0</mp>
+			<cp>770.82</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1338.3</hp>
+			<mp>610.8</mp>
+			<cp>802.98</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1392.3</hp>
+			<mp>637.8</mp>
+			<cp>835.38</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1446.7</hp>
+			<mp>665.0</mp>
+			<cp>868.02</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1501.5</hp>
+			<mp>692.4</mp>
+			<cp>900.9</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1556.7</hp>
+			<mp>720.0</mp>
+			<cp>934.02</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1612.3</hp>
+			<mp>747.8</mp>
+			<cp>967.38</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1668.3</hp>
+			<mp>775.8</mp>
+			<cp>1000.98</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1724.7</hp>
+			<mp>804.0</mp>
+			<cp>1034.82</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1781.5</hp>
+			<mp>832.4</mp>
+			<cp>1068.9</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1838.7</hp>
+			<mp>861.0</mp>
+			<cp>1103.22</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1896.3</hp>
+			<mp>889.8</mp>
+			<cp>1137.78</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1954.3</hp>
+			<mp>918.8</mp>
+			<cp>1172.58</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2012.7</hp>
+			<mp>948.0</mp>
+			<cp>1207.62</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2071.5</hp>
+			<mp>977.4</mp>
+			<cp>1242.9</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2130.7</hp>
+			<mp>1007.0</mp>
+			<cp>1278.42</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2190.3</hp>
+			<mp>1036.8</mp>
+			<cp>1314.18</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2250.3</hp>
+			<mp>1066.8</mp>
+			<cp>1350.18</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2310.7</hp>
+			<mp>1097.0</mp>
+			<cp>1386.42</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2371.5</hp>
+			<mp>1127.4</mp>
+			<cp>1422.9</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2432.7</hp>
+			<mp>1158.0</mp>
+			<cp>1459.62</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2494.3</hp>
+			<mp>1188.8</mp>
+			<cp>1496.58</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2556.3</hp>
+			<mp>1219.8</mp>
+			<cp>1533.78</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2618.7</hp>
+			<mp>1251.0</mp>
+			<cp>1571.22</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2681.5</hp>
+			<mp>1282.4</mp>
+			<cp>1608.9</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2744.7</hp>
+			<mp>1314.0</mp>
+			<cp>1646.82</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2808.3</hp>
+			<mp>1345.8</mp>
+			<cp>1684.98</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2872.3</hp>
+			<mp>1377.8</mp>
+			<cp>1723.38</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2936.7</hp>
+			<mp>1410.0</mp>
+			<cp>1762.02</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>3001.5</hp>
+			<mp>1442.4</mp>
+			<cp>1800.9</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3066.7</hp>
+			<mp>1475.0</mp>
+			<cp>1840.02</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3132.3</hp>
+			<mp>1507.8</mp>
+			<cp>1879.38</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3198.3</hp>
+			<mp>1540.8</mp>
+			<cp>1918.98</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3264.7</hp>
+			<mp>1574.0</mp>
+			<cp>1958.82</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3331.5</hp>
+			<mp>1607.4</mp>
+			<cp>1998.9</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3398.7</hp>
+			<mp>1641.0</mp>
+			<cp>2039.22</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3466.3</hp>
+			<mp>1674.8</mp>
+			<cp>2079.78</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3534.3</hp>
+			<mp>1708.8</mp>
+			<cp>2120.58</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3602.7</hp>
+			<mp>1743.0</mp>
+			<cp>2161.62</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3671.5</hp>
+			<mp>1777.4</mp>
+			<cp>2202.9</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3740.7</hp>
+			<mp>1812.0</mp>
+			<cp>2244.42</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3810.3</hp>
+			<mp>1846.8</mp>
+			<cp>2286.18</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3880.3</hp>
+			<mp>1881.8</mp>
+			<cp>2328.18</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3950.7</hp>
+			<mp>1917.0</mp>
+			<cp>2370.42</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4021.5</hp>
+			<mp>1952.4</mp>
+			<cp>2412.9</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4092.7</hp>
+			<mp>1988.0</mp>
+			<cp>2455.62</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4164.3</hp>
+			<mp>2023.8</mp>
+			<cp>2498.58</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4236.3</hp>
+			<mp>2059.8</mp>
+			<cp>2541.78</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4308.7</hp>
+			<mp>2096.0</mp>
+			<cp>2585.22</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4381.5</hp>
+			<mp>2132.4</mp>
+			<cp>2628.9</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4454.7</hp>
+			<mp>2169.0</mp>
+			<cp>2672.82</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4528.3</hp>
+			<mp>2205.8</mp>
+			<cp>2716.98</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4602.3</hp>
+			<mp>2242.8</mp>
+			<cp>2761.38</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4676.7</hp>
+			<mp>2280.0</mp>
+			<cp>2806.02</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4751.5</hp>
+			<mp>2317.4</mp>
+			<cp>2850.9</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4826.7</hp>
+			<mp>2355.0</mp>
+			<cp>2896.02</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4902.3</hp>
+			<mp>2392.8</mp>
+			<cp>2941.38</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4978.3</hp>
+			<mp>2430.8</mp>
+			<cp>2986.98</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5054.7</hp>
+			<mp>2469</mp>
+			<cp>3032.82</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5131.5</hp>
+			<mp>2507.4</mp>
+			<cp>3078.9</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5208.7</hp>
+			<mp>2546</mp>
+			<cp>3125.22</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5286.3</hp>
+			<mp>2584.8</mp>
+			<cp>3171.78</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5364.3</hp>
+			<mp>2623.8</mp>
+			<cp>3218.58</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5442.7</hp>
+			<mp>2663</mp>
+			<cp>3265.62</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/PhoenixKnight.xml
+++ b/data/stats/chars/baseStats/PhoenixKnight.xml
@@ -1,798 +1,926 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>90</classId>
-    <staticData>
-        <baseINT>21</baseINT>
-        <baseSTR>40</baseSTR>
-        <baseCON>43</baseCON>
-        <baseMEN>25</baseMEN>
-        <baseDEX>30</baseDEX>
-        <baseWIT>11</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-71338" y="258271" z="-3104"/>
-            <node x="-71417" y="258270" z="-3104"/>
-            <node x="-71453" y="258305" z="-3104"/>
-            <node x="-71467" y="258378" z="-3104"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>80</walk>
-            <run>132</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>100</baseBreath>
-        <baseSafeFall>250</baseSafeFall>
-        <collisionMale>
-            <radius>9.0</radius>
-            <height>23</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>8.0</radius>
-            <height>23.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>80.0</hp>
-            <mp>30.0</mp>
-            <cp>48.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>91.83</hp>
-            <mp>35.46</mp>
-            <cp>55.098</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>103.79</hp>
-            <mp>40.98</mp>
-            <cp>62.274</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>115.88</hp>
-            <mp>46.56</mp>
-            <cp>69.528</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>128.1</hp>
-            <mp>52.2</mp>
-            <cp>76.86</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>140.45</hp>
-            <mp>57.9</mp>
-            <cp>84.27</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>152.93</hp>
-            <mp>63.66</mp>
-            <cp>91.758</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>165.54</hp>
-            <mp>69.48</mp>
-            <cp>99.324</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>178.28</hp>
-            <mp>75.36</mp>
-            <cp>106.968</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>191.15</hp>
-            <mp>81.3</mp>
-            <cp>114.69</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>204.15</hp>
-            <mp>87.3</mp>
-            <cp>122.49</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>217.28</hp>
-            <mp>93.36</mp>
-            <cp>130.368</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>230.54</hp>
-            <mp>99.48</mp>
-            <cp>138.324</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>243.93</hp>
-            <mp>105.66</mp>
-            <cp>146.358</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>257.45</hp>
-            <mp>111.9</mp>
-            <cp>154.47</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>271.1</hp>
-            <mp>118.2</mp>
-            <cp>162.66</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>284.88</hp>
-            <mp>124.56</mp>
-            <cp>170.928</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>298.79</hp>
-            <mp>130.98</mp>
-            <cp>179.274</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>312.83</hp>
-            <mp>137.46</mp>
-            <cp>187.698</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>327.0</hp>
-            <mp>144.0</mp>
-            <cp>196.2</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>356.7</hp>
-            <mp>153.9</mp>
-            <cp>214.02</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>386.67</hp>
-            <mp>163.89</mp>
-            <cp>232.002</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>416.91</hp>
-            <mp>173.97</mp>
-            <cp>250.146</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>447.42</hp>
-            <mp>184.14</mp>
-            <cp>268.452</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>478.2</hp>
-            <mp>194.4</mp>
-            <cp>286.92</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>509.25</hp>
-            <mp>204.75</mp>
-            <cp>305.55</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>540.57</hp>
-            <mp>215.19</mp>
-            <cp>324.342</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>572.16</hp>
-            <mp>225.72</mp>
-            <cp>343.296</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>604.02</hp>
-            <mp>236.34</mp>
-            <cp>362.412</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>636.15</hp>
-            <mp>247.05</mp>
-            <cp>381.69</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>668.55</hp>
-            <mp>257.85</mp>
-            <cp>401.13</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>701.22</hp>
-            <mp>268.74</mp>
-            <cp>420.732</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>734.16</hp>
-            <mp>279.72</mp>
-            <cp>440.496</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>767.37</hp>
-            <mp>290.79</mp>
-            <cp>460.422</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>800.85</hp>
-            <mp>301.95</mp>
-            <cp>480.51</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>834.6</hp>
-            <mp>313.2</mp>
-            <cp>500.76</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>868.62</hp>
-            <mp>324.54</mp>
-            <cp>521.172</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>902.91</hp>
-            <mp>335.97</mp>
-            <cp>541.746</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>937.47</hp>
-            <mp>347.49</mp>
-            <cp>562.482</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>972.3</hp>
-            <mp>359.1</mp>
-            <cp>583.38</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1019.1</hp>
-            <mp>378.6</mp>
-            <cp>611.46</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1066.26</hp>
-            <mp>398.25</mp>
-            <cp>639.756</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1113.78</hp>
-            <mp>418.05</mp>
-            <cp>668.268</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1161.66</hp>
-            <mp>438.0</mp>
-            <cp>696.996</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1209.9</hp>
-            <mp>458.1</mp>
-            <cp>725.94</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1258.5</hp>
-            <mp>478.35</mp>
-            <cp>755.1</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1307.46</hp>
-            <mp>498.75</mp>
-            <cp>784.476</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1356.78</hp>
-            <mp>519.3</mp>
-            <cp>814.068</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1406.46</hp>
-            <mp>540.0</mp>
-            <cp>843.876</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1456.5</hp>
-            <mp>560.85</mp>
-            <cp>873.9</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1506.9</hp>
-            <mp>581.85</mp>
-            <cp>904.14</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1557.66</hp>
-            <mp>603.0</mp>
-            <cp>934.596</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1608.78</hp>
-            <mp>624.3</mp>
-            <cp>965.268</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1660.26</hp>
-            <mp>645.75</mp>
-            <cp>996.156</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1712.1</hp>
-            <mp>667.35</mp>
-            <cp>1027.26</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1764.3</hp>
-            <mp>689.1</mp>
-            <cp>1058.58</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1816.86</hp>
-            <mp>711.0</mp>
-            <cp>1090.116</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1869.78</hp>
-            <mp>733.05</mp>
-            <cp>1121.868</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>1923.06</hp>
-            <mp>755.25</mp>
-            <cp>1153.836</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>1976.7</hp>
-            <mp>777.6</mp>
-            <cp>1186.02</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2030.7</hp>
-            <mp>800.1</mp>
-            <cp>1218.42</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2085.06</hp>
-            <mp>822.75</mp>
-            <cp>1251.036</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2139.78</hp>
-            <mp>845.55</mp>
-            <cp>1283.868</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2194.86</hp>
-            <mp>868.5</mp>
-            <cp>1316.916</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2250.3</hp>
-            <mp>891.6</mp>
-            <cp>1350.18</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2306.1</hp>
-            <mp>914.85</mp>
-            <cp>1383.66</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2362.26</hp>
-            <mp>938.25</mp>
-            <cp>1417.356</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2418.78</hp>
-            <mp>961.8</mp>
-            <cp>1451.268</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2475.66</hp>
-            <mp>985.5</mp>
-            <cp>1485.396</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2532.9</hp>
-            <mp>1009.35</mp>
-            <cp>1519.74</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2590.5</hp>
-            <mp>1033.35</mp>
-            <cp>1554.3</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2648.46</hp>
-            <mp>1057.5</mp>
-            <cp>1589.076</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2706.78</hp>
-            <mp>1081.8</mp>
-            <cp>1624.068</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2765.46</hp>
-            <mp>1106.25</mp>
-            <cp>1659.276</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2824.5</hp>
-            <mp>1130.85</mp>
-            <cp>1694.7</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>2883.9</hp>
-            <mp>1155.6</mp>
-            <cp>1730.34</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>2943.66</hp>
-            <mp>1180.5</mp>
-            <cp>1766.196</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3003.78</hp>
-            <mp>1205.55</mp>
-            <cp>1802.268</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3064.26</hp>
-            <mp>1230.75</mp>
-            <cp>1838.556</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3125.1</hp>
-            <mp>1256.1</mp>
-            <cp>1875.06</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3186.3</hp>
-            <mp>1281.6</mp>
-            <cp>1911.78</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3247.86</hp>
-            <mp>1307.25</mp>
-            <cp>1948.716</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3309.78</hp>
-            <mp>1333.05</mp>
-            <cp>1985.868</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3372.06</hp>
-            <mp>1359.0</mp>
-            <cp>2023.236</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3434.7</hp>
-            <mp>1385.1</mp>
-            <cp>2060.82</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3497.7</hp>
-            <mp>1411.35</mp>
-            <cp>2098.62</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3561.06</hp>
-            <mp>1437.75</mp>
-            <cp>2136.636</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3624.78</hp>
-            <mp>1464.3</mp>
-            <cp>2174.868</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3688.86</hp>
-            <mp>1491.0</mp>
-            <cp>2213.316</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3753.3</hp>
-            <mp>1517.85</mp>
-            <cp>2251.98</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>3818.1</hp>
-            <mp>1544.85</mp>
-            <cp>2290.86</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>90</classId>
+	<staticData>
+		<baseINT>21</baseINT>
+		<baseSTR>40</baseSTR>
+		<baseCON>43</baseCON>
+		<baseMEN>25</baseMEN>
+		<baseDEX>30</baseDEX>
+		<baseWIT>11</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-71338" y="258271" z="-3104" />
+			<node x="-71417" y="258270" z="-3104" />
+			<node x="-71453" y="258305" z="-3104" />
+			<node x="-71467" y="258378" z="-3104" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>80</walk>
+			<run>132</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>250</baseSafeFall>
+		<collisionMale>
+			<radius>9.0</radius>
+			<height>23</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>8.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>80.0</hp>
+			<mp>30.0</mp>
+			<cp>48.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>91.83</hp>
+			<mp>35.46</mp>
+			<cp>55.098</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>103.79</hp>
+			<mp>40.98</mp>
+			<cp>62.274</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>115.88</hp>
+			<mp>46.56</mp>
+			<cp>69.528</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>128.1</hp>
+			<mp>52.2</mp>
+			<cp>76.86</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>140.45</hp>
+			<mp>57.9</mp>
+			<cp>84.27</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>152.93</hp>
+			<mp>63.66</mp>
+			<cp>91.758</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>165.54</hp>
+			<mp>69.48</mp>
+			<cp>99.324</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>178.28</hp>
+			<mp>75.36</mp>
+			<cp>106.968</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>191.15</hp>
+			<mp>81.3</mp>
+			<cp>114.69</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>204.15</hp>
+			<mp>87.3</mp>
+			<cp>122.49</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>217.28</hp>
+			<mp>93.36</mp>
+			<cp>130.368</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>230.54</hp>
+			<mp>99.48</mp>
+			<cp>138.324</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>243.93</hp>
+			<mp>105.66</mp>
+			<cp>146.358</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>257.45</hp>
+			<mp>111.9</mp>
+			<cp>154.47</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>271.1</hp>
+			<mp>118.2</mp>
+			<cp>162.66</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>284.88</hp>
+			<mp>124.56</mp>
+			<cp>170.928</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>298.79</hp>
+			<mp>130.98</mp>
+			<cp>179.274</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>312.83</hp>
+			<mp>137.46</mp>
+			<cp>187.698</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>327.0</hp>
+			<mp>144.0</mp>
+			<cp>196.2</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>356.7</hp>
+			<mp>153.9</mp>
+			<cp>214.02</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>386.67</hp>
+			<mp>163.89</mp>
+			<cp>232.002</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>416.91</hp>
+			<mp>173.97</mp>
+			<cp>250.146</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>447.42</hp>
+			<mp>184.14</mp>
+			<cp>268.452</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>478.2</hp>
+			<mp>194.4</mp>
+			<cp>286.92</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>509.25</hp>
+			<mp>204.75</mp>
+			<cp>305.55</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>540.57</hp>
+			<mp>215.19</mp>
+			<cp>324.342</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>572.16</hp>
+			<mp>225.72</mp>
+			<cp>343.296</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>604.02</hp>
+			<mp>236.34</mp>
+			<cp>362.412</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>636.15</hp>
+			<mp>247.05</mp>
+			<cp>381.69</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>668.55</hp>
+			<mp>257.85</mp>
+			<cp>401.13</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>701.22</hp>
+			<mp>268.74</mp>
+			<cp>420.732</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>734.16</hp>
+			<mp>279.72</mp>
+			<cp>440.496</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>767.37</hp>
+			<mp>290.79</mp>
+			<cp>460.422</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>800.85</hp>
+			<mp>301.95</mp>
+			<cp>480.51</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>834.6</hp>
+			<mp>313.2</mp>
+			<cp>500.76</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>868.62</hp>
+			<mp>324.54</mp>
+			<cp>521.172</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>902.91</hp>
+			<mp>335.97</mp>
+			<cp>541.746</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>937.47</hp>
+			<mp>347.49</mp>
+			<cp>562.482</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>972.3</hp>
+			<mp>359.1</mp>
+			<cp>583.38</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1019.1</hp>
+			<mp>378.6</mp>
+			<cp>611.46</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1066.26</hp>
+			<mp>398.25</mp>
+			<cp>639.756</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1113.78</hp>
+			<mp>418.05</mp>
+			<cp>668.268</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1161.66</hp>
+			<mp>438.0</mp>
+			<cp>696.996</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1209.9</hp>
+			<mp>458.1</mp>
+			<cp>725.94</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1258.5</hp>
+			<mp>478.35</mp>
+			<cp>755.1</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1307.46</hp>
+			<mp>498.75</mp>
+			<cp>784.476</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1356.78</hp>
+			<mp>519.3</mp>
+			<cp>814.068</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1406.46</hp>
+			<mp>540.0</mp>
+			<cp>843.876</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1456.5</hp>
+			<mp>560.85</mp>
+			<cp>873.9</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1506.9</hp>
+			<mp>581.85</mp>
+			<cp>904.14</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1557.66</hp>
+			<mp>603.0</mp>
+			<cp>934.596</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1608.78</hp>
+			<mp>624.3</mp>
+			<cp>965.268</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1660.26</hp>
+			<mp>645.75</mp>
+			<cp>996.156</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1712.1</hp>
+			<mp>667.35</mp>
+			<cp>1027.26</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1764.3</hp>
+			<mp>689.1</mp>
+			<cp>1058.58</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1816.86</hp>
+			<mp>711.0</mp>
+			<cp>1090.116</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1869.78</hp>
+			<mp>733.05</mp>
+			<cp>1121.868</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1923.06</hp>
+			<mp>755.25</mp>
+			<cp>1153.836</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1976.7</hp>
+			<mp>777.6</mp>
+			<cp>1186.02</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2030.7</hp>
+			<mp>800.1</mp>
+			<cp>1218.42</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2085.06</hp>
+			<mp>822.75</mp>
+			<cp>1251.036</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2139.78</hp>
+			<mp>845.55</mp>
+			<cp>1283.868</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2194.86</hp>
+			<mp>868.5</mp>
+			<cp>1316.916</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2250.3</hp>
+			<mp>891.6</mp>
+			<cp>1350.18</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2306.1</hp>
+			<mp>914.85</mp>
+			<cp>1383.66</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2362.26</hp>
+			<mp>938.25</mp>
+			<cp>1417.356</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2418.78</hp>
+			<mp>961.8</mp>
+			<cp>1451.268</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2475.66</hp>
+			<mp>985.5</mp>
+			<cp>1485.396</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2532.9</hp>
+			<mp>1009.35</mp>
+			<cp>1519.74</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2590.5</hp>
+			<mp>1033.35</mp>
+			<cp>1554.3</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2648.46</hp>
+			<mp>1057.5</mp>
+			<cp>1589.076</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2706.78</hp>
+			<mp>1081.8</mp>
+			<cp>1624.068</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2765.46</hp>
+			<mp>1106.25</mp>
+			<cp>1659.276</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2824.5</hp>
+			<mp>1130.85</mp>
+			<cp>1694.7</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>2883.9</hp>
+			<mp>1155.6</mp>
+			<cp>1730.34</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>2943.66</hp>
+			<mp>1180.5</mp>
+			<cp>1766.196</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3003.78</hp>
+			<mp>1205.55</mp>
+			<cp>1802.268</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3064.26</hp>
+			<mp>1230.75</mp>
+			<cp>1838.556</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3125.1</hp>
+			<mp>1256.1</mp>
+			<cp>1875.06</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3186.3</hp>
+			<mp>1281.6</mp>
+			<cp>1911.78</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3247.86</hp>
+			<mp>1307.25</mp>
+			<cp>1948.716</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3309.78</hp>
+			<mp>1333.05</mp>
+			<cp>1985.868</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3372.06</hp>
+			<mp>1359.0</mp>
+			<cp>2023.236</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3434.7</hp>
+			<mp>1385.1</mp>
+			<cp>2060.82</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3497.7</hp>
+			<mp>1411.35</mp>
+			<cp>2098.62</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3561.06</hp>
+			<mp>1437.75</mp>
+			<cp>2136.636</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3624.78</hp>
+			<mp>1464.3</mp>
+			<cp>2174.868</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3688.86</hp>
+			<mp>1491.0</mp>
+			<cp>2213.316</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3753.3</hp>
+			<mp>1517.85</mp>
+			<cp>2251.98</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3818.1</hp>
+			<mp>1544.85</mp>
+			<cp>2290.86</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>3883.26</hp>
+			<mp>1572.0</mp>
+			<cp>2329.956</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>3948.78</hp>
+			<mp>1599.3</mp>
+			<cp>2369.268</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4014.66</hp>
+			<mp>1626.75</mp>
+			<cp>2408.796</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4080.9</hp>
+			<mp>1654.35</mp>
+			<cp>2448.54</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4147.5</hp>
+			<mp>1682.1</mp>
+			<cp>2488.5</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4214.46</hp>
+			<mp>1710.0</mp>
+			<cp>2528.676</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4281.78</hp>
+			<mp>1738.05</mp>
+			<cp>2569.068</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4349.46</hp>
+			<mp>1766.25</mp>
+			<cp>2609.676</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4417.5</hp>
+			<mp>1794.6</mp>
+			<cp>2650.5</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4485.9</hp>
+			<mp>1823.1</mp>
+			<cp>2691.55</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4554.66</hp>
+			<mp>1851.75</mp>
+			<cp>2732.82</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4623.78</hp>
+			<mp>1880.55</mp>
+			<cp>2774.31</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4693.26</hp>
+			<mp>1909.5</mp>
+			<cp>2816.02</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>4763.1</hp>
+			<mp>1938.6</mp>
+			<cp>2857.94</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>4833.3</hp>
+			<mp>1967.85</mp>
+			<cp>2900.09</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>4903.86</hp>
+			<mp>1997.25</mp>
+			<cp>2942.316</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/PlainsWalker.xml
+++ b/data/stats/chars/baseStats/PlainsWalker.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>23</classId>
-    <staticData>
-        <baseINT>23</baseINT>
-        <baseSTR>36</baseSTR>
-        <baseCON>36</baseCON>
-        <baseMEN>26</baseMEN>
-        <baseDEX>35</baseDEX>
-        <baseWIT>14</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>15</magicAbnormalResist>
-        <creationPoints>
-            <node x="46045" y="41251" z="-3440"/>
-            <node x="46117" y="41247" z="-3440"/>
-            <node x="46182" y="41198" z="-3440"/>
-            <node x="46115" y="41141" z="-3440"/>
-            <node x="46048" y="41141" z="-3440"/>
-            <node x="45978" y="41196" z="-3440"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>90</walk>
-            <run>143</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>150</baseBreath>
-        <baseSafeFall>350</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>24</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.5</radius>
-            <height>23</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>89.0</hp>
-            <mp>30.0</mp>
-            <cp>48.95</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>101.74</hp>
-            <mp>35.46</mp>
-            <cp>55.957</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>114.62</hp>
-            <mp>40.98</mp>
-            <cp>63.041</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>127.64</hp>
-            <mp>46.56</mp>
-            <cp>70.202</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>140.8</hp>
-            <mp>52.2</mp>
-            <cp>77.44</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>154.1</hp>
-            <mp>57.9</mp>
-            <cp>84.755</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>167.54</hp>
-            <mp>63.66</mp>
-            <cp>92.147</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>181.12</hp>
-            <mp>69.48</mp>
-            <cp>99.616</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>194.84</hp>
-            <mp>75.36</mp>
-            <cp>107.162</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>208.7</hp>
-            <mp>81.3</mp>
-            <cp>114.785</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>222.7</hp>
-            <mp>87.3</mp>
-            <cp>122.485</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>236.84</hp>
-            <mp>93.36</mp>
-            <cp>130.262</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>251.12</hp>
-            <mp>99.48</mp>
-            <cp>138.116</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>265.54</hp>
-            <mp>105.66</mp>
-            <cp>146.047</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>280.1</hp>
-            <mp>111.9</mp>
-            <cp>154.055</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>294.8</hp>
-            <mp>118.2</mp>
-            <cp>162.14</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>309.64</hp>
-            <mp>124.56</mp>
-            <cp>170.302</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>324.62</hp>
-            <mp>130.98</mp>
-            <cp>178.541</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>339.74</hp>
-            <mp>137.46</mp>
-            <cp>186.857</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>355.0</hp>
-            <mp>144.0</mp>
-            <cp>195.25</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>385.8</hp>
-            <mp>153.9</mp>
-            <cp>212.19</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>416.88</hp>
-            <mp>163.89</mp>
-            <cp>229.284</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>448.24</hp>
-            <mp>173.97</mp>
-            <cp>246.532</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>479.88</hp>
-            <mp>184.14</mp>
-            <cp>263.934</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>511.8</hp>
-            <mp>194.4</mp>
-            <cp>281.49</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>544.0</hp>
-            <mp>204.75</mp>
-            <cp>299.2</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>576.48</hp>
-            <mp>215.19</mp>
-            <cp>317.064</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>609.24</hp>
-            <mp>225.72</mp>
-            <cp>335.082</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>642.28</hp>
-            <mp>236.34</mp>
-            <cp>353.254</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>675.6</hp>
-            <mp>247.05</mp>
-            <cp>371.58</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>709.2</hp>
-            <mp>257.85</mp>
-            <cp>390.06</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>743.08</hp>
-            <mp>268.74</mp>
-            <cp>408.694</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>777.24</hp>
-            <mp>279.72</mp>
-            <cp>427.482</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>811.68</hp>
-            <mp>290.79</mp>
-            <cp>446.424</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>846.4</hp>
-            <mp>301.95</mp>
-            <cp>465.52</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>881.4</hp>
-            <mp>313.2</mp>
-            <cp>484.77</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>916.68</hp>
-            <mp>324.54</mp>
-            <cp>504.174</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>952.24</hp>
-            <mp>335.97</mp>
-            <cp>523.732</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>988.08</hp>
-            <mp>347.49</mp>
-            <cp>543.444</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1024.2</hp>
-            <mp>359.1</mp>
-            <cp>563.31</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1071.0</hp>
-            <mp>378.6</mp>
-            <cp>589.05</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1118.16</hp>
-            <mp>398.25</mp>
-            <cp>614.988</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1165.68</hp>
-            <mp>418.05</mp>
-            <cp>641.124</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1213.56</hp>
-            <mp>438.0</mp>
-            <cp>667.458</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1261.8</hp>
-            <mp>458.1</mp>
-            <cp>693.99</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1310.4</hp>
-            <mp>478.35</mp>
-            <cp>720.72</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1359.36</hp>
-            <mp>498.75</mp>
-            <cp>747.648</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1408.68</hp>
-            <mp>519.3</mp>
-            <cp>774.774</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1458.36</hp>
-            <mp>540.0</mp>
-            <cp>802.098</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1508.4</hp>
-            <mp>560.85</mp>
-            <cp>829.62</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1558.8</hp>
-            <mp>581.85</mp>
-            <cp>857.34</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1609.56</hp>
-            <mp>603.0</mp>
-            <cp>885.258</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1660.68</hp>
-            <mp>624.3</mp>
-            <cp>913.374</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1712.16</hp>
-            <mp>645.75</mp>
-            <cp>941.688</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1764.0</hp>
-            <mp>667.35</mp>
-            <cp>970.2</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1816.2</hp>
-            <mp>689.1</mp>
-            <cp>998.91</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1868.76</hp>
-            <mp>711.0</mp>
-            <cp>1027.818</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1921.68</hp>
-            <mp>733.05</mp>
-            <cp>1056.924</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>1974.96</hp>
-            <mp>755.25</mp>
-            <cp>1086.228</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2028.6</hp>
-            <mp>777.6</mp>
-            <cp>1115.73</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2082.6</hp>
-            <mp>800.1</mp>
-            <cp>1145.43</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2136.96</hp>
-            <mp>822.75</mp>
-            <cp>1175.328</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2191.68</hp>
-            <mp>845.55</mp>
-            <cp>1205.424</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2246.76</hp>
-            <mp>868.5</mp>
-            <cp>1235.718</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2302.2</hp>
-            <mp>891.6</mp>
-            <cp>1266.21</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2358.0</hp>
-            <mp>914.85</mp>
-            <cp>1296.9</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2414.16</hp>
-            <mp>938.25</mp>
-            <cp>1327.788</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2470.68</hp>
-            <mp>961.8</mp>
-            <cp>1358.874</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2527.56</hp>
-            <mp>985.5</mp>
-            <cp>1390.158</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2584.8</hp>
-            <mp>1009.35</mp>
-            <cp>1421.64</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2642.4</hp>
-            <mp>1033.35</mp>
-            <cp>1453.32</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2700.36</hp>
-            <mp>1057.5</mp>
-            <cp>1485.198</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2758.68</hp>
-            <mp>1081.8</mp>
-            <cp>1517.274</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2817.36</hp>
-            <mp>1106.25</mp>
-            <cp>1549.548</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2876.4</hp>
-            <mp>1130.85</mp>
-            <cp>1582.02</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>2935.8</hp>
-            <mp>1155.6</mp>
-            <cp>1614.69</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>2995.56</hp>
-            <mp>1180.5</mp>
-            <cp>1647.558</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3055.68</hp>
-            <mp>1205.55</mp>
-            <cp>1680.624</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3116.16</hp>
-            <mp>1230.75</mp>
-            <cp>1713.888</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3177.0</hp>
-            <mp>1256.1</mp>
-            <cp>1747.35</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3238.2</hp>
-            <mp>1281.6</mp>
-            <cp>1781.01</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3299.76</hp>
-            <mp>1307.25</mp>
-            <cp>1814.868</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3361.68</hp>
-            <mp>1333.05</mp>
-            <cp>1848.924</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3423.96</hp>
-            <mp>1359.0</mp>
-            <cp>1883.178</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3486.6</hp>
-            <mp>1385.1</mp>
-            <cp>1917.63</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3549.6</hp>
-            <mp>1411.35</mp>
-            <cp>1952.28</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3612.96</hp>
-            <mp>1437.75</mp>
-            <cp>1987.128</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3676.68</hp>
-            <mp>1464.3</mp>
-            <cp>2022.174</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3740.76</hp>
-            <mp>1491.0</mp>
-            <cp>2057.418</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3805.2</hp>
-            <mp>1517.85</mp>
-            <cp>2092.86</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>3870.0</hp>
-            <mp>1544.85</mp>
-            <cp>2128.5</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>23</classId>
+	<staticData>
+		<baseINT>23</baseINT>
+		<baseSTR>36</baseSTR>
+		<baseCON>36</baseCON>
+		<baseMEN>26</baseMEN>
+		<baseDEX>35</baseDEX>
+		<baseWIT>14</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="46045" y="41251" z="-3440" />
+			<node x="46117" y="41247" z="-3440" />
+			<node x="46182" y="41198" z="-3440" />
+			<node x="46115" y="41141" z="-3440" />
+			<node x="46048" y="41141" z="-3440" />
+			<node x="45978" y="41196" z="-3440" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>90</walk>
+			<run>143</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>350</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.5</radius>
+			<height>23</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>89.0</hp>
+			<mp>30.0</mp>
+			<cp>48.95</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>101.74</hp>
+			<mp>35.46</mp>
+			<cp>55.957</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>114.62</hp>
+			<mp>40.98</mp>
+			<cp>63.041</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>127.64</hp>
+			<mp>46.56</mp>
+			<cp>70.202</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>140.8</hp>
+			<mp>52.2</mp>
+			<cp>77.44</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>154.1</hp>
+			<mp>57.9</mp>
+			<cp>84.755</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>167.54</hp>
+			<mp>63.66</mp>
+			<cp>92.147</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>181.12</hp>
+			<mp>69.48</mp>
+			<cp>99.616</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>194.84</hp>
+			<mp>75.36</mp>
+			<cp>107.162</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>208.7</hp>
+			<mp>81.3</mp>
+			<cp>114.785</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>222.7</hp>
+			<mp>87.3</mp>
+			<cp>122.485</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>236.84</hp>
+			<mp>93.36</mp>
+			<cp>130.262</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>251.12</hp>
+			<mp>99.48</mp>
+			<cp>138.116</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>265.54</hp>
+			<mp>105.66</mp>
+			<cp>146.047</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>280.1</hp>
+			<mp>111.9</mp>
+			<cp>154.055</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>294.8</hp>
+			<mp>118.2</mp>
+			<cp>162.14</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>309.64</hp>
+			<mp>124.56</mp>
+			<cp>170.302</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>324.62</hp>
+			<mp>130.98</mp>
+			<cp>178.541</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>339.74</hp>
+			<mp>137.46</mp>
+			<cp>186.857</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>355.0</hp>
+			<mp>144.0</mp>
+			<cp>195.25</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>385.8</hp>
+			<mp>153.9</mp>
+			<cp>212.19</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>416.88</hp>
+			<mp>163.89</mp>
+			<cp>229.284</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>448.24</hp>
+			<mp>173.97</mp>
+			<cp>246.532</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>479.88</hp>
+			<mp>184.14</mp>
+			<cp>263.934</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>511.8</hp>
+			<mp>194.4</mp>
+			<cp>281.49</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>544.0</hp>
+			<mp>204.75</mp>
+			<cp>299.2</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>576.48</hp>
+			<mp>215.19</mp>
+			<cp>317.064</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>609.24</hp>
+			<mp>225.72</mp>
+			<cp>335.082</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>642.28</hp>
+			<mp>236.34</mp>
+			<cp>353.254</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>675.6</hp>
+			<mp>247.05</mp>
+			<cp>371.58</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>709.2</hp>
+			<mp>257.85</mp>
+			<cp>390.06</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>743.08</hp>
+			<mp>268.74</mp>
+			<cp>408.694</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>777.24</hp>
+			<mp>279.72</mp>
+			<cp>427.482</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>811.68</hp>
+			<mp>290.79</mp>
+			<cp>446.424</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>846.4</hp>
+			<mp>301.95</mp>
+			<cp>465.52</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>881.4</hp>
+			<mp>313.2</mp>
+			<cp>484.77</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>916.68</hp>
+			<mp>324.54</mp>
+			<cp>504.174</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>952.24</hp>
+			<mp>335.97</mp>
+			<cp>523.732</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>988.08</hp>
+			<mp>347.49</mp>
+			<cp>543.444</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1024.2</hp>
+			<mp>359.1</mp>
+			<cp>563.31</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1071.0</hp>
+			<mp>378.6</mp>
+			<cp>589.05</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1118.16</hp>
+			<mp>398.25</mp>
+			<cp>614.988</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1165.68</hp>
+			<mp>418.05</mp>
+			<cp>641.124</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1213.56</hp>
+			<mp>438.0</mp>
+			<cp>667.458</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1261.8</hp>
+			<mp>458.1</mp>
+			<cp>693.99</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1310.4</hp>
+			<mp>478.35</mp>
+			<cp>720.72</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1359.36</hp>
+			<mp>498.75</mp>
+			<cp>747.648</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1408.68</hp>
+			<mp>519.3</mp>
+			<cp>774.774</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1458.36</hp>
+			<mp>540.0</mp>
+			<cp>802.098</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1508.4</hp>
+			<mp>560.85</mp>
+			<cp>829.62</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1558.8</hp>
+			<mp>581.85</mp>
+			<cp>857.34</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1609.56</hp>
+			<mp>603.0</mp>
+			<cp>885.258</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1660.68</hp>
+			<mp>624.3</mp>
+			<cp>913.374</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1712.16</hp>
+			<mp>645.75</mp>
+			<cp>941.688</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1764.0</hp>
+			<mp>667.35</mp>
+			<cp>970.2</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1816.2</hp>
+			<mp>689.1</mp>
+			<cp>998.91</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1868.76</hp>
+			<mp>711.0</mp>
+			<cp>1027.818</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1921.68</hp>
+			<mp>733.05</mp>
+			<cp>1056.924</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1974.96</hp>
+			<mp>755.25</mp>
+			<cp>1086.228</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2028.6</hp>
+			<mp>777.6</mp>
+			<cp>1115.73</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2082.6</hp>
+			<mp>800.1</mp>
+			<cp>1145.43</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2136.96</hp>
+			<mp>822.75</mp>
+			<cp>1175.328</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2191.68</hp>
+			<mp>845.55</mp>
+			<cp>1205.424</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2246.76</hp>
+			<mp>868.5</mp>
+			<cp>1235.718</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2302.2</hp>
+			<mp>891.6</mp>
+			<cp>1266.21</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2358.0</hp>
+			<mp>914.85</mp>
+			<cp>1296.9</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2414.16</hp>
+			<mp>938.25</mp>
+			<cp>1327.788</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2470.68</hp>
+			<mp>961.8</mp>
+			<cp>1358.874</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2527.56</hp>
+			<mp>985.5</mp>
+			<cp>1390.158</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2584.8</hp>
+			<mp>1009.35</mp>
+			<cp>1421.64</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2642.4</hp>
+			<mp>1033.35</mp>
+			<cp>1453.32</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2700.36</hp>
+			<mp>1057.5</mp>
+			<cp>1485.198</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2758.68</hp>
+			<mp>1081.8</mp>
+			<cp>1517.274</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2817.36</hp>
+			<mp>1106.25</mp>
+			<cp>1549.548</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2876.4</hp>
+			<mp>1130.85</mp>
+			<cp>1582.02</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>2935.8</hp>
+			<mp>1155.6</mp>
+			<cp>1614.69</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>2995.56</hp>
+			<mp>1180.5</mp>
+			<cp>1647.558</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3055.68</hp>
+			<mp>1205.55</mp>
+			<cp>1680.624</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3116.16</hp>
+			<mp>1230.75</mp>
+			<cp>1713.888</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3177.0</hp>
+			<mp>1256.1</mp>
+			<cp>1747.35</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3238.2</hp>
+			<mp>1281.6</mp>
+			<cp>1781.01</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3299.76</hp>
+			<mp>1307.25</mp>
+			<cp>1814.868</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3361.68</hp>
+			<mp>1333.05</mp>
+			<cp>1848.924</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3423.96</hp>
+			<mp>1359.0</mp>
+			<cp>1883.178</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3486.6</hp>
+			<mp>1385.1</mp>
+			<cp>1917.63</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3549.6</hp>
+			<mp>1411.35</mp>
+			<cp>1952.28</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3612.96</hp>
+			<mp>1437.75</mp>
+			<cp>1987.128</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3676.68</hp>
+			<mp>1464.3</mp>
+			<cp>2022.174</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3740.76</hp>
+			<mp>1491.0</mp>
+			<cp>2057.418</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3805.2</hp>
+			<mp>1517.85</mp>
+			<cp>2092.86</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3870.0</hp>
+			<mp>1544.85</mp>
+			<cp>2128.5</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>3935.16</hp>
+			<mp>1572.0</mp>
+			<cp>2164.338</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4000.68</hp>
+			<mp>1599.3</mp>
+			<cp>2200.374</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4066.56</hp>
+			<mp>1626.75</mp>
+			<cp>2236.608</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4132.8</hp>
+			<mp>1654.35</mp>
+			<cp>2273.04</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4199.4</hp>
+			<mp>1682.1</mp>
+			<cp>2309.67</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4266.36</hp>
+			<mp>1710.0</mp>
+			<cp>2346.498</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4333.68</hp>
+			<mp>1738.05</mp>
+			<cp>2383.524</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4401.36</hp>
+			<mp>1766.25</mp>
+			<cp>2420.748</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4469.4</hp>
+			<mp>1794.6</mp>
+			<cp>2458.17</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4537.8</hp>
+			<mp>1823.1</mp>
+			<cp>2495.8</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4606.56</hp>
+			<mp>1851.75</mp>
+			<cp>2533.62</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4675.68</hp>
+			<mp>1880.55</mp>
+			<cp>2571.64</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4745.16</hp>
+			<mp>1909.5</mp>
+			<cp>2609.87</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>4815</hp>
+			<mp>1938.6</mp>
+			<cp>2648.29</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>4885.2</hp>
+			<mp>1967.85</mp>
+			<cp>2686.92</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>4955.76</hp>
+			<mp>1997.25</mp>
+			<cp>2725.668</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Prophet.xml
+++ b/data/stats/chars/baseStats/Prophet.xml
@@ -1,798 +1,926 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>17</classId>
-    <staticData>
-        <baseINT>41</baseINT>
-        <baseSTR>22</baseSTR>
-        <baseCON>27</baseCON>
-        <baseMEN>39</baseMEN>
-        <baseDEX>21</baseDEX>
-        <baseWIT>20</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-90875" y="248162" z="-3570"/>
-            <node x="-90954" y="248118" z="-3570"/>
-            <node x="-90918" y="248070" z="-3570"/>
-            <node x="-90890" y="248027" z="-3570"/>
-        </creationPoints>
-        <basePAtk>3</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>15</chest>
-            <legs>8</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>78</walk>
-            <run>124</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>100</baseBreath>
-        <baseSafeFall>200</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>22.8</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>6.5</radius>
-            <height>22.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>101.0</hp>
-            <mp>40.0</mp>
-            <cp>50.5</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>116.47</hp>
-            <mp>47.28</mp>
-            <cp>58.235</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>132.11</hp>
-            <mp>54.64</mp>
-            <cp>66.055</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>147.92</hp>
-            <mp>62.08</mp>
-            <cp>73.96</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>163.9</hp>
-            <mp>69.6</mp>
-            <cp>81.95</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>180.05</hp>
-            <mp>77.2</mp>
-            <cp>90.025</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>196.37</hp>
-            <mp>84.88</mp>
-            <cp>98.185</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>212.86</hp>
-            <mp>92.64</mp>
-            <cp>106.43</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>229.52</hp>
-            <mp>100.48</mp>
-            <cp>114.76</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>246.35</hp>
-            <mp>108.4</mp>
-            <cp>123.175</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>263.35</hp>
-            <mp>116.4</mp>
-            <cp>131.675</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>280.52</hp>
-            <mp>124.48</mp>
-            <cp>140.26</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>297.86</hp>
-            <mp>132.64</mp>
-            <cp>148.93</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>315.37</hp>
-            <mp>140.88</mp>
-            <cp>157.685</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>333.05</hp>
-            <mp>149.2</mp>
-            <cp>166.525</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>350.9</hp>
-            <mp>157.6</mp>
-            <cp>175.45</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>368.92</hp>
-            <mp>166.08</mp>
-            <cp>184.46</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>387.11</hp>
-            <mp>174.64</mp>
-            <cp>193.555</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>405.47</hp>
-            <mp>183.28</mp>
-            <cp>202.735</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>424.0</hp>
-            <mp>192.0</mp>
-            <cp>212.0</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>458.1</hp>
-            <mp>205.2</mp>
-            <cp>229.05</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>492.51</hp>
-            <mp>218.52</mp>
-            <cp>246.255</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>527.23</hp>
-            <mp>231.96</mp>
-            <cp>263.615</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>562.26</hp>
-            <mp>245.52</mp>
-            <cp>281.13</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>597.6</hp>
-            <mp>259.2</mp>
-            <cp>298.8</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>633.25</hp>
-            <mp>273.0</mp>
-            <cp>316.625</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>669.21</hp>
-            <mp>286.92</mp>
-            <cp>334.605</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>705.48</hp>
-            <mp>300.96</mp>
-            <cp>352.74</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>742.06</hp>
-            <mp>315.12</mp>
-            <cp>371.03</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>778.95</hp>
-            <mp>329.4</mp>
-            <cp>389.475</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>816.15</hp>
-            <mp>343.8</mp>
-            <cp>408.075</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>853.66</hp>
-            <mp>358.32</mp>
-            <cp>426.83</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>891.48</hp>
-            <mp>372.96</mp>
-            <cp>445.74</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>929.61</hp>
-            <mp>387.72</mp>
-            <cp>464.805</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>968.05</hp>
-            <mp>402.6</mp>
-            <cp>484.025</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>1006.8</hp>
-            <mp>417.6</mp>
-            <cp>503.4</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>1045.86</hp>
-            <mp>432.72</mp>
-            <cp>522.93</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1085.23</hp>
-            <mp>447.96</mp>
-            <cp>542.615</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1124.91</hp>
-            <mp>463.32</mp>
-            <cp>562.455</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1164.9</hp>
-            <mp>478.8</mp>
-            <cp>582.45</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1218.2</hp>
-            <mp>504.8</mp>
-            <cp>609.1</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1271.91</hp>
-            <mp>531.0</mp>
-            <cp>635.955</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1326.03</hp>
-            <mp>557.4</mp>
-            <cp>663.015</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1380.56</hp>
-            <mp>584.0</mp>
-            <cp>690.28</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1435.5</hp>
-            <mp>610.8</mp>
-            <cp>717.75</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1490.85</hp>
-            <mp>637.8</mp>
-            <cp>745.425</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1546.61</hp>
-            <mp>665.0</mp>
-            <cp>773.305</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1602.78</hp>
-            <mp>692.4</mp>
-            <cp>801.39</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1659.36</hp>
-            <mp>720.0</mp>
-            <cp>829.68</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1716.35</hp>
-            <mp>747.8</mp>
-            <cp>858.175</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1773.75</hp>
-            <mp>775.8</mp>
-            <cp>886.875</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1831.56</hp>
-            <mp>804.0</mp>
-            <cp>915.78</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1889.78</hp>
-            <mp>832.4</mp>
-            <cp>944.89</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1948.41</hp>
-            <mp>861.0</mp>
-            <cp>974.205</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>2007.45</hp>
-            <mp>889.8</mp>
-            <cp>1003.725</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>2066.9</hp>
-            <mp>918.8</mp>
-            <cp>1033.45</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>2126.76</hp>
-            <mp>948.0</mp>
-            <cp>1063.38</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2187.03</hp>
-            <mp>977.4</mp>
-            <cp>1093.515</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2247.71</hp>
-            <mp>1007.0</mp>
-            <cp>1123.855</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2308.8</hp>
-            <mp>1036.8</mp>
-            <cp>1154.4</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2370.3</hp>
-            <mp>1066.8</mp>
-            <cp>1185.15</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2432.21</hp>
-            <mp>1097.0</mp>
-            <cp>1216.105</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2494.53</hp>
-            <mp>1127.4</mp>
-            <cp>1247.265</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2557.26</hp>
-            <mp>1158.0</mp>
-            <cp>1278.63</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2620.4</hp>
-            <mp>1188.8</mp>
-            <cp>1310.2</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2683.95</hp>
-            <mp>1219.8</mp>
-            <cp>1341.975</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2747.91</hp>
-            <mp>1251.0</mp>
-            <cp>1373.955</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2812.28</hp>
-            <mp>1282.4</mp>
-            <cp>1406.14</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2877.06</hp>
-            <mp>1314.0</mp>
-            <cp>1438.53</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2942.25</hp>
-            <mp>1345.8</mp>
-            <cp>1471.125</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>3007.85</hp>
-            <mp>1377.8</mp>
-            <cp>1503.925</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>3073.86</hp>
-            <mp>1410.0</mp>
-            <cp>1536.93</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>3140.28</hp>
-            <mp>1442.4</mp>
-            <cp>1570.14</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>3207.11</hp>
-            <mp>1475.0</mp>
-            <cp>1603.555</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3274.35</hp>
-            <mp>1507.8</mp>
-            <cp>1637.175</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3342.0</hp>
-            <mp>1540.8</mp>
-            <cp>1671.0</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3410.06</hp>
-            <mp>1574.0</mp>
-            <cp>1705.03</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3478.53</hp>
-            <mp>1607.4</mp>
-            <cp>1739.265</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3547.41</hp>
-            <mp>1641.0</mp>
-            <cp>1773.705</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3616.7</hp>
-            <mp>1674.8</mp>
-            <cp>1808.35</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3686.4</hp>
-            <mp>1708.8</mp>
-            <cp>1843.2</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3756.51</hp>
-            <mp>1743.0</mp>
-            <cp>1878.255</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3827.03</hp>
-            <mp>1777.4</mp>
-            <cp>1913.515</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3897.96</hp>
-            <mp>1812.0</mp>
-            <cp>1948.98</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3969.3</hp>
-            <mp>1846.8</mp>
-            <cp>1984.65</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>4041.05</hp>
-            <mp>1881.8</mp>
-            <cp>2020.525</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>4113.21</hp>
-            <mp>1917.0</mp>
-            <cp>2056.605</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>4185.78</hp>
-            <mp>1952.4</mp>
-            <cp>2092.89</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>4258.76</hp>
-            <mp>1988.0</mp>
-            <cp>2129.38</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4332.15</hp>
-            <mp>2023.8</mp>
-            <cp>2166.075</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4405.95</hp>
-            <mp>2059.8</mp>
-            <cp>2202.975</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>17</classId>
+	<staticData>
+		<baseINT>41</baseINT>
+		<baseSTR>22</baseSTR>
+		<baseCON>27</baseCON>
+		<baseMEN>39</baseMEN>
+		<baseDEX>21</baseDEX>
+		<baseWIT>20</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-90875" y="248162" z="-3570" />
+			<node x="-90954" y="248118" z="-3570" />
+			<node x="-90918" y="248070" z="-3570" />
+			<node x="-90890" y="248027" z="-3570" />
+		</creationPoints>
+		<basePAtk>3</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>15</chest>
+			<legs>8</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>78</walk>
+			<run>124</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>200</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>22.8</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>6.5</radius>
+			<height>22.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>101.0</hp>
+			<mp>40.0</mp>
+			<cp>50.5</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>116.47</hp>
+			<mp>47.28</mp>
+			<cp>58.235</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>132.11</hp>
+			<mp>54.64</mp>
+			<cp>66.055</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>147.92</hp>
+			<mp>62.08</mp>
+			<cp>73.96</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>163.9</hp>
+			<mp>69.6</mp>
+			<cp>81.95</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>180.05</hp>
+			<mp>77.2</mp>
+			<cp>90.025</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>196.37</hp>
+			<mp>84.88</mp>
+			<cp>98.185</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>212.86</hp>
+			<mp>92.64</mp>
+			<cp>106.43</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>229.52</hp>
+			<mp>100.48</mp>
+			<cp>114.76</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>246.35</hp>
+			<mp>108.4</mp>
+			<cp>123.175</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>263.35</hp>
+			<mp>116.4</mp>
+			<cp>131.675</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>280.52</hp>
+			<mp>124.48</mp>
+			<cp>140.26</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>297.86</hp>
+			<mp>132.64</mp>
+			<cp>148.93</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>315.37</hp>
+			<mp>140.88</mp>
+			<cp>157.685</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>333.05</hp>
+			<mp>149.2</mp>
+			<cp>166.525</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>350.9</hp>
+			<mp>157.6</mp>
+			<cp>175.45</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>368.92</hp>
+			<mp>166.08</mp>
+			<cp>184.46</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>387.11</hp>
+			<mp>174.64</mp>
+			<cp>193.555</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>405.47</hp>
+			<mp>183.28</mp>
+			<cp>202.735</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>424.0</hp>
+			<mp>192.0</mp>
+			<cp>212.0</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>458.1</hp>
+			<mp>205.2</mp>
+			<cp>229.05</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>492.51</hp>
+			<mp>218.52</mp>
+			<cp>246.255</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>527.23</hp>
+			<mp>231.96</mp>
+			<cp>263.615</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>562.26</hp>
+			<mp>245.52</mp>
+			<cp>281.13</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>597.6</hp>
+			<mp>259.2</mp>
+			<cp>298.8</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>633.25</hp>
+			<mp>273.0</mp>
+			<cp>316.625</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>669.21</hp>
+			<mp>286.92</mp>
+			<cp>334.605</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>705.48</hp>
+			<mp>300.96</mp>
+			<cp>352.74</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>742.06</hp>
+			<mp>315.12</mp>
+			<cp>371.03</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>778.95</hp>
+			<mp>329.4</mp>
+			<cp>389.475</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>816.15</hp>
+			<mp>343.8</mp>
+			<cp>408.075</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>853.66</hp>
+			<mp>358.32</mp>
+			<cp>426.83</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>891.48</hp>
+			<mp>372.96</mp>
+			<cp>445.74</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>929.61</hp>
+			<mp>387.72</mp>
+			<cp>464.805</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>968.05</hp>
+			<mp>402.6</mp>
+			<cp>484.025</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>1006.8</hp>
+			<mp>417.6</mp>
+			<cp>503.4</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>1045.86</hp>
+			<mp>432.72</mp>
+			<cp>522.93</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1085.23</hp>
+			<mp>447.96</mp>
+			<cp>542.615</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1124.91</hp>
+			<mp>463.32</mp>
+			<cp>562.455</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1164.9</hp>
+			<mp>478.8</mp>
+			<cp>582.45</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1218.2</hp>
+			<mp>504.8</mp>
+			<cp>609.1</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1271.91</hp>
+			<mp>531.0</mp>
+			<cp>635.955</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1326.03</hp>
+			<mp>557.4</mp>
+			<cp>663.015</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1380.56</hp>
+			<mp>584.0</mp>
+			<cp>690.28</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1435.5</hp>
+			<mp>610.8</mp>
+			<cp>717.75</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1490.85</hp>
+			<mp>637.8</mp>
+			<cp>745.425</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1546.61</hp>
+			<mp>665.0</mp>
+			<cp>773.305</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1602.78</hp>
+			<mp>692.4</mp>
+			<cp>801.39</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1659.36</hp>
+			<mp>720.0</mp>
+			<cp>829.68</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1716.35</hp>
+			<mp>747.8</mp>
+			<cp>858.175</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1773.75</hp>
+			<mp>775.8</mp>
+			<cp>886.875</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1831.56</hp>
+			<mp>804.0</mp>
+			<cp>915.78</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1889.78</hp>
+			<mp>832.4</mp>
+			<cp>944.89</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1948.41</hp>
+			<mp>861.0</mp>
+			<cp>974.205</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>2007.45</hp>
+			<mp>889.8</mp>
+			<cp>1003.725</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>2066.9</hp>
+			<mp>918.8</mp>
+			<cp>1033.45</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2126.76</hp>
+			<mp>948.0</mp>
+			<cp>1063.38</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2187.03</hp>
+			<mp>977.4</mp>
+			<cp>1093.515</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2247.71</hp>
+			<mp>1007.0</mp>
+			<cp>1123.855</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2308.8</hp>
+			<mp>1036.8</mp>
+			<cp>1154.4</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2370.3</hp>
+			<mp>1066.8</mp>
+			<cp>1185.15</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2432.21</hp>
+			<mp>1097.0</mp>
+			<cp>1216.105</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2494.53</hp>
+			<mp>1127.4</mp>
+			<cp>1247.265</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2557.26</hp>
+			<mp>1158.0</mp>
+			<cp>1278.63</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2620.4</hp>
+			<mp>1188.8</mp>
+			<cp>1310.2</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2683.95</hp>
+			<mp>1219.8</mp>
+			<cp>1341.975</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2747.91</hp>
+			<mp>1251.0</mp>
+			<cp>1373.955</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2812.28</hp>
+			<mp>1282.4</mp>
+			<cp>1406.14</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2877.06</hp>
+			<mp>1314.0</mp>
+			<cp>1438.53</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2942.25</hp>
+			<mp>1345.8</mp>
+			<cp>1471.125</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>3007.85</hp>
+			<mp>1377.8</mp>
+			<cp>1503.925</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>3073.86</hp>
+			<mp>1410.0</mp>
+			<cp>1536.93</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>3140.28</hp>
+			<mp>1442.4</mp>
+			<cp>1570.14</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3207.11</hp>
+			<mp>1475.0</mp>
+			<cp>1603.555</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3274.35</hp>
+			<mp>1507.8</mp>
+			<cp>1637.175</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3342.0</hp>
+			<mp>1540.8</mp>
+			<cp>1671.0</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3410.06</hp>
+			<mp>1574.0</mp>
+			<cp>1705.03</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3478.53</hp>
+			<mp>1607.4</mp>
+			<cp>1739.265</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3547.41</hp>
+			<mp>1641.0</mp>
+			<cp>1773.705</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3616.7</hp>
+			<mp>1674.8</mp>
+			<cp>1808.35</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3686.4</hp>
+			<mp>1708.8</mp>
+			<cp>1843.2</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3756.51</hp>
+			<mp>1743.0</mp>
+			<cp>1878.255</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3827.03</hp>
+			<mp>1777.4</mp>
+			<cp>1913.515</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3897.96</hp>
+			<mp>1812.0</mp>
+			<cp>1948.98</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3969.3</hp>
+			<mp>1846.8</mp>
+			<cp>1984.65</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>4041.05</hp>
+			<mp>1881.8</mp>
+			<cp>2020.525</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>4113.21</hp>
+			<mp>1917.0</mp>
+			<cp>2056.605</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4185.78</hp>
+			<mp>1952.4</mp>
+			<cp>2092.89</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4258.76</hp>
+			<mp>1988.0</mp>
+			<cp>2129.38</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4332.15</hp>
+			<mp>2023.8</mp>
+			<cp>2166.075</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4405.95</hp>
+			<mp>2059.8</mp>
+			<cp>2202.975</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4480.16</hp>
+			<mp>2096.0</mp>
+			<cp>2240.08</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4554.78</hp>
+			<mp>2132.4</mp>
+			<cp>2277.39</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4629.81</hp>
+			<mp>2169.0</mp>
+			<cp>2314.905</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4705.25</hp>
+			<mp>2205.8</mp>
+			<cp>2352.625</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4781.1</hp>
+			<mp>2242.8</mp>
+			<cp>2390.55</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4857.36</hp>
+			<mp>2280.0</mp>
+			<cp>2428.68</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4934.03</hp>
+			<mp>2317.4</mp>
+			<cp>2467.015</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>5011.11</hp>
+			<mp>2355.0</mp>
+			<cp>2505.555</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>5088.6</hp>
+			<mp>2392.8</mp>
+			<cp>2544.3</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>5166.5</hp>
+			<mp>2430.8</mp>
+			<cp>2583.24</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5244.81</hp>
+			<mp>2469</mp>
+			<cp>2622.38</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5323.53</hp>
+			<mp>2507.4</mp>
+			<cp>2661.72</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5402.66</hp>
+			<mp>2546</mp>
+			<cp>2701.26</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5482.2</hp>
+			<mp>2584.8</mp>
+			<cp>2741</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5562.15</hp>
+			<mp>2623.8</mp>
+			<cp>2780.94</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5642.51</hp>
+			<mp>2663</mp>
+			<cp>2821.255</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Rogue.xml
+++ b/data/stats/chars/baseStats/Rogue.xml
@@ -1,798 +1,926 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>7</classId>
-    <staticData>
-        <baseINT>21</baseINT>
-        <baseSTR>40</baseSTR>
-        <baseCON>43</baseCON>
-        <baseMEN>25</baseMEN>
-        <baseDEX>30</baseDEX>
-        <baseWIT>11</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-71338" y="258271" z="-3104"/>
-            <node x="-71417" y="258270" z="-3104"/>
-            <node x="-71453" y="258305" z="-3104"/>
-            <node x="-71467" y="258378" z="-3104"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>80</walk>
-            <run>132</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>100</baseBreath>
-        <baseSafeFall>250</baseSafeFall>
-        <collisionMale>
-            <radius>9.0</radius>
-            <height>23</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>8.0</radius>
-            <height>23.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>80.0</hp>
-            <mp>30.0</mp>
-            <cp>40.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>91.83</hp>
-            <mp>35.46</mp>
-            <cp>45.915</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>103.79</hp>
-            <mp>40.98</mp>
-            <cp>51.895</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>115.88</hp>
-            <mp>46.56</mp>
-            <cp>57.94</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>128.1</hp>
-            <mp>52.2</mp>
-            <cp>64.05</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>140.45</hp>
-            <mp>57.9</mp>
-            <cp>70.225</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>152.93</hp>
-            <mp>63.66</mp>
-            <cp>76.465</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>165.54</hp>
-            <mp>69.48</mp>
-            <cp>82.77</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>178.28</hp>
-            <mp>75.36</mp>
-            <cp>89.14</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>191.15</hp>
-            <mp>81.3</mp>
-            <cp>95.575</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>204.15</hp>
-            <mp>87.3</mp>
-            <cp>102.075</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>217.28</hp>
-            <mp>93.36</mp>
-            <cp>108.64</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>230.54</hp>
-            <mp>99.48</mp>
-            <cp>115.27</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>243.93</hp>
-            <mp>105.66</mp>
-            <cp>121.965</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>257.45</hp>
-            <mp>111.9</mp>
-            <cp>128.725</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>271.1</hp>
-            <mp>118.2</mp>
-            <cp>135.55</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>284.88</hp>
-            <mp>124.56</mp>
-            <cp>142.44</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>298.79</hp>
-            <mp>130.98</mp>
-            <cp>149.395</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>312.83</hp>
-            <mp>137.46</mp>
-            <cp>156.415</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>327.0</hp>
-            <mp>144.0</mp>
-            <cp>163.5</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>354.5</hp>
-            <mp>153.9</mp>
-            <cp>177.25</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>382.25</hp>
-            <mp>163.89</mp>
-            <cp>191.125</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>410.25</hp>
-            <mp>173.97</mp>
-            <cp>205.125</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>438.5</hp>
-            <mp>184.14</mp>
-            <cp>219.25</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>467.0</hp>
-            <mp>194.4</mp>
-            <cp>233.5</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>495.75</hp>
-            <mp>204.75</mp>
-            <cp>247.875</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>524.75</hp>
-            <mp>215.19</mp>
-            <cp>262.375</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>554.0</hp>
-            <mp>225.72</mp>
-            <cp>277.0</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>583.5</hp>
-            <mp>236.34</mp>
-            <cp>291.75</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>613.25</hp>
-            <mp>247.05</mp>
-            <cp>306.625</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>643.25</hp>
-            <mp>257.85</mp>
-            <cp>321.625</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>673.5</hp>
-            <mp>268.74</mp>
-            <cp>336.75</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>704.0</hp>
-            <mp>279.72</mp>
-            <cp>352.0</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>734.75</hp>
-            <mp>290.79</mp>
-            <cp>367.375</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>765.75</hp>
-            <mp>301.95</mp>
-            <cp>382.875</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>797.0</hp>
-            <mp>313.2</mp>
-            <cp>398.5</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>828.5</hp>
-            <mp>324.54</mp>
-            <cp>414.25</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>860.25</hp>
-            <mp>335.97</mp>
-            <cp>430.125</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>892.25</hp>
-            <mp>347.49</mp>
-            <cp>446.125</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>924.5</hp>
-            <mp>359.1</mp>
-            <cp>462.25</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>957.0</hp>
-            <mp>370.8</mp>
-            <cp>478.5</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>989.75</hp>
-            <mp>382.59</mp>
-            <cp>494.875</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1022.75</hp>
-            <mp>394.47</mp>
-            <cp>511.375</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1056.0</hp>
-            <mp>406.44</mp>
-            <cp>528.0</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1089.5</hp>
-            <mp>418.5</mp>
-            <cp>544.75</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1123.25</hp>
-            <mp>430.65</mp>
-            <cp>561.625</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1157.25</hp>
-            <mp>442.89</mp>
-            <cp>578.625</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1191.5</hp>
-            <mp>455.22</mp>
-            <cp>595.75</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1226.0</hp>
-            <mp>467.64</mp>
-            <cp>613.0</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1260.75</hp>
-            <mp>480.15</mp>
-            <cp>630.375</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1295.75</hp>
-            <mp>492.75</mp>
-            <cp>647.875</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1331.0</hp>
-            <mp>505.44</mp>
-            <cp>665.5</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1366.5</hp>
-            <mp>518.22</mp>
-            <cp>683.25</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1402.25</hp>
-            <mp>531.09</mp>
-            <cp>701.125</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1438.25</hp>
-            <mp>544.05</mp>
-            <cp>719.125</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1474.5</hp>
-            <mp>557.1</mp>
-            <cp>737.25</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1511.0</hp>
-            <mp>570.24</mp>
-            <cp>755.5</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1547.75</hp>
-            <mp>583.47</mp>
-            <cp>773.875</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>1584.75</hp>
-            <mp>596.79</mp>
-            <cp>792.375</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>1622.0</hp>
-            <mp>610.2</mp>
-            <cp>811.0</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>1659.5</hp>
-            <mp>623.7</mp>
-            <cp>829.75</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>1697.25</hp>
-            <mp>637.29</mp>
-            <cp>848.625</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>1735.25</hp>
-            <mp>650.97</mp>
-            <cp>867.625</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>1773.5</hp>
-            <mp>664.74</mp>
-            <cp>886.75</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>1812.0</hp>
-            <mp>678.6</mp>
-            <cp>906.0</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>1850.75</hp>
-            <mp>692.55</mp>
-            <cp>925.375</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>1889.75</hp>
-            <mp>706.59</mp>
-            <cp>944.875</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>1929.0</hp>
-            <mp>720.72</mp>
-            <cp>964.5</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>1968.5</hp>
-            <mp>734.94</mp>
-            <cp>984.25</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2008.25</hp>
-            <mp>749.25</mp>
-            <cp>1004.125</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2048.25</hp>
-            <mp>763.65</mp>
-            <cp>1024.125</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2088.5</hp>
-            <mp>778.14</mp>
-            <cp>1044.25</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2129.0</hp>
-            <mp>792.72</mp>
-            <cp>1064.5</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2169.75</hp>
-            <mp>807.39</mp>
-            <cp>1084.875</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2210.75</hp>
-            <mp>822.15</mp>
-            <cp>1105.375</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>2252.0</hp>
-            <mp>837.0</mp>
-            <cp>1126.0</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>2293.5</hp>
-            <mp>851.94</mp>
-            <cp>1146.75</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>2335.25</hp>
-            <mp>866.97</mp>
-            <cp>1167.625</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>2377.25</hp>
-            <mp>882.09</mp>
-            <cp>1188.625</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>2419.5</hp>
-            <mp>897.3</mp>
-            <cp>1209.75</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>2462.0</hp>
-            <mp>912.6</mp>
-            <cp>1231.0</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>2504.75</hp>
-            <mp>927.99</mp>
-            <cp>1252.375</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>2547.75</hp>
-            <mp>943.47</mp>
-            <cp>1273.875</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>2591.0</hp>
-            <mp>959.04</mp>
-            <cp>1295.5</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>2634.5</hp>
-            <mp>974.7</mp>
-            <cp>1317.25</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>2678.25</hp>
-            <mp>990.45</mp>
-            <cp>1339.125</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>2722.25</hp>
-            <mp>1006.29</mp>
-            <cp>1361.125</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>2766.5</hp>
-            <mp>1022.22</mp>
-            <cp>1383.25</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>2811.0</hp>
-            <mp>1038.24</mp>
-            <cp>1405.5</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>2855.75</hp>
-            <mp>1054.35</mp>
-            <cp>1427.875</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>2900.75</hp>
-            <mp>1070.55</mp>
-            <cp>1450.375</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>7</classId>
+	<staticData>
+		<baseINT>21</baseINT>
+		<baseSTR>40</baseSTR>
+		<baseCON>43</baseCON>
+		<baseMEN>25</baseMEN>
+		<baseDEX>30</baseDEX>
+		<baseWIT>11</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-71338" y="258271" z="-3104" />
+			<node x="-71417" y="258270" z="-3104" />
+			<node x="-71453" y="258305" z="-3104" />
+			<node x="-71467" y="258378" z="-3104" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>80</walk>
+			<run>132</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>250</baseSafeFall>
+		<collisionMale>
+			<radius>9.0</radius>
+			<height>23</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>8.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>80.0</hp>
+			<mp>30.0</mp>
+			<cp>40.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>91.83</hp>
+			<mp>35.46</mp>
+			<cp>45.915</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>103.79</hp>
+			<mp>40.98</mp>
+			<cp>51.895</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>115.88</hp>
+			<mp>46.56</mp>
+			<cp>57.94</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>128.1</hp>
+			<mp>52.2</mp>
+			<cp>64.05</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>140.45</hp>
+			<mp>57.9</mp>
+			<cp>70.225</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>152.93</hp>
+			<mp>63.66</mp>
+			<cp>76.465</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>165.54</hp>
+			<mp>69.48</mp>
+			<cp>82.77</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>178.28</hp>
+			<mp>75.36</mp>
+			<cp>89.14</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>191.15</hp>
+			<mp>81.3</mp>
+			<cp>95.575</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>204.15</hp>
+			<mp>87.3</mp>
+			<cp>102.075</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>217.28</hp>
+			<mp>93.36</mp>
+			<cp>108.64</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>230.54</hp>
+			<mp>99.48</mp>
+			<cp>115.27</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>243.93</hp>
+			<mp>105.66</mp>
+			<cp>121.965</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>257.45</hp>
+			<mp>111.9</mp>
+			<cp>128.725</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>271.1</hp>
+			<mp>118.2</mp>
+			<cp>135.55</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>284.88</hp>
+			<mp>124.56</mp>
+			<cp>142.44</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>298.79</hp>
+			<mp>130.98</mp>
+			<cp>149.395</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>312.83</hp>
+			<mp>137.46</mp>
+			<cp>156.415</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>327.0</hp>
+			<mp>144.0</mp>
+			<cp>163.5</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>354.5</hp>
+			<mp>153.9</mp>
+			<cp>177.25</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>382.25</hp>
+			<mp>163.89</mp>
+			<cp>191.125</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>410.25</hp>
+			<mp>173.97</mp>
+			<cp>205.125</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>438.5</hp>
+			<mp>184.14</mp>
+			<cp>219.25</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>467.0</hp>
+			<mp>194.4</mp>
+			<cp>233.5</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>495.75</hp>
+			<mp>204.75</mp>
+			<cp>247.875</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>524.75</hp>
+			<mp>215.19</mp>
+			<cp>262.375</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>554.0</hp>
+			<mp>225.72</mp>
+			<cp>277.0</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>583.5</hp>
+			<mp>236.34</mp>
+			<cp>291.75</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>613.25</hp>
+			<mp>247.05</mp>
+			<cp>306.625</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>643.25</hp>
+			<mp>257.85</mp>
+			<cp>321.625</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>673.5</hp>
+			<mp>268.74</mp>
+			<cp>336.75</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>704.0</hp>
+			<mp>279.72</mp>
+			<cp>352.0</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>734.75</hp>
+			<mp>290.79</mp>
+			<cp>367.375</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>765.75</hp>
+			<mp>301.95</mp>
+			<cp>382.875</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>797.0</hp>
+			<mp>313.2</mp>
+			<cp>398.5</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>828.5</hp>
+			<mp>324.54</mp>
+			<cp>414.25</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>860.25</hp>
+			<mp>335.97</mp>
+			<cp>430.125</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>892.25</hp>
+			<mp>347.49</mp>
+			<cp>446.125</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>924.5</hp>
+			<mp>359.1</mp>
+			<cp>462.25</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>957.0</hp>
+			<mp>370.8</mp>
+			<cp>478.5</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>989.75</hp>
+			<mp>382.59</mp>
+			<cp>494.875</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1022.75</hp>
+			<mp>394.47</mp>
+			<cp>511.375</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1056.0</hp>
+			<mp>406.44</mp>
+			<cp>528.0</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1089.5</hp>
+			<mp>418.5</mp>
+			<cp>544.75</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1123.25</hp>
+			<mp>430.65</mp>
+			<cp>561.625</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1157.25</hp>
+			<mp>442.89</mp>
+			<cp>578.625</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1191.5</hp>
+			<mp>455.22</mp>
+			<cp>595.75</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1226.0</hp>
+			<mp>467.64</mp>
+			<cp>613.0</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1260.75</hp>
+			<mp>480.15</mp>
+			<cp>630.375</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1295.75</hp>
+			<mp>492.75</mp>
+			<cp>647.875</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1331.0</hp>
+			<mp>505.44</mp>
+			<cp>665.5</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1366.5</hp>
+			<mp>518.22</mp>
+			<cp>683.25</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1402.25</hp>
+			<mp>531.09</mp>
+			<cp>701.125</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1438.25</hp>
+			<mp>544.05</mp>
+			<cp>719.125</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1474.5</hp>
+			<mp>557.1</mp>
+			<cp>737.25</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1511.0</hp>
+			<mp>570.24</mp>
+			<cp>755.5</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1547.75</hp>
+			<mp>583.47</mp>
+			<cp>773.875</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1584.75</hp>
+			<mp>596.79</mp>
+			<cp>792.375</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1622.0</hp>
+			<mp>610.2</mp>
+			<cp>811.0</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>1659.5</hp>
+			<mp>623.7</mp>
+			<cp>829.75</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>1697.25</hp>
+			<mp>637.29</mp>
+			<cp>848.625</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>1735.25</hp>
+			<mp>650.97</mp>
+			<cp>867.625</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>1773.5</hp>
+			<mp>664.74</mp>
+			<cp>886.75</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>1812.0</hp>
+			<mp>678.6</mp>
+			<cp>906.0</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>1850.75</hp>
+			<mp>692.55</mp>
+			<cp>925.375</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>1889.75</hp>
+			<mp>706.59</mp>
+			<cp>944.875</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>1929.0</hp>
+			<mp>720.72</mp>
+			<cp>964.5</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>1968.5</hp>
+			<mp>734.94</mp>
+			<cp>984.25</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2008.25</hp>
+			<mp>749.25</mp>
+			<cp>1004.125</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2048.25</hp>
+			<mp>763.65</mp>
+			<cp>1024.125</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2088.5</hp>
+			<mp>778.14</mp>
+			<cp>1044.25</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2129.0</hp>
+			<mp>792.72</mp>
+			<cp>1064.5</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2169.75</hp>
+			<mp>807.39</mp>
+			<cp>1084.875</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2210.75</hp>
+			<mp>822.15</mp>
+			<cp>1105.375</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>2252.0</hp>
+			<mp>837.0</mp>
+			<cp>1126.0</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>2293.5</hp>
+			<mp>851.94</mp>
+			<cp>1146.75</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>2335.25</hp>
+			<mp>866.97</mp>
+			<cp>1167.625</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>2377.25</hp>
+			<mp>882.09</mp>
+			<cp>1188.625</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>2419.5</hp>
+			<mp>897.3</mp>
+			<cp>1209.75</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>2462.0</hp>
+			<mp>912.6</mp>
+			<cp>1231.0</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>2504.75</hp>
+			<mp>927.99</mp>
+			<cp>1252.375</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>2547.75</hp>
+			<mp>943.47</mp>
+			<cp>1273.875</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>2591.0</hp>
+			<mp>959.04</mp>
+			<cp>1295.5</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>2634.5</hp>
+			<mp>974.7</mp>
+			<cp>1317.25</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>2678.25</hp>
+			<mp>990.45</mp>
+			<cp>1339.125</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>2722.25</hp>
+			<mp>1006.29</mp>
+			<cp>1361.125</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>2766.5</hp>
+			<mp>1022.22</mp>
+			<cp>1383.25</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>2811.0</hp>
+			<mp>1038.24</mp>
+			<cp>1405.5</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>2855.75</hp>
+			<mp>1054.35</mp>
+			<cp>1427.875</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>2900.75</hp>
+			<mp>1070.55</mp>
+			<cp>1450.375</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>2946.0</hp>
+			<mp>1086.84</mp>
+			<cp>1473.0</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>2991.5</hp>
+			<mp>1103.22</mp>
+			<cp>1495.75</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>3037.25</hp>
+			<mp>1119.69</mp>
+			<cp>1518.625</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>3083.25</hp>
+			<mp>1136.25</mp>
+			<cp>1541.625</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>3129.5</hp>
+			<mp>1152.9</mp>
+			<cp>1564.75</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>3176.0</hp>
+			<mp>1169.64</mp>
+			<cp>1588.0</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>3222.75</hp>
+			<mp>1186.47</mp>
+			<cp>1611.375</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>3269.75</hp>
+			<mp>1203.39</mp>
+			<cp>1634.875</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>3317</hp>
+			<mp>1220.4</mp>
+			<cp>1658.51</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>3364.5</hp>
+			<mp>1237.5</mp>
+			<cp>1682.27</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>3412.25</hp>
+			<mp>1254.69</mp>
+			<cp>1706.16</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>3460.25</hp>
+			<mp>1271.97</mp>
+			<cp>1730.18</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>3508.5</hp>
+			<mp>1289.34</mp>
+			<cp>1754.33</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>3557</hp>
+			<mp>1306.8</mp>
+			<cp>1778.61</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>3605.75</hp>
+			<mp>1324.35</mp>
+			<cp>1803.02</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>3654.75</hp>
+			<mp>1341.99</mp>
+			<cp>1827.375</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Sagittarius.xml
+++ b/data/stats/chars/baseStats/Sagittarius.xml
@@ -1,798 +1,926 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>92</classId>
-    <staticData>
-        <baseINT>21</baseINT>
-        <baseSTR>40</baseSTR>
-        <baseCON>43</baseCON>
-        <baseMEN>25</baseMEN>
-        <baseDEX>30</baseDEX>
-        <baseWIT>11</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-71338" y="258271" z="-3104"/>
-            <node x="-71417" y="258270" z="-3104"/>
-            <node x="-71453" y="258305" z="-3104"/>
-            <node x="-71467" y="258378" z="-3104"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>80</walk>
-            <run>132</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>100</baseBreath>
-        <baseSafeFall>250</baseSafeFall>
-        <collisionMale>
-            <radius>9.0</radius>
-            <height>23</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>8.0</radius>
-            <height>23.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>80.0</hp>
-            <mp>30.0</mp>
-            <cp>56.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>91.83</hp>
-            <mp>35.46</mp>
-            <cp>64.281</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>103.79</hp>
-            <mp>40.98</mp>
-            <cp>72.653</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>115.88</hp>
-            <mp>46.56</mp>
-            <cp>81.116</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>128.1</hp>
-            <mp>52.2</mp>
-            <cp>89.67</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>140.45</hp>
-            <mp>57.9</mp>
-            <cp>98.315</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>152.93</hp>
-            <mp>63.66</mp>
-            <cp>107.051</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>165.54</hp>
-            <mp>69.48</mp>
-            <cp>115.878</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>178.28</hp>
-            <mp>75.36</mp>
-            <cp>124.796</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>191.15</hp>
-            <mp>81.3</mp>
-            <cp>133.805</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>204.15</hp>
-            <mp>87.3</mp>
-            <cp>142.905</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>217.28</hp>
-            <mp>93.36</mp>
-            <cp>152.096</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>230.54</hp>
-            <mp>99.48</mp>
-            <cp>161.378</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>243.93</hp>
-            <mp>105.66</mp>
-            <cp>170.751</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>257.45</hp>
-            <mp>111.9</mp>
-            <cp>180.215</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>271.1</hp>
-            <mp>118.2</mp>
-            <cp>189.77</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>284.88</hp>
-            <mp>124.56</mp>
-            <cp>199.416</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>298.79</hp>
-            <mp>130.98</mp>
-            <cp>209.153</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>312.83</hp>
-            <mp>137.46</mp>
-            <cp>218.981</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>327.0</hp>
-            <mp>144.0</mp>
-            <cp>228.9</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>354.5</hp>
-            <mp>153.9</mp>
-            <cp>248.15</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>382.25</hp>
-            <mp>163.89</mp>
-            <cp>267.575</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>410.25</hp>
-            <mp>173.97</mp>
-            <cp>287.175</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>438.5</hp>
-            <mp>184.14</mp>
-            <cp>306.95</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>467.0</hp>
-            <mp>194.4</mp>
-            <cp>326.9</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>495.75</hp>
-            <mp>204.75</mp>
-            <cp>347.025</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>524.75</hp>
-            <mp>215.19</mp>
-            <cp>367.325</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>554.0</hp>
-            <mp>225.72</mp>
-            <cp>387.8</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>583.5</hp>
-            <mp>236.34</mp>
-            <cp>408.45</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>613.25</hp>
-            <mp>247.05</mp>
-            <cp>429.275</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>643.25</hp>
-            <mp>257.85</mp>
-            <cp>450.275</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>673.5</hp>
-            <mp>268.74</mp>
-            <cp>471.45</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>704.0</hp>
-            <mp>279.72</mp>
-            <cp>492.8</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>734.75</hp>
-            <mp>290.79</mp>
-            <cp>514.325</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>765.75</hp>
-            <mp>301.95</mp>
-            <cp>536.025</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>797.0</hp>
-            <mp>313.2</mp>
-            <cp>557.9</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>828.5</hp>
-            <mp>324.54</mp>
-            <cp>579.95</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>860.25</hp>
-            <mp>335.97</mp>
-            <cp>602.175</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>892.25</hp>
-            <mp>347.49</mp>
-            <cp>624.575</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>924.5</hp>
-            <mp>359.1</mp>
-            <cp>647.15</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>968.7</hp>
-            <mp>378.6</mp>
-            <cp>678.09</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1013.24</hp>
-            <mp>398.25</mp>
-            <cp>709.268</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1058.12</hp>
-            <mp>418.05</mp>
-            <cp>740.684</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1103.34</hp>
-            <mp>438.0</mp>
-            <cp>772.338</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1148.9</hp>
-            <mp>458.1</mp>
-            <cp>804.23</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1194.8</hp>
-            <mp>478.35</mp>
-            <cp>836.36</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1241.04</hp>
-            <mp>498.75</mp>
-            <cp>868.728</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1287.62</hp>
-            <mp>519.3</mp>
-            <cp>901.334</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1334.54</hp>
-            <mp>540.0</mp>
-            <cp>934.178</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1381.8</hp>
-            <mp>560.85</mp>
-            <cp>967.26</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1429.4</hp>
-            <mp>581.85</mp>
-            <cp>1000.58</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1477.34</hp>
-            <mp>603.0</mp>
-            <cp>1034.138</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1525.62</hp>
-            <mp>624.3</mp>
-            <cp>1067.934</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1574.24</hp>
-            <mp>645.75</mp>
-            <cp>1101.968</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1623.2</hp>
-            <mp>667.35</mp>
-            <cp>1136.24</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1672.5</hp>
-            <mp>689.1</mp>
-            <cp>1170.75</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1722.14</hp>
-            <mp>711.0</mp>
-            <cp>1205.498</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1772.12</hp>
-            <mp>733.05</mp>
-            <cp>1240.484</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>1822.44</hp>
-            <mp>755.25</mp>
-            <cp>1275.708</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>1873.1</hp>
-            <mp>777.6</mp>
-            <cp>1311.17</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>1924.1</hp>
-            <mp>800.1</mp>
-            <cp>1346.87</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>1975.44</hp>
-            <mp>822.75</mp>
-            <cp>1382.808</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2027.12</hp>
-            <mp>845.55</mp>
-            <cp>1418.984</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2079.14</hp>
-            <mp>868.5</mp>
-            <cp>1455.398</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2131.5</hp>
-            <mp>891.6</mp>
-            <cp>1492.05</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2184.2</hp>
-            <mp>914.85</mp>
-            <cp>1528.94</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2237.24</hp>
-            <mp>938.25</mp>
-            <cp>1566.068</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2290.62</hp>
-            <mp>961.8</mp>
-            <cp>1603.434</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2344.34</hp>
-            <mp>985.5</mp>
-            <cp>1641.038</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2398.4</hp>
-            <mp>1009.35</mp>
-            <cp>1678.88</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2452.8</hp>
-            <mp>1033.35</mp>
-            <cp>1716.96</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2507.54</hp>
-            <mp>1057.5</mp>
-            <cp>1755.278</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2562.62</hp>
-            <mp>1081.8</mp>
-            <cp>1793.834</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2618.04</hp>
-            <mp>1106.25</mp>
-            <cp>1832.628</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2673.8</hp>
-            <mp>1130.85</mp>
-            <cp>1871.66</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>2729.9</hp>
-            <mp>1155.6</mp>
-            <cp>1910.93</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>2786.34</hp>
-            <mp>1180.5</mp>
-            <cp>1950.438</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>2843.12</hp>
-            <mp>1205.55</mp>
-            <cp>1990.184</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>2900.24</hp>
-            <mp>1230.75</mp>
-            <cp>2030.168</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>2957.7</hp>
-            <mp>1256.1</mp>
-            <cp>2070.39</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3015.5</hp>
-            <mp>1281.6</mp>
-            <cp>2110.85</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3073.64</hp>
-            <mp>1307.25</mp>
-            <cp>2151.548</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3132.12</hp>
-            <mp>1333.05</mp>
-            <cp>2192.484</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3190.94</hp>
-            <mp>1359.0</mp>
-            <cp>2233.658</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3250.1</hp>
-            <mp>1385.1</mp>
-            <cp>2275.07</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3309.6</hp>
-            <mp>1411.35</mp>
-            <cp>2316.72</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3369.44</hp>
-            <mp>1437.75</mp>
-            <cp>2358.608</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3429.62</hp>
-            <mp>1464.3</mp>
-            <cp>2400.734</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3490.14</hp>
-            <mp>1491.0</mp>
-            <cp>2443.098</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3551.0</hp>
-            <mp>1517.85</mp>
-            <cp>2485.7</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>3612.2</hp>
-            <mp>1544.85</mp>
-            <cp>2528.54</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>92</classId>
+	<staticData>
+		<baseINT>21</baseINT>
+		<baseSTR>40</baseSTR>
+		<baseCON>43</baseCON>
+		<baseMEN>25</baseMEN>
+		<baseDEX>30</baseDEX>
+		<baseWIT>11</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-71338" y="258271" z="-3104" />
+			<node x="-71417" y="258270" z="-3104" />
+			<node x="-71453" y="258305" z="-3104" />
+			<node x="-71467" y="258378" z="-3104" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>80</walk>
+			<run>132</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>250</baseSafeFall>
+		<collisionMale>
+			<radius>9.0</radius>
+			<height>23</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>8.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>80.0</hp>
+			<mp>30.0</mp>
+			<cp>56.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>91.83</hp>
+			<mp>35.46</mp>
+			<cp>64.281</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>103.79</hp>
+			<mp>40.98</mp>
+			<cp>72.653</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>115.88</hp>
+			<mp>46.56</mp>
+			<cp>81.116</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>128.1</hp>
+			<mp>52.2</mp>
+			<cp>89.67</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>140.45</hp>
+			<mp>57.9</mp>
+			<cp>98.315</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>152.93</hp>
+			<mp>63.66</mp>
+			<cp>107.051</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>165.54</hp>
+			<mp>69.48</mp>
+			<cp>115.878</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>178.28</hp>
+			<mp>75.36</mp>
+			<cp>124.796</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>191.15</hp>
+			<mp>81.3</mp>
+			<cp>133.805</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>204.15</hp>
+			<mp>87.3</mp>
+			<cp>142.905</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>217.28</hp>
+			<mp>93.36</mp>
+			<cp>152.096</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>230.54</hp>
+			<mp>99.48</mp>
+			<cp>161.378</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>243.93</hp>
+			<mp>105.66</mp>
+			<cp>170.751</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>257.45</hp>
+			<mp>111.9</mp>
+			<cp>180.215</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>271.1</hp>
+			<mp>118.2</mp>
+			<cp>189.77</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>284.88</hp>
+			<mp>124.56</mp>
+			<cp>199.416</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>298.79</hp>
+			<mp>130.98</mp>
+			<cp>209.153</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>312.83</hp>
+			<mp>137.46</mp>
+			<cp>218.981</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>327.0</hp>
+			<mp>144.0</mp>
+			<cp>228.9</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>354.5</hp>
+			<mp>153.9</mp>
+			<cp>248.15</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>382.25</hp>
+			<mp>163.89</mp>
+			<cp>267.575</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>410.25</hp>
+			<mp>173.97</mp>
+			<cp>287.175</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>438.5</hp>
+			<mp>184.14</mp>
+			<cp>306.95</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>467.0</hp>
+			<mp>194.4</mp>
+			<cp>326.9</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>495.75</hp>
+			<mp>204.75</mp>
+			<cp>347.025</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>524.75</hp>
+			<mp>215.19</mp>
+			<cp>367.325</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>554.0</hp>
+			<mp>225.72</mp>
+			<cp>387.8</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>583.5</hp>
+			<mp>236.34</mp>
+			<cp>408.45</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>613.25</hp>
+			<mp>247.05</mp>
+			<cp>429.275</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>643.25</hp>
+			<mp>257.85</mp>
+			<cp>450.275</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>673.5</hp>
+			<mp>268.74</mp>
+			<cp>471.45</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>704.0</hp>
+			<mp>279.72</mp>
+			<cp>492.8</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>734.75</hp>
+			<mp>290.79</mp>
+			<cp>514.325</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>765.75</hp>
+			<mp>301.95</mp>
+			<cp>536.025</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>797.0</hp>
+			<mp>313.2</mp>
+			<cp>557.9</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>828.5</hp>
+			<mp>324.54</mp>
+			<cp>579.95</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>860.25</hp>
+			<mp>335.97</mp>
+			<cp>602.175</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>892.25</hp>
+			<mp>347.49</mp>
+			<cp>624.575</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>924.5</hp>
+			<mp>359.1</mp>
+			<cp>647.15</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>968.7</hp>
+			<mp>378.6</mp>
+			<cp>678.09</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1013.24</hp>
+			<mp>398.25</mp>
+			<cp>709.268</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1058.12</hp>
+			<mp>418.05</mp>
+			<cp>740.684</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1103.34</hp>
+			<mp>438.0</mp>
+			<cp>772.338</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1148.9</hp>
+			<mp>458.1</mp>
+			<cp>804.23</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1194.8</hp>
+			<mp>478.35</mp>
+			<cp>836.36</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1241.04</hp>
+			<mp>498.75</mp>
+			<cp>868.728</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1287.62</hp>
+			<mp>519.3</mp>
+			<cp>901.334</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1334.54</hp>
+			<mp>540.0</mp>
+			<cp>934.178</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1381.8</hp>
+			<mp>560.85</mp>
+			<cp>967.26</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1429.4</hp>
+			<mp>581.85</mp>
+			<cp>1000.58</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1477.34</hp>
+			<mp>603.0</mp>
+			<cp>1034.138</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1525.62</hp>
+			<mp>624.3</mp>
+			<cp>1067.934</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1574.24</hp>
+			<mp>645.75</mp>
+			<cp>1101.968</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1623.2</hp>
+			<mp>667.35</mp>
+			<cp>1136.24</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1672.5</hp>
+			<mp>689.1</mp>
+			<cp>1170.75</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1722.14</hp>
+			<mp>711.0</mp>
+			<cp>1205.498</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1772.12</hp>
+			<mp>733.05</mp>
+			<cp>1240.484</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1822.44</hp>
+			<mp>755.25</mp>
+			<cp>1275.708</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1873.1</hp>
+			<mp>777.6</mp>
+			<cp>1311.17</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>1924.1</hp>
+			<mp>800.1</mp>
+			<cp>1346.87</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>1975.44</hp>
+			<mp>822.75</mp>
+			<cp>1382.808</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2027.12</hp>
+			<mp>845.55</mp>
+			<cp>1418.984</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2079.14</hp>
+			<mp>868.5</mp>
+			<cp>1455.398</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2131.5</hp>
+			<mp>891.6</mp>
+			<cp>1492.05</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2184.2</hp>
+			<mp>914.85</mp>
+			<cp>1528.94</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2237.24</hp>
+			<mp>938.25</mp>
+			<cp>1566.068</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2290.62</hp>
+			<mp>961.8</mp>
+			<cp>1603.434</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2344.34</hp>
+			<mp>985.5</mp>
+			<cp>1641.038</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2398.4</hp>
+			<mp>1009.35</mp>
+			<cp>1678.88</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2452.8</hp>
+			<mp>1033.35</mp>
+			<cp>1716.96</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2507.54</hp>
+			<mp>1057.5</mp>
+			<cp>1755.278</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2562.62</hp>
+			<mp>1081.8</mp>
+			<cp>1793.834</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2618.04</hp>
+			<mp>1106.25</mp>
+			<cp>1832.628</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2673.8</hp>
+			<mp>1130.85</mp>
+			<cp>1871.66</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>2729.9</hp>
+			<mp>1155.6</mp>
+			<cp>1910.93</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>2786.34</hp>
+			<mp>1180.5</mp>
+			<cp>1950.438</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>2843.12</hp>
+			<mp>1205.55</mp>
+			<cp>1990.184</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>2900.24</hp>
+			<mp>1230.75</mp>
+			<cp>2030.168</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>2957.7</hp>
+			<mp>1256.1</mp>
+			<cp>2070.39</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3015.5</hp>
+			<mp>1281.6</mp>
+			<cp>2110.85</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3073.64</hp>
+			<mp>1307.25</mp>
+			<cp>2151.548</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3132.12</hp>
+			<mp>1333.05</mp>
+			<cp>2192.484</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3190.94</hp>
+			<mp>1359.0</mp>
+			<cp>2233.658</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3250.1</hp>
+			<mp>1385.1</mp>
+			<cp>2275.07</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3309.6</hp>
+			<mp>1411.35</mp>
+			<cp>2316.72</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3369.44</hp>
+			<mp>1437.75</mp>
+			<cp>2358.608</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3429.62</hp>
+			<mp>1464.3</mp>
+			<cp>2400.734</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3490.14</hp>
+			<mp>1491.0</mp>
+			<cp>2443.098</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3551.0</hp>
+			<mp>1517.85</mp>
+			<cp>2485.7</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3612.2</hp>
+			<mp>1544.85</mp>
+			<cp>2528.54</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>3673.74</hp>
+			<mp>1572.0</mp>
+			<cp>2571.618</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>3735.62</hp>
+			<mp>1599.3</mp>
+			<cp>2614.934</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>3797.84</hp>
+			<mp>1626.75</mp>
+			<cp>2658.488</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>3860.4</hp>
+			<mp>1654.35</mp>
+			<cp>2702.28</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>3923.3</hp>
+			<mp>1682.1</mp>
+			<cp>2746.31</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>3986.54</hp>
+			<mp>1710.0</mp>
+			<cp>2790.578</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4050.12</hp>
+			<mp>1738.05</mp>
+			<cp>2835.084</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4114.04</hp>
+			<mp>1766.25</mp>
+			<cp>2879.828</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4178.3</hp>
+			<mp>1794.6</mp>
+			<cp>2924.81</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4242.9</hp>
+			<mp>1823.1</mp>
+			<cp>2970.04</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4307.84</hp>
+			<mp>1851.75</mp>
+			<cp>3015.5</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4373.12</hp>
+			<mp>1880.55</mp>
+			<cp>3061.2</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4438.74</hp>
+			<mp>1909.5</mp>
+			<cp>3107.15</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>4504.7</hp>
+			<mp>1938.6</mp>
+			<cp>3153.33</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>4571</hp>
+			<mp>1967.85</mp>
+			<cp>3199.76</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>4637.64</hp>
+			<mp>1997.25</mp>
+			<cp>3246.348</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Scavenger.xml
+++ b/data/stats/chars/baseStats/Scavenger.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>54</classId>
-    <staticData>
-        <baseINT>20</baseINT>
-        <baseSTR>39</baseSTR>
-        <baseCON>45</baseCON>
-        <baseMEN>27</baseMEN>
-        <baseDEX>29</baseDEX>
-        <baseWIT>10</baseWIT>
-        <physicalAbnormalResist>15</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="108644" y="-173947" z="-400"/>
-            <node x="108678" y="-174002" z="-400"/>
-            <node x="108505" y="-173964" z="-400"/>
-            <node x="108512" y="-174026" z="-400"/>
-            <node x="108549" y="-174075" z="-400"/>
-            <node x="108576" y="-174122" z="-400"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>80</walk>
-            <run>131</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>80</baseBreath>
-        <baseSafeFall>180</baseSafeFall>
-        <collisionMale>
-            <radius>9.0</radius>
-            <height>18.0</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>5.0</radius>
-            <height>19.0</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>80.0</hp>
-            <mp>30.0</mp>
-            <cp>56.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>92.74</hp>
-            <mp>35.46</mp>
-            <cp>64.918</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>105.62</hp>
-            <mp>40.98</mp>
-            <cp>73.934</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>118.64</hp>
-            <mp>46.56</mp>
-            <cp>83.048</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>131.8</hp>
-            <mp>52.2</mp>
-            <cp>92.26</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>145.1</hp>
-            <mp>57.9</mp>
-            <cp>101.57</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>158.54</hp>
-            <mp>63.66</mp>
-            <cp>110.978</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>172.12</hp>
-            <mp>69.48</mp>
-            <cp>120.484</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>185.84</hp>
-            <mp>75.36</mp>
-            <cp>130.088</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>199.7</hp>
-            <mp>81.3</mp>
-            <cp>139.79</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>213.7</hp>
-            <mp>87.3</mp>
-            <cp>149.59</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>227.84</hp>
-            <mp>93.36</mp>
-            <cp>159.488</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>242.12</hp>
-            <mp>99.48</mp>
-            <cp>169.484</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>256.54</hp>
-            <mp>105.66</mp>
-            <cp>179.578</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>271.1</hp>
-            <mp>111.9</mp>
-            <cp>189.77</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>285.8</hp>
-            <mp>118.2</mp>
-            <cp>200.06</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>300.64</hp>
-            <mp>124.56</mp>
-            <cp>210.448</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>315.62</hp>
-            <mp>130.98</mp>
-            <cp>220.934</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>330.74</hp>
-            <mp>137.46</mp>
-            <cp>231.518</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>346.0</hp>
-            <mp>144.0</mp>
-            <cp>242.2</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>381.2</hp>
-            <mp>153.9</mp>
-            <cp>266.84</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>416.72</hp>
-            <mp>163.89</mp>
-            <cp>291.704</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>452.56</hp>
-            <mp>173.97</mp>
-            <cp>316.792</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>488.72</hp>
-            <mp>184.14</mp>
-            <cp>342.104</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>525.2</hp>
-            <mp>194.4</mp>
-            <cp>367.64</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>562.0</hp>
-            <mp>204.75</mp>
-            <cp>393.4</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>599.12</hp>
-            <mp>215.19</mp>
-            <cp>419.384</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>636.56</hp>
-            <mp>225.72</mp>
-            <cp>445.592</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>674.32</hp>
-            <mp>236.34</mp>
-            <cp>472.024</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>712.4</hp>
-            <mp>247.05</mp>
-            <cp>498.68</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>750.8</hp>
-            <mp>257.85</mp>
-            <cp>525.56</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>789.52</hp>
-            <mp>268.74</mp>
-            <cp>552.664</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>828.56</hp>
-            <mp>279.72</mp>
-            <cp>579.992</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>867.92</hp>
-            <mp>290.79</mp>
-            <cp>607.544</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>907.6</hp>
-            <mp>301.95</mp>
-            <cp>635.32</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>947.6</hp>
-            <mp>313.2</mp>
-            <cp>663.32</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>987.92</hp>
-            <mp>324.54</mp>
-            <cp>691.544</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1028.56</hp>
-            <mp>335.97</mp>
-            <cp>719.992</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1069.52</hp>
-            <mp>347.49</mp>
-            <cp>748.664</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1110.8</hp>
-            <mp>359.1</mp>
-            <cp>777.56</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1152.4</hp>
-            <mp>370.8</mp>
-            <cp>806.68</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1194.32</hp>
-            <mp>382.59</mp>
-            <cp>836.024</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1236.56</hp>
-            <mp>394.47</mp>
-            <cp>865.592</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1279.12</hp>
-            <mp>406.44</mp>
-            <cp>895.384</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1322.0</hp>
-            <mp>418.5</mp>
-            <cp>925.4</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1365.2</hp>
-            <mp>430.65</mp>
-            <cp>955.64</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1408.72</hp>
-            <mp>442.89</mp>
-            <cp>986.104</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1452.56</hp>
-            <mp>455.22</mp>
-            <cp>1016.792</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1496.72</hp>
-            <mp>467.64</mp>
-            <cp>1047.704</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1541.2</hp>
-            <mp>480.15</mp>
-            <cp>1078.84</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1586.0</hp>
-            <mp>492.75</mp>
-            <cp>1110.2</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1631.12</hp>
-            <mp>505.44</mp>
-            <cp>1141.784</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1676.56</hp>
-            <mp>518.22</mp>
-            <cp>1173.592</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1722.32</hp>
-            <mp>531.09</mp>
-            <cp>1205.624</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1768.4</hp>
-            <mp>544.05</mp>
-            <cp>1237.88</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1814.8</hp>
-            <mp>557.1</mp>
-            <cp>1270.36</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1861.52</hp>
-            <mp>570.24</mp>
-            <cp>1303.064</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1908.56</hp>
-            <mp>583.47</mp>
-            <cp>1335.992</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>1955.92</hp>
-            <mp>596.79</mp>
-            <cp>1369.144</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2003.6</hp>
-            <mp>610.2</mp>
-            <cp>1402.52</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2051.6</hp>
-            <mp>623.7</mp>
-            <cp>1436.12</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2099.92</hp>
-            <mp>637.29</mp>
-            <cp>1469.944</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2148.56</hp>
-            <mp>650.97</mp>
-            <cp>1503.992</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2197.52</hp>
-            <mp>664.74</mp>
-            <cp>1538.264</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2246.8</hp>
-            <mp>678.6</mp>
-            <cp>1572.76</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2296.4</hp>
-            <mp>692.55</mp>
-            <cp>1607.48</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2346.32</hp>
-            <mp>706.59</mp>
-            <cp>1642.424</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2396.56</hp>
-            <mp>720.72</mp>
-            <cp>1677.592</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2447.12</hp>
-            <mp>734.94</mp>
-            <cp>1712.984</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2498.0</hp>
-            <mp>749.25</mp>
-            <cp>1748.6</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2549.2</hp>
-            <mp>763.65</mp>
-            <cp>1784.44</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2600.72</hp>
-            <mp>778.14</mp>
-            <cp>1820.504</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2652.56</hp>
-            <mp>792.72</mp>
-            <cp>1856.792</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2704.72</hp>
-            <mp>807.39</mp>
-            <cp>1893.304</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2757.2</hp>
-            <mp>822.15</mp>
-            <cp>1930.04</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>2810.0</hp>
-            <mp>837.0</mp>
-            <cp>1967.0</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>2863.12</hp>
-            <mp>851.94</mp>
-            <cp>2004.184</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>2916.56</hp>
-            <mp>866.97</mp>
-            <cp>2041.592</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>2970.32</hp>
-            <mp>882.09</mp>
-            <cp>2079.224</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3024.4</hp>
-            <mp>897.3</mp>
-            <cp>2117.08</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3078.8</hp>
-            <mp>912.6</mp>
-            <cp>2155.16</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3133.52</hp>
-            <mp>927.99</mp>
-            <cp>2193.464</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3188.56</hp>
-            <mp>943.47</mp>
-            <cp>2231.992</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3243.92</hp>
-            <mp>959.04</mp>
-            <cp>2270.744</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3299.6</hp>
-            <mp>974.7</mp>
-            <cp>2309.72</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3355.6</hp>
-            <mp>990.45</mp>
-            <cp>2348.92</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3411.92</hp>
-            <mp>1006.29</mp>
-            <cp>2388.344</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3468.56</hp>
-            <mp>1022.22</mp>
-            <cp>2427.992</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3525.52</hp>
-            <mp>1038.24</mp>
-            <cp>2467.864</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3582.8</hp>
-            <mp>1054.35</mp>
-            <cp>2507.96</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>3640.4</hp>
-            <mp>1070.55</mp>
-            <cp>2548.28</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>54</classId>
+	<staticData>
+		<baseINT>20</baseINT>
+		<baseSTR>39</baseSTR>
+		<baseCON>45</baseCON>
+		<baseMEN>27</baseMEN>
+		<baseDEX>29</baseDEX>
+		<baseWIT>10</baseWIT>
+		<physicalAbnormalResist>15</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="108644" y="-173947" z="-400" />
+			<node x="108678" y="-174002" z="-400" />
+			<node x="108505" y="-173964" z="-400" />
+			<node x="108512" y="-174026" z="-400" />
+			<node x="108549" y="-174075" z="-400" />
+			<node x="108576" y="-174122" z="-400" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>80</walk>
+			<run>131</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>80</baseBreath>
+		<baseSafeFall>180</baseSafeFall>
+		<collisionMale>
+			<radius>9.0</radius>
+			<height>18.0</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>5.0</radius>
+			<height>19.0</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>80.0</hp>
+			<mp>30.0</mp>
+			<cp>56.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>92.74</hp>
+			<mp>35.46</mp>
+			<cp>64.918</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>105.62</hp>
+			<mp>40.98</mp>
+			<cp>73.934</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>118.64</hp>
+			<mp>46.56</mp>
+			<cp>83.048</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>131.8</hp>
+			<mp>52.2</mp>
+			<cp>92.26</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>145.1</hp>
+			<mp>57.9</mp>
+			<cp>101.57</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>158.54</hp>
+			<mp>63.66</mp>
+			<cp>110.978</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>172.12</hp>
+			<mp>69.48</mp>
+			<cp>120.484</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>185.84</hp>
+			<mp>75.36</mp>
+			<cp>130.088</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>199.7</hp>
+			<mp>81.3</mp>
+			<cp>139.79</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>213.7</hp>
+			<mp>87.3</mp>
+			<cp>149.59</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>227.84</hp>
+			<mp>93.36</mp>
+			<cp>159.488</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>242.12</hp>
+			<mp>99.48</mp>
+			<cp>169.484</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>256.54</hp>
+			<mp>105.66</mp>
+			<cp>179.578</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>271.1</hp>
+			<mp>111.9</mp>
+			<cp>189.77</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>285.8</hp>
+			<mp>118.2</mp>
+			<cp>200.06</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>300.64</hp>
+			<mp>124.56</mp>
+			<cp>210.448</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>315.62</hp>
+			<mp>130.98</mp>
+			<cp>220.934</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>330.74</hp>
+			<mp>137.46</mp>
+			<cp>231.518</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>346.0</hp>
+			<mp>144.0</mp>
+			<cp>242.2</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>381.2</hp>
+			<mp>153.9</mp>
+			<cp>266.84</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>416.72</hp>
+			<mp>163.89</mp>
+			<cp>291.704</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>452.56</hp>
+			<mp>173.97</mp>
+			<cp>316.792</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>488.72</hp>
+			<mp>184.14</mp>
+			<cp>342.104</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>525.2</hp>
+			<mp>194.4</mp>
+			<cp>367.64</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>562.0</hp>
+			<mp>204.75</mp>
+			<cp>393.4</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>599.12</hp>
+			<mp>215.19</mp>
+			<cp>419.384</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>636.56</hp>
+			<mp>225.72</mp>
+			<cp>445.592</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>674.32</hp>
+			<mp>236.34</mp>
+			<cp>472.024</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>712.4</hp>
+			<mp>247.05</mp>
+			<cp>498.68</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>750.8</hp>
+			<mp>257.85</mp>
+			<cp>525.56</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>789.52</hp>
+			<mp>268.74</mp>
+			<cp>552.664</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>828.56</hp>
+			<mp>279.72</mp>
+			<cp>579.992</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>867.92</hp>
+			<mp>290.79</mp>
+			<cp>607.544</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>907.6</hp>
+			<mp>301.95</mp>
+			<cp>635.32</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>947.6</hp>
+			<mp>313.2</mp>
+			<cp>663.32</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>987.92</hp>
+			<mp>324.54</mp>
+			<cp>691.544</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1028.56</hp>
+			<mp>335.97</mp>
+			<cp>719.992</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1069.52</hp>
+			<mp>347.49</mp>
+			<cp>748.664</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1110.8</hp>
+			<mp>359.1</mp>
+			<cp>777.56</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1152.4</hp>
+			<mp>370.8</mp>
+			<cp>806.68</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1194.32</hp>
+			<mp>382.59</mp>
+			<cp>836.024</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1236.56</hp>
+			<mp>394.47</mp>
+			<cp>865.592</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1279.12</hp>
+			<mp>406.44</mp>
+			<cp>895.384</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1322.0</hp>
+			<mp>418.5</mp>
+			<cp>925.4</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1365.2</hp>
+			<mp>430.65</mp>
+			<cp>955.64</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1408.72</hp>
+			<mp>442.89</mp>
+			<cp>986.104</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1452.56</hp>
+			<mp>455.22</mp>
+			<cp>1016.792</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1496.72</hp>
+			<mp>467.64</mp>
+			<cp>1047.704</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1541.2</hp>
+			<mp>480.15</mp>
+			<cp>1078.84</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1586.0</hp>
+			<mp>492.75</mp>
+			<cp>1110.2</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1631.12</hp>
+			<mp>505.44</mp>
+			<cp>1141.784</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1676.56</hp>
+			<mp>518.22</mp>
+			<cp>1173.592</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1722.32</hp>
+			<mp>531.09</mp>
+			<cp>1205.624</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1768.4</hp>
+			<mp>544.05</mp>
+			<cp>1237.88</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1814.8</hp>
+			<mp>557.1</mp>
+			<cp>1270.36</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1861.52</hp>
+			<mp>570.24</mp>
+			<cp>1303.064</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1908.56</hp>
+			<mp>583.47</mp>
+			<cp>1335.992</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1955.92</hp>
+			<mp>596.79</mp>
+			<cp>1369.144</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2003.6</hp>
+			<mp>610.2</mp>
+			<cp>1402.52</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2051.6</hp>
+			<mp>623.7</mp>
+			<cp>1436.12</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2099.92</hp>
+			<mp>637.29</mp>
+			<cp>1469.944</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2148.56</hp>
+			<mp>650.97</mp>
+			<cp>1503.992</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2197.52</hp>
+			<mp>664.74</mp>
+			<cp>1538.264</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2246.8</hp>
+			<mp>678.6</mp>
+			<cp>1572.76</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2296.4</hp>
+			<mp>692.55</mp>
+			<cp>1607.48</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2346.32</hp>
+			<mp>706.59</mp>
+			<cp>1642.424</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2396.56</hp>
+			<mp>720.72</mp>
+			<cp>1677.592</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2447.12</hp>
+			<mp>734.94</mp>
+			<cp>1712.984</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2498.0</hp>
+			<mp>749.25</mp>
+			<cp>1748.6</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2549.2</hp>
+			<mp>763.65</mp>
+			<cp>1784.44</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2600.72</hp>
+			<mp>778.14</mp>
+			<cp>1820.504</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2652.56</hp>
+			<mp>792.72</mp>
+			<cp>1856.792</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2704.72</hp>
+			<mp>807.39</mp>
+			<cp>1893.304</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2757.2</hp>
+			<mp>822.15</mp>
+			<cp>1930.04</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>2810.0</hp>
+			<mp>837.0</mp>
+			<cp>1967.0</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>2863.12</hp>
+			<mp>851.94</mp>
+			<cp>2004.184</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>2916.56</hp>
+			<mp>866.97</mp>
+			<cp>2041.592</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>2970.32</hp>
+			<mp>882.09</mp>
+			<cp>2079.224</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3024.4</hp>
+			<mp>897.3</mp>
+			<cp>2117.08</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3078.8</hp>
+			<mp>912.6</mp>
+			<cp>2155.16</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3133.52</hp>
+			<mp>927.99</mp>
+			<cp>2193.464</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3188.56</hp>
+			<mp>943.47</mp>
+			<cp>2231.992</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3243.92</hp>
+			<mp>959.04</mp>
+			<cp>2270.744</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3299.6</hp>
+			<mp>974.7</mp>
+			<cp>2309.72</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3355.6</hp>
+			<mp>990.45</mp>
+			<cp>2348.92</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3411.92</hp>
+			<mp>1006.29</mp>
+			<cp>2388.344</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3468.56</hp>
+			<mp>1022.22</mp>
+			<cp>2427.992</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3525.52</hp>
+			<mp>1038.24</mp>
+			<cp>2467.864</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3582.8</hp>
+			<mp>1054.35</mp>
+			<cp>2507.96</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3640.4</hp>
+			<mp>1070.55</mp>
+			<cp>2548.28</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>3698.32</hp>
+			<mp>1086.84</mp>
+			<cp>2588.824</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>3756.56</hp>
+			<mp>1103.22</mp>
+			<cp>2629.592</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>3815.12</hp>
+			<mp>1119.69</mp>
+			<cp>2670.584</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>3874.0</hp>
+			<mp>1136.25</mp>
+			<cp>2711.8</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>3933.2</hp>
+			<mp>1152.9</mp>
+			<cp>2753.24</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>3992.72</hp>
+			<mp>1169.64</mp>
+			<cp>2794.904</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4052.56</hp>
+			<mp>1186.47</mp>
+			<cp>2836.792</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4112.72</hp>
+			<mp>1203.39</mp>
+			<cp>2878.904</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4173.2</hp>
+			<mp>1220.4</mp>
+			<cp>2921.24</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4234</hp>
+			<mp>1237.5</mp>
+			<cp>2963.79</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4295.12</hp>
+			<mp>1254.69</mp>
+			<cp>3006.56</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4356.56</hp>
+			<mp>1271.97</mp>
+			<cp>3049.55</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4418.32</hp>
+			<mp>1289.34</mp>
+			<cp>3092.76</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>4480.4</hp>
+			<mp>1306.8</mp>
+			<cp>3136.2</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>4542.8</hp>
+			<mp>1324.35</mp>
+			<cp>3179.85</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>4605.52</hp>
+			<mp>1341.99</mp>
+			<cp>3223.864</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/ShillienElder.xml
+++ b/data/stats/chars/baseStats/ShillienElder.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>43</classId>
-    <staticData>
-        <baseINT>44</baseINT>
-        <baseSTR>23</baseSTR>
-        <baseCON>24</baseCON>
-        <baseMEN>37</baseMEN>
-        <baseDEX>23</baseDEX>
-        <baseWIT>19</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>15</magicAbnormalResist>
-        <creationPoints>
-            <node x="28295" y="11063" z="-4224"/>
-            <node x="28302" y="11008" z="-4224"/>
-            <node x="28377" y="10916" z="-4224"/>
-            <node x="28456" y="10997" z="-4224"/>
-            <node x="28461" y="11044" z="-4224"/>
-            <node x="28395" y="11127" z="-4224"/>
-        </creationPoints>
-        <basePAtk>3</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>15</chest>
-            <legs>8</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>85</walk>
-            <run>128</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>150</baseBreath>
-        <baseSafeFall>300</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>24</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.0</radius>
-            <height>23.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>106.0</hp>
-            <mp>40.0</mp>
-            <cp>95.4</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>121.47</hp>
-            <mp>47.28</mp>
-            <cp>109.323</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>137.11</hp>
-            <mp>54.64</mp>
-            <cp>123.399</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>152.92</hp>
-            <mp>62.08</mp>
-            <cp>137.628</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>168.9</hp>
-            <mp>69.6</mp>
-            <cp>152.01</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>185.05</hp>
-            <mp>77.2</mp>
-            <cp>166.545</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>201.37</hp>
-            <mp>84.88</mp>
-            <cp>181.233</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>217.86</hp>
-            <mp>92.64</mp>
-            <cp>196.074</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>234.52</hp>
-            <mp>100.48</mp>
-            <cp>211.068</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>251.35</hp>
-            <mp>108.4</mp>
-            <cp>226.215</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>268.35</hp>
-            <mp>116.4</mp>
-            <cp>241.515</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>285.52</hp>
-            <mp>124.48</mp>
-            <cp>256.968</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>302.86</hp>
-            <mp>132.64</mp>
-            <cp>272.574</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>320.37</hp>
-            <mp>140.88</mp>
-            <cp>288.333</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>338.05</hp>
-            <mp>149.2</mp>
-            <cp>304.245</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>355.9</hp>
-            <mp>157.6</mp>
-            <cp>320.31</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>373.92</hp>
-            <mp>166.08</mp>
-            <cp>336.528</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>392.11</hp>
-            <mp>174.64</mp>
-            <cp>352.899</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>410.47</hp>
-            <mp>183.28</mp>
-            <cp>369.423</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>429.0</hp>
-            <mp>192.0</mp>
-            <cp>386.1</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>465.3</hp>
-            <mp>205.2</mp>
-            <cp>418.77</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>501.93</hp>
-            <mp>218.52</mp>
-            <cp>451.737</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>538.89</hp>
-            <mp>231.96</mp>
-            <cp>485.001</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>576.18</hp>
-            <mp>245.52</mp>
-            <cp>518.562</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>613.8</hp>
-            <mp>259.2</mp>
-            <cp>552.42</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>651.75</hp>
-            <mp>273.0</mp>
-            <cp>586.575</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>690.03</hp>
-            <mp>286.92</mp>
-            <cp>621.027</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>728.64</hp>
-            <mp>300.96</mp>
-            <cp>655.776</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>767.58</hp>
-            <mp>315.12</mp>
-            <cp>690.822</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>806.85</hp>
-            <mp>329.4</mp>
-            <cp>726.165</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>846.45</hp>
-            <mp>343.8</mp>
-            <cp>761.805</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>886.38</hp>
-            <mp>358.32</mp>
-            <cp>797.742</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>926.64</hp>
-            <mp>372.96</mp>
-            <cp>833.976</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>967.23</hp>
-            <mp>387.72</mp>
-            <cp>870.507</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>1008.15</hp>
-            <mp>402.6</mp>
-            <cp>907.335</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>1049.4</hp>
-            <mp>417.6</mp>
-            <cp>944.46</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>1090.98</hp>
-            <mp>432.72</mp>
-            <cp>981.882</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1132.89</hp>
-            <mp>447.96</mp>
-            <cp>1019.601</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1175.13</hp>
-            <mp>463.32</mp>
-            <cp>1057.617</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1217.7</hp>
-            <mp>478.8</mp>
-            <cp>1095.93</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1272.3</hp>
-            <mp>504.8</mp>
-            <cp>1145.07</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1327.32</hp>
-            <mp>531.0</mp>
-            <cp>1194.588</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1382.76</hp>
-            <mp>557.4</mp>
-            <cp>1244.484</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1438.62</hp>
-            <mp>584.0</mp>
-            <cp>1294.758</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1494.9</hp>
-            <mp>610.8</mp>
-            <cp>1345.41</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1551.6</hp>
-            <mp>637.8</mp>
-            <cp>1396.44</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1608.72</hp>
-            <mp>665.0</mp>
-            <cp>1447.848</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1666.26</hp>
-            <mp>692.4</mp>
-            <cp>1499.634</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1724.22</hp>
-            <mp>720.0</mp>
-            <cp>1551.798</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1782.6</hp>
-            <mp>747.8</mp>
-            <cp>1604.34</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1841.4</hp>
-            <mp>775.8</mp>
-            <cp>1657.26</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1900.62</hp>
-            <mp>804.0</mp>
-            <cp>1710.558</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1960.26</hp>
-            <mp>832.4</mp>
-            <cp>1764.234</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>2020.32</hp>
-            <mp>861.0</mp>
-            <cp>1818.288</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>2080.8</hp>
-            <mp>889.8</mp>
-            <cp>1872.72</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>2141.7</hp>
-            <mp>918.8</mp>
-            <cp>1927.53</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>2203.02</hp>
-            <mp>948.0</mp>
-            <cp>1982.718</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2264.76</hp>
-            <mp>977.4</mp>
-            <cp>2038.284</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2326.92</hp>
-            <mp>1007.0</mp>
-            <cp>2094.228</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2389.5</hp>
-            <mp>1036.8</mp>
-            <cp>2150.55</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2452.5</hp>
-            <mp>1066.8</mp>
-            <cp>2207.25</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2515.92</hp>
-            <mp>1097.0</mp>
-            <cp>2264.328</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2579.76</hp>
-            <mp>1127.4</mp>
-            <cp>2321.784</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2644.02</hp>
-            <mp>1158.0</mp>
-            <cp>2379.618</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2708.7</hp>
-            <mp>1188.8</mp>
-            <cp>2437.83</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2773.8</hp>
-            <mp>1219.8</mp>
-            <cp>2496.42</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2839.32</hp>
-            <mp>1251.0</mp>
-            <cp>2555.388</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2905.26</hp>
-            <mp>1282.4</mp>
-            <cp>2614.734</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2971.62</hp>
-            <mp>1314.0</mp>
-            <cp>2674.458</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>3038.4</hp>
-            <mp>1345.8</mp>
-            <cp>2734.56</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>3105.6</hp>
-            <mp>1377.8</mp>
-            <cp>2795.04</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>3173.22</hp>
-            <mp>1410.0</mp>
-            <cp>2855.898</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>3241.26</hp>
-            <mp>1442.4</mp>
-            <cp>2917.134</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>3309.72</hp>
-            <mp>1475.0</mp>
-            <cp>2978.748</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3378.6</hp>
-            <mp>1507.8</mp>
-            <cp>3040.74</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3447.9</hp>
-            <mp>1540.8</mp>
-            <cp>3103.11</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3517.62</hp>
-            <mp>1574.0</mp>
-            <cp>3165.858</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3587.76</hp>
-            <mp>1607.4</mp>
-            <cp>3228.984</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3658.32</hp>
-            <mp>1641.0</mp>
-            <cp>3292.488</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3729.3</hp>
-            <mp>1674.8</mp>
-            <cp>3356.37</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3800.7</hp>
-            <mp>1708.8</mp>
-            <cp>3420.63</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3872.52</hp>
-            <mp>1743.0</mp>
-            <cp>3485.268</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3944.76</hp>
-            <mp>1777.4</mp>
-            <cp>3550.284</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>4017.42</hp>
-            <mp>1812.0</mp>
-            <cp>3615.678</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>4090.5</hp>
-            <mp>1846.8</mp>
-            <cp>3681.45</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>4164.0</hp>
-            <mp>1881.8</mp>
-            <cp>3747.6</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>4237.92</hp>
-            <mp>1917.0</mp>
-            <cp>3814.128</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>4312.26</hp>
-            <mp>1952.4</mp>
-            <cp>3881.034</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>4387.02</hp>
-            <mp>1988.0</mp>
-            <cp>3948.318</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4462.2</hp>
-            <mp>2023.8</mp>
-            <cp>4015.98</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4537.8</hp>
-            <mp>2059.8</mp>
-            <cp>4084.02</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>43</classId>
+	<staticData>
+		<baseINT>44</baseINT>
+		<baseSTR>23</baseSTR>
+		<baseCON>24</baseCON>
+		<baseMEN>37</baseMEN>
+		<baseDEX>23</baseDEX>
+		<baseWIT>19</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="28295" y="11063" z="-4224" />
+			<node x="28302" y="11008" z="-4224" />
+			<node x="28377" y="10916" z="-4224" />
+			<node x="28456" y="10997" z="-4224" />
+			<node x="28461" y="11044" z="-4224" />
+			<node x="28395" y="11127" z="-4224" />
+		</creationPoints>
+		<basePAtk>3</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>15</chest>
+			<legs>8</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>85</walk>
+			<run>128</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>300</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>106.0</hp>
+			<mp>40.0</mp>
+			<cp>95.4</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>121.47</hp>
+			<mp>47.28</mp>
+			<cp>109.323</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>137.11</hp>
+			<mp>54.64</mp>
+			<cp>123.399</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>152.92</hp>
+			<mp>62.08</mp>
+			<cp>137.628</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>168.9</hp>
+			<mp>69.6</mp>
+			<cp>152.01</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>185.05</hp>
+			<mp>77.2</mp>
+			<cp>166.545</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>201.37</hp>
+			<mp>84.88</mp>
+			<cp>181.233</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>217.86</hp>
+			<mp>92.64</mp>
+			<cp>196.074</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>234.52</hp>
+			<mp>100.48</mp>
+			<cp>211.068</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>251.35</hp>
+			<mp>108.4</mp>
+			<cp>226.215</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>268.35</hp>
+			<mp>116.4</mp>
+			<cp>241.515</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>285.52</hp>
+			<mp>124.48</mp>
+			<cp>256.968</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>302.86</hp>
+			<mp>132.64</mp>
+			<cp>272.574</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>320.37</hp>
+			<mp>140.88</mp>
+			<cp>288.333</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>338.05</hp>
+			<mp>149.2</mp>
+			<cp>304.245</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>355.9</hp>
+			<mp>157.6</mp>
+			<cp>320.31</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>373.92</hp>
+			<mp>166.08</mp>
+			<cp>336.528</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>392.11</hp>
+			<mp>174.64</mp>
+			<cp>352.899</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>410.47</hp>
+			<mp>183.28</mp>
+			<cp>369.423</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>429.0</hp>
+			<mp>192.0</mp>
+			<cp>386.1</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>465.3</hp>
+			<mp>205.2</mp>
+			<cp>418.77</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>501.93</hp>
+			<mp>218.52</mp>
+			<cp>451.737</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>538.89</hp>
+			<mp>231.96</mp>
+			<cp>485.001</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>576.18</hp>
+			<mp>245.52</mp>
+			<cp>518.562</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>613.8</hp>
+			<mp>259.2</mp>
+			<cp>552.42</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>651.75</hp>
+			<mp>273.0</mp>
+			<cp>586.575</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>690.03</hp>
+			<mp>286.92</mp>
+			<cp>621.027</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>728.64</hp>
+			<mp>300.96</mp>
+			<cp>655.776</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>767.58</hp>
+			<mp>315.12</mp>
+			<cp>690.822</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>806.85</hp>
+			<mp>329.4</mp>
+			<cp>726.165</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>846.45</hp>
+			<mp>343.8</mp>
+			<cp>761.805</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>886.38</hp>
+			<mp>358.32</mp>
+			<cp>797.742</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>926.64</hp>
+			<mp>372.96</mp>
+			<cp>833.976</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>967.23</hp>
+			<mp>387.72</mp>
+			<cp>870.507</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>1008.15</hp>
+			<mp>402.6</mp>
+			<cp>907.335</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>1049.4</hp>
+			<mp>417.6</mp>
+			<cp>944.46</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>1090.98</hp>
+			<mp>432.72</mp>
+			<cp>981.882</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1132.89</hp>
+			<mp>447.96</mp>
+			<cp>1019.601</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1175.13</hp>
+			<mp>463.32</mp>
+			<cp>1057.617</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1217.7</hp>
+			<mp>478.8</mp>
+			<cp>1095.93</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1272.3</hp>
+			<mp>504.8</mp>
+			<cp>1145.07</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1327.32</hp>
+			<mp>531.0</mp>
+			<cp>1194.588</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1382.76</hp>
+			<mp>557.4</mp>
+			<cp>1244.484</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1438.62</hp>
+			<mp>584.0</mp>
+			<cp>1294.758</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1494.9</hp>
+			<mp>610.8</mp>
+			<cp>1345.41</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1551.6</hp>
+			<mp>637.8</mp>
+			<cp>1396.44</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1608.72</hp>
+			<mp>665.0</mp>
+			<cp>1447.848</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1666.26</hp>
+			<mp>692.4</mp>
+			<cp>1499.634</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1724.22</hp>
+			<mp>720.0</mp>
+			<cp>1551.798</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1782.6</hp>
+			<mp>747.8</mp>
+			<cp>1604.34</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1841.4</hp>
+			<mp>775.8</mp>
+			<cp>1657.26</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1900.62</hp>
+			<mp>804.0</mp>
+			<cp>1710.558</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1960.26</hp>
+			<mp>832.4</mp>
+			<cp>1764.234</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>2020.32</hp>
+			<mp>861.0</mp>
+			<cp>1818.288</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>2080.8</hp>
+			<mp>889.8</mp>
+			<cp>1872.72</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>2141.7</hp>
+			<mp>918.8</mp>
+			<cp>1927.53</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2203.02</hp>
+			<mp>948.0</mp>
+			<cp>1982.718</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2264.76</hp>
+			<mp>977.4</mp>
+			<cp>2038.284</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2326.92</hp>
+			<mp>1007.0</mp>
+			<cp>2094.228</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2389.5</hp>
+			<mp>1036.8</mp>
+			<cp>2150.55</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2452.5</hp>
+			<mp>1066.8</mp>
+			<cp>2207.25</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2515.92</hp>
+			<mp>1097.0</mp>
+			<cp>2264.328</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2579.76</hp>
+			<mp>1127.4</mp>
+			<cp>2321.784</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2644.02</hp>
+			<mp>1158.0</mp>
+			<cp>2379.618</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2708.7</hp>
+			<mp>1188.8</mp>
+			<cp>2437.83</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2773.8</hp>
+			<mp>1219.8</mp>
+			<cp>2496.42</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2839.32</hp>
+			<mp>1251.0</mp>
+			<cp>2555.388</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2905.26</hp>
+			<mp>1282.4</mp>
+			<cp>2614.734</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2971.62</hp>
+			<mp>1314.0</mp>
+			<cp>2674.458</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>3038.4</hp>
+			<mp>1345.8</mp>
+			<cp>2734.56</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>3105.6</hp>
+			<mp>1377.8</mp>
+			<cp>2795.04</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>3173.22</hp>
+			<mp>1410.0</mp>
+			<cp>2855.898</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>3241.26</hp>
+			<mp>1442.4</mp>
+			<cp>2917.134</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3309.72</hp>
+			<mp>1475.0</mp>
+			<cp>2978.748</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3378.6</hp>
+			<mp>1507.8</mp>
+			<cp>3040.74</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3447.9</hp>
+			<mp>1540.8</mp>
+			<cp>3103.11</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3517.62</hp>
+			<mp>1574.0</mp>
+			<cp>3165.858</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3587.76</hp>
+			<mp>1607.4</mp>
+			<cp>3228.984</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3658.32</hp>
+			<mp>1641.0</mp>
+			<cp>3292.488</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3729.3</hp>
+			<mp>1674.8</mp>
+			<cp>3356.37</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3800.7</hp>
+			<mp>1708.8</mp>
+			<cp>3420.63</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3872.52</hp>
+			<mp>1743.0</mp>
+			<cp>3485.268</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3944.76</hp>
+			<mp>1777.4</mp>
+			<cp>3550.284</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>4017.42</hp>
+			<mp>1812.0</mp>
+			<cp>3615.678</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>4090.5</hp>
+			<mp>1846.8</mp>
+			<cp>3681.45</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>4164.0</hp>
+			<mp>1881.8</mp>
+			<cp>3747.6</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>4237.92</hp>
+			<mp>1917.0</mp>
+			<cp>3814.128</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4312.26</hp>
+			<mp>1952.4</mp>
+			<cp>3881.034</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4387.02</hp>
+			<mp>1988.0</mp>
+			<cp>3948.318</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4462.2</hp>
+			<mp>2023.8</mp>
+			<cp>4015.98</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4537.8</hp>
+			<mp>2059.8</mp>
+			<cp>4084.02</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4613.82</hp>
+			<mp>2096.0</mp>
+			<cp>4152.438</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4690.26</hp>
+			<mp>2132.4</mp>
+			<cp>4221.234</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4767.12</hp>
+			<mp>2169.0</mp>
+			<cp>4290.408</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4844.4</hp>
+			<mp>2205.8</mp>
+			<cp>4359.96</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4922.1</hp>
+			<mp>2242.8</mp>
+			<cp>4429.89</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>5000.22</hp>
+			<mp>2280.0</mp>
+			<cp>4500.198</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>5078.76</hp>
+			<mp>2317.4</mp>
+			<cp>4570.884</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>5157.72</hp>
+			<mp>2355.0</mp>
+			<cp>4641.948</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>5237.1</hp>
+			<mp>2392.8</mp>
+			<cp>4713.39</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>5316.9</hp>
+			<mp>2430.8</mp>
+			<cp>4785.22</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5397.12</hp>
+			<mp>2469</mp>
+			<cp>4857.42</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5477.76</hp>
+			<mp>2507.4</mp>
+			<cp>4930</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5558.82</hp>
+			<mp>2546</mp>
+			<cp>5002.97</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5640.3</hp>
+			<mp>2584.8</mp>
+			<cp>5076.31</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5722.2</hp>
+			<mp>2623.8</mp>
+			<cp>5150.04</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5804.52</hp>
+			<mp>2663</mp>
+			<cp>5224.068</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/ShillienKnight.xml
+++ b/data/stats/chars/baseStats/ShillienKnight.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>33</classId>
-    <staticData>
-        <baseINT>25</baseINT>
-        <baseSTR>41</baseSTR>
-        <baseCON>32</baseCON>
-        <baseMEN>26</baseMEN>
-        <baseDEX>34</baseDEX>
-        <baseWIT>12</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>15</magicAbnormalResist>
-        <creationPoints>
-            <node x="28295" y="11063" z="-4224"/>
-            <node x="28302" y="11008" z="-4224"/>
-            <node x="28377" y="10916" z="-4224"/>
-            <node x="28456" y="10997" z="-4224"/>
-            <node x="28461" y="11044" z="-4224"/>
-            <node x="28395" y="11127" z="-4224"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>85</walk>
-            <run>139</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>150</baseBreath>
-        <baseSafeFall>350</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>24</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.0</radius>
-            <height>23.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>94.0</hp>
-            <mp>30.0</mp>
-            <cp>56.4</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>107.65</hp>
-            <mp>35.46</mp>
-            <cp>64.59</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>121.45</hp>
-            <mp>40.98</mp>
-            <cp>72.87</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>135.4</hp>
-            <mp>46.56</mp>
-            <cp>81.24</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>149.5</hp>
-            <mp>52.2</mp>
-            <cp>89.7</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>163.75</hp>
-            <mp>57.9</mp>
-            <cp>98.25</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>178.15</hp>
-            <mp>63.66</mp>
-            <cp>106.89</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>192.7</hp>
-            <mp>69.48</mp>
-            <cp>115.62</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>207.4</hp>
-            <mp>75.36</mp>
-            <cp>124.44</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>222.25</hp>
-            <mp>81.3</mp>
-            <cp>133.35</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>237.25</hp>
-            <mp>87.3</mp>
-            <cp>142.35</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>252.4</hp>
-            <mp>93.36</mp>
-            <cp>151.44</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>267.7</hp>
-            <mp>99.48</mp>
-            <cp>160.62</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>283.15</hp>
-            <mp>105.66</mp>
-            <cp>169.89</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>298.75</hp>
-            <mp>111.9</mp>
-            <cp>179.25</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>314.5</hp>
-            <mp>118.2</mp>
-            <cp>188.7</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>330.4</hp>
-            <mp>124.56</mp>
-            <cp>198.24</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>346.45</hp>
-            <mp>130.98</mp>
-            <cp>207.87</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>362.65</hp>
-            <mp>137.46</mp>
-            <cp>217.59</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>379.0</hp>
-            <mp>144.0</mp>
-            <cp>227.4</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>414.2</hp>
-            <mp>153.9</mp>
-            <cp>248.52</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>449.72</hp>
-            <mp>163.89</mp>
-            <cp>269.832</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>485.56</hp>
-            <mp>173.97</mp>
-            <cp>291.336</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>521.72</hp>
-            <mp>184.14</mp>
-            <cp>313.032</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>558.2</hp>
-            <mp>194.4</mp>
-            <cp>334.92</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>595.0</hp>
-            <mp>204.75</mp>
-            <cp>357.0</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>632.12</hp>
-            <mp>215.19</mp>
-            <cp>379.272</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>669.56</hp>
-            <mp>225.72</mp>
-            <cp>401.736</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>707.32</hp>
-            <mp>236.34</mp>
-            <cp>424.392</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>745.4</hp>
-            <mp>247.05</mp>
-            <cp>447.24</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>783.8</hp>
-            <mp>257.85</mp>
-            <cp>470.28</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>822.52</hp>
-            <mp>268.74</mp>
-            <cp>493.512</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>861.56</hp>
-            <mp>279.72</mp>
-            <cp>516.936</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>900.92</hp>
-            <mp>290.79</mp>
-            <cp>540.552</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>940.6</hp>
-            <mp>301.95</mp>
-            <cp>564.36</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>980.6</hp>
-            <mp>313.2</mp>
-            <cp>588.36</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>1020.92</hp>
-            <mp>324.54</mp>
-            <cp>612.552</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1061.56</hp>
-            <mp>335.97</mp>
-            <cp>636.936</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1102.52</hp>
-            <mp>347.49</mp>
-            <cp>661.512</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1143.8</hp>
-            <mp>359.1</mp>
-            <cp>686.28</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1198.4</hp>
-            <mp>378.6</mp>
-            <cp>719.04</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1253.42</hp>
-            <mp>398.25</mp>
-            <cp>752.052</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1308.86</hp>
-            <mp>418.05</mp>
-            <cp>785.316</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1364.72</hp>
-            <mp>438.0</mp>
-            <cp>818.832</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1421.0</hp>
-            <mp>458.1</mp>
-            <cp>852.6</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1477.7</hp>
-            <mp>478.35</mp>
-            <cp>886.62</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1534.82</hp>
-            <mp>498.75</mp>
-            <cp>920.892</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1592.36</hp>
-            <mp>519.3</mp>
-            <cp>955.416</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1650.32</hp>
-            <mp>540.0</mp>
-            <cp>990.192</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1708.7</hp>
-            <mp>560.85</mp>
-            <cp>1025.22</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1767.5</hp>
-            <mp>581.85</mp>
-            <cp>1060.5</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1826.72</hp>
-            <mp>603.0</mp>
-            <cp>1096.032</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1886.36</hp>
-            <mp>624.3</mp>
-            <cp>1131.816</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1946.42</hp>
-            <mp>645.75</mp>
-            <cp>1167.852</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>2006.9</hp>
-            <mp>667.35</mp>
-            <cp>1204.14</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>2067.8</hp>
-            <mp>689.1</mp>
-            <cp>1240.68</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>2129.12</hp>
-            <mp>711.0</mp>
-            <cp>1277.472</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2190.86</hp>
-            <mp>733.05</mp>
-            <cp>1314.516</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2253.02</hp>
-            <mp>755.25</mp>
-            <cp>1351.812</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2315.6</hp>
-            <mp>777.6</mp>
-            <cp>1389.36</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2378.6</hp>
-            <mp>800.1</mp>
-            <cp>1427.16</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2442.02</hp>
-            <mp>822.75</mp>
-            <cp>1465.212</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2505.86</hp>
-            <mp>845.55</mp>
-            <cp>1503.516</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2570.12</hp>
-            <mp>868.5</mp>
-            <cp>1542.072</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2634.8</hp>
-            <mp>891.6</mp>
-            <cp>1580.88</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2699.9</hp>
-            <mp>914.85</mp>
-            <cp>1619.94</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2765.42</hp>
-            <mp>938.25</mp>
-            <cp>1659.252</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2831.36</hp>
-            <mp>961.8</mp>
-            <cp>1698.816</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2897.72</hp>
-            <mp>985.5</mp>
-            <cp>1738.632</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2964.5</hp>
-            <mp>1009.35</mp>
-            <cp>1778.7</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>3031.7</hp>
-            <mp>1033.35</mp>
-            <cp>1819.02</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>3099.32</hp>
-            <mp>1057.5</mp>
-            <cp>1859.592</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>3167.36</hp>
-            <mp>1081.8</mp>
-            <cp>1900.416</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>3235.82</hp>
-            <mp>1106.25</mp>
-            <cp>1941.492</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3304.7</hp>
-            <mp>1130.85</mp>
-            <cp>1982.82</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3374.0</hp>
-            <mp>1155.6</mp>
-            <cp>2024.4</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3443.72</hp>
-            <mp>1180.5</mp>
-            <cp>2066.232</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3513.86</hp>
-            <mp>1205.55</mp>
-            <cp>2108.316</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3584.42</hp>
-            <mp>1230.75</mp>
-            <cp>2150.652</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3655.4</hp>
-            <mp>1256.1</mp>
-            <cp>2193.24</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3726.8</hp>
-            <mp>1281.6</mp>
-            <cp>2236.08</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3798.62</hp>
-            <mp>1307.25</mp>
-            <cp>2279.172</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3870.86</hp>
-            <mp>1333.05</mp>
-            <cp>2322.516</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3943.52</hp>
-            <mp>1359.0</mp>
-            <cp>2366.112</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>4016.6</hp>
-            <mp>1385.1</mp>
-            <cp>2409.96</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>4090.1</hp>
-            <mp>1411.35</mp>
-            <cp>2454.06</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>4164.02</hp>
-            <mp>1437.75</mp>
-            <cp>2498.412</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>4238.36</hp>
-            <mp>1464.3</mp>
-            <cp>2543.016</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>4313.12</hp>
-            <mp>1491.0</mp>
-            <cp>2587.872</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4388.3</hp>
-            <mp>1517.85</mp>
-            <cp>2632.98</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4463.9</hp>
-            <mp>1544.85</mp>
-            <cp>2678.34</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>33</classId>
+	<staticData>
+		<baseINT>25</baseINT>
+		<baseSTR>41</baseSTR>
+		<baseCON>32</baseCON>
+		<baseMEN>26</baseMEN>
+		<baseDEX>34</baseDEX>
+		<baseWIT>12</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="28295" y="11063" z="-4224" />
+			<node x="28302" y="11008" z="-4224" />
+			<node x="28377" y="10916" z="-4224" />
+			<node x="28456" y="10997" z="-4224" />
+			<node x="28461" y="11044" z="-4224" />
+			<node x="28395" y="11127" z="-4224" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>85</walk>
+			<run>139</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>350</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>94.0</hp>
+			<mp>30.0</mp>
+			<cp>56.4</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>107.65</hp>
+			<mp>35.46</mp>
+			<cp>64.59</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>121.45</hp>
+			<mp>40.98</mp>
+			<cp>72.87</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>135.4</hp>
+			<mp>46.56</mp>
+			<cp>81.24</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>149.5</hp>
+			<mp>52.2</mp>
+			<cp>89.7</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>163.75</hp>
+			<mp>57.9</mp>
+			<cp>98.25</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>178.15</hp>
+			<mp>63.66</mp>
+			<cp>106.89</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>192.7</hp>
+			<mp>69.48</mp>
+			<cp>115.62</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>207.4</hp>
+			<mp>75.36</mp>
+			<cp>124.44</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>222.25</hp>
+			<mp>81.3</mp>
+			<cp>133.35</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>237.25</hp>
+			<mp>87.3</mp>
+			<cp>142.35</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>252.4</hp>
+			<mp>93.36</mp>
+			<cp>151.44</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>267.7</hp>
+			<mp>99.48</mp>
+			<cp>160.62</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>283.15</hp>
+			<mp>105.66</mp>
+			<cp>169.89</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>298.75</hp>
+			<mp>111.9</mp>
+			<cp>179.25</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>314.5</hp>
+			<mp>118.2</mp>
+			<cp>188.7</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>330.4</hp>
+			<mp>124.56</mp>
+			<cp>198.24</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>346.45</hp>
+			<mp>130.98</mp>
+			<cp>207.87</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>362.65</hp>
+			<mp>137.46</mp>
+			<cp>217.59</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>379.0</hp>
+			<mp>144.0</mp>
+			<cp>227.4</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>414.2</hp>
+			<mp>153.9</mp>
+			<cp>248.52</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>449.72</hp>
+			<mp>163.89</mp>
+			<cp>269.832</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>485.56</hp>
+			<mp>173.97</mp>
+			<cp>291.336</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>521.72</hp>
+			<mp>184.14</mp>
+			<cp>313.032</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>558.2</hp>
+			<mp>194.4</mp>
+			<cp>334.92</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>595.0</hp>
+			<mp>204.75</mp>
+			<cp>357.0</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>632.12</hp>
+			<mp>215.19</mp>
+			<cp>379.272</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>669.56</hp>
+			<mp>225.72</mp>
+			<cp>401.736</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>707.32</hp>
+			<mp>236.34</mp>
+			<cp>424.392</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>745.4</hp>
+			<mp>247.05</mp>
+			<cp>447.24</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>783.8</hp>
+			<mp>257.85</mp>
+			<cp>470.28</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>822.52</hp>
+			<mp>268.74</mp>
+			<cp>493.512</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>861.56</hp>
+			<mp>279.72</mp>
+			<cp>516.936</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>900.92</hp>
+			<mp>290.79</mp>
+			<cp>540.552</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>940.6</hp>
+			<mp>301.95</mp>
+			<cp>564.36</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>980.6</hp>
+			<mp>313.2</mp>
+			<cp>588.36</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>1020.92</hp>
+			<mp>324.54</mp>
+			<cp>612.552</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1061.56</hp>
+			<mp>335.97</mp>
+			<cp>636.936</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1102.52</hp>
+			<mp>347.49</mp>
+			<cp>661.512</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1143.8</hp>
+			<mp>359.1</mp>
+			<cp>686.28</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1198.4</hp>
+			<mp>378.6</mp>
+			<cp>719.04</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1253.42</hp>
+			<mp>398.25</mp>
+			<cp>752.052</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1308.86</hp>
+			<mp>418.05</mp>
+			<cp>785.316</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1364.72</hp>
+			<mp>438.0</mp>
+			<cp>818.832</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1421.0</hp>
+			<mp>458.1</mp>
+			<cp>852.6</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1477.7</hp>
+			<mp>478.35</mp>
+			<cp>886.62</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1534.82</hp>
+			<mp>498.75</mp>
+			<cp>920.892</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1592.36</hp>
+			<mp>519.3</mp>
+			<cp>955.416</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1650.32</hp>
+			<mp>540.0</mp>
+			<cp>990.192</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1708.7</hp>
+			<mp>560.85</mp>
+			<cp>1025.22</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1767.5</hp>
+			<mp>581.85</mp>
+			<cp>1060.5</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1826.72</hp>
+			<mp>603.0</mp>
+			<cp>1096.032</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1886.36</hp>
+			<mp>624.3</mp>
+			<cp>1131.816</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1946.42</hp>
+			<mp>645.75</mp>
+			<cp>1167.852</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>2006.9</hp>
+			<mp>667.35</mp>
+			<cp>1204.14</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>2067.8</hp>
+			<mp>689.1</mp>
+			<cp>1240.68</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2129.12</hp>
+			<mp>711.0</mp>
+			<cp>1277.472</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2190.86</hp>
+			<mp>733.05</mp>
+			<cp>1314.516</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2253.02</hp>
+			<mp>755.25</mp>
+			<cp>1351.812</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2315.6</hp>
+			<mp>777.6</mp>
+			<cp>1389.36</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2378.6</hp>
+			<mp>800.1</mp>
+			<cp>1427.16</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2442.02</hp>
+			<mp>822.75</mp>
+			<cp>1465.212</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2505.86</hp>
+			<mp>845.55</mp>
+			<cp>1503.516</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2570.12</hp>
+			<mp>868.5</mp>
+			<cp>1542.072</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2634.8</hp>
+			<mp>891.6</mp>
+			<cp>1580.88</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2699.9</hp>
+			<mp>914.85</mp>
+			<cp>1619.94</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2765.42</hp>
+			<mp>938.25</mp>
+			<cp>1659.252</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2831.36</hp>
+			<mp>961.8</mp>
+			<cp>1698.816</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2897.72</hp>
+			<mp>985.5</mp>
+			<cp>1738.632</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2964.5</hp>
+			<mp>1009.35</mp>
+			<cp>1778.7</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>3031.7</hp>
+			<mp>1033.35</mp>
+			<cp>1819.02</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>3099.32</hp>
+			<mp>1057.5</mp>
+			<cp>1859.592</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>3167.36</hp>
+			<mp>1081.8</mp>
+			<cp>1900.416</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3235.82</hp>
+			<mp>1106.25</mp>
+			<cp>1941.492</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3304.7</hp>
+			<mp>1130.85</mp>
+			<cp>1982.82</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3374.0</hp>
+			<mp>1155.6</mp>
+			<cp>2024.4</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3443.72</hp>
+			<mp>1180.5</mp>
+			<cp>2066.232</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3513.86</hp>
+			<mp>1205.55</mp>
+			<cp>2108.316</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3584.42</hp>
+			<mp>1230.75</mp>
+			<cp>2150.652</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3655.4</hp>
+			<mp>1256.1</mp>
+			<cp>2193.24</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3726.8</hp>
+			<mp>1281.6</mp>
+			<cp>2236.08</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3798.62</hp>
+			<mp>1307.25</mp>
+			<cp>2279.172</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3870.86</hp>
+			<mp>1333.05</mp>
+			<cp>2322.516</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3943.52</hp>
+			<mp>1359.0</mp>
+			<cp>2366.112</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>4016.6</hp>
+			<mp>1385.1</mp>
+			<cp>2409.96</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>4090.1</hp>
+			<mp>1411.35</mp>
+			<cp>2454.06</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>4164.02</hp>
+			<mp>1437.75</mp>
+			<cp>2498.412</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4238.36</hp>
+			<mp>1464.3</mp>
+			<cp>2543.016</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4313.12</hp>
+			<mp>1491.0</mp>
+			<cp>2587.872</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4388.3</hp>
+			<mp>1517.85</mp>
+			<cp>2632.98</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4463.9</hp>
+			<mp>1544.85</mp>
+			<cp>2678.34</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4539.92</hp>
+			<mp>1572.0</mp>
+			<cp>2723.952</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4616.36</hp>
+			<mp>1599.3</mp>
+			<cp>2769.816</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4693.22</hp>
+			<mp>1626.75</mp>
+			<cp>2815.932</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4770.5</hp>
+			<mp>1654.35</mp>
+			<cp>2862.3</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4848.2</hp>
+			<mp>1682.1</mp>
+			<cp>2908.92</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4926.32</hp>
+			<mp>1710.0</mp>
+			<cp>2955.792</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>5004.86</hp>
+			<mp>1738.05</mp>
+			<cp>3002.916</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>5083.82</hp>
+			<mp>1766.25</mp>
+			<cp>3050.292</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>5163.2</hp>
+			<mp>1794.6</mp>
+			<cp>3097.92</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>5243</hp>
+			<mp>1823.1</mp>
+			<cp>3145.79</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5323.22</hp>
+			<mp>1851.75</mp>
+			<cp>3193.92</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5403.86</hp>
+			<mp>1880.55</mp>
+			<cp>3242.3</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5484.92</hp>
+			<mp>1909.5</mp>
+			<cp>3290.92</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5566.4</hp>
+			<mp>1938.6</mp>
+			<cp>3339.8</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5648.3</hp>
+			<mp>1967.85</mp>
+			<cp>3388.92</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5730.62</hp>
+			<mp>1997.25</mp>
+			<cp>3438.372</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/ShillienOracle.xml
+++ b/data/stats/chars/baseStats/ShillienOracle.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>42</classId>
-    <staticData>
-        <baseINT>44</baseINT>
-        <baseSTR>23</baseSTR>
-        <baseCON>24</baseCON>
-        <baseMEN>37</baseMEN>
-        <baseDEX>23</baseDEX>
-        <baseWIT>19</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>15</magicAbnormalResist>
-        <creationPoints>
-            <node x="28295" y="11063" z="-4224"/>
-            <node x="28302" y="11008" z="-4224"/>
-            <node x="28377" y="10916" z="-4224"/>
-            <node x="28456" y="10997" z="-4224"/>
-            <node x="28461" y="11044" z="-4224"/>
-            <node x="28395" y="11127" z="-4224"/>
-        </creationPoints>
-        <basePAtk>3</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>15</chest>
-            <legs>8</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>85</walk>
-            <run>128</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>150</baseBreath>
-        <baseSafeFall>300</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>24</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.0</radius>
-            <height>23.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>106.0</hp>
-            <mp>40.0</mp>
-            <cp>53.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>121.47</hp>
-            <mp>47.28</mp>
-            <cp>60.735</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>137.11</hp>
-            <mp>54.64</mp>
-            <cp>68.555</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>152.92</hp>
-            <mp>62.08</mp>
-            <cp>76.46</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>168.9</hp>
-            <mp>69.6</mp>
-            <cp>84.45</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>185.05</hp>
-            <mp>77.2</mp>
-            <cp>92.525</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>201.37</hp>
-            <mp>84.88</mp>
-            <cp>100.685</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>217.86</hp>
-            <mp>92.64</mp>
-            <cp>108.93</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>234.52</hp>
-            <mp>100.48</mp>
-            <cp>117.26</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>251.35</hp>
-            <mp>108.4</mp>
-            <cp>125.675</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>268.35</hp>
-            <mp>116.4</mp>
-            <cp>134.175</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>285.52</hp>
-            <mp>124.48</mp>
-            <cp>142.76</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>302.86</hp>
-            <mp>132.64</mp>
-            <cp>151.43</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>320.37</hp>
-            <mp>140.88</mp>
-            <cp>160.185</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>338.05</hp>
-            <mp>149.2</mp>
-            <cp>169.025</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>355.9</hp>
-            <mp>157.6</mp>
-            <cp>177.95</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>373.92</hp>
-            <mp>166.08</mp>
-            <cp>186.96</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>392.11</hp>
-            <mp>174.64</mp>
-            <cp>196.055</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>410.47</hp>
-            <mp>183.28</mp>
-            <cp>205.235</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>429.0</hp>
-            <mp>192.0</mp>
-            <cp>214.5</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>465.3</hp>
-            <mp>205.2</mp>
-            <cp>232.65</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>501.93</hp>
-            <mp>218.52</mp>
-            <cp>250.965</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>538.89</hp>
-            <mp>231.96</mp>
-            <cp>269.445</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>576.18</hp>
-            <mp>245.52</mp>
-            <cp>288.09</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>613.8</hp>
-            <mp>259.2</mp>
-            <cp>306.9</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>651.75</hp>
-            <mp>273.0</mp>
-            <cp>325.875</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>690.03</hp>
-            <mp>286.92</mp>
-            <cp>345.015</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>728.64</hp>
-            <mp>300.96</mp>
-            <cp>364.32</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>767.58</hp>
-            <mp>315.12</mp>
-            <cp>383.79</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>806.85</hp>
-            <mp>329.4</mp>
-            <cp>403.425</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>846.45</hp>
-            <mp>343.8</mp>
-            <cp>423.225</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>886.38</hp>
-            <mp>358.32</mp>
-            <cp>443.19</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>926.64</hp>
-            <mp>372.96</mp>
-            <cp>463.32</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>967.23</hp>
-            <mp>387.72</mp>
-            <cp>483.615</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>1008.15</hp>
-            <mp>402.6</mp>
-            <cp>504.075</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>1049.4</hp>
-            <mp>417.6</mp>
-            <cp>524.7</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>1090.98</hp>
-            <mp>432.72</mp>
-            <cp>545.49</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1132.89</hp>
-            <mp>447.96</mp>
-            <cp>566.445</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1175.13</hp>
-            <mp>463.32</mp>
-            <cp>587.565</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1217.7</hp>
-            <mp>478.8</mp>
-            <cp>608.85</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1260.6</hp>
-            <mp>494.4</mp>
-            <cp>630.3</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1303.83</hp>
-            <mp>510.12</mp>
-            <cp>651.915</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1347.39</hp>
-            <mp>525.96</mp>
-            <cp>673.695</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1391.28</hp>
-            <mp>541.92</mp>
-            <cp>695.64</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1435.5</hp>
-            <mp>558.0</mp>
-            <cp>717.75</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1480.05</hp>
-            <mp>574.2</mp>
-            <cp>740.025</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1524.93</hp>
-            <mp>590.52</mp>
-            <cp>762.465</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1570.14</hp>
-            <mp>606.96</mp>
-            <cp>785.07</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1615.68</hp>
-            <mp>623.52</mp>
-            <cp>807.84</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1661.55</hp>
-            <mp>640.2</mp>
-            <cp>830.775</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1707.75</hp>
-            <mp>657.0</mp>
-            <cp>853.875</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1754.28</hp>
-            <mp>673.92</mp>
-            <cp>877.14</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1801.14</hp>
-            <mp>690.96</mp>
-            <cp>900.57</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1848.33</hp>
-            <mp>708.12</mp>
-            <cp>924.165</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1895.85</hp>
-            <mp>725.4</mp>
-            <cp>947.925</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1943.7</hp>
-            <mp>742.8</mp>
-            <cp>971.85</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1991.88</hp>
-            <mp>760.32</mp>
-            <cp>995.94</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2040.39</hp>
-            <mp>777.96</mp>
-            <cp>1020.195</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2089.23</hp>
-            <mp>795.72</mp>
-            <cp>1044.615</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2138.4</hp>
-            <mp>813.6</mp>
-            <cp>1069.2</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2187.9</hp>
-            <mp>831.6</mp>
-            <cp>1093.95</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2237.73</hp>
-            <mp>849.72</mp>
-            <cp>1118.865</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2287.89</hp>
-            <mp>867.96</mp>
-            <cp>1143.945</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2338.38</hp>
-            <mp>886.32</mp>
-            <cp>1169.19</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2389.2</hp>
-            <mp>904.8</mp>
-            <cp>1194.6</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2440.35</hp>
-            <mp>923.4</mp>
-            <cp>1220.175</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2491.83</hp>
-            <mp>942.12</mp>
-            <cp>1245.915</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2543.64</hp>
-            <mp>960.96</mp>
-            <cp>1271.82</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2595.78</hp>
-            <mp>979.92</mp>
-            <cp>1297.89</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2648.25</hp>
-            <mp>999.0</mp>
-            <cp>1324.125</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2701.05</hp>
-            <mp>1018.2</mp>
-            <cp>1350.525</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2754.18</hp>
-            <mp>1037.52</mp>
-            <cp>1377.09</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2807.64</hp>
-            <mp>1056.96</mp>
-            <cp>1403.82</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2861.43</hp>
-            <mp>1076.52</mp>
-            <cp>1430.715</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2915.55</hp>
-            <mp>1096.2</mp>
-            <cp>1457.775</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>2970.0</hp>
-            <mp>1116.0</mp>
-            <cp>1485.0</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3024.78</hp>
-            <mp>1135.92</mp>
-            <cp>1512.39</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3079.89</hp>
-            <mp>1155.96</mp>
-            <cp>1539.945</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3135.33</hp>
-            <mp>1176.12</mp>
-            <cp>1567.665</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3191.1</hp>
-            <mp>1196.4</mp>
-            <cp>1595.55</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3247.2</hp>
-            <mp>1216.8</mp>
-            <cp>1623.6</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3303.63</hp>
-            <mp>1237.32</mp>
-            <cp>1651.815</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3360.39</hp>
-            <mp>1257.96</mp>
-            <cp>1680.195</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3417.48</hp>
-            <mp>1278.72</mp>
-            <cp>1708.74</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3474.9</hp>
-            <mp>1299.6</mp>
-            <cp>1737.45</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3532.65</hp>
-            <mp>1320.6</mp>
-            <cp>1766.325</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3590.73</hp>
-            <mp>1341.72</mp>
-            <cp>1795.365</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3649.14</hp>
-            <mp>1362.96</mp>
-            <cp>1824.57</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3707.88</hp>
-            <mp>1384.32</mp>
-            <cp>1853.94</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3766.95</hp>
-            <mp>1405.8</mp>
-            <cp>1883.475</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>3826.35</hp>
-            <mp>1427.4</mp>
-            <cp>1913.175</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>42</classId>
+	<staticData>
+		<baseINT>44</baseINT>
+		<baseSTR>23</baseSTR>
+		<baseCON>24</baseCON>
+		<baseMEN>37</baseMEN>
+		<baseDEX>23</baseDEX>
+		<baseWIT>19</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="28295" y="11063" z="-4224" />
+			<node x="28302" y="11008" z="-4224" />
+			<node x="28377" y="10916" z="-4224" />
+			<node x="28456" y="10997" z="-4224" />
+			<node x="28461" y="11044" z="-4224" />
+			<node x="28395" y="11127" z="-4224" />
+		</creationPoints>
+		<basePAtk>3</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>15</chest>
+			<legs>8</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>85</walk>
+			<run>128</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>300</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>106.0</hp>
+			<mp>40.0</mp>
+			<cp>53.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>121.47</hp>
+			<mp>47.28</mp>
+			<cp>60.735</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>137.11</hp>
+			<mp>54.64</mp>
+			<cp>68.555</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>152.92</hp>
+			<mp>62.08</mp>
+			<cp>76.46</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>168.9</hp>
+			<mp>69.6</mp>
+			<cp>84.45</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>185.05</hp>
+			<mp>77.2</mp>
+			<cp>92.525</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>201.37</hp>
+			<mp>84.88</mp>
+			<cp>100.685</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>217.86</hp>
+			<mp>92.64</mp>
+			<cp>108.93</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>234.52</hp>
+			<mp>100.48</mp>
+			<cp>117.26</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>251.35</hp>
+			<mp>108.4</mp>
+			<cp>125.675</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>268.35</hp>
+			<mp>116.4</mp>
+			<cp>134.175</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>285.52</hp>
+			<mp>124.48</mp>
+			<cp>142.76</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>302.86</hp>
+			<mp>132.64</mp>
+			<cp>151.43</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>320.37</hp>
+			<mp>140.88</mp>
+			<cp>160.185</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>338.05</hp>
+			<mp>149.2</mp>
+			<cp>169.025</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>355.9</hp>
+			<mp>157.6</mp>
+			<cp>177.95</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>373.92</hp>
+			<mp>166.08</mp>
+			<cp>186.96</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>392.11</hp>
+			<mp>174.64</mp>
+			<cp>196.055</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>410.47</hp>
+			<mp>183.28</mp>
+			<cp>205.235</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>429.0</hp>
+			<mp>192.0</mp>
+			<cp>214.5</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>465.3</hp>
+			<mp>205.2</mp>
+			<cp>232.65</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>501.93</hp>
+			<mp>218.52</mp>
+			<cp>250.965</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>538.89</hp>
+			<mp>231.96</mp>
+			<cp>269.445</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>576.18</hp>
+			<mp>245.52</mp>
+			<cp>288.09</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>613.8</hp>
+			<mp>259.2</mp>
+			<cp>306.9</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>651.75</hp>
+			<mp>273.0</mp>
+			<cp>325.875</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>690.03</hp>
+			<mp>286.92</mp>
+			<cp>345.015</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>728.64</hp>
+			<mp>300.96</mp>
+			<cp>364.32</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>767.58</hp>
+			<mp>315.12</mp>
+			<cp>383.79</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>806.85</hp>
+			<mp>329.4</mp>
+			<cp>403.425</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>846.45</hp>
+			<mp>343.8</mp>
+			<cp>423.225</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>886.38</hp>
+			<mp>358.32</mp>
+			<cp>443.19</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>926.64</hp>
+			<mp>372.96</mp>
+			<cp>463.32</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>967.23</hp>
+			<mp>387.72</mp>
+			<cp>483.615</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>1008.15</hp>
+			<mp>402.6</mp>
+			<cp>504.075</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>1049.4</hp>
+			<mp>417.6</mp>
+			<cp>524.7</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>1090.98</hp>
+			<mp>432.72</mp>
+			<cp>545.49</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1132.89</hp>
+			<mp>447.96</mp>
+			<cp>566.445</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1175.13</hp>
+			<mp>463.32</mp>
+			<cp>587.565</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1217.7</hp>
+			<mp>478.8</mp>
+			<cp>608.85</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1260.6</hp>
+			<mp>494.4</mp>
+			<cp>630.3</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1303.83</hp>
+			<mp>510.12</mp>
+			<cp>651.915</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1347.39</hp>
+			<mp>525.96</mp>
+			<cp>673.695</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1391.28</hp>
+			<mp>541.92</mp>
+			<cp>695.64</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1435.5</hp>
+			<mp>558.0</mp>
+			<cp>717.75</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1480.05</hp>
+			<mp>574.2</mp>
+			<cp>740.025</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1524.93</hp>
+			<mp>590.52</mp>
+			<cp>762.465</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1570.14</hp>
+			<mp>606.96</mp>
+			<cp>785.07</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1615.68</hp>
+			<mp>623.52</mp>
+			<cp>807.84</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1661.55</hp>
+			<mp>640.2</mp>
+			<cp>830.775</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1707.75</hp>
+			<mp>657.0</mp>
+			<cp>853.875</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1754.28</hp>
+			<mp>673.92</mp>
+			<cp>877.14</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1801.14</hp>
+			<mp>690.96</mp>
+			<cp>900.57</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1848.33</hp>
+			<mp>708.12</mp>
+			<cp>924.165</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1895.85</hp>
+			<mp>725.4</mp>
+			<cp>947.925</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1943.7</hp>
+			<mp>742.8</mp>
+			<cp>971.85</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1991.88</hp>
+			<mp>760.32</mp>
+			<cp>995.94</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2040.39</hp>
+			<mp>777.96</mp>
+			<cp>1020.195</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2089.23</hp>
+			<mp>795.72</mp>
+			<cp>1044.615</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2138.4</hp>
+			<mp>813.6</mp>
+			<cp>1069.2</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2187.9</hp>
+			<mp>831.6</mp>
+			<cp>1093.95</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2237.73</hp>
+			<mp>849.72</mp>
+			<cp>1118.865</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2287.89</hp>
+			<mp>867.96</mp>
+			<cp>1143.945</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2338.38</hp>
+			<mp>886.32</mp>
+			<cp>1169.19</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2389.2</hp>
+			<mp>904.8</mp>
+			<cp>1194.6</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2440.35</hp>
+			<mp>923.4</mp>
+			<cp>1220.175</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2491.83</hp>
+			<mp>942.12</mp>
+			<cp>1245.915</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2543.64</hp>
+			<mp>960.96</mp>
+			<cp>1271.82</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2595.78</hp>
+			<mp>979.92</mp>
+			<cp>1297.89</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2648.25</hp>
+			<mp>999.0</mp>
+			<cp>1324.125</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2701.05</hp>
+			<mp>1018.2</mp>
+			<cp>1350.525</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2754.18</hp>
+			<mp>1037.52</mp>
+			<cp>1377.09</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2807.64</hp>
+			<mp>1056.96</mp>
+			<cp>1403.82</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2861.43</hp>
+			<mp>1076.52</mp>
+			<cp>1430.715</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2915.55</hp>
+			<mp>1096.2</mp>
+			<cp>1457.775</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>2970.0</hp>
+			<mp>1116.0</mp>
+			<cp>1485.0</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3024.78</hp>
+			<mp>1135.92</mp>
+			<cp>1512.39</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3079.89</hp>
+			<mp>1155.96</mp>
+			<cp>1539.945</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3135.33</hp>
+			<mp>1176.12</mp>
+			<cp>1567.665</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3191.1</hp>
+			<mp>1196.4</mp>
+			<cp>1595.55</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3247.2</hp>
+			<mp>1216.8</mp>
+			<cp>1623.6</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3303.63</hp>
+			<mp>1237.32</mp>
+			<cp>1651.815</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3360.39</hp>
+			<mp>1257.96</mp>
+			<cp>1680.195</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3417.48</hp>
+			<mp>1278.72</mp>
+			<cp>1708.74</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3474.9</hp>
+			<mp>1299.6</mp>
+			<cp>1737.45</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3532.65</hp>
+			<mp>1320.6</mp>
+			<cp>1766.325</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3590.73</hp>
+			<mp>1341.72</mp>
+			<cp>1795.365</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3649.14</hp>
+			<mp>1362.96</mp>
+			<cp>1824.57</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3707.88</hp>
+			<mp>1384.32</mp>
+			<cp>1853.94</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3766.95</hp>
+			<mp>1405.8</mp>
+			<cp>1883.475</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3826.35</hp>
+			<mp>1427.4</mp>
+			<cp>1913.175</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>3886.08</hp>
+			<mp>1449.12</mp>
+			<cp>1943.04</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>3946.14</hp>
+			<mp>1470.96</mp>
+			<cp>1973.07</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4006.53</hp>
+			<mp>1492.92</mp>
+			<cp>2003.265</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4067.25</hp>
+			<mp>1515.0</mp>
+			<cp>2033.625</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4128.3</hp>
+			<mp>1537.2</mp>
+			<cp>2064.15</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4189.68</hp>
+			<mp>1559.52</mp>
+			<cp>2094.84</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4251.39</hp>
+			<mp>1581.96</mp>
+			<cp>2125.695</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4313.43</hp>
+			<mp>1604.52</mp>
+			<cp>2156.715</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4375.8</hp>
+			<mp>1627.2</mp>
+			<cp>2187.9</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4438.5</hp>
+			<mp>1650</mp>
+			<cp>2219.24</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4501.53</hp>
+			<mp>1672.92</mp>
+			<cp>2250.74</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4564.89</hp>
+			<mp>1695.96</mp>
+			<cp>2282.4</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4628.58</hp>
+			<mp>1719.12</mp>
+			<cp>2314.22</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>4692.6</hp>
+			<mp>1742.4</mp>
+			<cp>2346.2</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>4756.95</hp>
+			<mp>1765.8</mp>
+			<cp>2378.34</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>4821.63</hp>
+			<mp>1789.32</mp>
+			<cp>2410.815</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/ShillienSaint.xml
+++ b/data/stats/chars/baseStats/ShillienSaint.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>112</classId>
-    <staticData>
-        <baseINT>44</baseINT>
-        <baseSTR>23</baseSTR>
-        <baseCON>24</baseCON>
-        <baseMEN>37</baseMEN>
-        <baseDEX>23</baseDEX>
-        <baseWIT>19</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>15</magicAbnormalResist>
-        <creationPoints>
-            <node x="28295" y="11063" z="-4224"/>
-            <node x="28302" y="11008" z="-4224"/>
-            <node x="28377" y="10916" z="-4224"/>
-            <node x="28456" y="10997" z="-4224"/>
-            <node x="28461" y="11044" z="-4224"/>
-            <node x="28395" y="11127" z="-4224"/>
-        </creationPoints>
-        <basePAtk>3</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>15</chest>
-            <legs>8</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>85</walk>
-            <run>128</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>150</baseBreath>
-        <baseSafeFall>300</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>24</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.0</radius>
-            <height>23.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>106.0</hp>
-            <mp>40.0</mp>
-            <cp>95.4</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>121.47</hp>
-            <mp>47.28</mp>
-            <cp>109.323</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>137.11</hp>
-            <mp>54.64</mp>
-            <cp>123.399</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>152.92</hp>
-            <mp>62.08</mp>
-            <cp>137.628</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>168.9</hp>
-            <mp>69.6</mp>
-            <cp>152.01</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>185.05</hp>
-            <mp>77.2</mp>
-            <cp>166.545</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>201.37</hp>
-            <mp>84.88</mp>
-            <cp>181.233</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>217.86</hp>
-            <mp>92.64</mp>
-            <cp>196.074</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>234.52</hp>
-            <mp>100.48</mp>
-            <cp>211.068</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>251.35</hp>
-            <mp>108.4</mp>
-            <cp>226.215</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>268.35</hp>
-            <mp>116.4</mp>
-            <cp>241.515</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>285.52</hp>
-            <mp>124.48</mp>
-            <cp>256.968</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>302.86</hp>
-            <mp>132.64</mp>
-            <cp>272.574</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>320.37</hp>
-            <mp>140.88</mp>
-            <cp>288.333</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>338.05</hp>
-            <mp>149.2</mp>
-            <cp>304.245</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>355.9</hp>
-            <mp>157.6</mp>
-            <cp>320.31</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>373.92</hp>
-            <mp>166.08</mp>
-            <cp>336.528</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>392.11</hp>
-            <mp>174.64</mp>
-            <cp>352.899</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>410.47</hp>
-            <mp>183.28</mp>
-            <cp>369.423</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>429.0</hp>
-            <mp>192.0</mp>
-            <cp>386.1</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>465.3</hp>
-            <mp>205.2</mp>
-            <cp>418.77</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>501.93</hp>
-            <mp>218.52</mp>
-            <cp>451.737</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>538.89</hp>
-            <mp>231.96</mp>
-            <cp>485.001</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>576.18</hp>
-            <mp>245.52</mp>
-            <cp>518.562</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>613.8</hp>
-            <mp>259.2</mp>
-            <cp>552.42</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>651.75</hp>
-            <mp>273.0</mp>
-            <cp>586.575</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>690.03</hp>
-            <mp>286.92</mp>
-            <cp>621.027</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>728.64</hp>
-            <mp>300.96</mp>
-            <cp>655.776</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>767.58</hp>
-            <mp>315.12</mp>
-            <cp>690.822</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>806.85</hp>
-            <mp>329.4</mp>
-            <cp>726.165</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>846.45</hp>
-            <mp>343.8</mp>
-            <cp>761.805</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>886.38</hp>
-            <mp>358.32</mp>
-            <cp>797.742</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>926.64</hp>
-            <mp>372.96</mp>
-            <cp>833.976</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>967.23</hp>
-            <mp>387.72</mp>
-            <cp>870.507</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>1008.15</hp>
-            <mp>402.6</mp>
-            <cp>907.335</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>1049.4</hp>
-            <mp>417.6</mp>
-            <cp>944.46</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>1090.98</hp>
-            <mp>432.72</mp>
-            <cp>981.882</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1132.89</hp>
-            <mp>447.96</mp>
-            <cp>1019.601</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1175.13</hp>
-            <mp>463.32</mp>
-            <cp>1057.617</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1217.7</hp>
-            <mp>478.8</mp>
-            <cp>1095.93</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1272.3</hp>
-            <mp>504.8</mp>
-            <cp>1145.07</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1327.32</hp>
-            <mp>531.0</mp>
-            <cp>1194.588</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1382.76</hp>
-            <mp>557.4</mp>
-            <cp>1244.484</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1438.62</hp>
-            <mp>584.0</mp>
-            <cp>1294.758</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1494.9</hp>
-            <mp>610.8</mp>
-            <cp>1345.41</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1551.6</hp>
-            <mp>637.8</mp>
-            <cp>1396.44</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1608.72</hp>
-            <mp>665.0</mp>
-            <cp>1447.848</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1666.26</hp>
-            <mp>692.4</mp>
-            <cp>1499.634</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1724.22</hp>
-            <mp>720.0</mp>
-            <cp>1551.798</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1782.6</hp>
-            <mp>747.8</mp>
-            <cp>1604.34</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1841.4</hp>
-            <mp>775.8</mp>
-            <cp>1657.26</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1900.62</hp>
-            <mp>804.0</mp>
-            <cp>1710.558</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1960.26</hp>
-            <mp>832.4</mp>
-            <cp>1764.234</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>2020.32</hp>
-            <mp>861.0</mp>
-            <cp>1818.288</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>2080.8</hp>
-            <mp>889.8</mp>
-            <cp>1872.72</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>2141.7</hp>
-            <mp>918.8</mp>
-            <cp>1927.53</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>2203.02</hp>
-            <mp>948.0</mp>
-            <cp>1982.718</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2264.76</hp>
-            <mp>977.4</mp>
-            <cp>2038.284</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2326.92</hp>
-            <mp>1007.0</mp>
-            <cp>2094.228</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2389.5</hp>
-            <mp>1036.8</mp>
-            <cp>2150.55</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2452.5</hp>
-            <mp>1066.8</mp>
-            <cp>2207.25</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2515.92</hp>
-            <mp>1097.0</mp>
-            <cp>2264.328</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2579.76</hp>
-            <mp>1127.4</mp>
-            <cp>2321.784</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2644.02</hp>
-            <mp>1158.0</mp>
-            <cp>2379.618</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2708.7</hp>
-            <mp>1188.8</mp>
-            <cp>2437.83</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2773.8</hp>
-            <mp>1219.8</mp>
-            <cp>2496.42</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2839.32</hp>
-            <mp>1251.0</mp>
-            <cp>2555.388</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2905.26</hp>
-            <mp>1282.4</mp>
-            <cp>2614.734</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2971.62</hp>
-            <mp>1314.0</mp>
-            <cp>2674.458</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>3038.4</hp>
-            <mp>1345.8</mp>
-            <cp>2734.56</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>3105.6</hp>
-            <mp>1377.8</mp>
-            <cp>2795.04</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>3173.22</hp>
-            <mp>1410.0</mp>
-            <cp>2855.898</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>3241.26</hp>
-            <mp>1442.4</mp>
-            <cp>2917.134</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>3309.72</hp>
-            <mp>1475.0</mp>
-            <cp>2978.748</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3378.6</hp>
-            <mp>1507.8</mp>
-            <cp>3040.74</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3447.9</hp>
-            <mp>1540.8</mp>
-            <cp>3103.11</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3517.62</hp>
-            <mp>1574.0</mp>
-            <cp>3165.858</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3587.76</hp>
-            <mp>1607.4</mp>
-            <cp>3228.984</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3658.32</hp>
-            <mp>1641.0</mp>
-            <cp>3292.488</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3729.3</hp>
-            <mp>1674.8</mp>
-            <cp>3356.37</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3800.7</hp>
-            <mp>1708.8</mp>
-            <cp>3420.63</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3872.52</hp>
-            <mp>1743.0</mp>
-            <cp>3485.268</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3944.76</hp>
-            <mp>1777.4</mp>
-            <cp>3550.284</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>4017.42</hp>
-            <mp>1812.0</mp>
-            <cp>3615.678</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>4090.5</hp>
-            <mp>1846.8</mp>
-            <cp>3681.45</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>4164.0</hp>
-            <mp>1881.8</mp>
-            <cp>3747.6</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>4237.92</hp>
-            <mp>1917.0</mp>
-            <cp>3814.128</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>4312.26</hp>
-            <mp>1952.4</mp>
-            <cp>3881.034</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>4387.02</hp>
-            <mp>1988.0</mp>
-            <cp>3948.318</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4462.2</hp>
-            <mp>2023.8</mp>
-            <cp>4015.98</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4537.8</hp>
-            <mp>2059.8</mp>
-            <cp>4084.02</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>112</classId>
+	<staticData>
+		<baseINT>44</baseINT>
+		<baseSTR>23</baseSTR>
+		<baseCON>24</baseCON>
+		<baseMEN>37</baseMEN>
+		<baseDEX>23</baseDEX>
+		<baseWIT>19</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="28295" y="11063" z="-4224" />
+			<node x="28302" y="11008" z="-4224" />
+			<node x="28377" y="10916" z="-4224" />
+			<node x="28456" y="10997" z="-4224" />
+			<node x="28461" y="11044" z="-4224" />
+			<node x="28395" y="11127" z="-4224" />
+		</creationPoints>
+		<basePAtk>3</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>15</chest>
+			<legs>8</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>85</walk>
+			<run>128</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>300</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>106.0</hp>
+			<mp>40.0</mp>
+			<cp>95.4</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>121.47</hp>
+			<mp>47.28</mp>
+			<cp>109.323</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>137.11</hp>
+			<mp>54.64</mp>
+			<cp>123.399</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>152.92</hp>
+			<mp>62.08</mp>
+			<cp>137.628</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>168.9</hp>
+			<mp>69.6</mp>
+			<cp>152.01</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>185.05</hp>
+			<mp>77.2</mp>
+			<cp>166.545</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>201.37</hp>
+			<mp>84.88</mp>
+			<cp>181.233</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>217.86</hp>
+			<mp>92.64</mp>
+			<cp>196.074</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>234.52</hp>
+			<mp>100.48</mp>
+			<cp>211.068</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>251.35</hp>
+			<mp>108.4</mp>
+			<cp>226.215</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>268.35</hp>
+			<mp>116.4</mp>
+			<cp>241.515</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>285.52</hp>
+			<mp>124.48</mp>
+			<cp>256.968</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>302.86</hp>
+			<mp>132.64</mp>
+			<cp>272.574</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>320.37</hp>
+			<mp>140.88</mp>
+			<cp>288.333</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>338.05</hp>
+			<mp>149.2</mp>
+			<cp>304.245</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>355.9</hp>
+			<mp>157.6</mp>
+			<cp>320.31</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>373.92</hp>
+			<mp>166.08</mp>
+			<cp>336.528</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>392.11</hp>
+			<mp>174.64</mp>
+			<cp>352.899</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>410.47</hp>
+			<mp>183.28</mp>
+			<cp>369.423</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>429.0</hp>
+			<mp>192.0</mp>
+			<cp>386.1</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>465.3</hp>
+			<mp>205.2</mp>
+			<cp>418.77</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>501.93</hp>
+			<mp>218.52</mp>
+			<cp>451.737</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>538.89</hp>
+			<mp>231.96</mp>
+			<cp>485.001</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>576.18</hp>
+			<mp>245.52</mp>
+			<cp>518.562</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>613.8</hp>
+			<mp>259.2</mp>
+			<cp>552.42</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>651.75</hp>
+			<mp>273.0</mp>
+			<cp>586.575</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>690.03</hp>
+			<mp>286.92</mp>
+			<cp>621.027</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>728.64</hp>
+			<mp>300.96</mp>
+			<cp>655.776</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>767.58</hp>
+			<mp>315.12</mp>
+			<cp>690.822</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>806.85</hp>
+			<mp>329.4</mp>
+			<cp>726.165</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>846.45</hp>
+			<mp>343.8</mp>
+			<cp>761.805</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>886.38</hp>
+			<mp>358.32</mp>
+			<cp>797.742</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>926.64</hp>
+			<mp>372.96</mp>
+			<cp>833.976</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>967.23</hp>
+			<mp>387.72</mp>
+			<cp>870.507</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>1008.15</hp>
+			<mp>402.6</mp>
+			<cp>907.335</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>1049.4</hp>
+			<mp>417.6</mp>
+			<cp>944.46</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>1090.98</hp>
+			<mp>432.72</mp>
+			<cp>981.882</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1132.89</hp>
+			<mp>447.96</mp>
+			<cp>1019.601</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1175.13</hp>
+			<mp>463.32</mp>
+			<cp>1057.617</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1217.7</hp>
+			<mp>478.8</mp>
+			<cp>1095.93</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1272.3</hp>
+			<mp>504.8</mp>
+			<cp>1145.07</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1327.32</hp>
+			<mp>531.0</mp>
+			<cp>1194.588</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1382.76</hp>
+			<mp>557.4</mp>
+			<cp>1244.484</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1438.62</hp>
+			<mp>584.0</mp>
+			<cp>1294.758</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1494.9</hp>
+			<mp>610.8</mp>
+			<cp>1345.41</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1551.6</hp>
+			<mp>637.8</mp>
+			<cp>1396.44</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1608.72</hp>
+			<mp>665.0</mp>
+			<cp>1447.848</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1666.26</hp>
+			<mp>692.4</mp>
+			<cp>1499.634</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1724.22</hp>
+			<mp>720.0</mp>
+			<cp>1551.798</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1782.6</hp>
+			<mp>747.8</mp>
+			<cp>1604.34</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1841.4</hp>
+			<mp>775.8</mp>
+			<cp>1657.26</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1900.62</hp>
+			<mp>804.0</mp>
+			<cp>1710.558</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1960.26</hp>
+			<mp>832.4</mp>
+			<cp>1764.234</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>2020.32</hp>
+			<mp>861.0</mp>
+			<cp>1818.288</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>2080.8</hp>
+			<mp>889.8</mp>
+			<cp>1872.72</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>2141.7</hp>
+			<mp>918.8</mp>
+			<cp>1927.53</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2203.02</hp>
+			<mp>948.0</mp>
+			<cp>1982.718</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2264.76</hp>
+			<mp>977.4</mp>
+			<cp>2038.284</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2326.92</hp>
+			<mp>1007.0</mp>
+			<cp>2094.228</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2389.5</hp>
+			<mp>1036.8</mp>
+			<cp>2150.55</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2452.5</hp>
+			<mp>1066.8</mp>
+			<cp>2207.25</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2515.92</hp>
+			<mp>1097.0</mp>
+			<cp>2264.328</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2579.76</hp>
+			<mp>1127.4</mp>
+			<cp>2321.784</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2644.02</hp>
+			<mp>1158.0</mp>
+			<cp>2379.618</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2708.7</hp>
+			<mp>1188.8</mp>
+			<cp>2437.83</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2773.8</hp>
+			<mp>1219.8</mp>
+			<cp>2496.42</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2839.32</hp>
+			<mp>1251.0</mp>
+			<cp>2555.388</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2905.26</hp>
+			<mp>1282.4</mp>
+			<cp>2614.734</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2971.62</hp>
+			<mp>1314.0</mp>
+			<cp>2674.458</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>3038.4</hp>
+			<mp>1345.8</mp>
+			<cp>2734.56</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>3105.6</hp>
+			<mp>1377.8</mp>
+			<cp>2795.04</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>3173.22</hp>
+			<mp>1410.0</mp>
+			<cp>2855.898</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>3241.26</hp>
+			<mp>1442.4</mp>
+			<cp>2917.134</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3309.72</hp>
+			<mp>1475.0</mp>
+			<cp>2978.748</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3378.6</hp>
+			<mp>1507.8</mp>
+			<cp>3040.74</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3447.9</hp>
+			<mp>1540.8</mp>
+			<cp>3103.11</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3517.62</hp>
+			<mp>1574.0</mp>
+			<cp>3165.858</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3587.76</hp>
+			<mp>1607.4</mp>
+			<cp>3228.984</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3658.32</hp>
+			<mp>1641.0</mp>
+			<cp>3292.488</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3729.3</hp>
+			<mp>1674.8</mp>
+			<cp>3356.37</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3800.7</hp>
+			<mp>1708.8</mp>
+			<cp>3420.63</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3872.52</hp>
+			<mp>1743.0</mp>
+			<cp>3485.268</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3944.76</hp>
+			<mp>1777.4</mp>
+			<cp>3550.284</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>4017.42</hp>
+			<mp>1812.0</mp>
+			<cp>3615.678</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>4090.5</hp>
+			<mp>1846.8</mp>
+			<cp>3681.45</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>4164.0</hp>
+			<mp>1881.8</mp>
+			<cp>3747.6</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>4237.92</hp>
+			<mp>1917.0</mp>
+			<cp>3814.128</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4312.26</hp>
+			<mp>1952.4</mp>
+			<cp>3881.034</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4387.02</hp>
+			<mp>1988.0</mp>
+			<cp>3948.318</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4462.2</hp>
+			<mp>2023.8</mp>
+			<cp>4015.98</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4537.8</hp>
+			<mp>2059.8</mp>
+			<cp>4084.02</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4613.82</hp>
+			<mp>2096.0</mp>
+			<cp>4152.438</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4690.26</hp>
+			<mp>2132.4</mp>
+			<cp>4221.234</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4767.12</hp>
+			<mp>2169.0</mp>
+			<cp>4290.408</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4844.4</hp>
+			<mp>2205.8</mp>
+			<cp>4359.96</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4922.1</hp>
+			<mp>2242.8</mp>
+			<cp>4429.89</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>5000.22</hp>
+			<mp>2280.0</mp>
+			<cp>4500.198</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>5078.76</hp>
+			<mp>2317.4</mp>
+			<cp>4570.884</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>5157.72</hp>
+			<mp>2355.0</mp>
+			<cp>4641.948</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>5237.1</hp>
+			<mp>2392.8</mp>
+			<cp>4713.39</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>5316.9</hp>
+			<mp>2430.8</mp>
+			<cp>4785.22</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5397.12</hp>
+			<mp>2469</mp>
+			<cp>4857.42</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5477.76</hp>
+			<mp>2507.4</mp>
+			<cp>4930</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5558.82</hp>
+			<mp>2546</mp>
+			<cp>5002.97</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5640.3</hp>
+			<mp>2584.8</mp>
+			<cp>5076.31</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5722.2</hp>
+			<mp>2623.8</mp>
+			<cp>5150.04</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5804.52</hp>
+			<mp>2663</mp>
+			<cp>5224.068</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/ShillienTemplar.xml
+++ b/data/stats/chars/baseStats/ShillienTemplar.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>106</classId>
-    <staticData>
-        <baseINT>25</baseINT>
-        <baseSTR>41</baseSTR>
-        <baseCON>32</baseCON>
-        <baseMEN>26</baseMEN>
-        <baseDEX>34</baseDEX>
-        <baseWIT>12</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>15</magicAbnormalResist>
-        <creationPoints>
-            <node x="28295" y="11063" z="-4224"/>
-            <node x="28302" y="11008" z="-4224"/>
-            <node x="28377" y="10916" z="-4224"/>
-            <node x="28456" y="10997" z="-4224"/>
-            <node x="28461" y="11044" z="-4224"/>
-            <node x="28395" y="11127" z="-4224"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>85</walk>
-            <run>139</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>150</baseBreath>
-        <baseSafeFall>350</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>24</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.0</radius>
-            <height>23.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>94.0</hp>
-            <mp>30.0</mp>
-            <cp>56.4</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>107.65</hp>
-            <mp>35.46</mp>
-            <cp>64.59</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>121.45</hp>
-            <mp>40.98</mp>
-            <cp>72.87</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>135.4</hp>
-            <mp>46.56</mp>
-            <cp>81.24</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>149.5</hp>
-            <mp>52.2</mp>
-            <cp>89.7</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>163.75</hp>
-            <mp>57.9</mp>
-            <cp>98.25</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>178.15</hp>
-            <mp>63.66</mp>
-            <cp>106.89</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>192.7</hp>
-            <mp>69.48</mp>
-            <cp>115.62</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>207.4</hp>
-            <mp>75.36</mp>
-            <cp>124.44</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>222.25</hp>
-            <mp>81.3</mp>
-            <cp>133.35</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>237.25</hp>
-            <mp>87.3</mp>
-            <cp>142.35</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>252.4</hp>
-            <mp>93.36</mp>
-            <cp>151.44</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>267.7</hp>
-            <mp>99.48</mp>
-            <cp>160.62</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>283.15</hp>
-            <mp>105.66</mp>
-            <cp>169.89</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>298.75</hp>
-            <mp>111.9</mp>
-            <cp>179.25</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>314.5</hp>
-            <mp>118.2</mp>
-            <cp>188.7</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>330.4</hp>
-            <mp>124.56</mp>
-            <cp>198.24</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>346.45</hp>
-            <mp>130.98</mp>
-            <cp>207.87</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>362.65</hp>
-            <mp>137.46</mp>
-            <cp>217.59</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>379.0</hp>
-            <mp>144.0</mp>
-            <cp>227.4</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>414.2</hp>
-            <mp>153.9</mp>
-            <cp>248.52</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>449.72</hp>
-            <mp>163.89</mp>
-            <cp>269.832</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>485.56</hp>
-            <mp>173.97</mp>
-            <cp>291.336</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>521.72</hp>
-            <mp>184.14</mp>
-            <cp>313.032</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>558.2</hp>
-            <mp>194.4</mp>
-            <cp>334.92</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>595.0</hp>
-            <mp>204.75</mp>
-            <cp>357.0</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>632.12</hp>
-            <mp>215.19</mp>
-            <cp>379.272</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>669.56</hp>
-            <mp>225.72</mp>
-            <cp>401.736</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>707.32</hp>
-            <mp>236.34</mp>
-            <cp>424.392</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>745.4</hp>
-            <mp>247.05</mp>
-            <cp>447.24</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>783.8</hp>
-            <mp>257.85</mp>
-            <cp>470.28</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>822.52</hp>
-            <mp>268.74</mp>
-            <cp>493.512</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>861.56</hp>
-            <mp>279.72</mp>
-            <cp>516.936</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>900.92</hp>
-            <mp>290.79</mp>
-            <cp>540.552</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>940.6</hp>
-            <mp>301.95</mp>
-            <cp>564.36</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>980.6</hp>
-            <mp>313.2</mp>
-            <cp>588.36</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>1020.92</hp>
-            <mp>324.54</mp>
-            <cp>612.552</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1061.56</hp>
-            <mp>335.97</mp>
-            <cp>636.936</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1102.52</hp>
-            <mp>347.49</mp>
-            <cp>661.512</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1143.8</hp>
-            <mp>359.1</mp>
-            <cp>686.28</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1198.4</hp>
-            <mp>378.6</mp>
-            <cp>719.04</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1253.42</hp>
-            <mp>398.25</mp>
-            <cp>752.052</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1308.86</hp>
-            <mp>418.05</mp>
-            <cp>785.316</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1364.72</hp>
-            <mp>438.0</mp>
-            <cp>818.832</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1421.0</hp>
-            <mp>458.1</mp>
-            <cp>852.6</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1477.7</hp>
-            <mp>478.35</mp>
-            <cp>886.62</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1534.82</hp>
-            <mp>498.75</mp>
-            <cp>920.892</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1592.36</hp>
-            <mp>519.3</mp>
-            <cp>955.416</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1650.32</hp>
-            <mp>540.0</mp>
-            <cp>990.192</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1708.7</hp>
-            <mp>560.85</mp>
-            <cp>1025.22</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1767.5</hp>
-            <mp>581.85</mp>
-            <cp>1060.5</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1826.72</hp>
-            <mp>603.0</mp>
-            <cp>1096.032</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1886.36</hp>
-            <mp>624.3</mp>
-            <cp>1131.816</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1946.42</hp>
-            <mp>645.75</mp>
-            <cp>1167.852</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>2006.9</hp>
-            <mp>667.35</mp>
-            <cp>1204.14</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>2067.8</hp>
-            <mp>689.1</mp>
-            <cp>1240.68</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>2129.12</hp>
-            <mp>711.0</mp>
-            <cp>1277.472</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2190.86</hp>
-            <mp>733.05</mp>
-            <cp>1314.516</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2253.02</hp>
-            <mp>755.25</mp>
-            <cp>1351.812</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2315.6</hp>
-            <mp>777.6</mp>
-            <cp>1389.36</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2378.6</hp>
-            <mp>800.1</mp>
-            <cp>1427.16</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2442.02</hp>
-            <mp>822.75</mp>
-            <cp>1465.212</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2505.86</hp>
-            <mp>845.55</mp>
-            <cp>1503.516</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2570.12</hp>
-            <mp>868.5</mp>
-            <cp>1542.072</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2634.8</hp>
-            <mp>891.6</mp>
-            <cp>1580.88</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2699.9</hp>
-            <mp>914.85</mp>
-            <cp>1619.94</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2765.42</hp>
-            <mp>938.25</mp>
-            <cp>1659.252</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2831.36</hp>
-            <mp>961.8</mp>
-            <cp>1698.816</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2897.72</hp>
-            <mp>985.5</mp>
-            <cp>1738.632</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2964.5</hp>
-            <mp>1009.35</mp>
-            <cp>1778.7</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>3031.7</hp>
-            <mp>1033.35</mp>
-            <cp>1819.02</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>3099.32</hp>
-            <mp>1057.5</mp>
-            <cp>1859.592</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>3167.36</hp>
-            <mp>1081.8</mp>
-            <cp>1900.416</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>3235.82</hp>
-            <mp>1106.25</mp>
-            <cp>1941.492</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3304.7</hp>
-            <mp>1130.85</mp>
-            <cp>1982.82</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3374.0</hp>
-            <mp>1155.6</mp>
-            <cp>2024.4</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3443.72</hp>
-            <mp>1180.5</mp>
-            <cp>2066.232</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3513.86</hp>
-            <mp>1205.55</mp>
-            <cp>2108.316</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3584.42</hp>
-            <mp>1230.75</mp>
-            <cp>2150.652</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3655.4</hp>
-            <mp>1256.1</mp>
-            <cp>2193.24</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3726.8</hp>
-            <mp>1281.6</mp>
-            <cp>2236.08</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3798.62</hp>
-            <mp>1307.25</mp>
-            <cp>2279.172</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3870.86</hp>
-            <mp>1333.05</mp>
-            <cp>2322.516</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3943.52</hp>
-            <mp>1359.0</mp>
-            <cp>2366.112</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>4016.6</hp>
-            <mp>1385.1</mp>
-            <cp>2409.96</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>4090.1</hp>
-            <mp>1411.35</mp>
-            <cp>2454.06</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>4164.02</hp>
-            <mp>1437.75</mp>
-            <cp>2498.412</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>4238.36</hp>
-            <mp>1464.3</mp>
-            <cp>2543.016</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>4313.12</hp>
-            <mp>1491.0</mp>
-            <cp>2587.872</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4388.3</hp>
-            <mp>1517.85</mp>
-            <cp>2632.98</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4463.9</hp>
-            <mp>1544.85</mp>
-            <cp>2678.34</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>106</classId>
+	<staticData>
+		<baseINT>25</baseINT>
+		<baseSTR>41</baseSTR>
+		<baseCON>32</baseCON>
+		<baseMEN>26</baseMEN>
+		<baseDEX>34</baseDEX>
+		<baseWIT>12</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="28295" y="11063" z="-4224" />
+			<node x="28302" y="11008" z="-4224" />
+			<node x="28377" y="10916" z="-4224" />
+			<node x="28456" y="10997" z="-4224" />
+			<node x="28461" y="11044" z="-4224" />
+			<node x="28395" y="11127" z="-4224" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>85</walk>
+			<run>139</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>350</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>94.0</hp>
+			<mp>30.0</mp>
+			<cp>56.4</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>107.65</hp>
+			<mp>35.46</mp>
+			<cp>64.59</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>121.45</hp>
+			<mp>40.98</mp>
+			<cp>72.87</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>135.4</hp>
+			<mp>46.56</mp>
+			<cp>81.24</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>149.5</hp>
+			<mp>52.2</mp>
+			<cp>89.7</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>163.75</hp>
+			<mp>57.9</mp>
+			<cp>98.25</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>178.15</hp>
+			<mp>63.66</mp>
+			<cp>106.89</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>192.7</hp>
+			<mp>69.48</mp>
+			<cp>115.62</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>207.4</hp>
+			<mp>75.36</mp>
+			<cp>124.44</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>222.25</hp>
+			<mp>81.3</mp>
+			<cp>133.35</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>237.25</hp>
+			<mp>87.3</mp>
+			<cp>142.35</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>252.4</hp>
+			<mp>93.36</mp>
+			<cp>151.44</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>267.7</hp>
+			<mp>99.48</mp>
+			<cp>160.62</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>283.15</hp>
+			<mp>105.66</mp>
+			<cp>169.89</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>298.75</hp>
+			<mp>111.9</mp>
+			<cp>179.25</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>314.5</hp>
+			<mp>118.2</mp>
+			<cp>188.7</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>330.4</hp>
+			<mp>124.56</mp>
+			<cp>198.24</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>346.45</hp>
+			<mp>130.98</mp>
+			<cp>207.87</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>362.65</hp>
+			<mp>137.46</mp>
+			<cp>217.59</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>379.0</hp>
+			<mp>144.0</mp>
+			<cp>227.4</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>414.2</hp>
+			<mp>153.9</mp>
+			<cp>248.52</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>449.72</hp>
+			<mp>163.89</mp>
+			<cp>269.832</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>485.56</hp>
+			<mp>173.97</mp>
+			<cp>291.336</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>521.72</hp>
+			<mp>184.14</mp>
+			<cp>313.032</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>558.2</hp>
+			<mp>194.4</mp>
+			<cp>334.92</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>595.0</hp>
+			<mp>204.75</mp>
+			<cp>357.0</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>632.12</hp>
+			<mp>215.19</mp>
+			<cp>379.272</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>669.56</hp>
+			<mp>225.72</mp>
+			<cp>401.736</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>707.32</hp>
+			<mp>236.34</mp>
+			<cp>424.392</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>745.4</hp>
+			<mp>247.05</mp>
+			<cp>447.24</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>783.8</hp>
+			<mp>257.85</mp>
+			<cp>470.28</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>822.52</hp>
+			<mp>268.74</mp>
+			<cp>493.512</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>861.56</hp>
+			<mp>279.72</mp>
+			<cp>516.936</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>900.92</hp>
+			<mp>290.79</mp>
+			<cp>540.552</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>940.6</hp>
+			<mp>301.95</mp>
+			<cp>564.36</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>980.6</hp>
+			<mp>313.2</mp>
+			<cp>588.36</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>1020.92</hp>
+			<mp>324.54</mp>
+			<cp>612.552</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1061.56</hp>
+			<mp>335.97</mp>
+			<cp>636.936</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1102.52</hp>
+			<mp>347.49</mp>
+			<cp>661.512</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1143.8</hp>
+			<mp>359.1</mp>
+			<cp>686.28</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1198.4</hp>
+			<mp>378.6</mp>
+			<cp>719.04</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1253.42</hp>
+			<mp>398.25</mp>
+			<cp>752.052</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1308.86</hp>
+			<mp>418.05</mp>
+			<cp>785.316</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1364.72</hp>
+			<mp>438.0</mp>
+			<cp>818.832</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1421.0</hp>
+			<mp>458.1</mp>
+			<cp>852.6</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1477.7</hp>
+			<mp>478.35</mp>
+			<cp>886.62</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1534.82</hp>
+			<mp>498.75</mp>
+			<cp>920.892</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1592.36</hp>
+			<mp>519.3</mp>
+			<cp>955.416</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1650.32</hp>
+			<mp>540.0</mp>
+			<cp>990.192</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1708.7</hp>
+			<mp>560.85</mp>
+			<cp>1025.22</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1767.5</hp>
+			<mp>581.85</mp>
+			<cp>1060.5</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1826.72</hp>
+			<mp>603.0</mp>
+			<cp>1096.032</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1886.36</hp>
+			<mp>624.3</mp>
+			<cp>1131.816</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1946.42</hp>
+			<mp>645.75</mp>
+			<cp>1167.852</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>2006.9</hp>
+			<mp>667.35</mp>
+			<cp>1204.14</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>2067.8</hp>
+			<mp>689.1</mp>
+			<cp>1240.68</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2129.12</hp>
+			<mp>711.0</mp>
+			<cp>1277.472</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2190.86</hp>
+			<mp>733.05</mp>
+			<cp>1314.516</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2253.02</hp>
+			<mp>755.25</mp>
+			<cp>1351.812</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2315.6</hp>
+			<mp>777.6</mp>
+			<cp>1389.36</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2378.6</hp>
+			<mp>800.1</mp>
+			<cp>1427.16</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2442.02</hp>
+			<mp>822.75</mp>
+			<cp>1465.212</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2505.86</hp>
+			<mp>845.55</mp>
+			<cp>1503.516</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2570.12</hp>
+			<mp>868.5</mp>
+			<cp>1542.072</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2634.8</hp>
+			<mp>891.6</mp>
+			<cp>1580.88</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2699.9</hp>
+			<mp>914.85</mp>
+			<cp>1619.94</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2765.42</hp>
+			<mp>938.25</mp>
+			<cp>1659.252</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2831.36</hp>
+			<mp>961.8</mp>
+			<cp>1698.816</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2897.72</hp>
+			<mp>985.5</mp>
+			<cp>1738.632</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2964.5</hp>
+			<mp>1009.35</mp>
+			<cp>1778.7</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>3031.7</hp>
+			<mp>1033.35</mp>
+			<cp>1819.02</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>3099.32</hp>
+			<mp>1057.5</mp>
+			<cp>1859.592</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>3167.36</hp>
+			<mp>1081.8</mp>
+			<cp>1900.416</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3235.82</hp>
+			<mp>1106.25</mp>
+			<cp>1941.492</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3304.7</hp>
+			<mp>1130.85</mp>
+			<cp>1982.82</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3374.0</hp>
+			<mp>1155.6</mp>
+			<cp>2024.4</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3443.72</hp>
+			<mp>1180.5</mp>
+			<cp>2066.232</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3513.86</hp>
+			<mp>1205.55</mp>
+			<cp>2108.316</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3584.42</hp>
+			<mp>1230.75</mp>
+			<cp>2150.652</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3655.4</hp>
+			<mp>1256.1</mp>
+			<cp>2193.24</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3726.8</hp>
+			<mp>1281.6</mp>
+			<cp>2236.08</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3798.62</hp>
+			<mp>1307.25</mp>
+			<cp>2279.172</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3870.86</hp>
+			<mp>1333.05</mp>
+			<cp>2322.516</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3943.52</hp>
+			<mp>1359.0</mp>
+			<cp>2366.112</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>4016.6</hp>
+			<mp>1385.1</mp>
+			<cp>2409.96</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>4090.1</hp>
+			<mp>1411.35</mp>
+			<cp>2454.06</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>4164.02</hp>
+			<mp>1437.75</mp>
+			<cp>2498.412</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4238.36</hp>
+			<mp>1464.3</mp>
+			<cp>2543.016</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4313.12</hp>
+			<mp>1491.0</mp>
+			<cp>2587.872</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4388.3</hp>
+			<mp>1517.85</mp>
+			<cp>2632.98</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4463.9</hp>
+			<mp>1544.85</mp>
+			<cp>2678.34</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4539.92</hp>
+			<mp>1572.0</mp>
+			<cp>2723.952</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4616.36</hp>
+			<mp>1599.3</mp>
+			<cp>2769.816</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4693.22</hp>
+			<mp>1626.75</mp>
+			<cp>2815.932</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4770.5</hp>
+			<mp>1654.35</mp>
+			<cp>2862.3</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4848.2</hp>
+			<mp>1682.1</mp>
+			<cp>2908.92</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4926.32</hp>
+			<mp>1710.0</mp>
+			<cp>2955.792</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>5004.86</hp>
+			<mp>1738.05</mp>
+			<cp>3002.916</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>5083.82</hp>
+			<mp>1766.25</mp>
+			<cp>3050.292</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>5163.2</hp>
+			<mp>1794.6</mp>
+			<cp>3097.92</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>5243</hp>
+			<mp>1823.1</mp>
+			<cp>3145.79</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5323.22</hp>
+			<mp>1851.75</mp>
+			<cp>3193.92</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5403.86</hp>
+			<mp>1880.55</mp>
+			<cp>3242.3</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5484.92</hp>
+			<mp>1909.5</mp>
+			<cp>3290.92</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5566.4</hp>
+			<mp>1938.6</mp>
+			<cp>3339.8</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5648.3</hp>
+			<mp>1967.85</mp>
+			<cp>3388.92</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5730.62</hp>
+			<mp>1997.25</mp>
+			<cp>3438.372</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/SilverRanger.xml
+++ b/data/stats/chars/baseStats/SilverRanger.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>24</classId>
-    <staticData>
-        <baseINT>23</baseINT>
-        <baseSTR>36</baseSTR>
-        <baseCON>36</baseCON>
-        <baseMEN>26</baseMEN>
-        <baseDEX>35</baseDEX>
-        <baseWIT>14</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>15</magicAbnormalResist>
-        <creationPoints>
-            <node x="46045" y="41251" z="-3440"/>
-            <node x="46117" y="41247" z="-3440"/>
-            <node x="46182" y="41198" z="-3440"/>
-            <node x="46115" y="41141" z="-3440"/>
-            <node x="46048" y="41141" z="-3440"/>
-            <node x="45978" y="41196" z="-3440"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>90</walk>
-            <run>143</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>150</baseBreath>
-        <baseSafeFall>350</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>24</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.5</radius>
-            <height>23</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>89.0</hp>
-            <mp>30.0</mp>
-            <cp>44.5</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>101.74</hp>
-            <mp>35.46</mp>
-            <cp>50.87</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>114.62</hp>
-            <mp>40.98</mp>
-            <cp>57.31</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>127.64</hp>
-            <mp>46.56</mp>
-            <cp>63.82</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>140.8</hp>
-            <mp>52.2</mp>
-            <cp>70.4</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>154.1</hp>
-            <mp>57.9</mp>
-            <cp>77.05</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>167.54</hp>
-            <mp>63.66</mp>
-            <cp>83.77</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>181.12</hp>
-            <mp>69.48</mp>
-            <cp>90.56</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>194.84</hp>
-            <mp>75.36</mp>
-            <cp>97.42</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>208.7</hp>
-            <mp>81.3</mp>
-            <cp>104.35</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>222.7</hp>
-            <mp>87.3</mp>
-            <cp>111.35</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>236.84</hp>
-            <mp>93.36</mp>
-            <cp>118.42</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>251.12</hp>
-            <mp>99.48</mp>
-            <cp>125.56</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>265.54</hp>
-            <mp>105.66</mp>
-            <cp>132.77</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>280.1</hp>
-            <mp>111.9</mp>
-            <cp>140.05</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>294.8</hp>
-            <mp>118.2</mp>
-            <cp>147.4</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>309.64</hp>
-            <mp>124.56</mp>
-            <cp>154.82</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>324.62</hp>
-            <mp>130.98</mp>
-            <cp>162.31</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>339.74</hp>
-            <mp>137.46</mp>
-            <cp>169.87</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>355.0</hp>
-            <mp>144.0</mp>
-            <cp>177.5</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>385.8</hp>
-            <mp>153.9</mp>
-            <cp>192.9</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>416.88</hp>
-            <mp>163.89</mp>
-            <cp>208.44</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>448.24</hp>
-            <mp>173.97</mp>
-            <cp>224.12</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>479.88</hp>
-            <mp>184.14</mp>
-            <cp>239.94</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>511.8</hp>
-            <mp>194.4</mp>
-            <cp>255.9</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>544.0</hp>
-            <mp>204.75</mp>
-            <cp>272.0</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>576.48</hp>
-            <mp>215.19</mp>
-            <cp>288.24</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>609.24</hp>
-            <mp>225.72</mp>
-            <cp>304.62</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>642.28</hp>
-            <mp>236.34</mp>
-            <cp>321.14</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>675.6</hp>
-            <mp>247.05</mp>
-            <cp>337.8</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>709.2</hp>
-            <mp>257.85</mp>
-            <cp>354.6</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>743.08</hp>
-            <mp>268.74</mp>
-            <cp>371.54</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>777.24</hp>
-            <mp>279.72</mp>
-            <cp>388.62</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>811.68</hp>
-            <mp>290.79</mp>
-            <cp>405.84</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>846.4</hp>
-            <mp>301.95</mp>
-            <cp>423.2</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>881.4</hp>
-            <mp>313.2</mp>
-            <cp>440.7</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>916.68</hp>
-            <mp>324.54</mp>
-            <cp>458.34</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>952.24</hp>
-            <mp>335.97</mp>
-            <cp>476.12</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>988.08</hp>
-            <mp>347.49</mp>
-            <cp>494.04</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1024.2</hp>
-            <mp>359.1</mp>
-            <cp>512.1</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1073.6</hp>
-            <mp>378.6</mp>
-            <cp>536.8</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1123.38</hp>
-            <mp>398.25</mp>
-            <cp>561.69</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1173.54</hp>
-            <mp>418.05</mp>
-            <cp>586.77</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1224.08</hp>
-            <mp>438.0</mp>
-            <cp>612.04</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1275.0</hp>
-            <mp>458.1</mp>
-            <cp>637.5</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1326.3</hp>
-            <mp>478.35</mp>
-            <cp>663.15</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1377.98</hp>
-            <mp>498.75</mp>
-            <cp>688.99</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1430.04</hp>
-            <mp>519.3</mp>
-            <cp>715.02</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1482.48</hp>
-            <mp>540.0</mp>
-            <cp>741.24</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1535.3</hp>
-            <mp>560.85</mp>
-            <cp>767.65</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1588.5</hp>
-            <mp>581.85</mp>
-            <cp>794.25</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1642.08</hp>
-            <mp>603.0</mp>
-            <cp>821.04</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1696.04</hp>
-            <mp>624.3</mp>
-            <cp>848.02</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1750.38</hp>
-            <mp>645.75</mp>
-            <cp>875.19</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1805.1</hp>
-            <mp>667.35</mp>
-            <cp>902.55</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1860.2</hp>
-            <mp>689.1</mp>
-            <cp>930.1</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1915.68</hp>
-            <mp>711.0</mp>
-            <cp>957.84</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1971.54</hp>
-            <mp>733.05</mp>
-            <cp>985.77</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2027.78</hp>
-            <mp>755.25</mp>
-            <cp>1013.89</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2084.4</hp>
-            <mp>777.6</mp>
-            <cp>1042.2</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2141.4</hp>
-            <mp>800.1</mp>
-            <cp>1070.7</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2198.78</hp>
-            <mp>822.75</mp>
-            <cp>1099.39</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2256.54</hp>
-            <mp>845.55</mp>
-            <cp>1128.27</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2314.68</hp>
-            <mp>868.5</mp>
-            <cp>1157.34</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2373.2</hp>
-            <mp>891.6</mp>
-            <cp>1186.6</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2432.1</hp>
-            <mp>914.85</mp>
-            <cp>1216.05</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2491.38</hp>
-            <mp>938.25</mp>
-            <cp>1245.69</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2551.04</hp>
-            <mp>961.8</mp>
-            <cp>1275.52</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2611.08</hp>
-            <mp>985.5</mp>
-            <cp>1305.54</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2671.5</hp>
-            <mp>1009.35</mp>
-            <cp>1335.75</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2732.3</hp>
-            <mp>1033.35</mp>
-            <cp>1366.15</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2793.48</hp>
-            <mp>1057.5</mp>
-            <cp>1396.74</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2855.04</hp>
-            <mp>1081.8</mp>
-            <cp>1427.52</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2916.98</hp>
-            <mp>1106.25</mp>
-            <cp>1458.49</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2979.3</hp>
-            <mp>1130.85</mp>
-            <cp>1489.65</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3042.0</hp>
-            <mp>1155.6</mp>
-            <cp>1521.0</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3105.08</hp>
-            <mp>1180.5</mp>
-            <cp>1552.54</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3168.54</hp>
-            <mp>1205.55</mp>
-            <cp>1584.27</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3232.38</hp>
-            <mp>1230.75</mp>
-            <cp>1616.19</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3296.6</hp>
-            <mp>1256.1</mp>
-            <cp>1648.3</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3361.2</hp>
-            <mp>1281.6</mp>
-            <cp>1680.6</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3426.18</hp>
-            <mp>1307.25</mp>
-            <cp>1713.09</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3491.54</hp>
-            <mp>1333.05</mp>
-            <cp>1745.77</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3557.28</hp>
-            <mp>1359.0</mp>
-            <cp>1778.64</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3623.4</hp>
-            <mp>1385.1</mp>
-            <cp>1811.7</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3689.9</hp>
-            <mp>1411.35</mp>
-            <cp>1844.95</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3756.78</hp>
-            <mp>1437.75</mp>
-            <cp>1878.39</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3824.04</hp>
-            <mp>1464.3</mp>
-            <cp>1912.02</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3891.68</hp>
-            <mp>1491.0</mp>
-            <cp>1945.84</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3959.7</hp>
-            <mp>1517.85</mp>
-            <cp>1979.85</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4028.1</hp>
-            <mp>1544.85</mp>
-            <cp>2014.05</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>24</classId>
+	<staticData>
+		<baseINT>23</baseINT>
+		<baseSTR>36</baseSTR>
+		<baseCON>36</baseCON>
+		<baseMEN>26</baseMEN>
+		<baseDEX>35</baseDEX>
+		<baseWIT>14</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="46045" y="41251" z="-3440" />
+			<node x="46117" y="41247" z="-3440" />
+			<node x="46182" y="41198" z="-3440" />
+			<node x="46115" y="41141" z="-3440" />
+			<node x="46048" y="41141" z="-3440" />
+			<node x="45978" y="41196" z="-3440" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>90</walk>
+			<run>143</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>350</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.5</radius>
+			<height>23</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>89.0</hp>
+			<mp>30.0</mp>
+			<cp>44.5</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>101.74</hp>
+			<mp>35.46</mp>
+			<cp>50.87</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>114.62</hp>
+			<mp>40.98</mp>
+			<cp>57.31</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>127.64</hp>
+			<mp>46.56</mp>
+			<cp>63.82</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>140.8</hp>
+			<mp>52.2</mp>
+			<cp>70.4</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>154.1</hp>
+			<mp>57.9</mp>
+			<cp>77.05</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>167.54</hp>
+			<mp>63.66</mp>
+			<cp>83.77</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>181.12</hp>
+			<mp>69.48</mp>
+			<cp>90.56</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>194.84</hp>
+			<mp>75.36</mp>
+			<cp>97.42</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>208.7</hp>
+			<mp>81.3</mp>
+			<cp>104.35</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>222.7</hp>
+			<mp>87.3</mp>
+			<cp>111.35</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>236.84</hp>
+			<mp>93.36</mp>
+			<cp>118.42</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>251.12</hp>
+			<mp>99.48</mp>
+			<cp>125.56</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>265.54</hp>
+			<mp>105.66</mp>
+			<cp>132.77</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>280.1</hp>
+			<mp>111.9</mp>
+			<cp>140.05</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>294.8</hp>
+			<mp>118.2</mp>
+			<cp>147.4</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>309.64</hp>
+			<mp>124.56</mp>
+			<cp>154.82</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>324.62</hp>
+			<mp>130.98</mp>
+			<cp>162.31</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>339.74</hp>
+			<mp>137.46</mp>
+			<cp>169.87</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>355.0</hp>
+			<mp>144.0</mp>
+			<cp>177.5</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>385.8</hp>
+			<mp>153.9</mp>
+			<cp>192.9</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>416.88</hp>
+			<mp>163.89</mp>
+			<cp>208.44</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>448.24</hp>
+			<mp>173.97</mp>
+			<cp>224.12</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>479.88</hp>
+			<mp>184.14</mp>
+			<cp>239.94</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>511.8</hp>
+			<mp>194.4</mp>
+			<cp>255.9</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>544.0</hp>
+			<mp>204.75</mp>
+			<cp>272.0</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>576.48</hp>
+			<mp>215.19</mp>
+			<cp>288.24</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>609.24</hp>
+			<mp>225.72</mp>
+			<cp>304.62</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>642.28</hp>
+			<mp>236.34</mp>
+			<cp>321.14</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>675.6</hp>
+			<mp>247.05</mp>
+			<cp>337.8</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>709.2</hp>
+			<mp>257.85</mp>
+			<cp>354.6</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>743.08</hp>
+			<mp>268.74</mp>
+			<cp>371.54</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>777.24</hp>
+			<mp>279.72</mp>
+			<cp>388.62</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>811.68</hp>
+			<mp>290.79</mp>
+			<cp>405.84</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>846.4</hp>
+			<mp>301.95</mp>
+			<cp>423.2</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>881.4</hp>
+			<mp>313.2</mp>
+			<cp>440.7</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>916.68</hp>
+			<mp>324.54</mp>
+			<cp>458.34</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>952.24</hp>
+			<mp>335.97</mp>
+			<cp>476.12</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>988.08</hp>
+			<mp>347.49</mp>
+			<cp>494.04</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1024.2</hp>
+			<mp>359.1</mp>
+			<cp>512.1</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1073.6</hp>
+			<mp>378.6</mp>
+			<cp>536.8</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1123.38</hp>
+			<mp>398.25</mp>
+			<cp>561.69</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1173.54</hp>
+			<mp>418.05</mp>
+			<cp>586.77</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1224.08</hp>
+			<mp>438.0</mp>
+			<cp>612.04</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1275.0</hp>
+			<mp>458.1</mp>
+			<cp>637.5</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1326.3</hp>
+			<mp>478.35</mp>
+			<cp>663.15</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1377.98</hp>
+			<mp>498.75</mp>
+			<cp>688.99</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1430.04</hp>
+			<mp>519.3</mp>
+			<cp>715.02</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1482.48</hp>
+			<mp>540.0</mp>
+			<cp>741.24</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1535.3</hp>
+			<mp>560.85</mp>
+			<cp>767.65</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1588.5</hp>
+			<mp>581.85</mp>
+			<cp>794.25</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1642.08</hp>
+			<mp>603.0</mp>
+			<cp>821.04</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1696.04</hp>
+			<mp>624.3</mp>
+			<cp>848.02</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1750.38</hp>
+			<mp>645.75</mp>
+			<cp>875.19</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1805.1</hp>
+			<mp>667.35</mp>
+			<cp>902.55</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1860.2</hp>
+			<mp>689.1</mp>
+			<cp>930.1</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1915.68</hp>
+			<mp>711.0</mp>
+			<cp>957.84</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1971.54</hp>
+			<mp>733.05</mp>
+			<cp>985.77</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2027.78</hp>
+			<mp>755.25</mp>
+			<cp>1013.89</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2084.4</hp>
+			<mp>777.6</mp>
+			<cp>1042.2</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2141.4</hp>
+			<mp>800.1</mp>
+			<cp>1070.7</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2198.78</hp>
+			<mp>822.75</mp>
+			<cp>1099.39</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2256.54</hp>
+			<mp>845.55</mp>
+			<cp>1128.27</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2314.68</hp>
+			<mp>868.5</mp>
+			<cp>1157.34</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2373.2</hp>
+			<mp>891.6</mp>
+			<cp>1186.6</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2432.1</hp>
+			<mp>914.85</mp>
+			<cp>1216.05</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2491.38</hp>
+			<mp>938.25</mp>
+			<cp>1245.69</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2551.04</hp>
+			<mp>961.8</mp>
+			<cp>1275.52</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2611.08</hp>
+			<mp>985.5</mp>
+			<cp>1305.54</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2671.5</hp>
+			<mp>1009.35</mp>
+			<cp>1335.75</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2732.3</hp>
+			<mp>1033.35</mp>
+			<cp>1366.15</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2793.48</hp>
+			<mp>1057.5</mp>
+			<cp>1396.74</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2855.04</hp>
+			<mp>1081.8</mp>
+			<cp>1427.52</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2916.98</hp>
+			<mp>1106.25</mp>
+			<cp>1458.49</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2979.3</hp>
+			<mp>1130.85</mp>
+			<cp>1489.65</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3042.0</hp>
+			<mp>1155.6</mp>
+			<cp>1521.0</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3105.08</hp>
+			<mp>1180.5</mp>
+			<cp>1552.54</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3168.54</hp>
+			<mp>1205.55</mp>
+			<cp>1584.27</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3232.38</hp>
+			<mp>1230.75</mp>
+			<cp>1616.19</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3296.6</hp>
+			<mp>1256.1</mp>
+			<cp>1648.3</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3361.2</hp>
+			<mp>1281.6</mp>
+			<cp>1680.6</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3426.18</hp>
+			<mp>1307.25</mp>
+			<cp>1713.09</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3491.54</hp>
+			<mp>1333.05</mp>
+			<cp>1745.77</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3557.28</hp>
+			<mp>1359.0</mp>
+			<cp>1778.64</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3623.4</hp>
+			<mp>1385.1</mp>
+			<cp>1811.7</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3689.9</hp>
+			<mp>1411.35</mp>
+			<cp>1844.95</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3756.78</hp>
+			<mp>1437.75</mp>
+			<cp>1878.39</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3824.04</hp>
+			<mp>1464.3</mp>
+			<cp>1912.02</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3891.68</hp>
+			<mp>1491.0</mp>
+			<cp>1945.84</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3959.7</hp>
+			<mp>1517.85</mp>
+			<cp>1979.85</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4028.1</hp>
+			<mp>1544.85</mp>
+			<cp>2014.05</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4096.88</hp>
+			<mp>1572.0</mp>
+			<cp>2048.44</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4166.04</hp>
+			<mp>1599.3</mp>
+			<cp>2083.02</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4235.58</hp>
+			<mp>1626.75</mp>
+			<cp>2117.79</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4305.5</hp>
+			<mp>1654.35</mp>
+			<cp>2152.75</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4375.8</hp>
+			<mp>1682.1</mp>
+			<cp>2187.9</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4446.48</hp>
+			<mp>1710.0</mp>
+			<cp>2223.24</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4517.54</hp>
+			<mp>1738.05</mp>
+			<cp>2258.77</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4588.98</hp>
+			<mp>1766.25</mp>
+			<cp>2294.49</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4660.8</hp>
+			<mp>1794.6</mp>
+			<cp>2330.4</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4733</hp>
+			<mp>1823.1</mp>
+			<cp>2366.5</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4805.58</hp>
+			<mp>1851.75</mp>
+			<cp>2402.79</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4878.54</hp>
+			<mp>1880.55</mp>
+			<cp>2439.27</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4951.88</hp>
+			<mp>1909.5</mp>
+			<cp>2475.94</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5025.6</hp>
+			<mp>1938.6</mp>
+			<cp>2512.8</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5099.7</hp>
+			<mp>1967.85</mp>
+			<cp>2549.85</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5174.18</hp>
+			<mp>1997.25</mp>
+			<cp>2587.09</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Sorcerer.xml
+++ b/data/stats/chars/baseStats/Sorcerer.xml
@@ -1,798 +1,926 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>12</classId>
-    <staticData>
-        <baseINT>41</baseINT>
-        <baseSTR>22</baseSTR>
-        <baseCON>27</baseCON>
-        <baseMEN>39</baseMEN>
-        <baseDEX>21</baseDEX>
-        <baseWIT>20</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-90875" y="248162" z="-3570"/>
-            <node x="-90954" y="248118" z="-3570"/>
-            <node x="-90918" y="248070" z="-3570"/>
-            <node x="-90890" y="248027" z="-3570"/>
-        </creationPoints>
-        <basePAtk>3</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>15</chest>
-            <legs>8</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>78</walk>
-            <run>124</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>100</baseBreath>
-        <baseSafeFall>200</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>22.8</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>6.5</radius>
-            <height>22.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>101.0</hp>
-            <mp>40.0</mp>
-            <cp>60.6</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>116.47</hp>
-            <mp>47.28</mp>
-            <cp>69.882</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>132.11</hp>
-            <mp>54.64</mp>
-            <cp>79.266</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>147.92</hp>
-            <mp>62.08</mp>
-            <cp>88.752</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>163.9</hp>
-            <mp>69.6</mp>
-            <cp>98.34</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>180.05</hp>
-            <mp>77.2</mp>
-            <cp>108.03</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>196.37</hp>
-            <mp>84.88</mp>
-            <cp>117.822</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>212.86</hp>
-            <mp>92.64</mp>
-            <cp>127.716</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>229.52</hp>
-            <mp>100.48</mp>
-            <cp>137.712</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>246.35</hp>
-            <mp>108.4</mp>
-            <cp>147.81</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>263.35</hp>
-            <mp>116.4</mp>
-            <cp>158.01</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>280.52</hp>
-            <mp>124.48</mp>
-            <cp>168.312</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>297.86</hp>
-            <mp>132.64</mp>
-            <cp>178.716</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>315.37</hp>
-            <mp>140.88</mp>
-            <cp>189.222</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>333.05</hp>
-            <mp>149.2</mp>
-            <cp>199.83</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>350.9</hp>
-            <mp>157.6</mp>
-            <cp>210.54</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>368.92</hp>
-            <mp>166.08</mp>
-            <cp>221.352</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>387.11</hp>
-            <mp>174.64</mp>
-            <cp>232.266</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>405.47</hp>
-            <mp>183.28</mp>
-            <cp>243.282</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>424.0</hp>
-            <mp>192.0</mp>
-            <cp>254.4</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>451.5</hp>
-            <mp>205.2</mp>
-            <cp>270.9</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>479.25</hp>
-            <mp>218.52</mp>
-            <cp>287.55</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>507.25</hp>
-            <mp>231.96</mp>
-            <cp>304.35</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>535.5</hp>
-            <mp>245.52</mp>
-            <cp>321.3</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>564.0</hp>
-            <mp>259.2</mp>
-            <cp>338.4</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>592.75</hp>
-            <mp>273.0</mp>
-            <cp>355.65</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>621.75</hp>
-            <mp>286.92</mp>
-            <cp>373.05</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>651.0</hp>
-            <mp>300.96</mp>
-            <cp>390.6</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>680.5</hp>
-            <mp>315.12</mp>
-            <cp>408.3</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>710.25</hp>
-            <mp>329.4</mp>
-            <cp>426.15</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>740.25</hp>
-            <mp>343.8</mp>
-            <cp>444.15</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>770.5</hp>
-            <mp>358.32</mp>
-            <cp>462.3</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>801.0</hp>
-            <mp>372.96</mp>
-            <cp>480.6</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>831.75</hp>
-            <mp>387.72</mp>
-            <cp>499.05</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>862.75</hp>
-            <mp>402.6</mp>
-            <cp>517.65</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>894.0</hp>
-            <mp>417.6</mp>
-            <cp>536.4</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>925.5</hp>
-            <mp>432.72</mp>
-            <cp>555.3</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>957.25</hp>
-            <mp>447.96</mp>
-            <cp>574.35</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>989.25</hp>
-            <mp>463.32</mp>
-            <cp>593.55</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1021.5</hp>
-            <mp>478.8</mp>
-            <cp>612.9</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1067.0</hp>
-            <mp>504.8</mp>
-            <cp>640.2</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1112.85</hp>
-            <mp>531.0</mp>
-            <cp>667.71</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1159.05</hp>
-            <mp>557.4</mp>
-            <cp>695.43</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1205.6</hp>
-            <mp>584.0</mp>
-            <cp>723.36</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1252.5</hp>
-            <mp>610.8</mp>
-            <cp>751.5</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1299.75</hp>
-            <mp>637.8</mp>
-            <cp>779.85</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1347.35</hp>
-            <mp>665.0</mp>
-            <cp>808.41</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1395.3</hp>
-            <mp>692.4</mp>
-            <cp>837.18</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1443.6</hp>
-            <mp>720.0</mp>
-            <cp>866.16</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1492.25</hp>
-            <mp>747.8</mp>
-            <cp>895.35</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1541.25</hp>
-            <mp>775.8</mp>
-            <cp>924.75</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1590.6</hp>
-            <mp>804.0</mp>
-            <cp>954.36</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1640.3</hp>
-            <mp>832.4</mp>
-            <cp>984.18</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1690.35</hp>
-            <mp>861.0</mp>
-            <cp>1014.21</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1740.75</hp>
-            <mp>889.8</mp>
-            <cp>1044.45</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1791.5</hp>
-            <mp>918.8</mp>
-            <cp>1074.9</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1842.6</hp>
-            <mp>948.0</mp>
-            <cp>1105.56</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1894.05</hp>
-            <mp>977.4</mp>
-            <cp>1136.43</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>1945.85</hp>
-            <mp>1007.0</mp>
-            <cp>1167.51</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>1998.0</hp>
-            <mp>1036.8</mp>
-            <cp>1198.8</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2050.5</hp>
-            <mp>1066.8</mp>
-            <cp>1230.3</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2103.35</hp>
-            <mp>1097.0</mp>
-            <cp>1262.01</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2156.55</hp>
-            <mp>1127.4</mp>
-            <cp>1293.93</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2210.1</hp>
-            <mp>1158.0</mp>
-            <cp>1326.06</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2264.0</hp>
-            <mp>1188.8</mp>
-            <cp>1358.4</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2318.25</hp>
-            <mp>1219.8</mp>
-            <cp>1390.95</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2372.85</hp>
-            <mp>1251.0</mp>
-            <cp>1423.71</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2427.8</hp>
-            <mp>1282.4</mp>
-            <cp>1456.68</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2483.1</hp>
-            <mp>1314.0</mp>
-            <cp>1489.86</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2538.75</hp>
-            <mp>1345.8</mp>
-            <cp>1523.25</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2594.75</hp>
-            <mp>1377.8</mp>
-            <cp>1556.85</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2651.1</hp>
-            <mp>1410.0</mp>
-            <cp>1590.66</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2707.8</hp>
-            <mp>1442.4</mp>
-            <cp>1624.68</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2764.85</hp>
-            <mp>1475.0</mp>
-            <cp>1658.91</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2822.25</hp>
-            <mp>1507.8</mp>
-            <cp>1693.35</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>2880.0</hp>
-            <mp>1540.8</mp>
-            <cp>1728.0</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>2938.1</hp>
-            <mp>1574.0</mp>
-            <cp>1762.86</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>2996.55</hp>
-            <mp>1607.4</mp>
-            <cp>1797.93</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3055.35</hp>
-            <mp>1641.0</mp>
-            <cp>1833.21</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3114.5</hp>
-            <mp>1674.8</mp>
-            <cp>1868.7</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3174.0</hp>
-            <mp>1708.8</mp>
-            <cp>1904.4</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3233.85</hp>
-            <mp>1743.0</mp>
-            <cp>1940.31</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3294.05</hp>
-            <mp>1777.4</mp>
-            <cp>1976.43</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3354.6</hp>
-            <mp>1812.0</mp>
-            <cp>2012.76</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3415.5</hp>
-            <mp>1846.8</mp>
-            <cp>2049.3</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3476.75</hp>
-            <mp>1881.8</mp>
-            <cp>2086.05</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3538.35</hp>
-            <mp>1917.0</mp>
-            <cp>2123.01</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3600.3</hp>
-            <mp>1952.4</mp>
-            <cp>2160.18</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3662.6</hp>
-            <mp>1988.0</mp>
-            <cp>2197.56</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3725.25</hp>
-            <mp>2023.8</mp>
-            <cp>2235.15</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>3788.25</hp>
-            <mp>2059.8</mp>
-            <cp>2272.95</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>12</classId>
+	<staticData>
+		<baseINT>41</baseINT>
+		<baseSTR>22</baseSTR>
+		<baseCON>27</baseCON>
+		<baseMEN>39</baseMEN>
+		<baseDEX>21</baseDEX>
+		<baseWIT>20</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-90875" y="248162" z="-3570" />
+			<node x="-90954" y="248118" z="-3570" />
+			<node x="-90918" y="248070" z="-3570" />
+			<node x="-90890" y="248027" z="-3570" />
+		</creationPoints>
+		<basePAtk>3</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>15</chest>
+			<legs>8</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>78</walk>
+			<run>124</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>200</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>22.8</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>6.5</radius>
+			<height>22.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>101.0</hp>
+			<mp>40.0</mp>
+			<cp>60.6</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>116.47</hp>
+			<mp>47.28</mp>
+			<cp>69.882</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>132.11</hp>
+			<mp>54.64</mp>
+			<cp>79.266</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>147.92</hp>
+			<mp>62.08</mp>
+			<cp>88.752</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>163.9</hp>
+			<mp>69.6</mp>
+			<cp>98.34</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>180.05</hp>
+			<mp>77.2</mp>
+			<cp>108.03</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>196.37</hp>
+			<mp>84.88</mp>
+			<cp>117.822</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>212.86</hp>
+			<mp>92.64</mp>
+			<cp>127.716</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>229.52</hp>
+			<mp>100.48</mp>
+			<cp>137.712</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>246.35</hp>
+			<mp>108.4</mp>
+			<cp>147.81</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>263.35</hp>
+			<mp>116.4</mp>
+			<cp>158.01</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>280.52</hp>
+			<mp>124.48</mp>
+			<cp>168.312</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>297.86</hp>
+			<mp>132.64</mp>
+			<cp>178.716</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>315.37</hp>
+			<mp>140.88</mp>
+			<cp>189.222</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>333.05</hp>
+			<mp>149.2</mp>
+			<cp>199.83</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>350.9</hp>
+			<mp>157.6</mp>
+			<cp>210.54</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>368.92</hp>
+			<mp>166.08</mp>
+			<cp>221.352</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>387.11</hp>
+			<mp>174.64</mp>
+			<cp>232.266</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>405.47</hp>
+			<mp>183.28</mp>
+			<cp>243.282</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>424.0</hp>
+			<mp>192.0</mp>
+			<cp>254.4</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>451.5</hp>
+			<mp>205.2</mp>
+			<cp>270.9</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>479.25</hp>
+			<mp>218.52</mp>
+			<cp>287.55</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>507.25</hp>
+			<mp>231.96</mp>
+			<cp>304.35</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>535.5</hp>
+			<mp>245.52</mp>
+			<cp>321.3</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>564.0</hp>
+			<mp>259.2</mp>
+			<cp>338.4</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>592.75</hp>
+			<mp>273.0</mp>
+			<cp>355.65</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>621.75</hp>
+			<mp>286.92</mp>
+			<cp>373.05</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>651.0</hp>
+			<mp>300.96</mp>
+			<cp>390.6</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>680.5</hp>
+			<mp>315.12</mp>
+			<cp>408.3</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>710.25</hp>
+			<mp>329.4</mp>
+			<cp>426.15</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>740.25</hp>
+			<mp>343.8</mp>
+			<cp>444.15</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>770.5</hp>
+			<mp>358.32</mp>
+			<cp>462.3</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>801.0</hp>
+			<mp>372.96</mp>
+			<cp>480.6</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>831.75</hp>
+			<mp>387.72</mp>
+			<cp>499.05</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>862.75</hp>
+			<mp>402.6</mp>
+			<cp>517.65</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>894.0</hp>
+			<mp>417.6</mp>
+			<cp>536.4</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>925.5</hp>
+			<mp>432.72</mp>
+			<cp>555.3</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>957.25</hp>
+			<mp>447.96</mp>
+			<cp>574.35</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>989.25</hp>
+			<mp>463.32</mp>
+			<cp>593.55</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1021.5</hp>
+			<mp>478.8</mp>
+			<cp>612.9</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1067.0</hp>
+			<mp>504.8</mp>
+			<cp>640.2</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1112.85</hp>
+			<mp>531.0</mp>
+			<cp>667.71</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1159.05</hp>
+			<mp>557.4</mp>
+			<cp>695.43</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1205.6</hp>
+			<mp>584.0</mp>
+			<cp>723.36</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1252.5</hp>
+			<mp>610.8</mp>
+			<cp>751.5</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1299.75</hp>
+			<mp>637.8</mp>
+			<cp>779.85</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1347.35</hp>
+			<mp>665.0</mp>
+			<cp>808.41</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1395.3</hp>
+			<mp>692.4</mp>
+			<cp>837.18</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1443.6</hp>
+			<mp>720.0</mp>
+			<cp>866.16</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1492.25</hp>
+			<mp>747.8</mp>
+			<cp>895.35</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1541.25</hp>
+			<mp>775.8</mp>
+			<cp>924.75</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1590.6</hp>
+			<mp>804.0</mp>
+			<cp>954.36</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1640.3</hp>
+			<mp>832.4</mp>
+			<cp>984.18</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1690.35</hp>
+			<mp>861.0</mp>
+			<cp>1014.21</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1740.75</hp>
+			<mp>889.8</mp>
+			<cp>1044.45</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1791.5</hp>
+			<mp>918.8</mp>
+			<cp>1074.9</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1842.6</hp>
+			<mp>948.0</mp>
+			<cp>1105.56</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1894.05</hp>
+			<mp>977.4</mp>
+			<cp>1136.43</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1945.85</hp>
+			<mp>1007.0</mp>
+			<cp>1167.51</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1998.0</hp>
+			<mp>1036.8</mp>
+			<cp>1198.8</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2050.5</hp>
+			<mp>1066.8</mp>
+			<cp>1230.3</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2103.35</hp>
+			<mp>1097.0</mp>
+			<cp>1262.01</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2156.55</hp>
+			<mp>1127.4</mp>
+			<cp>1293.93</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2210.1</hp>
+			<mp>1158.0</mp>
+			<cp>1326.06</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2264.0</hp>
+			<mp>1188.8</mp>
+			<cp>1358.4</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2318.25</hp>
+			<mp>1219.8</mp>
+			<cp>1390.95</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2372.85</hp>
+			<mp>1251.0</mp>
+			<cp>1423.71</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2427.8</hp>
+			<mp>1282.4</mp>
+			<cp>1456.68</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2483.1</hp>
+			<mp>1314.0</mp>
+			<cp>1489.86</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2538.75</hp>
+			<mp>1345.8</mp>
+			<cp>1523.25</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2594.75</hp>
+			<mp>1377.8</mp>
+			<cp>1556.85</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2651.1</hp>
+			<mp>1410.0</mp>
+			<cp>1590.66</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2707.8</hp>
+			<mp>1442.4</mp>
+			<cp>1624.68</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2764.85</hp>
+			<mp>1475.0</mp>
+			<cp>1658.91</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2822.25</hp>
+			<mp>1507.8</mp>
+			<cp>1693.35</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>2880.0</hp>
+			<mp>1540.8</mp>
+			<cp>1728.0</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>2938.1</hp>
+			<mp>1574.0</mp>
+			<cp>1762.86</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>2996.55</hp>
+			<mp>1607.4</mp>
+			<cp>1797.93</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3055.35</hp>
+			<mp>1641.0</mp>
+			<cp>1833.21</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3114.5</hp>
+			<mp>1674.8</mp>
+			<cp>1868.7</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3174.0</hp>
+			<mp>1708.8</mp>
+			<cp>1904.4</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3233.85</hp>
+			<mp>1743.0</mp>
+			<cp>1940.31</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3294.05</hp>
+			<mp>1777.4</mp>
+			<cp>1976.43</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3354.6</hp>
+			<mp>1812.0</mp>
+			<cp>2012.76</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3415.5</hp>
+			<mp>1846.8</mp>
+			<cp>2049.3</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3476.75</hp>
+			<mp>1881.8</mp>
+			<cp>2086.05</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3538.35</hp>
+			<mp>1917.0</mp>
+			<cp>2123.01</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3600.3</hp>
+			<mp>1952.4</mp>
+			<cp>2160.18</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3662.6</hp>
+			<mp>1988.0</mp>
+			<cp>2197.56</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3725.25</hp>
+			<mp>2023.8</mp>
+			<cp>2235.15</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3788.25</hp>
+			<mp>2059.8</mp>
+			<cp>2272.95</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>3851.6</hp>
+			<mp>2096.0</mp>
+			<cp>2310.96</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>3915.3</hp>
+			<mp>2132.4</mp>
+			<cp>2349.18</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>3979.35</hp>
+			<mp>2169.0</mp>
+			<cp>2387.61</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4043.75</hp>
+			<mp>2205.8</mp>
+			<cp>2426.25</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4108.5</hp>
+			<mp>2242.8</mp>
+			<cp>2465.1</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4173.6</hp>
+			<mp>2280.0</mp>
+			<cp>2504.16</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4239.05</hp>
+			<mp>2317.4</mp>
+			<cp>2543.43</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4304.85</hp>
+			<mp>2355.0</mp>
+			<cp>2582.91</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4371</hp>
+			<mp>2392.8</mp>
+			<cp>2622.6</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4437.5</hp>
+			<mp>2430.8</mp>
+			<cp>2662.5</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4504.35</hp>
+			<mp>2469</mp>
+			<cp>2702.61</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4571.55</hp>
+			<mp>2507.4</mp>
+			<cp>2742.93</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4639.1</hp>
+			<mp>2546</mp>
+			<cp>2783.46</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>4707</hp>
+			<mp>2584.8</mp>
+			<cp>2824.2</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>4775.25</hp>
+			<mp>2623.8</mp>
+			<cp>2865.15</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>4843.85</hp>
+			<mp>2663</mp>
+			<cp>2906.31</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/SoulBreaker.xml
+++ b/data/stats/chars/baseStats/SoulBreaker.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>194</classId> <!-- TODO update data -->
-    <staticData>
-        <baseINT>25</baseINT>
-        <baseSTR>41</baseSTR>
-        <baseCON>27</baseCON>
-        <baseMEN>22</baseMEN>
-        <baseDEX>35</baseDEX>
-        <baseWIT>20</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-125607" y="38452" z="1152"/>
-            <node x="-125472" y="38450" z="1152"/>
-            <node x="-125615" y="37771" z="1152"/>
-            <node x="-125464" y="37776" z="1152"/>
-            <node x="-125517" y="38267" z="1155"/>
-            <node x="-125531" y="37944" z="1155"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>87</walk>
-            <run>140</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>100</baseBreath>
-        <baseSafeFall>500</baseSafeFall>
-        <collisionMale>
-            <radius>8.0</radius>
-            <height>25.2</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.0</radius>
-            <height>22.6</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>97.0</hp>
-            <mp>40.0</mp>
-            <cp>48.5</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>113.38</hp>
-            <mp>47.28</mp>
-            <cp>56.69</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>129.94</hp>
-            <mp>54.64</mp>
-            <cp>64.97</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>146.68</hp>
-            <mp>62.08</mp>
-            <cp>73.34</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>163.6</hp>
-            <mp>69.6</mp>
-            <cp>81.8</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>180.7</hp>
-            <mp>77.2</mp>
-            <cp>90.35</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>197.98</hp>
-            <mp>84.88</mp>
-            <cp>98.99</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>215.44</hp>
-            <mp>92.64</mp>
-            <cp>107.72</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>233.08</hp>
-            <mp>100.48</mp>
-            <cp>116.54</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>250.9</hp>
-            <mp>108.4</mp>
-            <cp>125.45</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>268.9</hp>
-            <mp>116.4</mp>
-            <cp>134.45</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>287.08</hp>
-            <mp>124.48</mp>
-            <cp>143.54</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>305.44</hp>
-            <mp>132.64</mp>
-            <cp>152.72</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>323.98</hp>
-            <mp>140.88</mp>
-            <cp>161.99</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>342.7</hp>
-            <mp>149.2</mp>
-            <cp>171.35</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>361.6</hp>
-            <mp>157.6</mp>
-            <cp>180.8</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>380.68</hp>
-            <mp>166.08</mp>
-            <cp>190.34</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>399.94</hp>
-            <mp>174.64</mp>
-            <cp>199.97</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>419.38</hp>
-            <mp>183.28</mp>
-            <cp>209.69</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>449.9</hp>
-            <mp>196.36</mp>
-            <cp>224.95</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>480.7</hp>
-            <mp>209.56</mp>
-            <cp>240.35</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>511.78</hp>
-            <mp>222.88</mp>
-            <cp>255.89</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>543.14</hp>
-            <mp>236.32</mp>
-            <cp>271.57</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>574.78</hp>
-            <mp>249.88</mp>
-            <cp>287.39</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>606.7</hp>
-            <mp>263.56</mp>
-            <cp>303.35</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>638.9</hp>
-            <mp>277.36</mp>
-            <cp>319.45</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>671.38</hp>
-            <mp>291.28</mp>
-            <cp>335.69</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>704.14</hp>
-            <mp>305.32</mp>
-            <cp>352.07</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>737.18</hp>
-            <mp>319.48</mp>
-            <cp>368.59</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>770.5</hp>
-            <mp>333.76</mp>
-            <cp>385.25</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>804.1</hp>
-            <mp>348.16</mp>
-            <cp>402.05</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>837.98</hp>
-            <mp>362.68</mp>
-            <cp>418.99</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>872.14</hp>
-            <mp>377.32</mp>
-            <cp>436.07</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>906.58</hp>
-            <mp>392.08</mp>
-            <cp>453.29</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>941.3</hp>
-            <mp>406.96</mp>
-            <cp>470.65</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>976.3</hp>
-            <mp>421.96</mp>
-            <cp>488.15</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>1011.58</hp>
-            <mp>437.08</mp>
-            <cp>505.79</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1047.14</hp>
-            <mp>452.32</mp>
-            <cp>523.57</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1082.98</hp>
-            <mp>467.68</mp>
-            <cp>541.49</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1134.58</hp>
-            <mp>493.48</mp>
-            <cp>567.29</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1186.58</hp>
-            <mp>519.48</mp>
-            <cp>593.29</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1238.98</hp>
-            <mp>545.68</mp>
-            <cp>619.49</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1291.78</hp>
-            <mp>572.08</mp>
-            <cp>645.89</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1344.98</hp>
-            <mp>598.68</mp>
-            <cp>672.49</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1398.58</hp>
-            <mp>625.48</mp>
-            <cp>699.29</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1452.58</hp>
-            <mp>652.48</mp>
-            <cp>726.29</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1506.98</hp>
-            <mp>679.68</mp>
-            <cp>753.49</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1561.78</hp>
-            <mp>707.08</mp>
-            <cp>780.89</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1616.98</hp>
-            <mp>734.68</mp>
-            <cp>808.49</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1672.58</hp>
-            <mp>762.48</mp>
-            <cp>836.29</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1728.58</hp>
-            <mp>790.48</mp>
-            <cp>864.29</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1784.98</hp>
-            <mp>818.68</mp>
-            <cp>892.49</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1841.78</hp>
-            <mp>847.08</mp>
-            <cp>920.89</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1898.98</hp>
-            <mp>875.68</mp>
-            <cp>949.49</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1956.58</hp>
-            <mp>904.48</mp>
-            <cp>978.29</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>2014.58</hp>
-            <mp>933.48</mp>
-            <cp>1007.29</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>2072.98</hp>
-            <mp>962.68</mp>
-            <cp>1036.49</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2131.78</hp>
-            <mp>992.08</mp>
-            <cp>1065.89</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2190.98</hp>
-            <mp>1021.68</mp>
-            <cp>1095.49</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2250.58</hp>
-            <mp>1051.48</mp>
-            <cp>1125.29</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2310.58</hp>
-            <mp>1081.48</mp>
-            <cp>1155.29</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2370.98</hp>
-            <mp>1111.68</mp>
-            <cp>1185.49</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2431.78</hp>
-            <mp>1142.08</mp>
-            <cp>1215.89</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2492.98</hp>
-            <mp>1172.68</mp>
-            <cp>1246.49</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2554.58</hp>
-            <mp>1203.48</mp>
-            <cp>1277.29</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2616.58</hp>
-            <mp>1234.48</mp>
-            <cp>1308.29</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2678.98</hp>
-            <mp>1265.68</mp>
-            <cp>1339.49</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2741.78</hp>
-            <mp>1297.08</mp>
-            <cp>1370.89</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2804.98</hp>
-            <mp>1328.68</mp>
-            <cp>1402.49</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2868.58</hp>
-            <mp>1360.48</mp>
-            <cp>1434.29</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2932.58</hp>
-            <mp>1392.48</mp>
-            <cp>1466.29</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2996.98</hp>
-            <mp>1424.68</mp>
-            <cp>1498.49</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>3061.78</hp>
-            <mp>1457.08</mp>
-            <cp>1530.89</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>3126.98</hp>
-            <mp>1489.68</mp>
-            <cp>1563.49</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3192.58</hp>
-            <mp>1522.48</mp>
-            <cp>1596.29</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3258.58</hp>
-            <mp>1555.48</mp>
-            <cp>1629.29</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3324.98</hp>
-            <mp>1588.68</mp>
-            <cp>1662.49</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3391.78</hp>
-            <mp>1622.08</mp>
-            <cp>1695.89</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3458.98</hp>
-            <mp>1655.68</mp>
-            <cp>1729.49</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3526.58</hp>
-            <mp>1689.48</mp>
-            <cp>1763.29</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3594.58</hp>
-            <mp>1723.48</mp>
-            <cp>1797.29</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3662.98</hp>
-            <mp>1757.68</mp>
-            <cp>1831.49</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3731.78</hp>
-            <mp>1792.08</mp>
-            <cp>1865.89</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3800.98</hp>
-            <mp>1826.68</mp>
-            <cp>1900.49</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3870.58</hp>
-            <mp>1861.48</mp>
-            <cp>1935.29</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3940.58</hp>
-            <mp>1896.48</mp>
-            <cp>1970.29</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>4010.98</hp>
-            <mp>1931.68</mp>
-            <cp>2005.49</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>4081.78</hp>
-            <mp>1967.08</mp>
-            <cp>2040.89</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>4152.98</hp>
-            <mp>2002.68</mp>
-            <cp>2076.49</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4224.58</hp>
-            <mp>2038.48</mp>
-            <cp>2112.29</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4296.58</hp>
-            <mp>2074.48</mp>
-            <cp>2148.29</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>194</classId>
+	<staticData>
+		<baseINT>25</baseINT>
+		<baseSTR>41</baseSTR>
+		<baseCON>27</baseCON>
+		<baseMEN>22</baseMEN>
+		<baseDEX>35</baseDEX>
+		<baseWIT>20</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-125607" y="38452" z="1152" />
+			<node x="-125472" y="38450" z="1152" />
+			<node x="-125615" y="37771" z="1152" />
+			<node x="-125464" y="37776" z="1152" />
+			<node x="-125517" y="38267" z="1155" />
+			<node x="-125531" y="37944" z="1155" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>87</walk>
+			<run>140</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>500</baseSafeFall>
+		<collisionMale>
+			<radius>8.0</radius>
+			<height>25.2</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.0</radius>
+			<height>22.6</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>97.0</hp>
+			<mp>40.0</mp>
+			<cp>48.5</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>113.38</hp>
+			<mp>47.28</mp>
+			<cp>56.69</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>129.94</hp>
+			<mp>54.64</mp>
+			<cp>64.97</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>146.68</hp>
+			<mp>62.08</mp>
+			<cp>73.34</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>163.6</hp>
+			<mp>69.6</mp>
+			<cp>81.8</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>180.7</hp>
+			<mp>77.2</mp>
+			<cp>90.35</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>197.98</hp>
+			<mp>84.88</mp>
+			<cp>98.99</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>215.44</hp>
+			<mp>92.64</mp>
+			<cp>107.72</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>233.08</hp>
+			<mp>100.48</mp>
+			<cp>116.54</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>250.9</hp>
+			<mp>108.4</mp>
+			<cp>125.45</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>268.9</hp>
+			<mp>116.4</mp>
+			<cp>134.45</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>287.08</hp>
+			<mp>124.48</mp>
+			<cp>143.54</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>305.44</hp>
+			<mp>132.64</mp>
+			<cp>152.72</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>323.98</hp>
+			<mp>140.88</mp>
+			<cp>161.99</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>342.7</hp>
+			<mp>149.2</mp>
+			<cp>171.35</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>361.6</hp>
+			<mp>157.6</mp>
+			<cp>180.8</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>380.68</hp>
+			<mp>166.08</mp>
+			<cp>190.34</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>399.94</hp>
+			<mp>174.64</mp>
+			<cp>199.97</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>419.38</hp>
+			<mp>183.28</mp>
+			<cp>209.69</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>449.9</hp>
+			<mp>196.36</mp>
+			<cp>224.95</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>480.7</hp>
+			<mp>209.56</mp>
+			<cp>240.35</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>511.78</hp>
+			<mp>222.88</mp>
+			<cp>255.89</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>543.14</hp>
+			<mp>236.32</mp>
+			<cp>271.57</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>574.78</hp>
+			<mp>249.88</mp>
+			<cp>287.39</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>606.7</hp>
+			<mp>263.56</mp>
+			<cp>303.35</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>638.9</hp>
+			<mp>277.36</mp>
+			<cp>319.45</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>671.38</hp>
+			<mp>291.28</mp>
+			<cp>335.69</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>704.14</hp>
+			<mp>305.32</mp>
+			<cp>352.07</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>737.18</hp>
+			<mp>319.48</mp>
+			<cp>368.59</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>770.5</hp>
+			<mp>333.76</mp>
+			<cp>385.25</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>804.1</hp>
+			<mp>348.16</mp>
+			<cp>402.05</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>837.98</hp>
+			<mp>362.68</mp>
+			<cp>418.99</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>872.14</hp>
+			<mp>377.32</mp>
+			<cp>436.07</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>906.58</hp>
+			<mp>392.08</mp>
+			<cp>453.29</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>941.3</hp>
+			<mp>406.96</mp>
+			<cp>470.65</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>976.3</hp>
+			<mp>421.96</mp>
+			<cp>488.15</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>1011.58</hp>
+			<mp>437.08</mp>
+			<cp>505.79</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1047.14</hp>
+			<mp>452.32</mp>
+			<cp>523.57</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1082.98</hp>
+			<mp>467.68</mp>
+			<cp>541.49</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1134.58</hp>
+			<mp>493.48</mp>
+			<cp>567.29</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1186.58</hp>
+			<mp>519.48</mp>
+			<cp>593.29</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1238.98</hp>
+			<mp>545.68</mp>
+			<cp>619.49</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1291.78</hp>
+			<mp>572.08</mp>
+			<cp>645.89</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1344.98</hp>
+			<mp>598.68</mp>
+			<cp>672.49</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1398.58</hp>
+			<mp>625.48</mp>
+			<cp>699.29</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1452.58</hp>
+			<mp>652.48</mp>
+			<cp>726.29</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1506.98</hp>
+			<mp>679.68</mp>
+			<cp>753.49</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1561.78</hp>
+			<mp>707.08</mp>
+			<cp>780.89</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1616.98</hp>
+			<mp>734.68</mp>
+			<cp>808.49</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1672.58</hp>
+			<mp>762.48</mp>
+			<cp>836.29</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1728.58</hp>
+			<mp>790.48</mp>
+			<cp>864.29</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1784.98</hp>
+			<mp>818.68</mp>
+			<cp>892.49</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1841.78</hp>
+			<mp>847.08</mp>
+			<cp>920.89</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1898.98</hp>
+			<mp>875.68</mp>
+			<cp>949.49</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1956.58</hp>
+			<mp>904.48</mp>
+			<cp>978.29</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>2014.58</hp>
+			<mp>933.48</mp>
+			<cp>1007.29</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2072.98</hp>
+			<mp>962.68</mp>
+			<cp>1036.49</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2131.78</hp>
+			<mp>992.08</mp>
+			<cp>1065.89</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2190.98</hp>
+			<mp>1021.68</mp>
+			<cp>1095.49</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2250.58</hp>
+			<mp>1051.48</mp>
+			<cp>1125.29</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2310.58</hp>
+			<mp>1081.48</mp>
+			<cp>1155.29</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2370.98</hp>
+			<mp>1111.68</mp>
+			<cp>1185.49</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2431.78</hp>
+			<mp>1142.08</mp>
+			<cp>1215.89</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2492.98</hp>
+			<mp>1172.68</mp>
+			<cp>1246.49</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2554.58</hp>
+			<mp>1203.48</mp>
+			<cp>1277.29</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2616.58</hp>
+			<mp>1234.48</mp>
+			<cp>1308.29</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2678.98</hp>
+			<mp>1265.68</mp>
+			<cp>1339.49</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2741.78</hp>
+			<mp>1297.08</mp>
+			<cp>1370.89</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2804.98</hp>
+			<mp>1328.68</mp>
+			<cp>1402.49</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2868.58</hp>
+			<mp>1360.48</mp>
+			<cp>1434.29</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2932.58</hp>
+			<mp>1392.48</mp>
+			<cp>1466.29</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2996.98</hp>
+			<mp>1424.68</mp>
+			<cp>1498.49</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>3061.78</hp>
+			<mp>1457.08</mp>
+			<cp>1530.89</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3126.98</hp>
+			<mp>1489.68</mp>
+			<cp>1563.49</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3192.58</hp>
+			<mp>1522.48</mp>
+			<cp>1596.29</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3258.58</hp>
+			<mp>1555.48</mp>
+			<cp>1629.29</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3324.98</hp>
+			<mp>1588.68</mp>
+			<cp>1662.49</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3391.78</hp>
+			<mp>1622.08</mp>
+			<cp>1695.89</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3458.98</hp>
+			<mp>1655.68</mp>
+			<cp>1729.49</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3526.58</hp>
+			<mp>1689.48</mp>
+			<cp>1763.29</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3594.58</hp>
+			<mp>1723.48</mp>
+			<cp>1797.29</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3662.98</hp>
+			<mp>1757.68</mp>
+			<cp>1831.49</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3731.78</hp>
+			<mp>1792.08</mp>
+			<cp>1865.89</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3800.98</hp>
+			<mp>1826.68</mp>
+			<cp>1900.49</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3870.58</hp>
+			<mp>1861.48</mp>
+			<cp>1935.29</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3940.58</hp>
+			<mp>1896.48</mp>
+			<cp>1970.29</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>4010.98</hp>
+			<mp>1931.68</mp>
+			<cp>2005.49</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4081.78</hp>
+			<mp>1967.08</mp>
+			<cp>2040.89</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4152.98</hp>
+			<mp>2002.68</mp>
+			<cp>2076.49</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4224.58</hp>
+			<mp>2038.48</mp>
+			<cp>2112.29</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4296.58</hp>
+			<mp>2074.48</mp>
+			<cp>2148.29</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4408.05</hp>
+			<mp>1993.76</mp>
+			<cp>2204.025</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4480.85</hp>
+			<mp>2030.16</mp>
+			<cp>2240.425</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4554.05</hp>
+			<mp>2066.76</mp>
+			<cp>2277.025</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4627.65</hp>
+			<mp>2103.56</mp>
+			<cp>2313.825</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4701.65</hp>
+			<mp>2140.56</mp>
+			<cp>2350.825</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4776.05</hp>
+			<mp>2177.76</mp>
+			<cp>2388.025</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4850.85</hp>
+			<mp>2215.16</mp>
+			<cp>2425.425</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4926.05</hp>
+			<mp>2252.76</mp>
+			<cp>2463.025</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>5001.65</hp>
+			<mp>2290.56</mp>
+			<cp>2500.83</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>5077.65</hp>
+			<mp>2328.56</mp>
+			<cp>2538.83</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5154.05</hp>
+			<mp>2366.76</mp>
+			<cp>2577.03</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5230.85</hp>
+			<mp>2405.16</mp>
+			<cp>2615.43</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5308.05</hp>
+			<mp>2443.76</mp>
+			<cp>2654.03</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5385.65</hp>
+			<mp>2482.56</mp>
+			<cp>2692.83</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5463.65</hp>
+			<mp>2521.56</mp>
+			<cp>2731.83</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5542.05</hp>
+			<mp>2560.76</mp>
+			<cp>2771.025</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/SoulFinder.xml
+++ b/data/stats/chars/baseStats/SoulFinder.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>193</classId> <!-- TODO update data -->
-    <staticData>
-        <baseINT>25</baseINT>
-        <baseSTR>41</baseSTR>
-        <baseCON>27</baseCON>
-        <baseMEN>22</baseMEN>
-        <baseDEX>35</baseDEX>
-        <baseWIT>20</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-125607" y="38452" z="1152"/>
-            <node x="-125472" y="38450" z="1152"/>
-            <node x="-125615" y="37771" z="1152"/>
-            <node x="-125464" y="37776" z="1152"/>
-            <node x="-125517" y="38267" z="1155"/>
-            <node x="-125531" y="37944" z="1155"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>87</walk>
-            <run>140</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>100</baseBreath>
-        <baseSafeFall>500</baseSafeFall>
-        <collisionMale>
-            <radius>8.0</radius>
-            <height>25.2</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.0</radius>
-            <height>22.6</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>97.0</hp>
-            <mp>40.0</mp>
-            <cp>48.5</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>113.38</hp>
-            <mp>47.28</mp>
-            <cp>56.69</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>129.94</hp>
-            <mp>54.64</mp>
-            <cp>64.97</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>146.68</hp>
-            <mp>62.08</mp>
-            <cp>73.34</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>163.6</hp>
-            <mp>69.6</mp>
-            <cp>81.8</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>180.7</hp>
-            <mp>77.2</mp>
-            <cp>90.35</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>197.98</hp>
-            <mp>84.88</mp>
-            <cp>98.99</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>215.44</hp>
-            <mp>92.64</mp>
-            <cp>107.72</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>233.08</hp>
-            <mp>100.48</mp>
-            <cp>116.54</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>250.9</hp>
-            <mp>108.4</mp>
-            <cp>125.45</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>268.9</hp>
-            <mp>116.4</mp>
-            <cp>134.45</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>287.08</hp>
-            <mp>124.48</mp>
-            <cp>143.54</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>305.44</hp>
-            <mp>132.64</mp>
-            <cp>152.72</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>323.98</hp>
-            <mp>140.88</mp>
-            <cp>161.99</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>342.7</hp>
-            <mp>149.2</mp>
-            <cp>171.35</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>361.6</hp>
-            <mp>157.6</mp>
-            <cp>180.8</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>380.68</hp>
-            <mp>166.08</mp>
-            <cp>190.34</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>399.94</hp>
-            <mp>174.64</mp>
-            <cp>199.97</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>419.38</hp>
-            <mp>183.28</mp>
-            <cp>209.69</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>449.9</hp>
-            <mp>196.36</mp>
-            <cp>224.95</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>480.7</hp>
-            <mp>209.56</mp>
-            <cp>240.35</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>511.78</hp>
-            <mp>222.88</mp>
-            <cp>255.89</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>543.14</hp>
-            <mp>236.32</mp>
-            <cp>271.57</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>574.78</hp>
-            <mp>249.88</mp>
-            <cp>287.39</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>606.7</hp>
-            <mp>263.56</mp>
-            <cp>303.35</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>638.9</hp>
-            <mp>277.36</mp>
-            <cp>319.45</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>671.38</hp>
-            <mp>291.28</mp>
-            <cp>335.69</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>704.14</hp>
-            <mp>305.32</mp>
-            <cp>352.07</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>737.18</hp>
-            <mp>319.48</mp>
-            <cp>368.59</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>770.5</hp>
-            <mp>333.76</mp>
-            <cp>385.25</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>804.1</hp>
-            <mp>348.16</mp>
-            <cp>402.05</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>837.98</hp>
-            <mp>362.68</mp>
-            <cp>418.99</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>872.14</hp>
-            <mp>377.32</mp>
-            <cp>436.07</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>906.58</hp>
-            <mp>392.08</mp>
-            <cp>453.29</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>941.3</hp>
-            <mp>406.96</mp>
-            <cp>470.65</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>976.3</hp>
-            <mp>421.96</mp>
-            <cp>488.15</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>1011.58</hp>
-            <mp>437.08</mp>
-            <cp>505.79</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1047.14</hp>
-            <mp>452.32</mp>
-            <cp>523.57</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1082.98</hp>
-            <mp>467.68</mp>
-            <cp>541.49</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1119.1</hp>
-            <mp>483.16</mp>
-            <cp>559.55</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1155.5</hp>
-            <mp>498.76</mp>
-            <cp>577.75</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1192.18</hp>
-            <mp>514.48</mp>
-            <cp>596.09</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1229.14</hp>
-            <mp>530.32</mp>
-            <cp>614.57</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1266.38</hp>
-            <mp>546.28</mp>
-            <cp>633.19</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1303.9</hp>
-            <mp>562.36</mp>
-            <cp>651.95</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1341.7</hp>
-            <mp>578.56</mp>
-            <cp>670.85</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1379.78</hp>
-            <mp>594.88</mp>
-            <cp>689.89</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1418.14</hp>
-            <mp>611.32</mp>
-            <cp>709.07</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1456.78</hp>
-            <mp>627.88</mp>
-            <cp>728.39</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1495.7</hp>
-            <mp>644.56</mp>
-            <cp>747.85</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1534.9</hp>
-            <mp>661.36</mp>
-            <cp>767.45</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1574.38</hp>
-            <mp>678.28</mp>
-            <cp>787.19</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1614.14</hp>
-            <mp>695.32</mp>
-            <cp>807.07</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1654.18</hp>
-            <mp>712.48</mp>
-            <cp>827.09</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1694.5</hp>
-            <mp>729.76</mp>
-            <cp>847.25</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1735.1</hp>
-            <mp>747.16</mp>
-            <cp>867.55</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1775.98</hp>
-            <mp>764.68</mp>
-            <cp>887.99</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1817.14</hp>
-            <mp>782.32</mp>
-            <cp>908.57</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>1858.58</hp>
-            <mp>800.08</mp>
-            <cp>929.29</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>1900.3</hp>
-            <mp>817.96</mp>
-            <cp>950.15</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>1942.3</hp>
-            <mp>835.96</mp>
-            <cp>971.15</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>1984.58</hp>
-            <mp>854.08</mp>
-            <cp>992.29</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2027.14</hp>
-            <mp>872.32</mp>
-            <cp>1013.57</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2069.98</hp>
-            <mp>890.68</mp>
-            <cp>1034.99</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2113.1</hp>
-            <mp>909.16</mp>
-            <cp>1056.55</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2156.5</hp>
-            <mp>927.76</mp>
-            <cp>1078.25</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2200.18</hp>
-            <mp>946.48</mp>
-            <cp>1100.09</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2244.14</hp>
-            <mp>965.32</mp>
-            <cp>1122.07</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2288.38</hp>
-            <mp>984.28</mp>
-            <cp>1144.19</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2332.9</hp>
-            <mp>1003.36</mp>
-            <cp>1166.45</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2377.7</hp>
-            <mp>1022.56</mp>
-            <cp>1188.85</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2422.78</hp>
-            <mp>1041.88</mp>
-            <cp>1211.39</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2468.14</hp>
-            <mp>1061.32</mp>
-            <cp>1234.07</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2513.78</hp>
-            <mp>1080.88</mp>
-            <cp>1256.89</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2559.7</hp>
-            <mp>1100.56</mp>
-            <cp>1279.85</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>2605.9</hp>
-            <mp>1120.36</mp>
-            <cp>1302.95</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>2652.38</hp>
-            <mp>1140.28</mp>
-            <cp>1326.19</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>2699.14</hp>
-            <mp>1160.32</mp>
-            <cp>1349.57</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>2746.18</hp>
-            <mp>1180.48</mp>
-            <cp>1373.09</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>2793.5</hp>
-            <mp>1200.76</mp>
-            <cp>1396.75</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>2841.1</hp>
-            <mp>1221.16</mp>
-            <cp>1420.55</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>2888.98</hp>
-            <mp>1241.68</mp>
-            <cp>1444.49</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>2937.14</hp>
-            <mp>1262.32</mp>
-            <cp>1468.57</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>2985.58</hp>
-            <mp>1283.08</mp>
-            <cp>1492.79</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3034.3</hp>
-            <mp>1303.96</mp>
-            <cp>1517.15</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3083.3</hp>
-            <mp>1324.96</mp>
-            <cp>1541.65</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3132.58</hp>
-            <mp>1346.08</mp>
-            <cp>1566.29</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3182.14</hp>
-            <mp>1367.32</mp>
-            <cp>1591.07</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3231.98</hp>
-            <mp>1388.68</mp>
-            <cp>1615.99</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3282.1</hp>
-            <mp>1410.16</mp>
-            <cp>1641.05</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>3332.5</hp>
-            <mp>1431.76</mp>
-            <cp>1666.25</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>193</classId>
+	<staticData>
+		<baseINT>25</baseINT>
+		<baseSTR>41</baseSTR>
+		<baseCON>27</baseCON>
+		<baseMEN>22</baseMEN>
+		<baseDEX>35</baseDEX>
+		<baseWIT>20</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-125607" y="38452" z="1152" />
+			<node x="-125472" y="38450" z="1152" />
+			<node x="-125615" y="37771" z="1152" />
+			<node x="-125464" y="37776" z="1152" />
+			<node x="-125517" y="38267" z="1155" />
+			<node x="-125531" y="37944" z="1155" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>87</walk>
+			<run>140</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>500</baseSafeFall>
+		<collisionMale>
+			<radius>8.0</radius>
+			<height>25.2</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.0</radius>
+			<height>22.6</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>97.0</hp>
+			<mp>40.0</mp>
+			<cp>48.5</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>113.38</hp>
+			<mp>47.28</mp>
+			<cp>56.69</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>129.94</hp>
+			<mp>54.64</mp>
+			<cp>64.97</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>146.68</hp>
+			<mp>62.08</mp>
+			<cp>73.34</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>163.6</hp>
+			<mp>69.6</mp>
+			<cp>81.8</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>180.7</hp>
+			<mp>77.2</mp>
+			<cp>90.35</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>197.98</hp>
+			<mp>84.88</mp>
+			<cp>98.99</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>215.44</hp>
+			<mp>92.64</mp>
+			<cp>107.72</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>233.08</hp>
+			<mp>100.48</mp>
+			<cp>116.54</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>250.9</hp>
+			<mp>108.4</mp>
+			<cp>125.45</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>268.9</hp>
+			<mp>116.4</mp>
+			<cp>134.45</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>287.08</hp>
+			<mp>124.48</mp>
+			<cp>143.54</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>305.44</hp>
+			<mp>132.64</mp>
+			<cp>152.72</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>323.98</hp>
+			<mp>140.88</mp>
+			<cp>161.99</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>342.7</hp>
+			<mp>149.2</mp>
+			<cp>171.35</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>361.6</hp>
+			<mp>157.6</mp>
+			<cp>180.8</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>380.68</hp>
+			<mp>166.08</mp>
+			<cp>190.34</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>399.94</hp>
+			<mp>174.64</mp>
+			<cp>199.97</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>419.38</hp>
+			<mp>183.28</mp>
+			<cp>209.69</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>449.9</hp>
+			<mp>196.36</mp>
+			<cp>224.95</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>480.7</hp>
+			<mp>209.56</mp>
+			<cp>240.35</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>511.78</hp>
+			<mp>222.88</mp>
+			<cp>255.89</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>543.14</hp>
+			<mp>236.32</mp>
+			<cp>271.57</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>574.78</hp>
+			<mp>249.88</mp>
+			<cp>287.39</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>606.7</hp>
+			<mp>263.56</mp>
+			<cp>303.35</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>638.9</hp>
+			<mp>277.36</mp>
+			<cp>319.45</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>671.38</hp>
+			<mp>291.28</mp>
+			<cp>335.69</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>704.14</hp>
+			<mp>305.32</mp>
+			<cp>352.07</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>737.18</hp>
+			<mp>319.48</mp>
+			<cp>368.59</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>770.5</hp>
+			<mp>333.76</mp>
+			<cp>385.25</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>804.1</hp>
+			<mp>348.16</mp>
+			<cp>402.05</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>837.98</hp>
+			<mp>362.68</mp>
+			<cp>418.99</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>872.14</hp>
+			<mp>377.32</mp>
+			<cp>436.07</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>906.58</hp>
+			<mp>392.08</mp>
+			<cp>453.29</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>941.3</hp>
+			<mp>406.96</mp>
+			<cp>470.65</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>976.3</hp>
+			<mp>421.96</mp>
+			<cp>488.15</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>1011.58</hp>
+			<mp>437.08</mp>
+			<cp>505.79</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1047.14</hp>
+			<mp>452.32</mp>
+			<cp>523.57</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1082.98</hp>
+			<mp>467.68</mp>
+			<cp>541.49</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1119.1</hp>
+			<mp>483.16</mp>
+			<cp>559.55</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1155.5</hp>
+			<mp>498.76</mp>
+			<cp>577.75</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1192.18</hp>
+			<mp>514.48</mp>
+			<cp>596.09</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1229.14</hp>
+			<mp>530.32</mp>
+			<cp>614.57</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1266.38</hp>
+			<mp>546.28</mp>
+			<cp>633.19</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1303.9</hp>
+			<mp>562.36</mp>
+			<cp>651.95</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1341.7</hp>
+			<mp>578.56</mp>
+			<cp>670.85</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1379.78</hp>
+			<mp>594.88</mp>
+			<cp>689.89</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1418.14</hp>
+			<mp>611.32</mp>
+			<cp>709.07</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1456.78</hp>
+			<mp>627.88</mp>
+			<cp>728.39</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1495.7</hp>
+			<mp>644.56</mp>
+			<cp>747.85</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1534.9</hp>
+			<mp>661.36</mp>
+			<cp>767.45</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1574.38</hp>
+			<mp>678.28</mp>
+			<cp>787.19</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1614.14</hp>
+			<mp>695.32</mp>
+			<cp>807.07</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1654.18</hp>
+			<mp>712.48</mp>
+			<cp>827.09</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1694.5</hp>
+			<mp>729.76</mp>
+			<cp>847.25</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1735.1</hp>
+			<mp>747.16</mp>
+			<cp>867.55</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1775.98</hp>
+			<mp>764.68</mp>
+			<cp>887.99</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1817.14</hp>
+			<mp>782.32</mp>
+			<cp>908.57</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1858.58</hp>
+			<mp>800.08</mp>
+			<cp>929.29</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1900.3</hp>
+			<mp>817.96</mp>
+			<cp>950.15</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>1942.3</hp>
+			<mp>835.96</mp>
+			<cp>971.15</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>1984.58</hp>
+			<mp>854.08</mp>
+			<cp>992.29</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2027.14</hp>
+			<mp>872.32</mp>
+			<cp>1013.57</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2069.98</hp>
+			<mp>890.68</mp>
+			<cp>1034.99</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2113.1</hp>
+			<mp>909.16</mp>
+			<cp>1056.55</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2156.5</hp>
+			<mp>927.76</mp>
+			<cp>1078.25</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2200.18</hp>
+			<mp>946.48</mp>
+			<cp>1100.09</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2244.14</hp>
+			<mp>965.32</mp>
+			<cp>1122.07</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2288.38</hp>
+			<mp>984.28</mp>
+			<cp>1144.19</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2332.9</hp>
+			<mp>1003.36</mp>
+			<cp>1166.45</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2377.7</hp>
+			<mp>1022.56</mp>
+			<cp>1188.85</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2422.78</hp>
+			<mp>1041.88</mp>
+			<cp>1211.39</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2468.14</hp>
+			<mp>1061.32</mp>
+			<cp>1234.07</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2513.78</hp>
+			<mp>1080.88</mp>
+			<cp>1256.89</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2559.7</hp>
+			<mp>1100.56</mp>
+			<cp>1279.85</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>2605.9</hp>
+			<mp>1120.36</mp>
+			<cp>1302.95</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>2652.38</hp>
+			<mp>1140.28</mp>
+			<cp>1326.19</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>2699.14</hp>
+			<mp>1160.32</mp>
+			<cp>1349.57</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>2746.18</hp>
+			<mp>1180.48</mp>
+			<cp>1373.09</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>2793.5</hp>
+			<mp>1200.76</mp>
+			<cp>1396.75</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>2841.1</hp>
+			<mp>1221.16</mp>
+			<cp>1420.55</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>2888.98</hp>
+			<mp>1241.68</mp>
+			<cp>1444.49</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>2937.14</hp>
+			<mp>1262.32</mp>
+			<cp>1468.57</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>2985.58</hp>
+			<mp>1283.08</mp>
+			<cp>1492.79</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3034.3</hp>
+			<mp>1303.96</mp>
+			<cp>1517.15</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3083.3</hp>
+			<mp>1324.96</mp>
+			<cp>1541.65</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3132.58</hp>
+			<mp>1346.08</mp>
+			<cp>1566.29</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3182.14</hp>
+			<mp>1367.32</mp>
+			<cp>1591.07</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3231.98</hp>
+			<mp>1388.68</mp>
+			<cp>1615.99</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3282.1</hp>
+			<mp>1410.16</mp>
+			<cp>1641.05</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3332.5</hp>
+			<mp>1431.76</mp>
+			<cp>1666.25</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4408.05</hp>
+			<mp>1993.76</mp>
+			<cp>2204.025</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4480.85</hp>
+			<mp>2030.16</mp>
+			<cp>2240.425</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4554.05</hp>
+			<mp>2066.76</mp>
+			<cp>2277.025</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4627.65</hp>
+			<mp>2103.56</mp>
+			<cp>2313.825</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4701.65</hp>
+			<mp>2140.56</mp>
+			<cp>2350.825</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4776.05</hp>
+			<mp>2177.76</mp>
+			<cp>2388.025</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4850.85</hp>
+			<mp>2215.16</mp>
+			<cp>2425.425</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4926.05</hp>
+			<mp>2252.76</mp>
+			<cp>2463.025</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>5001.65</hp>
+			<mp>2290.56</mp>
+			<cp>2500.83</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>5077.65</hp>
+			<mp>2328.56</mp>
+			<cp>2538.83</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5154.05</hp>
+			<mp>2366.76</mp>
+			<cp>2577.03</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5230.85</hp>
+			<mp>2405.16</mp>
+			<cp>2615.43</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5308.05</hp>
+			<mp>2443.76</mp>
+			<cp>2654.03</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5385.65</hp>
+			<mp>2482.56</mp>
+			<cp>2692.83</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5463.65</hp>
+			<mp>2521.56</mp>
+			<cp>2731.83</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5542.05</hp>
+			<mp>2560.76</mp>
+			<cp>2771.025</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/SoulHound.xml
+++ b/data/stats/chars/baseStats/SoulHound.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>195</classId> <!-- TODO update data -->
-    <staticData>
-        <baseINT>25</baseINT>
-        <baseSTR>41</baseSTR>
-        <baseCON>27</baseCON>
-        <baseMEN>22</baseMEN>
-        <baseDEX>35</baseDEX>
-        <baseWIT>20</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-125607" y="38452" z="1152"/>
-            <node x="-125472" y="38450" z="1152"/>
-            <node x="-125615" y="37771" z="1152"/>
-            <node x="-125464" y="37776" z="1152"/>
-            <node x="-125517" y="38267" z="1155"/>
-            <node x="-125531" y="37944" z="1155"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>87</walk>
-            <run>140</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>100</baseBreath>
-        <baseSafeFall>500</baseSafeFall>
-        <collisionMale>
-            <radius>8.0</radius>
-            <height>25.2</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.0</radius>
-            <height>22.6</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>97.0</hp>
-            <mp>40.0</mp>
-            <cp>48.5</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>113.38</hp>
-            <mp>47.28</mp>
-            <cp>56.69</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>129.94</hp>
-            <mp>54.64</mp>
-            <cp>64.97</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>146.68</hp>
-            <mp>62.08</mp>
-            <cp>73.34</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>163.6</hp>
-            <mp>69.6</mp>
-            <cp>81.8</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>180.7</hp>
-            <mp>77.2</mp>
-            <cp>90.35</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>197.98</hp>
-            <mp>84.88</mp>
-            <cp>98.99</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>215.44</hp>
-            <mp>92.64</mp>
-            <cp>107.72</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>233.08</hp>
-            <mp>100.48</mp>
-            <cp>116.54</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>250.9</hp>
-            <mp>108.4</mp>
-            <cp>125.45</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>268.9</hp>
-            <mp>116.4</mp>
-            <cp>134.45</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>287.08</hp>
-            <mp>124.48</mp>
-            <cp>143.54</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>305.44</hp>
-            <mp>132.64</mp>
-            <cp>152.72</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>323.98</hp>
-            <mp>140.88</mp>
-            <cp>161.99</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>342.7</hp>
-            <mp>149.2</mp>
-            <cp>171.35</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>361.6</hp>
-            <mp>157.6</mp>
-            <cp>180.8</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>380.68</hp>
-            <mp>166.08</mp>
-            <cp>190.34</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>399.94</hp>
-            <mp>174.64</mp>
-            <cp>199.97</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>419.38</hp>
-            <mp>183.28</mp>
-            <cp>209.69</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>449.9</hp>
-            <mp>196.36</mp>
-            <cp>224.95</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>480.7</hp>
-            <mp>209.56</mp>
-            <cp>240.35</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>511.78</hp>
-            <mp>222.88</mp>
-            <cp>255.89</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>543.14</hp>
-            <mp>236.32</mp>
-            <cp>271.57</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>574.78</hp>
-            <mp>249.88</mp>
-            <cp>287.39</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>606.7</hp>
-            <mp>263.56</mp>
-            <cp>303.35</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>638.9</hp>
-            <mp>277.36</mp>
-            <cp>319.45</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>671.38</hp>
-            <mp>291.28</mp>
-            <cp>335.69</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>704.14</hp>
-            <mp>305.32</mp>
-            <cp>352.07</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>737.18</hp>
-            <mp>319.48</mp>
-            <cp>368.59</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>770.5</hp>
-            <mp>333.76</mp>
-            <cp>385.25</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>804.1</hp>
-            <mp>348.16</mp>
-            <cp>402.05</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>837.98</hp>
-            <mp>362.68</mp>
-            <cp>418.99</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>872.14</hp>
-            <mp>377.32</mp>
-            <cp>436.07</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>906.58</hp>
-            <mp>392.08</mp>
-            <cp>453.29</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>941.3</hp>
-            <mp>406.96</mp>
-            <cp>470.65</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>976.3</hp>
-            <mp>421.96</mp>
-            <cp>488.15</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>1011.58</hp>
-            <mp>437.08</mp>
-            <cp>505.79</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1047.14</hp>
-            <mp>452.32</mp>
-            <cp>523.57</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1082.98</hp>
-            <mp>467.68</mp>
-            <cp>541.49</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1134.58</hp>
-            <mp>493.48</mp>
-            <cp>567.29</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1186.58</hp>
-            <mp>519.48</mp>
-            <cp>593.29</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1238.98</hp>
-            <mp>545.68</mp>
-            <cp>619.49</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1291.78</hp>
-            <mp>572.08</mp>
-            <cp>645.89</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1344.98</hp>
-            <mp>598.68</mp>
-            <cp>672.49</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1398.58</hp>
-            <mp>625.48</mp>
-            <cp>699.29</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1452.58</hp>
-            <mp>652.48</mp>
-            <cp>726.29</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1506.98</hp>
-            <mp>679.68</mp>
-            <cp>753.49</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1561.78</hp>
-            <mp>707.08</mp>
-            <cp>780.89</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1616.98</hp>
-            <mp>734.68</mp>
-            <cp>808.49</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1672.58</hp>
-            <mp>762.48</mp>
-            <cp>836.29</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1728.58</hp>
-            <mp>790.48</mp>
-            <cp>864.29</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1784.98</hp>
-            <mp>818.68</mp>
-            <cp>892.49</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1841.78</hp>
-            <mp>847.08</mp>
-            <cp>920.89</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1898.98</hp>
-            <mp>875.68</mp>
-            <cp>949.49</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1956.58</hp>
-            <mp>904.48</mp>
-            <cp>978.29</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>2014.58</hp>
-            <mp>933.48</mp>
-            <cp>1007.29</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>2072.98</hp>
-            <mp>962.68</mp>
-            <cp>1036.49</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2131.78</hp>
-            <mp>992.08</mp>
-            <cp>1065.89</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2190.98</hp>
-            <mp>1021.68</mp>
-            <cp>1095.49</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2250.58</hp>
-            <mp>1051.48</mp>
-            <cp>1125.29</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2310.58</hp>
-            <mp>1081.48</mp>
-            <cp>1155.29</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2370.98</hp>
-            <mp>1111.68</mp>
-            <cp>1185.49</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2431.78</hp>
-            <mp>1142.08</mp>
-            <cp>1215.89</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2492.98</hp>
-            <mp>1172.68</mp>
-            <cp>1246.49</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2554.58</hp>
-            <mp>1203.48</mp>
-            <cp>1277.29</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2616.58</hp>
-            <mp>1234.48</mp>
-            <cp>1308.29</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2678.98</hp>
-            <mp>1265.68</mp>
-            <cp>1339.49</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2741.78</hp>
-            <mp>1297.08</mp>
-            <cp>1370.89</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2804.98</hp>
-            <mp>1328.68</mp>
-            <cp>1402.49</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2868.58</hp>
-            <mp>1360.48</mp>
-            <cp>1434.29</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2932.58</hp>
-            <mp>1392.48</mp>
-            <cp>1466.29</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2996.98</hp>
-            <mp>1424.68</mp>
-            <cp>1498.49</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>3061.78</hp>
-            <mp>1457.08</mp>
-            <cp>1530.89</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>3126.98</hp>
-            <mp>1489.68</mp>
-            <cp>1563.49</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3192.58</hp>
-            <mp>1522.48</mp>
-            <cp>1596.29</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3258.58</hp>
-            <mp>1555.48</mp>
-            <cp>1629.29</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3324.98</hp>
-            <mp>1588.68</mp>
-            <cp>1662.49</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3391.78</hp>
-            <mp>1622.08</mp>
-            <cp>1695.89</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3458.98</hp>
-            <mp>1655.68</mp>
-            <cp>1729.49</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3526.58</hp>
-            <mp>1689.48</mp>
-            <cp>1763.29</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3594.58</hp>
-            <mp>1723.48</mp>
-            <cp>1797.29</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3662.98</hp>
-            <mp>1757.68</mp>
-            <cp>1831.49</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3731.78</hp>
-            <mp>1792.08</mp>
-            <cp>1865.89</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3800.98</hp>
-            <mp>1826.68</mp>
-            <cp>1900.49</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3870.58</hp>
-            <mp>1861.48</mp>
-            <cp>1935.29</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3940.58</hp>
-            <mp>1896.48</mp>
-            <cp>1970.29</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>4010.98</hp>
-            <mp>1931.68</mp>
-            <cp>2005.49</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>4081.78</hp>
-            <mp>1967.08</mp>
-            <cp>2040.89</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>4152.98</hp>
-            <mp>2002.68</mp>
-            <cp>2076.49</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4224.58</hp>
-            <mp>2038.48</mp>
-            <cp>2112.29</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4296.58</hp>
-            <mp>2074.48</mp>
-            <cp>2148.29</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>195</classId>
+	<staticData>
+		<baseINT>25</baseINT>
+		<baseSTR>41</baseSTR>
+		<baseCON>27</baseCON>
+		<baseMEN>22</baseMEN>
+		<baseDEX>35</baseDEX>
+		<baseWIT>20</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-125607" y="38452" z="1152" />
+			<node x="-125472" y="38450" z="1152" />
+			<node x="-125615" y="37771" z="1152" />
+			<node x="-125464" y="37776" z="1152" />
+			<node x="-125517" y="38267" z="1155" />
+			<node x="-125531" y="37944" z="1155" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>87</walk>
+			<run>140</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>500</baseSafeFall>
+		<collisionMale>
+			<radius>8.0</radius>
+			<height>25.2</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.0</radius>
+			<height>22.6</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>97.0</hp>
+			<mp>40.0</mp>
+			<cp>48.5</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>113.38</hp>
+			<mp>47.28</mp>
+			<cp>56.69</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>129.94</hp>
+			<mp>54.64</mp>
+			<cp>64.97</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>146.68</hp>
+			<mp>62.08</mp>
+			<cp>73.34</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>163.6</hp>
+			<mp>69.6</mp>
+			<cp>81.8</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>180.7</hp>
+			<mp>77.2</mp>
+			<cp>90.35</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>197.98</hp>
+			<mp>84.88</mp>
+			<cp>98.99</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>215.44</hp>
+			<mp>92.64</mp>
+			<cp>107.72</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>233.08</hp>
+			<mp>100.48</mp>
+			<cp>116.54</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>250.9</hp>
+			<mp>108.4</mp>
+			<cp>125.45</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>268.9</hp>
+			<mp>116.4</mp>
+			<cp>134.45</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>287.08</hp>
+			<mp>124.48</mp>
+			<cp>143.54</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>305.44</hp>
+			<mp>132.64</mp>
+			<cp>152.72</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>323.98</hp>
+			<mp>140.88</mp>
+			<cp>161.99</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>342.7</hp>
+			<mp>149.2</mp>
+			<cp>171.35</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>361.6</hp>
+			<mp>157.6</mp>
+			<cp>180.8</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>380.68</hp>
+			<mp>166.08</mp>
+			<cp>190.34</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>399.94</hp>
+			<mp>174.64</mp>
+			<cp>199.97</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>419.38</hp>
+			<mp>183.28</mp>
+			<cp>209.69</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>449.9</hp>
+			<mp>196.36</mp>
+			<cp>224.95</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>480.7</hp>
+			<mp>209.56</mp>
+			<cp>240.35</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>511.78</hp>
+			<mp>222.88</mp>
+			<cp>255.89</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>543.14</hp>
+			<mp>236.32</mp>
+			<cp>271.57</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>574.78</hp>
+			<mp>249.88</mp>
+			<cp>287.39</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>606.7</hp>
+			<mp>263.56</mp>
+			<cp>303.35</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>638.9</hp>
+			<mp>277.36</mp>
+			<cp>319.45</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>671.38</hp>
+			<mp>291.28</mp>
+			<cp>335.69</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>704.14</hp>
+			<mp>305.32</mp>
+			<cp>352.07</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>737.18</hp>
+			<mp>319.48</mp>
+			<cp>368.59</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>770.5</hp>
+			<mp>333.76</mp>
+			<cp>385.25</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>804.1</hp>
+			<mp>348.16</mp>
+			<cp>402.05</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>837.98</hp>
+			<mp>362.68</mp>
+			<cp>418.99</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>872.14</hp>
+			<mp>377.32</mp>
+			<cp>436.07</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>906.58</hp>
+			<mp>392.08</mp>
+			<cp>453.29</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>941.3</hp>
+			<mp>406.96</mp>
+			<cp>470.65</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>976.3</hp>
+			<mp>421.96</mp>
+			<cp>488.15</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>1011.58</hp>
+			<mp>437.08</mp>
+			<cp>505.79</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1047.14</hp>
+			<mp>452.32</mp>
+			<cp>523.57</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1082.98</hp>
+			<mp>467.68</mp>
+			<cp>541.49</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1134.58</hp>
+			<mp>493.48</mp>
+			<cp>567.29</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1186.58</hp>
+			<mp>519.48</mp>
+			<cp>593.29</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1238.98</hp>
+			<mp>545.68</mp>
+			<cp>619.49</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1291.78</hp>
+			<mp>572.08</mp>
+			<cp>645.89</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1344.98</hp>
+			<mp>598.68</mp>
+			<cp>672.49</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1398.58</hp>
+			<mp>625.48</mp>
+			<cp>699.29</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1452.58</hp>
+			<mp>652.48</mp>
+			<cp>726.29</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1506.98</hp>
+			<mp>679.68</mp>
+			<cp>753.49</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1561.78</hp>
+			<mp>707.08</mp>
+			<cp>780.89</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1616.98</hp>
+			<mp>734.68</mp>
+			<cp>808.49</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1672.58</hp>
+			<mp>762.48</mp>
+			<cp>836.29</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1728.58</hp>
+			<mp>790.48</mp>
+			<cp>864.29</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1784.98</hp>
+			<mp>818.68</mp>
+			<cp>892.49</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1841.78</hp>
+			<mp>847.08</mp>
+			<cp>920.89</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1898.98</hp>
+			<mp>875.68</mp>
+			<cp>949.49</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1956.58</hp>
+			<mp>904.48</mp>
+			<cp>978.29</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>2014.58</hp>
+			<mp>933.48</mp>
+			<cp>1007.29</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2072.98</hp>
+			<mp>962.68</mp>
+			<cp>1036.49</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2131.78</hp>
+			<mp>992.08</mp>
+			<cp>1065.89</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2190.98</hp>
+			<mp>1021.68</mp>
+			<cp>1095.49</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2250.58</hp>
+			<mp>1051.48</mp>
+			<cp>1125.29</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2310.58</hp>
+			<mp>1081.48</mp>
+			<cp>1155.29</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2370.98</hp>
+			<mp>1111.68</mp>
+			<cp>1185.49</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2431.78</hp>
+			<mp>1142.08</mp>
+			<cp>1215.89</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2492.98</hp>
+			<mp>1172.68</mp>
+			<cp>1246.49</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2554.58</hp>
+			<mp>1203.48</mp>
+			<cp>1277.29</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2616.58</hp>
+			<mp>1234.48</mp>
+			<cp>1308.29</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2678.98</hp>
+			<mp>1265.68</mp>
+			<cp>1339.49</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2741.78</hp>
+			<mp>1297.08</mp>
+			<cp>1370.89</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2804.98</hp>
+			<mp>1328.68</mp>
+			<cp>1402.49</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2868.58</hp>
+			<mp>1360.48</mp>
+			<cp>1434.29</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2932.58</hp>
+			<mp>1392.48</mp>
+			<cp>1466.29</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2996.98</hp>
+			<mp>1424.68</mp>
+			<cp>1498.49</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>3061.78</hp>
+			<mp>1457.08</mp>
+			<cp>1530.89</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3126.98</hp>
+			<mp>1489.68</mp>
+			<cp>1563.49</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3192.58</hp>
+			<mp>1522.48</mp>
+			<cp>1596.29</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3258.58</hp>
+			<mp>1555.48</mp>
+			<cp>1629.29</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3324.98</hp>
+			<mp>1588.68</mp>
+			<cp>1662.49</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3391.78</hp>
+			<mp>1622.08</mp>
+			<cp>1695.89</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3458.98</hp>
+			<mp>1655.68</mp>
+			<cp>1729.49</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3526.58</hp>
+			<mp>1689.48</mp>
+			<cp>1763.29</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3594.58</hp>
+			<mp>1723.48</mp>
+			<cp>1797.29</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3662.98</hp>
+			<mp>1757.68</mp>
+			<cp>1831.49</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3731.78</hp>
+			<mp>1792.08</mp>
+			<cp>1865.89</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3800.98</hp>
+			<mp>1826.68</mp>
+			<cp>1900.49</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3870.58</hp>
+			<mp>1861.48</mp>
+			<cp>1935.29</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3940.58</hp>
+			<mp>1896.48</mp>
+			<cp>1970.29</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>4010.98</hp>
+			<mp>1931.68</mp>
+			<cp>2005.49</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4081.78</hp>
+			<mp>1967.08</mp>
+			<cp>2040.89</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4152.98</hp>
+			<mp>2002.68</mp>
+			<cp>2076.49</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4224.58</hp>
+			<mp>2038.48</mp>
+			<cp>2112.29</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4296.58</hp>
+			<mp>2074.48</mp>
+			<cp>2148.29</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>7441.44</hp>
+			<mp>3144</mp>
+			<cp>10275.18</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>7514.4</hp>
+			<mp>3198.6</mp>
+			<cp>10375.92</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>7588.07</hp>
+			<mp>3253.5</mp>
+			<cp>10477.65</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>7662.46</hp>
+			<mp>3308.7</mp>
+			<cp>10580.37</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>7737.58</hp>
+			<mp>3364.2</mp>
+			<cp>10684.1</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>7813.44</hp>
+			<mp>3420</mp>
+			<cp>10788.84</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>7890.04</hp>
+			<mp>3476.1</mp>
+			<cp>10894.62</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>7967.39</hp>
+			<mp>3532.5</mp>
+			<cp>11001.43</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>8045.49</hp>
+			<mp>3589.2</mp>
+			<cp>11109.27</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>8124.34</hp>
+			<mp>3646.2</mp>
+			<cp>11218.14</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>8203.94</hp>
+			<mp>3703.5</mp>
+			<cp>11328.04</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>8284.29</hp>
+			<mp>3761.1</mp>
+			<cp>11438.97</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>8365.39</hp>
+			<mp>3819</mp>
+			<cp>11550.93</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>8447.24</hp>
+			<mp>3877.2</mp>
+			<cp>11663.92</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>8529.84</hp>
+			<mp>3935.7</mp>
+			<cp>11777.94</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5445.148003</hp>
+			<mp>2571.71672</mp>
+			<cp>6313.533247</cp>
+			<hpRegen>12.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Soultaker.xml
+++ b/data/stats/chars/baseStats/Soultaker.xml
@@ -1,798 +1,926 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>95</classId>
-    <staticData>
-        <baseINT>41</baseINT>
-        <baseSTR>22</baseSTR>
-        <baseCON>27</baseCON>
-        <baseMEN>39</baseMEN>
-        <baseDEX>21</baseDEX>
-        <baseWIT>20</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-90875" y="248162" z="-3570"/>
-            <node x="-90954" y="248118" z="-3570"/>
-            <node x="-90918" y="248070" z="-3570"/>
-            <node x="-90890" y="248027" z="-3570"/>
-        </creationPoints>
-        <basePAtk>3</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>15</chest>
-            <legs>8</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>78</walk>
-            <run>124</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>100</baseBreath>
-        <baseSafeFall>200</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>22.8</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>6.5</radius>
-            <height>22.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>101.0</hp>
-            <mp>40.0</mp>
-            <cp>50.5</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>116.47</hp>
-            <mp>47.28</mp>
-            <cp>58.235</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>132.11</hp>
-            <mp>54.64</mp>
-            <cp>66.055</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>147.92</hp>
-            <mp>62.08</mp>
-            <cp>73.96</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>163.9</hp>
-            <mp>69.6</mp>
-            <cp>81.95</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>180.05</hp>
-            <mp>77.2</mp>
-            <cp>90.025</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>196.37</hp>
-            <mp>84.88</mp>
-            <cp>98.185</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>212.86</hp>
-            <mp>92.64</mp>
-            <cp>106.43</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>229.52</hp>
-            <mp>100.48</mp>
-            <cp>114.76</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>246.35</hp>
-            <mp>108.4</mp>
-            <cp>123.175</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>263.35</hp>
-            <mp>116.4</mp>
-            <cp>131.675</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>280.52</hp>
-            <mp>124.48</mp>
-            <cp>140.26</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>297.86</hp>
-            <mp>132.64</mp>
-            <cp>148.93</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>315.37</hp>
-            <mp>140.88</mp>
-            <cp>157.685</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>333.05</hp>
-            <mp>149.2</mp>
-            <cp>166.525</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>350.9</hp>
-            <mp>157.6</mp>
-            <cp>175.45</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>368.92</hp>
-            <mp>166.08</mp>
-            <cp>184.46</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>387.11</hp>
-            <mp>174.64</mp>
-            <cp>193.555</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>405.47</hp>
-            <mp>183.28</mp>
-            <cp>202.735</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>424.0</hp>
-            <mp>192.0</mp>
-            <cp>212.0</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>451.5</hp>
-            <mp>205.2</mp>
-            <cp>225.75</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>479.25</hp>
-            <mp>218.52</mp>
-            <cp>239.625</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>507.25</hp>
-            <mp>231.96</mp>
-            <cp>253.625</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>535.5</hp>
-            <mp>245.52</mp>
-            <cp>267.75</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>564.0</hp>
-            <mp>259.2</mp>
-            <cp>282.0</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>592.75</hp>
-            <mp>273.0</mp>
-            <cp>296.375</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>621.75</hp>
-            <mp>286.92</mp>
-            <cp>310.875</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>651.0</hp>
-            <mp>300.96</mp>
-            <cp>325.5</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>680.5</hp>
-            <mp>315.12</mp>
-            <cp>340.25</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>710.25</hp>
-            <mp>329.4</mp>
-            <cp>355.125</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>740.25</hp>
-            <mp>343.8</mp>
-            <cp>370.125</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>770.5</hp>
-            <mp>358.32</mp>
-            <cp>385.25</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>801.0</hp>
-            <mp>372.96</mp>
-            <cp>400.5</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>831.75</hp>
-            <mp>387.72</mp>
-            <cp>415.875</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>862.75</hp>
-            <mp>402.6</mp>
-            <cp>431.375</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>894.0</hp>
-            <mp>417.6</mp>
-            <cp>447.0</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>925.5</hp>
-            <mp>432.72</mp>
-            <cp>462.75</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>957.25</hp>
-            <mp>447.96</mp>
-            <cp>478.625</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>989.25</hp>
-            <mp>463.32</mp>
-            <cp>494.625</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1021.5</hp>
-            <mp>478.8</mp>
-            <cp>510.75</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1067.0</hp>
-            <mp>504.8</mp>
-            <cp>533.5</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1112.85</hp>
-            <mp>531.0</mp>
-            <cp>556.425</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1159.05</hp>
-            <mp>557.4</mp>
-            <cp>579.525</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1205.6</hp>
-            <mp>584.0</mp>
-            <cp>602.8</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1252.5</hp>
-            <mp>610.8</mp>
-            <cp>626.25</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1299.75</hp>
-            <mp>637.8</mp>
-            <cp>649.875</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1347.35</hp>
-            <mp>665.0</mp>
-            <cp>673.675</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1395.3</hp>
-            <mp>692.4</mp>
-            <cp>697.65</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1443.6</hp>
-            <mp>720.0</mp>
-            <cp>721.8</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1492.25</hp>
-            <mp>747.8</mp>
-            <cp>746.125</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1541.25</hp>
-            <mp>775.8</mp>
-            <cp>770.625</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1590.6</hp>
-            <mp>804.0</mp>
-            <cp>795.3</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1640.3</hp>
-            <mp>832.4</mp>
-            <cp>820.15</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1690.35</hp>
-            <mp>861.0</mp>
-            <cp>845.175</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1740.75</hp>
-            <mp>889.8</mp>
-            <cp>870.375</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1791.5</hp>
-            <mp>918.8</mp>
-            <cp>895.75</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1842.6</hp>
-            <mp>948.0</mp>
-            <cp>921.3</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1894.05</hp>
-            <mp>977.4</mp>
-            <cp>947.025</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>1945.85</hp>
-            <mp>1007.0</mp>
-            <cp>972.925</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>1998.0</hp>
-            <mp>1036.8</mp>
-            <cp>999.0</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2050.5</hp>
-            <mp>1066.8</mp>
-            <cp>1025.25</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2103.35</hp>
-            <mp>1097.0</mp>
-            <cp>1051.675</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2156.55</hp>
-            <mp>1127.4</mp>
-            <cp>1078.275</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2210.1</hp>
-            <mp>1158.0</mp>
-            <cp>1105.05</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2264.0</hp>
-            <mp>1188.8</mp>
-            <cp>1132.0</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2318.25</hp>
-            <mp>1219.8</mp>
-            <cp>1159.125</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2372.85</hp>
-            <mp>1251.0</mp>
-            <cp>1186.425</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2427.8</hp>
-            <mp>1282.4</mp>
-            <cp>1213.9</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2483.1</hp>
-            <mp>1314.0</mp>
-            <cp>1241.55</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2538.75</hp>
-            <mp>1345.8</mp>
-            <cp>1269.375</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2594.75</hp>
-            <mp>1377.8</mp>
-            <cp>1297.375</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2651.1</hp>
-            <mp>1410.0</mp>
-            <cp>1325.55</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2707.8</hp>
-            <mp>1442.4</mp>
-            <cp>1353.9</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2764.85</hp>
-            <mp>1475.0</mp>
-            <cp>1382.425</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2822.25</hp>
-            <mp>1507.8</mp>
-            <cp>1411.125</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>2880.0</hp>
-            <mp>1540.8</mp>
-            <cp>1440.0</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>2938.1</hp>
-            <mp>1574.0</mp>
-            <cp>1469.05</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>2996.55</hp>
-            <mp>1607.4</mp>
-            <cp>1498.275</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3055.35</hp>
-            <mp>1641.0</mp>
-            <cp>1527.675</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3114.5</hp>
-            <mp>1674.8</mp>
-            <cp>1557.25</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3174.0</hp>
-            <mp>1708.8</mp>
-            <cp>1587.0</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3233.85</hp>
-            <mp>1743.0</mp>
-            <cp>1616.925</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3294.05</hp>
-            <mp>1777.4</mp>
-            <cp>1647.025</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3354.6</hp>
-            <mp>1812.0</mp>
-            <cp>1677.3</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3415.5</hp>
-            <mp>1846.8</mp>
-            <cp>1707.75</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3476.75</hp>
-            <mp>1881.8</mp>
-            <cp>1738.375</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3538.35</hp>
-            <mp>1917.0</mp>
-            <cp>1769.175</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3600.3</hp>
-            <mp>1952.4</mp>
-            <cp>1800.15</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3662.6</hp>
-            <mp>1988.0</mp>
-            <cp>1831.3</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3725.25</hp>
-            <mp>2023.8</mp>
-            <cp>1862.625</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>3788.25</hp>
-            <mp>2059.8</mp>
-            <cp>1894.125</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>95</classId>
+	<staticData>
+		<baseINT>41</baseINT>
+		<baseSTR>22</baseSTR>
+		<baseCON>27</baseCON>
+		<baseMEN>39</baseMEN>
+		<baseDEX>21</baseDEX>
+		<baseWIT>20</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-90875" y="248162" z="-3570" />
+			<node x="-90954" y="248118" z="-3570" />
+			<node x="-90918" y="248070" z="-3570" />
+			<node x="-90890" y="248027" z="-3570" />
+		</creationPoints>
+		<basePAtk>3</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>15</chest>
+			<legs>8</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>78</walk>
+			<run>124</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>200</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>22.8</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>6.5</radius>
+			<height>22.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>101.0</hp>
+			<mp>40.0</mp>
+			<cp>50.5</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>116.47</hp>
+			<mp>47.28</mp>
+			<cp>58.235</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>132.11</hp>
+			<mp>54.64</mp>
+			<cp>66.055</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>147.92</hp>
+			<mp>62.08</mp>
+			<cp>73.96</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>163.9</hp>
+			<mp>69.6</mp>
+			<cp>81.95</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>180.05</hp>
+			<mp>77.2</mp>
+			<cp>90.025</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>196.37</hp>
+			<mp>84.88</mp>
+			<cp>98.185</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>212.86</hp>
+			<mp>92.64</mp>
+			<cp>106.43</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>229.52</hp>
+			<mp>100.48</mp>
+			<cp>114.76</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>246.35</hp>
+			<mp>108.4</mp>
+			<cp>123.175</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>263.35</hp>
+			<mp>116.4</mp>
+			<cp>131.675</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>280.52</hp>
+			<mp>124.48</mp>
+			<cp>140.26</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>297.86</hp>
+			<mp>132.64</mp>
+			<cp>148.93</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>315.37</hp>
+			<mp>140.88</mp>
+			<cp>157.685</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>333.05</hp>
+			<mp>149.2</mp>
+			<cp>166.525</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>350.9</hp>
+			<mp>157.6</mp>
+			<cp>175.45</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>368.92</hp>
+			<mp>166.08</mp>
+			<cp>184.46</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>387.11</hp>
+			<mp>174.64</mp>
+			<cp>193.555</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>405.47</hp>
+			<mp>183.28</mp>
+			<cp>202.735</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>424.0</hp>
+			<mp>192.0</mp>
+			<cp>212.0</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>451.5</hp>
+			<mp>205.2</mp>
+			<cp>225.75</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>479.25</hp>
+			<mp>218.52</mp>
+			<cp>239.625</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>507.25</hp>
+			<mp>231.96</mp>
+			<cp>253.625</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>535.5</hp>
+			<mp>245.52</mp>
+			<cp>267.75</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>564.0</hp>
+			<mp>259.2</mp>
+			<cp>282.0</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>592.75</hp>
+			<mp>273.0</mp>
+			<cp>296.375</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>621.75</hp>
+			<mp>286.92</mp>
+			<cp>310.875</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>651.0</hp>
+			<mp>300.96</mp>
+			<cp>325.5</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>680.5</hp>
+			<mp>315.12</mp>
+			<cp>340.25</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>710.25</hp>
+			<mp>329.4</mp>
+			<cp>355.125</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>740.25</hp>
+			<mp>343.8</mp>
+			<cp>370.125</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>770.5</hp>
+			<mp>358.32</mp>
+			<cp>385.25</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>801.0</hp>
+			<mp>372.96</mp>
+			<cp>400.5</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>831.75</hp>
+			<mp>387.72</mp>
+			<cp>415.875</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>862.75</hp>
+			<mp>402.6</mp>
+			<cp>431.375</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>894.0</hp>
+			<mp>417.6</mp>
+			<cp>447.0</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>925.5</hp>
+			<mp>432.72</mp>
+			<cp>462.75</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>957.25</hp>
+			<mp>447.96</mp>
+			<cp>478.625</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>989.25</hp>
+			<mp>463.32</mp>
+			<cp>494.625</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1021.5</hp>
+			<mp>478.8</mp>
+			<cp>510.75</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1067.0</hp>
+			<mp>504.8</mp>
+			<cp>533.5</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1112.85</hp>
+			<mp>531.0</mp>
+			<cp>556.425</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1159.05</hp>
+			<mp>557.4</mp>
+			<cp>579.525</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1205.6</hp>
+			<mp>584.0</mp>
+			<cp>602.8</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1252.5</hp>
+			<mp>610.8</mp>
+			<cp>626.25</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1299.75</hp>
+			<mp>637.8</mp>
+			<cp>649.875</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1347.35</hp>
+			<mp>665.0</mp>
+			<cp>673.675</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1395.3</hp>
+			<mp>692.4</mp>
+			<cp>697.65</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1443.6</hp>
+			<mp>720.0</mp>
+			<cp>721.8</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1492.25</hp>
+			<mp>747.8</mp>
+			<cp>746.125</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1541.25</hp>
+			<mp>775.8</mp>
+			<cp>770.625</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1590.6</hp>
+			<mp>804.0</mp>
+			<cp>795.3</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1640.3</hp>
+			<mp>832.4</mp>
+			<cp>820.15</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1690.35</hp>
+			<mp>861.0</mp>
+			<cp>845.175</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1740.75</hp>
+			<mp>889.8</mp>
+			<cp>870.375</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1791.5</hp>
+			<mp>918.8</mp>
+			<cp>895.75</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1842.6</hp>
+			<mp>948.0</mp>
+			<cp>921.3</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1894.05</hp>
+			<mp>977.4</mp>
+			<cp>947.025</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1945.85</hp>
+			<mp>1007.0</mp>
+			<cp>972.925</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1998.0</hp>
+			<mp>1036.8</mp>
+			<cp>999.0</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2050.5</hp>
+			<mp>1066.8</mp>
+			<cp>1025.25</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2103.35</hp>
+			<mp>1097.0</mp>
+			<cp>1051.675</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2156.55</hp>
+			<mp>1127.4</mp>
+			<cp>1078.275</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2210.1</hp>
+			<mp>1158.0</mp>
+			<cp>1105.05</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2264.0</hp>
+			<mp>1188.8</mp>
+			<cp>1132.0</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2318.25</hp>
+			<mp>1219.8</mp>
+			<cp>1159.125</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2372.85</hp>
+			<mp>1251.0</mp>
+			<cp>1186.425</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2427.8</hp>
+			<mp>1282.4</mp>
+			<cp>1213.9</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2483.1</hp>
+			<mp>1314.0</mp>
+			<cp>1241.55</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2538.75</hp>
+			<mp>1345.8</mp>
+			<cp>1269.375</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2594.75</hp>
+			<mp>1377.8</mp>
+			<cp>1297.375</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2651.1</hp>
+			<mp>1410.0</mp>
+			<cp>1325.55</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2707.8</hp>
+			<mp>1442.4</mp>
+			<cp>1353.9</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2764.85</hp>
+			<mp>1475.0</mp>
+			<cp>1382.425</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2822.25</hp>
+			<mp>1507.8</mp>
+			<cp>1411.125</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>2880.0</hp>
+			<mp>1540.8</mp>
+			<cp>1440.0</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>2938.1</hp>
+			<mp>1574.0</mp>
+			<cp>1469.05</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>2996.55</hp>
+			<mp>1607.4</mp>
+			<cp>1498.275</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3055.35</hp>
+			<mp>1641.0</mp>
+			<cp>1527.675</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3114.5</hp>
+			<mp>1674.8</mp>
+			<cp>1557.25</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3174.0</hp>
+			<mp>1708.8</mp>
+			<cp>1587.0</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3233.85</hp>
+			<mp>1743.0</mp>
+			<cp>1616.925</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3294.05</hp>
+			<mp>1777.4</mp>
+			<cp>1647.025</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3354.6</hp>
+			<mp>1812.0</mp>
+			<cp>1677.3</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3415.5</hp>
+			<mp>1846.8</mp>
+			<cp>1707.75</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3476.75</hp>
+			<mp>1881.8</mp>
+			<cp>1738.375</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3538.35</hp>
+			<mp>1917.0</mp>
+			<cp>1769.175</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3600.3</hp>
+			<mp>1952.4</mp>
+			<cp>1800.15</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3662.6</hp>
+			<mp>1988.0</mp>
+			<cp>1831.3</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3725.25</hp>
+			<mp>2023.8</mp>
+			<cp>1862.625</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3788.25</hp>
+			<mp>2059.8</mp>
+			<cp>1894.125</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>3851.6</hp>
+			<mp>2096.0</mp>
+			<cp>1925.8</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>3915.3</hp>
+			<mp>2132.4</mp>
+			<cp>1957.65</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>3979.35</hp>
+			<mp>2169.0</mp>
+			<cp>1989.675</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4043.75</hp>
+			<mp>2205.8</mp>
+			<cp>2021.875</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4108.5</hp>
+			<mp>2242.8</mp>
+			<cp>2054.25</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4173.6</hp>
+			<mp>2280.0</mp>
+			<cp>2086.8</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4239.05</hp>
+			<mp>2317.4</mp>
+			<cp>2119.525</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4304.85</hp>
+			<mp>2355.0</mp>
+			<cp>2152.425</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4371</hp>
+			<mp>2392.8</mp>
+			<cp>2185.51</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4437.5</hp>
+			<mp>2430.8</mp>
+			<cp>2218.77</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4504.35</hp>
+			<mp>2469</mp>
+			<cp>2252.21</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4571.55</hp>
+			<mp>2507.4</mp>
+			<cp>2285.83</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4639.1</hp>
+			<mp>2546</mp>
+			<cp>2319.63</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>4707</hp>
+			<mp>2584.8</mp>
+			<cp>2353.61</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>4775.25</hp>
+			<mp>2623.8</mp>
+			<cp>2387.77</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>4843.85</hp>
+			<mp>2663</mp>
+			<cp>2421.925</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/SpectralDancer.xml
+++ b/data/stats/chars/baseStats/SpectralDancer.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>107</classId>
-    <staticData>
-        <baseINT>25</baseINT>
-        <baseSTR>41</baseSTR>
-        <baseCON>32</baseCON>
-        <baseMEN>26</baseMEN>
-        <baseDEX>34</baseDEX>
-        <baseWIT>12</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>15</magicAbnormalResist>
-        <creationPoints>
-            <node x="28295" y="11063" z="-4224"/>
-            <node x="28302" y="11008" z="-4224"/>
-            <node x="28377" y="10916" z="-4224"/>
-            <node x="28456" y="10997" z="-4224"/>
-            <node x="28461" y="11044" z="-4224"/>
-            <node x="28395" y="11127" z="-4224"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>85</walk>
-            <run>139</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>150</baseBreath>
-        <baseSafeFall>350</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>24</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.0</radius>
-            <height>23.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>94.0</hp>
-            <mp>30.0</mp>
-            <cp>47.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>107.65</hp>
-            <mp>35.46</mp>
-            <cp>53.825</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>121.45</hp>
-            <mp>40.98</mp>
-            <cp>60.725</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>135.4</hp>
-            <mp>46.56</mp>
-            <cp>67.7</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>149.5</hp>
-            <mp>52.2</mp>
-            <cp>74.75</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>163.75</hp>
-            <mp>57.9</mp>
-            <cp>81.875</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>178.15</hp>
-            <mp>63.66</mp>
-            <cp>89.075</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>192.7</hp>
-            <mp>69.48</mp>
-            <cp>96.35</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>207.4</hp>
-            <mp>75.36</mp>
-            <cp>103.7</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>222.25</hp>
-            <mp>81.3</mp>
-            <cp>111.125</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>237.25</hp>
-            <mp>87.3</mp>
-            <cp>118.625</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>252.4</hp>
-            <mp>93.36</mp>
-            <cp>126.2</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>267.7</hp>
-            <mp>99.48</mp>
-            <cp>133.85</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>283.15</hp>
-            <mp>105.66</mp>
-            <cp>141.575</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>298.75</hp>
-            <mp>111.9</mp>
-            <cp>149.375</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>314.5</hp>
-            <mp>118.2</mp>
-            <cp>157.25</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>330.4</hp>
-            <mp>124.56</mp>
-            <cp>165.2</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>346.45</hp>
-            <mp>130.98</mp>
-            <cp>173.225</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>362.65</hp>
-            <mp>137.46</mp>
-            <cp>181.325</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>379.0</hp>
-            <mp>144.0</mp>
-            <cp>189.5</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>414.2</hp>
-            <mp>153.9</mp>
-            <cp>207.1</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>449.72</hp>
-            <mp>163.89</mp>
-            <cp>224.86</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>485.56</hp>
-            <mp>173.97</mp>
-            <cp>242.78</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>521.72</hp>
-            <mp>184.14</mp>
-            <cp>260.86</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>558.2</hp>
-            <mp>194.4</mp>
-            <cp>279.1</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>595.0</hp>
-            <mp>204.75</mp>
-            <cp>297.5</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>632.12</hp>
-            <mp>215.19</mp>
-            <cp>316.06</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>669.56</hp>
-            <mp>225.72</mp>
-            <cp>334.78</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>707.32</hp>
-            <mp>236.34</mp>
-            <cp>353.66</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>745.4</hp>
-            <mp>247.05</mp>
-            <cp>372.7</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>783.8</hp>
-            <mp>257.85</mp>
-            <cp>391.9</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>822.52</hp>
-            <mp>268.74</mp>
-            <cp>411.26</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>861.56</hp>
-            <mp>279.72</mp>
-            <cp>430.78</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>900.92</hp>
-            <mp>290.79</mp>
-            <cp>450.46</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>940.6</hp>
-            <mp>301.95</mp>
-            <cp>470.3</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>980.6</hp>
-            <mp>313.2</mp>
-            <cp>490.3</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>1020.92</hp>
-            <mp>324.54</mp>
-            <cp>510.46</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1061.56</hp>
-            <mp>335.97</mp>
-            <cp>530.78</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1102.52</hp>
-            <mp>347.49</mp>
-            <cp>551.26</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1143.8</hp>
-            <mp>359.1</mp>
-            <cp>571.9</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1202.3</hp>
-            <mp>378.6</mp>
-            <cp>601.15</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1261.25</hp>
-            <mp>398.25</mp>
-            <cp>630.625</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1320.65</hp>
-            <mp>418.05</mp>
-            <cp>660.325</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1380.5</hp>
-            <mp>438.0</mp>
-            <cp>690.25</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1440.8</hp>
-            <mp>458.1</mp>
-            <cp>720.4</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1501.55</hp>
-            <mp>478.35</mp>
-            <cp>750.775</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1562.75</hp>
-            <mp>498.75</mp>
-            <cp>781.375</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1624.4</hp>
-            <mp>519.3</mp>
-            <cp>812.2</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1686.5</hp>
-            <mp>540.0</mp>
-            <cp>843.25</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1749.05</hp>
-            <mp>560.85</mp>
-            <cp>874.525</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1812.05</hp>
-            <mp>581.85</mp>
-            <cp>906.025</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1875.5</hp>
-            <mp>603.0</mp>
-            <cp>937.75</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1939.4</hp>
-            <mp>624.3</mp>
-            <cp>969.7</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>2003.75</hp>
-            <mp>645.75</mp>
-            <cp>1001.875</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>2068.55</hp>
-            <mp>667.35</mp>
-            <cp>1034.275</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>2133.8</hp>
-            <mp>689.1</mp>
-            <cp>1066.9</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>2199.5</hp>
-            <mp>711.0</mp>
-            <cp>1099.75</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2265.65</hp>
-            <mp>733.05</mp>
-            <cp>1132.825</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2332.25</hp>
-            <mp>755.25</mp>
-            <cp>1166.125</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2399.3</hp>
-            <mp>777.6</mp>
-            <cp>1199.65</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2466.8</hp>
-            <mp>800.1</mp>
-            <cp>1233.4</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2534.75</hp>
-            <mp>822.75</mp>
-            <cp>1267.375</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2603.15</hp>
-            <mp>845.55</mp>
-            <cp>1301.575</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2672.0</hp>
-            <mp>868.5</mp>
-            <cp>1336.0</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2741.3</hp>
-            <mp>891.6</mp>
-            <cp>1370.65</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2811.05</hp>
-            <mp>914.85</mp>
-            <cp>1405.525</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2881.25</hp>
-            <mp>938.25</mp>
-            <cp>1440.625</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2951.9</hp>
-            <mp>961.8</mp>
-            <cp>1475.95</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>3023.0</hp>
-            <mp>985.5</mp>
-            <cp>1511.5</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>3094.55</hp>
-            <mp>1009.35</mp>
-            <cp>1547.275</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>3166.55</hp>
-            <mp>1033.35</mp>
-            <cp>1583.275</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>3239.0</hp>
-            <mp>1057.5</mp>
-            <cp>1619.5</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>3311.9</hp>
-            <mp>1081.8</mp>
-            <cp>1655.95</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>3385.25</hp>
-            <mp>1106.25</mp>
-            <cp>1692.625</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3459.05</hp>
-            <mp>1130.85</mp>
-            <cp>1729.525</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3533.3</hp>
-            <mp>1155.6</mp>
-            <cp>1766.65</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3608.0</hp>
-            <mp>1180.5</mp>
-            <cp>1804.0</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3683.15</hp>
-            <mp>1205.55</mp>
-            <cp>1841.575</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3758.75</hp>
-            <mp>1230.75</mp>
-            <cp>1879.375</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3834.8</hp>
-            <mp>1256.1</mp>
-            <cp>1917.4</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3911.3</hp>
-            <mp>1281.6</mp>
-            <cp>1955.65</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3988.25</hp>
-            <mp>1307.25</mp>
-            <cp>1994.125</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>4065.65</hp>
-            <mp>1333.05</mp>
-            <cp>2032.825</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>4143.5</hp>
-            <mp>1359.0</mp>
-            <cp>2071.75</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>4221.8</hp>
-            <mp>1385.1</mp>
-            <cp>2110.9</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>4300.55</hp>
-            <mp>1411.35</mp>
-            <cp>2150.275</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>4379.75</hp>
-            <mp>1437.75</mp>
-            <cp>2189.875</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>4459.4</hp>
-            <mp>1464.3</mp>
-            <cp>2229.7</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>4539.5</hp>
-            <mp>1491.0</mp>
-            <cp>2269.75</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4620.05</hp>
-            <mp>1517.85</mp>
-            <cp>2310.025</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4701.05</hp>
-            <mp>1544.85</mp>
-            <cp>2350.525</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>107</classId>
+	<staticData>
+		<baseINT>25</baseINT>
+		<baseSTR>41</baseSTR>
+		<baseCON>32</baseCON>
+		<baseMEN>26</baseMEN>
+		<baseDEX>34</baseDEX>
+		<baseWIT>12</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="28295" y="11063" z="-4224" />
+			<node x="28302" y="11008" z="-4224" />
+			<node x="28377" y="10916" z="-4224" />
+			<node x="28456" y="10997" z="-4224" />
+			<node x="28461" y="11044" z="-4224" />
+			<node x="28395" y="11127" z="-4224" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>85</walk>
+			<run>139</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>350</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>94.0</hp>
+			<mp>30.0</mp>
+			<cp>47.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>107.65</hp>
+			<mp>35.46</mp>
+			<cp>53.825</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>121.45</hp>
+			<mp>40.98</mp>
+			<cp>60.725</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>135.4</hp>
+			<mp>46.56</mp>
+			<cp>67.7</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>149.5</hp>
+			<mp>52.2</mp>
+			<cp>74.75</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>163.75</hp>
+			<mp>57.9</mp>
+			<cp>81.875</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>178.15</hp>
+			<mp>63.66</mp>
+			<cp>89.075</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>192.7</hp>
+			<mp>69.48</mp>
+			<cp>96.35</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>207.4</hp>
+			<mp>75.36</mp>
+			<cp>103.7</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>222.25</hp>
+			<mp>81.3</mp>
+			<cp>111.125</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>237.25</hp>
+			<mp>87.3</mp>
+			<cp>118.625</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>252.4</hp>
+			<mp>93.36</mp>
+			<cp>126.2</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>267.7</hp>
+			<mp>99.48</mp>
+			<cp>133.85</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>283.15</hp>
+			<mp>105.66</mp>
+			<cp>141.575</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>298.75</hp>
+			<mp>111.9</mp>
+			<cp>149.375</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>314.5</hp>
+			<mp>118.2</mp>
+			<cp>157.25</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>330.4</hp>
+			<mp>124.56</mp>
+			<cp>165.2</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>346.45</hp>
+			<mp>130.98</mp>
+			<cp>173.225</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>362.65</hp>
+			<mp>137.46</mp>
+			<cp>181.325</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>379.0</hp>
+			<mp>144.0</mp>
+			<cp>189.5</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>414.2</hp>
+			<mp>153.9</mp>
+			<cp>207.1</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>449.72</hp>
+			<mp>163.89</mp>
+			<cp>224.86</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>485.56</hp>
+			<mp>173.97</mp>
+			<cp>242.78</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>521.72</hp>
+			<mp>184.14</mp>
+			<cp>260.86</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>558.2</hp>
+			<mp>194.4</mp>
+			<cp>279.1</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>595.0</hp>
+			<mp>204.75</mp>
+			<cp>297.5</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>632.12</hp>
+			<mp>215.19</mp>
+			<cp>316.06</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>669.56</hp>
+			<mp>225.72</mp>
+			<cp>334.78</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>707.32</hp>
+			<mp>236.34</mp>
+			<cp>353.66</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>745.4</hp>
+			<mp>247.05</mp>
+			<cp>372.7</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>783.8</hp>
+			<mp>257.85</mp>
+			<cp>391.9</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>822.52</hp>
+			<mp>268.74</mp>
+			<cp>411.26</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>861.56</hp>
+			<mp>279.72</mp>
+			<cp>430.78</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>900.92</hp>
+			<mp>290.79</mp>
+			<cp>450.46</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>940.6</hp>
+			<mp>301.95</mp>
+			<cp>470.3</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>980.6</hp>
+			<mp>313.2</mp>
+			<cp>490.3</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>1020.92</hp>
+			<mp>324.54</mp>
+			<cp>510.46</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1061.56</hp>
+			<mp>335.97</mp>
+			<cp>530.78</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1102.52</hp>
+			<mp>347.49</mp>
+			<cp>551.26</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1143.8</hp>
+			<mp>359.1</mp>
+			<cp>571.9</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1202.3</hp>
+			<mp>378.6</mp>
+			<cp>601.15</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1261.25</hp>
+			<mp>398.25</mp>
+			<cp>630.625</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1320.65</hp>
+			<mp>418.05</mp>
+			<cp>660.325</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1380.5</hp>
+			<mp>438.0</mp>
+			<cp>690.25</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1440.8</hp>
+			<mp>458.1</mp>
+			<cp>720.4</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1501.55</hp>
+			<mp>478.35</mp>
+			<cp>750.775</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1562.75</hp>
+			<mp>498.75</mp>
+			<cp>781.375</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1624.4</hp>
+			<mp>519.3</mp>
+			<cp>812.2</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1686.5</hp>
+			<mp>540.0</mp>
+			<cp>843.25</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1749.05</hp>
+			<mp>560.85</mp>
+			<cp>874.525</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1812.05</hp>
+			<mp>581.85</mp>
+			<cp>906.025</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1875.5</hp>
+			<mp>603.0</mp>
+			<cp>937.75</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1939.4</hp>
+			<mp>624.3</mp>
+			<cp>969.7</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>2003.75</hp>
+			<mp>645.75</mp>
+			<cp>1001.875</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>2068.55</hp>
+			<mp>667.35</mp>
+			<cp>1034.275</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>2133.8</hp>
+			<mp>689.1</mp>
+			<cp>1066.9</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2199.5</hp>
+			<mp>711.0</mp>
+			<cp>1099.75</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2265.65</hp>
+			<mp>733.05</mp>
+			<cp>1132.825</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2332.25</hp>
+			<mp>755.25</mp>
+			<cp>1166.125</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2399.3</hp>
+			<mp>777.6</mp>
+			<cp>1199.65</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2466.8</hp>
+			<mp>800.1</mp>
+			<cp>1233.4</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2534.75</hp>
+			<mp>822.75</mp>
+			<cp>1267.375</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2603.15</hp>
+			<mp>845.55</mp>
+			<cp>1301.575</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2672.0</hp>
+			<mp>868.5</mp>
+			<cp>1336.0</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2741.3</hp>
+			<mp>891.6</mp>
+			<cp>1370.65</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2811.05</hp>
+			<mp>914.85</mp>
+			<cp>1405.525</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2881.25</hp>
+			<mp>938.25</mp>
+			<cp>1440.625</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2951.9</hp>
+			<mp>961.8</mp>
+			<cp>1475.95</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>3023.0</hp>
+			<mp>985.5</mp>
+			<cp>1511.5</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>3094.55</hp>
+			<mp>1009.35</mp>
+			<cp>1547.275</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>3166.55</hp>
+			<mp>1033.35</mp>
+			<cp>1583.275</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>3239.0</hp>
+			<mp>1057.5</mp>
+			<cp>1619.5</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>3311.9</hp>
+			<mp>1081.8</mp>
+			<cp>1655.95</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3385.25</hp>
+			<mp>1106.25</mp>
+			<cp>1692.625</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3459.05</hp>
+			<mp>1130.85</mp>
+			<cp>1729.525</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3533.3</hp>
+			<mp>1155.6</mp>
+			<cp>1766.65</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3608.0</hp>
+			<mp>1180.5</mp>
+			<cp>1804.0</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3683.15</hp>
+			<mp>1205.55</mp>
+			<cp>1841.575</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3758.75</hp>
+			<mp>1230.75</mp>
+			<cp>1879.375</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3834.8</hp>
+			<mp>1256.1</mp>
+			<cp>1917.4</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3911.3</hp>
+			<mp>1281.6</mp>
+			<cp>1955.65</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3988.25</hp>
+			<mp>1307.25</mp>
+			<cp>1994.125</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>4065.65</hp>
+			<mp>1333.05</mp>
+			<cp>2032.825</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>4143.5</hp>
+			<mp>1359.0</mp>
+			<cp>2071.75</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>4221.8</hp>
+			<mp>1385.1</mp>
+			<cp>2110.9</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>4300.55</hp>
+			<mp>1411.35</mp>
+			<cp>2150.275</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>4379.75</hp>
+			<mp>1437.75</mp>
+			<cp>2189.875</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4459.4</hp>
+			<mp>1464.3</mp>
+			<cp>2229.7</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4539.5</hp>
+			<mp>1491.0</mp>
+			<cp>2269.75</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4620.05</hp>
+			<mp>1517.85</mp>
+			<cp>2310.025</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4701.05</hp>
+			<mp>1544.85</mp>
+			<cp>2350.525</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4782.5</hp>
+			<mp>1572.0</mp>
+			<cp>2391.25</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4864.4</hp>
+			<mp>1599.3</mp>
+			<cp>2432.2</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4946.75</hp>
+			<mp>1626.75</mp>
+			<cp>2473.375</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>5029.55</hp>
+			<mp>1654.35</mp>
+			<cp>2514.775</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>5112.8</hp>
+			<mp>1682.1</mp>
+			<cp>2556.4</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>5196.5</hp>
+			<mp>1710.0</mp>
+			<cp>2598.25</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>5280.65</hp>
+			<mp>1738.05</mp>
+			<cp>2640.325</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>5365.25</hp>
+			<mp>1766.25</mp>
+			<cp>2682.625</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>5450.3</hp>
+			<mp>1794.6</mp>
+			<cp>2725.16</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>5535.8</hp>
+			<mp>1823.1</mp>
+			<cp>2767.92</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5621.75</hp>
+			<mp>1851.75</mp>
+			<cp>2810.91</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5708.15</hp>
+			<mp>1880.55</mp>
+			<cp>2854.13</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5795</hp>
+			<mp>1909.5</mp>
+			<cp>2897.58</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5882.3</hp>
+			<mp>1938.6</mp>
+			<cp>2941.26</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5970.05</hp>
+			<mp>1967.85</mp>
+			<cp>2985.17</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>6058.25</hp>
+			<mp>1997.25</mp>
+			<cp>3029.125</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/SpectralMaster.xml
+++ b/data/stats/chars/baseStats/SpectralMaster.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>111</classId>
-    <staticData>
-        <baseINT>44</baseINT>
-        <baseSTR>23</baseSTR>
-        <baseCON>24</baseCON>
-        <baseMEN>37</baseMEN>
-        <baseDEX>23</baseDEX>
-        <baseWIT>19</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>15</magicAbnormalResist>
-        <creationPoints>
-            <node x="28295" y="11063" z="-4224"/>
-            <node x="28302" y="11008" z="-4224"/>
-            <node x="28377" y="10916" z="-4224"/>
-            <node x="28456" y="10997" z="-4224"/>
-            <node x="28461" y="11044" z="-4224"/>
-            <node x="28395" y="11127" z="-4224"/>
-        </creationPoints>
-        <basePAtk>3</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>15</chest>
-            <legs>8</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>85</walk>
-            <run>128</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>150</baseBreath>
-        <baseSafeFall>300</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>24</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.0</radius>
-            <height>23.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>106.0</hp>
-            <mp>40.0</mp>
-            <cp>63.6</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>121.47</hp>
-            <mp>47.28</mp>
-            <cp>72.882</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>137.11</hp>
-            <mp>54.64</mp>
-            <cp>82.266</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>152.92</hp>
-            <mp>62.08</mp>
-            <cp>91.752</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>168.9</hp>
-            <mp>69.6</mp>
-            <cp>101.34</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>185.05</hp>
-            <mp>77.2</mp>
-            <cp>111.03</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>201.37</hp>
-            <mp>84.88</mp>
-            <cp>120.822</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>217.86</hp>
-            <mp>92.64</mp>
-            <cp>130.716</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>234.52</hp>
-            <mp>100.48</mp>
-            <cp>140.712</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>251.35</hp>
-            <mp>108.4</mp>
-            <cp>150.81</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>268.35</hp>
-            <mp>116.4</mp>
-            <cp>161.01</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>285.52</hp>
-            <mp>124.48</mp>
-            <cp>171.312</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>302.86</hp>
-            <mp>132.64</mp>
-            <cp>181.716</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>320.37</hp>
-            <mp>140.88</mp>
-            <cp>192.222</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>338.05</hp>
-            <mp>149.2</mp>
-            <cp>202.83</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>355.9</hp>
-            <mp>157.6</mp>
-            <cp>213.54</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>373.92</hp>
-            <mp>166.08</mp>
-            <cp>224.352</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>392.11</hp>
-            <mp>174.64</mp>
-            <cp>235.266</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>410.47</hp>
-            <mp>183.28</mp>
-            <cp>246.282</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>429.0</hp>
-            <mp>192.0</mp>
-            <cp>257.4</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>458.7</hp>
-            <mp>205.2</mp>
-            <cp>275.22</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>488.67</hp>
-            <mp>218.52</mp>
-            <cp>293.202</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>518.91</hp>
-            <mp>231.96</mp>
-            <cp>311.346</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>549.42</hp>
-            <mp>245.52</mp>
-            <cp>329.652</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>580.2</hp>
-            <mp>259.2</mp>
-            <cp>348.12</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>611.25</hp>
-            <mp>273.0</mp>
-            <cp>366.75</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>642.57</hp>
-            <mp>286.92</mp>
-            <cp>385.542</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>674.16</hp>
-            <mp>300.96</mp>
-            <cp>404.496</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>706.02</hp>
-            <mp>315.12</mp>
-            <cp>423.612</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>738.15</hp>
-            <mp>329.4</mp>
-            <cp>442.89</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>770.55</hp>
-            <mp>343.8</mp>
-            <cp>462.33</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>803.22</hp>
-            <mp>358.32</mp>
-            <cp>481.932</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>836.16</hp>
-            <mp>372.96</mp>
-            <cp>501.696</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>869.37</hp>
-            <mp>387.72</mp>
-            <cp>521.622</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>902.85</hp>
-            <mp>402.6</mp>
-            <cp>541.71</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>936.6</hp>
-            <mp>417.6</mp>
-            <cp>561.96</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>970.62</hp>
-            <mp>432.72</mp>
-            <cp>582.372</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1004.91</hp>
-            <mp>447.96</mp>
-            <cp>602.946</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1039.47</hp>
-            <mp>463.32</mp>
-            <cp>623.682</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1074.3</hp>
-            <mp>478.8</mp>
-            <cp>644.58</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1126.3</hp>
-            <mp>504.8</mp>
-            <cp>675.78</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1178.7</hp>
-            <mp>531.0</mp>
-            <cp>707.22</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1231.5</hp>
-            <mp>557.4</mp>
-            <cp>738.9</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1284.7</hp>
-            <mp>584.0</mp>
-            <cp>770.82</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1338.3</hp>
-            <mp>610.8</mp>
-            <cp>802.98</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1392.3</hp>
-            <mp>637.8</mp>
-            <cp>835.38</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1446.7</hp>
-            <mp>665.0</mp>
-            <cp>868.02</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1501.5</hp>
-            <mp>692.4</mp>
-            <cp>900.9</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1556.7</hp>
-            <mp>720.0</mp>
-            <cp>934.02</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1612.3</hp>
-            <mp>747.8</mp>
-            <cp>967.38</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1668.3</hp>
-            <mp>775.8</mp>
-            <cp>1000.98</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1724.7</hp>
-            <mp>804.0</mp>
-            <cp>1034.82</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1781.5</hp>
-            <mp>832.4</mp>
-            <cp>1068.9</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1838.7</hp>
-            <mp>861.0</mp>
-            <cp>1103.22</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1896.3</hp>
-            <mp>889.8</mp>
-            <cp>1137.78</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1954.3</hp>
-            <mp>918.8</mp>
-            <cp>1172.58</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>2012.7</hp>
-            <mp>948.0</mp>
-            <cp>1207.62</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2071.5</hp>
-            <mp>977.4</mp>
-            <cp>1242.9</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2130.7</hp>
-            <mp>1007.0</mp>
-            <cp>1278.42</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2190.3</hp>
-            <mp>1036.8</mp>
-            <cp>1314.18</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2250.3</hp>
-            <mp>1066.8</mp>
-            <cp>1350.18</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2310.7</hp>
-            <mp>1097.0</mp>
-            <cp>1386.42</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2371.5</hp>
-            <mp>1127.4</mp>
-            <cp>1422.9</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2432.7</hp>
-            <mp>1158.0</mp>
-            <cp>1459.62</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2494.3</hp>
-            <mp>1188.8</mp>
-            <cp>1496.58</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2556.3</hp>
-            <mp>1219.8</mp>
-            <cp>1533.78</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2618.7</hp>
-            <mp>1251.0</mp>
-            <cp>1571.22</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2681.5</hp>
-            <mp>1282.4</mp>
-            <cp>1608.9</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2744.7</hp>
-            <mp>1314.0</mp>
-            <cp>1646.82</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2808.3</hp>
-            <mp>1345.8</mp>
-            <cp>1684.98</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2872.3</hp>
-            <mp>1377.8</mp>
-            <cp>1723.38</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2936.7</hp>
-            <mp>1410.0</mp>
-            <cp>1762.02</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>3001.5</hp>
-            <mp>1442.4</mp>
-            <cp>1800.9</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>3066.7</hp>
-            <mp>1475.0</mp>
-            <cp>1840.02</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3132.3</hp>
-            <mp>1507.8</mp>
-            <cp>1879.38</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3198.3</hp>
-            <mp>1540.8</mp>
-            <cp>1918.98</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3264.7</hp>
-            <mp>1574.0</mp>
-            <cp>1958.82</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3331.5</hp>
-            <mp>1607.4</mp>
-            <cp>1998.9</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3398.7</hp>
-            <mp>1641.0</mp>
-            <cp>2039.22</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3466.3</hp>
-            <mp>1674.8</mp>
-            <cp>2079.78</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3534.3</hp>
-            <mp>1708.8</mp>
-            <cp>2120.58</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3602.7</hp>
-            <mp>1743.0</mp>
-            <cp>2161.62</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3671.5</hp>
-            <mp>1777.4</mp>
-            <cp>2202.9</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3740.7</hp>
-            <mp>1812.0</mp>
-            <cp>2244.42</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3810.3</hp>
-            <mp>1846.8</mp>
-            <cp>2286.18</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3880.3</hp>
-            <mp>1881.8</mp>
-            <cp>2328.18</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3950.7</hp>
-            <mp>1917.0</mp>
-            <cp>2370.42</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>4021.5</hp>
-            <mp>1952.4</mp>
-            <cp>2412.9</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>4092.7</hp>
-            <mp>1988.0</mp>
-            <cp>2455.62</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4164.3</hp>
-            <mp>2023.8</mp>
-            <cp>2498.58</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4236.3</hp>
-            <mp>2059.8</mp>
-            <cp>2541.78</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>111</classId>
+	<staticData>
+		<baseINT>44</baseINT>
+		<baseSTR>23</baseSTR>
+		<baseCON>24</baseCON>
+		<baseMEN>37</baseMEN>
+		<baseDEX>23</baseDEX>
+		<baseWIT>19</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="28295" y="11063" z="-4224" />
+			<node x="28302" y="11008" z="-4224" />
+			<node x="28377" y="10916" z="-4224" />
+			<node x="28456" y="10997" z="-4224" />
+			<node x="28461" y="11044" z="-4224" />
+			<node x="28395" y="11127" z="-4224" />
+		</creationPoints>
+		<basePAtk>3</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>15</chest>
+			<legs>8</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>85</walk>
+			<run>128</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>300</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>106.0</hp>
+			<mp>40.0</mp>
+			<cp>63.6</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>121.47</hp>
+			<mp>47.28</mp>
+			<cp>72.882</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>137.11</hp>
+			<mp>54.64</mp>
+			<cp>82.266</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>152.92</hp>
+			<mp>62.08</mp>
+			<cp>91.752</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>168.9</hp>
+			<mp>69.6</mp>
+			<cp>101.34</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>185.05</hp>
+			<mp>77.2</mp>
+			<cp>111.03</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>201.37</hp>
+			<mp>84.88</mp>
+			<cp>120.822</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>217.86</hp>
+			<mp>92.64</mp>
+			<cp>130.716</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>234.52</hp>
+			<mp>100.48</mp>
+			<cp>140.712</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>251.35</hp>
+			<mp>108.4</mp>
+			<cp>150.81</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>268.35</hp>
+			<mp>116.4</mp>
+			<cp>161.01</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>285.52</hp>
+			<mp>124.48</mp>
+			<cp>171.312</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>302.86</hp>
+			<mp>132.64</mp>
+			<cp>181.716</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>320.37</hp>
+			<mp>140.88</mp>
+			<cp>192.222</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>338.05</hp>
+			<mp>149.2</mp>
+			<cp>202.83</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>355.9</hp>
+			<mp>157.6</mp>
+			<cp>213.54</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>373.92</hp>
+			<mp>166.08</mp>
+			<cp>224.352</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>392.11</hp>
+			<mp>174.64</mp>
+			<cp>235.266</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>410.47</hp>
+			<mp>183.28</mp>
+			<cp>246.282</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>429.0</hp>
+			<mp>192.0</mp>
+			<cp>257.4</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>458.7</hp>
+			<mp>205.2</mp>
+			<cp>275.22</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>488.67</hp>
+			<mp>218.52</mp>
+			<cp>293.202</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>518.91</hp>
+			<mp>231.96</mp>
+			<cp>311.346</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>549.42</hp>
+			<mp>245.52</mp>
+			<cp>329.652</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>580.2</hp>
+			<mp>259.2</mp>
+			<cp>348.12</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>611.25</hp>
+			<mp>273.0</mp>
+			<cp>366.75</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>642.57</hp>
+			<mp>286.92</mp>
+			<cp>385.542</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>674.16</hp>
+			<mp>300.96</mp>
+			<cp>404.496</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>706.02</hp>
+			<mp>315.12</mp>
+			<cp>423.612</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>738.15</hp>
+			<mp>329.4</mp>
+			<cp>442.89</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>770.55</hp>
+			<mp>343.8</mp>
+			<cp>462.33</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>803.22</hp>
+			<mp>358.32</mp>
+			<cp>481.932</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>836.16</hp>
+			<mp>372.96</mp>
+			<cp>501.696</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>869.37</hp>
+			<mp>387.72</mp>
+			<cp>521.622</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>902.85</hp>
+			<mp>402.6</mp>
+			<cp>541.71</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>936.6</hp>
+			<mp>417.6</mp>
+			<cp>561.96</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>970.62</hp>
+			<mp>432.72</mp>
+			<cp>582.372</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1004.91</hp>
+			<mp>447.96</mp>
+			<cp>602.946</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1039.47</hp>
+			<mp>463.32</mp>
+			<cp>623.682</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1074.3</hp>
+			<mp>478.8</mp>
+			<cp>644.58</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1126.3</hp>
+			<mp>504.8</mp>
+			<cp>675.78</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1178.7</hp>
+			<mp>531.0</mp>
+			<cp>707.22</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1231.5</hp>
+			<mp>557.4</mp>
+			<cp>738.9</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1284.7</hp>
+			<mp>584.0</mp>
+			<cp>770.82</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1338.3</hp>
+			<mp>610.8</mp>
+			<cp>802.98</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1392.3</hp>
+			<mp>637.8</mp>
+			<cp>835.38</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1446.7</hp>
+			<mp>665.0</mp>
+			<cp>868.02</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1501.5</hp>
+			<mp>692.4</mp>
+			<cp>900.9</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1556.7</hp>
+			<mp>720.0</mp>
+			<cp>934.02</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1612.3</hp>
+			<mp>747.8</mp>
+			<cp>967.38</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1668.3</hp>
+			<mp>775.8</mp>
+			<cp>1000.98</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1724.7</hp>
+			<mp>804.0</mp>
+			<cp>1034.82</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1781.5</hp>
+			<mp>832.4</mp>
+			<cp>1068.9</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1838.7</hp>
+			<mp>861.0</mp>
+			<cp>1103.22</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1896.3</hp>
+			<mp>889.8</mp>
+			<cp>1137.78</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1954.3</hp>
+			<mp>918.8</mp>
+			<cp>1172.58</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2012.7</hp>
+			<mp>948.0</mp>
+			<cp>1207.62</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2071.5</hp>
+			<mp>977.4</mp>
+			<cp>1242.9</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2130.7</hp>
+			<mp>1007.0</mp>
+			<cp>1278.42</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2190.3</hp>
+			<mp>1036.8</mp>
+			<cp>1314.18</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2250.3</hp>
+			<mp>1066.8</mp>
+			<cp>1350.18</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2310.7</hp>
+			<mp>1097.0</mp>
+			<cp>1386.42</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2371.5</hp>
+			<mp>1127.4</mp>
+			<cp>1422.9</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2432.7</hp>
+			<mp>1158.0</mp>
+			<cp>1459.62</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2494.3</hp>
+			<mp>1188.8</mp>
+			<cp>1496.58</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2556.3</hp>
+			<mp>1219.8</mp>
+			<cp>1533.78</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2618.7</hp>
+			<mp>1251.0</mp>
+			<cp>1571.22</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2681.5</hp>
+			<mp>1282.4</mp>
+			<cp>1608.9</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2744.7</hp>
+			<mp>1314.0</mp>
+			<cp>1646.82</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2808.3</hp>
+			<mp>1345.8</mp>
+			<cp>1684.98</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2872.3</hp>
+			<mp>1377.8</mp>
+			<cp>1723.38</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2936.7</hp>
+			<mp>1410.0</mp>
+			<cp>1762.02</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>3001.5</hp>
+			<mp>1442.4</mp>
+			<cp>1800.9</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3066.7</hp>
+			<mp>1475.0</mp>
+			<cp>1840.02</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3132.3</hp>
+			<mp>1507.8</mp>
+			<cp>1879.38</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3198.3</hp>
+			<mp>1540.8</mp>
+			<cp>1918.98</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3264.7</hp>
+			<mp>1574.0</mp>
+			<cp>1958.82</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3331.5</hp>
+			<mp>1607.4</mp>
+			<cp>1998.9</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3398.7</hp>
+			<mp>1641.0</mp>
+			<cp>2039.22</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3466.3</hp>
+			<mp>1674.8</mp>
+			<cp>2079.78</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3534.3</hp>
+			<mp>1708.8</mp>
+			<cp>2120.58</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3602.7</hp>
+			<mp>1743.0</mp>
+			<cp>2161.62</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3671.5</hp>
+			<mp>1777.4</mp>
+			<cp>2202.9</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3740.7</hp>
+			<mp>1812.0</mp>
+			<cp>2244.42</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3810.3</hp>
+			<mp>1846.8</mp>
+			<cp>2286.18</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3880.3</hp>
+			<mp>1881.8</mp>
+			<cp>2328.18</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3950.7</hp>
+			<mp>1917.0</mp>
+			<cp>2370.42</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4021.5</hp>
+			<mp>1952.4</mp>
+			<cp>2412.9</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4092.7</hp>
+			<mp>1988.0</mp>
+			<cp>2455.62</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4164.3</hp>
+			<mp>2023.8</mp>
+			<cp>2498.58</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4236.3</hp>
+			<mp>2059.8</mp>
+			<cp>2541.78</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4308.7</hp>
+			<mp>2096.0</mp>
+			<cp>2585.22</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4381.5</hp>
+			<mp>2132.4</mp>
+			<cp>2628.9</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4454.7</hp>
+			<mp>2169.0</mp>
+			<cp>2672.82</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4528.3</hp>
+			<mp>2205.8</mp>
+			<cp>2716.98</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4602.3</hp>
+			<mp>2242.8</mp>
+			<cp>2761.38</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4676.7</hp>
+			<mp>2280.0</mp>
+			<cp>2806.02</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4751.5</hp>
+			<mp>2317.4</mp>
+			<cp>2850.9</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4826.7</hp>
+			<mp>2355.0</mp>
+			<cp>2896.02</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4902.3</hp>
+			<mp>2392.8</mp>
+			<cp>2941.38</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4978.3</hp>
+			<mp>2430.8</mp>
+			<cp>2986.98</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5054.7</hp>
+			<mp>2469</mp>
+			<cp>3032.82</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5131.5</hp>
+			<mp>2507.4</mp>
+			<cp>3078.9</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5208.7</hp>
+			<mp>2546</mp>
+			<cp>3125.22</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5286.3</hp>
+			<mp>2584.8</mp>
+			<cp>3171.78</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5364.3</hp>
+			<mp>2623.8</mp>
+			<cp>3218.58</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5442.7</hp>
+			<mp>2663</mp>
+			<cp>3265.62</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Spellhowler.xml
+++ b/data/stats/chars/baseStats/Spellhowler.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>40</classId>
-    <staticData>
-        <baseINT>44</baseINT>
-        <baseSTR>23</baseSTR>
-        <baseCON>24</baseCON>
-        <baseMEN>37</baseMEN>
-        <baseDEX>23</baseDEX>
-        <baseWIT>19</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>15</magicAbnormalResist>
-        <creationPoints>
-            <node x="28295" y="11063" z="-4224"/>
-            <node x="28302" y="11008" z="-4224"/>
-            <node x="28377" y="10916" z="-4224"/>
-            <node x="28456" y="10997" z="-4224"/>
-            <node x="28461" y="11044" z="-4224"/>
-            <node x="28395" y="11127" z="-4224"/>
-        </creationPoints>
-        <basePAtk>3</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>15</chest>
-            <legs>8</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>85</walk>
-            <run>128</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>150</baseBreath>
-        <baseSafeFall>300</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>24</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.0</radius>
-            <height>23.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>106.0</hp>
-            <mp>40.0</mp>
-            <cp>63.6</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>121.47</hp>
-            <mp>47.28</mp>
-            <cp>72.882</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>137.11</hp>
-            <mp>54.64</mp>
-            <cp>82.266</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>152.92</hp>
-            <mp>62.08</mp>
-            <cp>91.752</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>168.9</hp>
-            <mp>69.6</mp>
-            <cp>101.34</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>185.05</hp>
-            <mp>77.2</mp>
-            <cp>111.03</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>201.37</hp>
-            <mp>84.88</mp>
-            <cp>120.822</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>217.86</hp>
-            <mp>92.64</mp>
-            <cp>130.716</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>234.52</hp>
-            <mp>100.48</mp>
-            <cp>140.712</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>251.35</hp>
-            <mp>108.4</mp>
-            <cp>150.81</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>268.35</hp>
-            <mp>116.4</mp>
-            <cp>161.01</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>285.52</hp>
-            <mp>124.48</mp>
-            <cp>171.312</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>302.86</hp>
-            <mp>132.64</mp>
-            <cp>181.716</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>320.37</hp>
-            <mp>140.88</mp>
-            <cp>192.222</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>338.05</hp>
-            <mp>149.2</mp>
-            <cp>202.83</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>355.9</hp>
-            <mp>157.6</mp>
-            <cp>213.54</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>373.92</hp>
-            <mp>166.08</mp>
-            <cp>224.352</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>392.11</hp>
-            <mp>174.64</mp>
-            <cp>235.266</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>410.47</hp>
-            <mp>183.28</mp>
-            <cp>246.282</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>429.0</hp>
-            <mp>192.0</mp>
-            <cp>257.4</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>458.7</hp>
-            <mp>205.2</mp>
-            <cp>275.22</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>488.67</hp>
-            <mp>218.52</mp>
-            <cp>293.202</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>518.91</hp>
-            <mp>231.96</mp>
-            <cp>311.346</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>549.42</hp>
-            <mp>245.52</mp>
-            <cp>329.652</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>580.2</hp>
-            <mp>259.2</mp>
-            <cp>348.12</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>611.25</hp>
-            <mp>273.0</mp>
-            <cp>366.75</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>642.57</hp>
-            <mp>286.92</mp>
-            <cp>385.542</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>674.16</hp>
-            <mp>300.96</mp>
-            <cp>404.496</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>706.02</hp>
-            <mp>315.12</mp>
-            <cp>423.612</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>738.15</hp>
-            <mp>329.4</mp>
-            <cp>442.89</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>770.55</hp>
-            <mp>343.8</mp>
-            <cp>462.33</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>803.22</hp>
-            <mp>358.32</mp>
-            <cp>481.932</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>836.16</hp>
-            <mp>372.96</mp>
-            <cp>501.696</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>869.37</hp>
-            <mp>387.72</mp>
-            <cp>521.622</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>902.85</hp>
-            <mp>402.6</mp>
-            <cp>541.71</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>936.6</hp>
-            <mp>417.6</mp>
-            <cp>561.96</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>970.62</hp>
-            <mp>432.72</mp>
-            <cp>582.372</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1004.91</hp>
-            <mp>447.96</mp>
-            <cp>602.946</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1039.47</hp>
-            <mp>463.32</mp>
-            <cp>623.682</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1074.3</hp>
-            <mp>478.8</mp>
-            <cp>644.58</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1122.4</hp>
-            <mp>504.8</mp>
-            <cp>673.44</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1170.87</hp>
-            <mp>531.0</mp>
-            <cp>702.522</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1219.71</hp>
-            <mp>557.4</mp>
-            <cp>731.826</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1268.92</hp>
-            <mp>584.0</mp>
-            <cp>761.352</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1318.5</hp>
-            <mp>610.8</mp>
-            <cp>791.1</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1368.45</hp>
-            <mp>637.8</mp>
-            <cp>821.07</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1418.77</hp>
-            <mp>665.0</mp>
-            <cp>851.262</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1469.46</hp>
-            <mp>692.4</mp>
-            <cp>881.676</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1520.52</hp>
-            <mp>720.0</mp>
-            <cp>912.312</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1571.95</hp>
-            <mp>747.8</mp>
-            <cp>943.17</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1623.75</hp>
-            <mp>775.8</mp>
-            <cp>974.25</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1675.92</hp>
-            <mp>804.0</mp>
-            <cp>1005.552</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1728.46</hp>
-            <mp>832.4</mp>
-            <cp>1037.076</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1781.37</hp>
-            <mp>861.0</mp>
-            <cp>1068.822</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1834.65</hp>
-            <mp>889.8</mp>
-            <cp>1100.79</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1888.3</hp>
-            <mp>918.8</mp>
-            <cp>1132.98</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1942.32</hp>
-            <mp>948.0</mp>
-            <cp>1165.392</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1996.71</hp>
-            <mp>977.4</mp>
-            <cp>1198.026</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2051.47</hp>
-            <mp>1007.0</mp>
-            <cp>1230.882</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2106.6</hp>
-            <mp>1036.8</mp>
-            <cp>1263.96</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2162.1</hp>
-            <mp>1066.8</mp>
-            <cp>1297.26</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2217.97</hp>
-            <mp>1097.0</mp>
-            <cp>1330.782</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2274.21</hp>
-            <mp>1127.4</mp>
-            <cp>1364.526</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2330.82</hp>
-            <mp>1158.0</mp>
-            <cp>1398.492</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2387.8</hp>
-            <mp>1188.8</mp>
-            <cp>1432.68</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2445.15</hp>
-            <mp>1219.8</mp>
-            <cp>1467.09</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2502.87</hp>
-            <mp>1251.0</mp>
-            <cp>1501.722</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2560.96</hp>
-            <mp>1282.4</mp>
-            <cp>1536.576</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2619.42</hp>
-            <mp>1314.0</mp>
-            <cp>1571.652</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2678.25</hp>
-            <mp>1345.8</mp>
-            <cp>1606.95</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2737.45</hp>
-            <mp>1377.8</mp>
-            <cp>1642.47</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2797.02</hp>
-            <mp>1410.0</mp>
-            <cp>1678.212</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2856.96</hp>
-            <mp>1442.4</mp>
-            <cp>1714.176</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2917.27</hp>
-            <mp>1475.0</mp>
-            <cp>1750.362</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2977.95</hp>
-            <mp>1507.8</mp>
-            <cp>1786.77</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3039.0</hp>
-            <mp>1540.8</mp>
-            <cp>1823.4</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3100.42</hp>
-            <mp>1574.0</mp>
-            <cp>1860.252</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3162.21</hp>
-            <mp>1607.4</mp>
-            <cp>1897.326</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3224.37</hp>
-            <mp>1641.0</mp>
-            <cp>1934.622</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3286.9</hp>
-            <mp>1674.8</mp>
-            <cp>1972.14</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3349.8</hp>
-            <mp>1708.8</mp>
-            <cp>2009.88</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3413.07</hp>
-            <mp>1743.0</mp>
-            <cp>2047.842</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3476.71</hp>
-            <mp>1777.4</mp>
-            <cp>2086.026</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3540.72</hp>
-            <mp>1812.0</mp>
-            <cp>2124.432</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3605.1</hp>
-            <mp>1846.8</mp>
-            <cp>2163.06</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3669.85</hp>
-            <mp>1881.8</mp>
-            <cp>2201.91</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3734.97</hp>
-            <mp>1917.0</mp>
-            <cp>2240.982</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3800.46</hp>
-            <mp>1952.4</mp>
-            <cp>2280.276</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3866.32</hp>
-            <mp>1988.0</mp>
-            <cp>2319.792</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3932.55</hp>
-            <mp>2023.8</mp>
-            <cp>2359.53</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>3999.15</hp>
-            <mp>2059.8</mp>
-            <cp>2399.49</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>40</classId>
+	<staticData>
+		<baseINT>44</baseINT>
+		<baseSTR>23</baseSTR>
+		<baseCON>24</baseCON>
+		<baseMEN>37</baseMEN>
+		<baseDEX>23</baseDEX>
+		<baseWIT>19</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="28295" y="11063" z="-4224" />
+			<node x="28302" y="11008" z="-4224" />
+			<node x="28377" y="10916" z="-4224" />
+			<node x="28456" y="10997" z="-4224" />
+			<node x="28461" y="11044" z="-4224" />
+			<node x="28395" y="11127" z="-4224" />
+		</creationPoints>
+		<basePAtk>3</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>15</chest>
+			<legs>8</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>85</walk>
+			<run>128</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>300</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>106.0</hp>
+			<mp>40.0</mp>
+			<cp>63.6</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>121.47</hp>
+			<mp>47.28</mp>
+			<cp>72.882</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>137.11</hp>
+			<mp>54.64</mp>
+			<cp>82.266</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>152.92</hp>
+			<mp>62.08</mp>
+			<cp>91.752</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>168.9</hp>
+			<mp>69.6</mp>
+			<cp>101.34</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>185.05</hp>
+			<mp>77.2</mp>
+			<cp>111.03</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>201.37</hp>
+			<mp>84.88</mp>
+			<cp>120.822</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>217.86</hp>
+			<mp>92.64</mp>
+			<cp>130.716</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>234.52</hp>
+			<mp>100.48</mp>
+			<cp>140.712</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>251.35</hp>
+			<mp>108.4</mp>
+			<cp>150.81</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>268.35</hp>
+			<mp>116.4</mp>
+			<cp>161.01</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>285.52</hp>
+			<mp>124.48</mp>
+			<cp>171.312</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>302.86</hp>
+			<mp>132.64</mp>
+			<cp>181.716</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>320.37</hp>
+			<mp>140.88</mp>
+			<cp>192.222</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>338.05</hp>
+			<mp>149.2</mp>
+			<cp>202.83</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>355.9</hp>
+			<mp>157.6</mp>
+			<cp>213.54</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>373.92</hp>
+			<mp>166.08</mp>
+			<cp>224.352</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>392.11</hp>
+			<mp>174.64</mp>
+			<cp>235.266</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>410.47</hp>
+			<mp>183.28</mp>
+			<cp>246.282</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>429.0</hp>
+			<mp>192.0</mp>
+			<cp>257.4</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>458.7</hp>
+			<mp>205.2</mp>
+			<cp>275.22</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>488.67</hp>
+			<mp>218.52</mp>
+			<cp>293.202</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>518.91</hp>
+			<mp>231.96</mp>
+			<cp>311.346</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>549.42</hp>
+			<mp>245.52</mp>
+			<cp>329.652</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>580.2</hp>
+			<mp>259.2</mp>
+			<cp>348.12</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>611.25</hp>
+			<mp>273.0</mp>
+			<cp>366.75</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>642.57</hp>
+			<mp>286.92</mp>
+			<cp>385.542</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>674.16</hp>
+			<mp>300.96</mp>
+			<cp>404.496</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>706.02</hp>
+			<mp>315.12</mp>
+			<cp>423.612</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>738.15</hp>
+			<mp>329.4</mp>
+			<cp>442.89</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>770.55</hp>
+			<mp>343.8</mp>
+			<cp>462.33</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>803.22</hp>
+			<mp>358.32</mp>
+			<cp>481.932</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>836.16</hp>
+			<mp>372.96</mp>
+			<cp>501.696</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>869.37</hp>
+			<mp>387.72</mp>
+			<cp>521.622</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>902.85</hp>
+			<mp>402.6</mp>
+			<cp>541.71</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>936.6</hp>
+			<mp>417.6</mp>
+			<cp>561.96</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>970.62</hp>
+			<mp>432.72</mp>
+			<cp>582.372</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1004.91</hp>
+			<mp>447.96</mp>
+			<cp>602.946</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1039.47</hp>
+			<mp>463.32</mp>
+			<cp>623.682</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1074.3</hp>
+			<mp>478.8</mp>
+			<cp>644.58</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1122.4</hp>
+			<mp>504.8</mp>
+			<cp>673.44</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1170.87</hp>
+			<mp>531.0</mp>
+			<cp>702.522</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1219.71</hp>
+			<mp>557.4</mp>
+			<cp>731.826</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1268.92</hp>
+			<mp>584.0</mp>
+			<cp>761.352</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1318.5</hp>
+			<mp>610.8</mp>
+			<cp>791.1</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1368.45</hp>
+			<mp>637.8</mp>
+			<cp>821.07</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1418.77</hp>
+			<mp>665.0</mp>
+			<cp>851.262</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1469.46</hp>
+			<mp>692.4</mp>
+			<cp>881.676</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1520.52</hp>
+			<mp>720.0</mp>
+			<cp>912.312</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1571.95</hp>
+			<mp>747.8</mp>
+			<cp>943.17</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1623.75</hp>
+			<mp>775.8</mp>
+			<cp>974.25</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1675.92</hp>
+			<mp>804.0</mp>
+			<cp>1005.552</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1728.46</hp>
+			<mp>832.4</mp>
+			<cp>1037.076</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1781.37</hp>
+			<mp>861.0</mp>
+			<cp>1068.822</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1834.65</hp>
+			<mp>889.8</mp>
+			<cp>1100.79</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1888.3</hp>
+			<mp>918.8</mp>
+			<cp>1132.98</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1942.32</hp>
+			<mp>948.0</mp>
+			<cp>1165.392</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1996.71</hp>
+			<mp>977.4</mp>
+			<cp>1198.026</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2051.47</hp>
+			<mp>1007.0</mp>
+			<cp>1230.882</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2106.6</hp>
+			<mp>1036.8</mp>
+			<cp>1263.96</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2162.1</hp>
+			<mp>1066.8</mp>
+			<cp>1297.26</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2217.97</hp>
+			<mp>1097.0</mp>
+			<cp>1330.782</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2274.21</hp>
+			<mp>1127.4</mp>
+			<cp>1364.526</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2330.82</hp>
+			<mp>1158.0</mp>
+			<cp>1398.492</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2387.8</hp>
+			<mp>1188.8</mp>
+			<cp>1432.68</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2445.15</hp>
+			<mp>1219.8</mp>
+			<cp>1467.09</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2502.87</hp>
+			<mp>1251.0</mp>
+			<cp>1501.722</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2560.96</hp>
+			<mp>1282.4</mp>
+			<cp>1536.576</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2619.42</hp>
+			<mp>1314.0</mp>
+			<cp>1571.652</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2678.25</hp>
+			<mp>1345.8</mp>
+			<cp>1606.95</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2737.45</hp>
+			<mp>1377.8</mp>
+			<cp>1642.47</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2797.02</hp>
+			<mp>1410.0</mp>
+			<cp>1678.212</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2856.96</hp>
+			<mp>1442.4</mp>
+			<cp>1714.176</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2917.27</hp>
+			<mp>1475.0</mp>
+			<cp>1750.362</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2977.95</hp>
+			<mp>1507.8</mp>
+			<cp>1786.77</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3039.0</hp>
+			<mp>1540.8</mp>
+			<cp>1823.4</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3100.42</hp>
+			<mp>1574.0</mp>
+			<cp>1860.252</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3162.21</hp>
+			<mp>1607.4</mp>
+			<cp>1897.326</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3224.37</hp>
+			<mp>1641.0</mp>
+			<cp>1934.622</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3286.9</hp>
+			<mp>1674.8</mp>
+			<cp>1972.14</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3349.8</hp>
+			<mp>1708.8</mp>
+			<cp>2009.88</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3413.07</hp>
+			<mp>1743.0</mp>
+			<cp>2047.842</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3476.71</hp>
+			<mp>1777.4</mp>
+			<cp>2086.026</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3540.72</hp>
+			<mp>1812.0</mp>
+			<cp>2124.432</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3605.1</hp>
+			<mp>1846.8</mp>
+			<cp>2163.06</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3669.85</hp>
+			<mp>1881.8</mp>
+			<cp>2201.91</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3734.97</hp>
+			<mp>1917.0</mp>
+			<cp>2240.982</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3800.46</hp>
+			<mp>1952.4</mp>
+			<cp>2280.276</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3866.32</hp>
+			<mp>1988.0</mp>
+			<cp>2319.792</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3932.55</hp>
+			<mp>2023.8</mp>
+			<cp>2359.53</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3999.15</hp>
+			<mp>2059.8</mp>
+			<cp>2399.49</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4066.12</hp>
+			<mp>2096.0</mp>
+			<cp>2439.672</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4133.46</hp>
+			<mp>2132.4</mp>
+			<cp>2480.076</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4201.17</hp>
+			<mp>2169.0</mp>
+			<cp>2520.702</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4269.25</hp>
+			<mp>2205.8</mp>
+			<cp>2561.55</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4337.7</hp>
+			<mp>2242.8</mp>
+			<cp>2602.62</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4406.52</hp>
+			<mp>2280.0</mp>
+			<cp>2643.912</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4475.71</hp>
+			<mp>2317.4</mp>
+			<cp>2685.426</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4545.27</hp>
+			<mp>2355.0</mp>
+			<cp>2727.162</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4615.2</hp>
+			<mp>2392.8</mp>
+			<cp>2769.12</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4685.5</hp>
+			<mp>2430.8</mp>
+			<cp>2811.29</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4756.17</hp>
+			<mp>2469</mp>
+			<cp>2853.69</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4827.21</hp>
+			<mp>2507.4</mp>
+			<cp>2896.31</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4898.62</hp>
+			<mp>2546</mp>
+			<cp>2939.14</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>4970.4</hp>
+			<mp>2584.8</mp>
+			<cp>2982.2</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5042.55</hp>
+			<mp>2623.8</mp>
+			<cp>3025.47</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5115.07</hp>
+			<mp>2663</mp>
+			<cp>3069.042</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Spellsinger.xml
+++ b/data/stats/chars/baseStats/Spellsinger.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>27</classId>
-    <staticData>
-        <baseINT>37</baseINT>
-        <baseSTR>21</baseSTR>
-        <baseCON>25</baseCON>
-        <baseMEN>40</baseMEN>
-        <baseDEX>24</baseDEX>
-        <baseWIT>23</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>15</magicAbnormalResist>
-        <creationPoints>
-            <node x="46045" y="41251" z="-3440"/>
-            <node x="46117" y="41247" z="-3440"/>
-            <node x="46182" y="41198" z="-3440"/>
-            <node x="46115" y="41141" z="-3440"/>
-            <node x="46048" y="41141" z="-3440"/>
-            <node x="45978" y="41196" z="-3440"/>
-        </creationPoints>
-        <basePAtk>3</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>15</chest>
-            <legs>8</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>85</walk>
-            <run>129</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>150</baseBreath>
-        <baseSafeFall>300</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>24</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.5</radius>
-            <height>23</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>104.0</hp>
-            <mp>40.0</mp>
-            <cp>62.4</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>119.47</hp>
-            <mp>47.28</mp>
-            <cp>71.682</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>135.11</hp>
-            <mp>54.64</mp>
-            <cp>81.066</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>150.92</hp>
-            <mp>62.08</mp>
-            <cp>90.552</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>166.9</hp>
-            <mp>69.6</mp>
-            <cp>100.14</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>183.05</hp>
-            <mp>77.2</mp>
-            <cp>109.83</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>199.37</hp>
-            <mp>84.88</mp>
-            <cp>119.622</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>215.86</hp>
-            <mp>92.64</mp>
-            <cp>129.516</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>232.52</hp>
-            <mp>100.48</mp>
-            <cp>139.512</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>249.35</hp>
-            <mp>108.4</mp>
-            <cp>149.61</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>266.35</hp>
-            <mp>116.4</mp>
-            <cp>159.81</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>283.52</hp>
-            <mp>124.48</mp>
-            <cp>170.112</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>300.86</hp>
-            <mp>132.64</mp>
-            <cp>180.516</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>318.37</hp>
-            <mp>140.88</mp>
-            <cp>191.022</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>336.05</hp>
-            <mp>149.2</mp>
-            <cp>201.63</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>353.9</hp>
-            <mp>157.6</mp>
-            <cp>212.34</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>371.92</hp>
-            <mp>166.08</mp>
-            <cp>223.152</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>390.11</hp>
-            <mp>174.64</mp>
-            <cp>234.066</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>408.47</hp>
-            <mp>183.28</mp>
-            <cp>245.082</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>427.0</hp>
-            <mp>192.0</mp>
-            <cp>256.2</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>455.6</hp>
-            <mp>205.2</mp>
-            <cp>273.36</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>484.46</hp>
-            <mp>218.52</mp>
-            <cp>290.676</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>513.58</hp>
-            <mp>231.96</mp>
-            <cp>308.148</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>542.96</hp>
-            <mp>245.52</mp>
-            <cp>325.776</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>572.6</hp>
-            <mp>259.2</mp>
-            <cp>343.56</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>602.5</hp>
-            <mp>273.0</mp>
-            <cp>361.5</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>632.66</hp>
-            <mp>286.92</mp>
-            <cp>379.596</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>663.08</hp>
-            <mp>300.96</mp>
-            <cp>397.848</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>693.76</hp>
-            <mp>315.12</mp>
-            <cp>416.256</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>724.7</hp>
-            <mp>329.4</mp>
-            <cp>434.82</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>755.9</hp>
-            <mp>343.8</mp>
-            <cp>453.54</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>787.36</hp>
-            <mp>358.32</mp>
-            <cp>472.416</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>819.08</hp>
-            <mp>372.96</mp>
-            <cp>491.448</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>851.06</hp>
-            <mp>387.72</mp>
-            <cp>510.636</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>883.3</hp>
-            <mp>402.6</mp>
-            <cp>529.98</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>915.8</hp>
-            <mp>417.6</mp>
-            <cp>549.48</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>948.56</hp>
-            <mp>432.72</mp>
-            <cp>569.136</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>981.58</hp>
-            <mp>447.96</mp>
-            <cp>588.948</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1014.86</hp>
-            <mp>463.32</mp>
-            <cp>608.916</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1048.4</hp>
-            <mp>478.8</mp>
-            <cp>629.04</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1096.5</hp>
-            <mp>504.8</mp>
-            <cp>657.9</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1144.97</hp>
-            <mp>531.0</mp>
-            <cp>686.982</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1193.81</hp>
-            <mp>557.4</mp>
-            <cp>716.286</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1243.02</hp>
-            <mp>584.0</mp>
-            <cp>745.812</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1292.6</hp>
-            <mp>610.8</mp>
-            <cp>775.56</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1342.55</hp>
-            <mp>637.8</mp>
-            <cp>805.53</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1392.87</hp>
-            <mp>665.0</mp>
-            <cp>835.722</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1443.56</hp>
-            <mp>692.4</mp>
-            <cp>866.136</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1494.62</hp>
-            <mp>720.0</mp>
-            <cp>896.772</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1546.05</hp>
-            <mp>747.8</mp>
-            <cp>927.63</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1597.85</hp>
-            <mp>775.8</mp>
-            <cp>958.71</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1650.02</hp>
-            <mp>804.0</mp>
-            <cp>990.012</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1702.56</hp>
-            <mp>832.4</mp>
-            <cp>1021.536</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1755.47</hp>
-            <mp>861.0</mp>
-            <cp>1053.282</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1808.75</hp>
-            <mp>889.8</mp>
-            <cp>1085.25</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1862.4</hp>
-            <mp>918.8</mp>
-            <cp>1117.44</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1916.42</hp>
-            <mp>948.0</mp>
-            <cp>1149.852</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1970.81</hp>
-            <mp>977.4</mp>
-            <cp>1182.486</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2025.57</hp>
-            <mp>1007.0</mp>
-            <cp>1215.342</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2080.7</hp>
-            <mp>1036.8</mp>
-            <cp>1248.42</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2136.2</hp>
-            <mp>1066.8</mp>
-            <cp>1281.72</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2192.07</hp>
-            <mp>1097.0</mp>
-            <cp>1315.242</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2248.31</hp>
-            <mp>1127.4</mp>
-            <cp>1348.986</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2304.92</hp>
-            <mp>1158.0</mp>
-            <cp>1382.952</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2361.9</hp>
-            <mp>1188.8</mp>
-            <cp>1417.14</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2419.25</hp>
-            <mp>1219.8</mp>
-            <cp>1451.55</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2476.97</hp>
-            <mp>1251.0</mp>
-            <cp>1486.182</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2535.06</hp>
-            <mp>1282.4</mp>
-            <cp>1521.036</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2593.52</hp>
-            <mp>1314.0</mp>
-            <cp>1556.112</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2652.35</hp>
-            <mp>1345.8</mp>
-            <cp>1591.41</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2711.55</hp>
-            <mp>1377.8</mp>
-            <cp>1626.93</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2771.12</hp>
-            <mp>1410.0</mp>
-            <cp>1662.672</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2831.06</hp>
-            <mp>1442.4</mp>
-            <cp>1698.636</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2891.37</hp>
-            <mp>1475.0</mp>
-            <cp>1734.822</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2952.05</hp>
-            <mp>1507.8</mp>
-            <cp>1771.23</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3013.1</hp>
-            <mp>1540.8</mp>
-            <cp>1807.86</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3074.52</hp>
-            <mp>1574.0</mp>
-            <cp>1844.712</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3136.31</hp>
-            <mp>1607.4</mp>
-            <cp>1881.786</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3198.47</hp>
-            <mp>1641.0</mp>
-            <cp>1919.082</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3261.0</hp>
-            <mp>1674.8</mp>
-            <cp>1956.6</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3323.9</hp>
-            <mp>1708.8</mp>
-            <cp>1994.34</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3387.17</hp>
-            <mp>1743.0</mp>
-            <cp>2032.302</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3450.81</hp>
-            <mp>1777.4</mp>
-            <cp>2070.486</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3514.82</hp>
-            <mp>1812.0</mp>
-            <cp>2108.892</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3579.2</hp>
-            <mp>1846.8</mp>
-            <cp>2147.52</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3643.95</hp>
-            <mp>1881.8</mp>
-            <cp>2186.37</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3709.07</hp>
-            <mp>1917.0</mp>
-            <cp>2225.442</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3774.56</hp>
-            <mp>1952.4</mp>
-            <cp>2264.736</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3840.42</hp>
-            <mp>1988.0</mp>
-            <cp>2304.252</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3906.65</hp>
-            <mp>2023.8</mp>
-            <cp>2343.99</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>3973.25</hp>
-            <mp>2059.8</mp>
-            <cp>2383.95</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>27</classId>
+	<staticData>
+		<baseINT>37</baseINT>
+		<baseSTR>21</baseSTR>
+		<baseCON>25</baseCON>
+		<baseMEN>40</baseMEN>
+		<baseDEX>24</baseDEX>
+		<baseWIT>23</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="46045" y="41251" z="-3440" />
+			<node x="46117" y="41247" z="-3440" />
+			<node x="46182" y="41198" z="-3440" />
+			<node x="46115" y="41141" z="-3440" />
+			<node x="46048" y="41141" z="-3440" />
+			<node x="45978" y="41196" z="-3440" />
+		</creationPoints>
+		<basePAtk>3</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>15</chest>
+			<legs>8</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>85</walk>
+			<run>129</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>300</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.5</radius>
+			<height>23</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>104.0</hp>
+			<mp>40.0</mp>
+			<cp>62.4</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>119.47</hp>
+			<mp>47.28</mp>
+			<cp>71.682</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>135.11</hp>
+			<mp>54.64</mp>
+			<cp>81.066</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>150.92</hp>
+			<mp>62.08</mp>
+			<cp>90.552</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>166.9</hp>
+			<mp>69.6</mp>
+			<cp>100.14</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>183.05</hp>
+			<mp>77.2</mp>
+			<cp>109.83</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>199.37</hp>
+			<mp>84.88</mp>
+			<cp>119.622</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>215.86</hp>
+			<mp>92.64</mp>
+			<cp>129.516</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>232.52</hp>
+			<mp>100.48</mp>
+			<cp>139.512</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>249.35</hp>
+			<mp>108.4</mp>
+			<cp>149.61</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>266.35</hp>
+			<mp>116.4</mp>
+			<cp>159.81</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>283.52</hp>
+			<mp>124.48</mp>
+			<cp>170.112</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>300.86</hp>
+			<mp>132.64</mp>
+			<cp>180.516</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>318.37</hp>
+			<mp>140.88</mp>
+			<cp>191.022</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>336.05</hp>
+			<mp>149.2</mp>
+			<cp>201.63</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>353.9</hp>
+			<mp>157.6</mp>
+			<cp>212.34</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>371.92</hp>
+			<mp>166.08</mp>
+			<cp>223.152</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>390.11</hp>
+			<mp>174.64</mp>
+			<cp>234.066</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>408.47</hp>
+			<mp>183.28</mp>
+			<cp>245.082</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>427.0</hp>
+			<mp>192.0</mp>
+			<cp>256.2</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>455.6</hp>
+			<mp>205.2</mp>
+			<cp>273.36</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>484.46</hp>
+			<mp>218.52</mp>
+			<cp>290.676</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>513.58</hp>
+			<mp>231.96</mp>
+			<cp>308.148</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>542.96</hp>
+			<mp>245.52</mp>
+			<cp>325.776</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>572.6</hp>
+			<mp>259.2</mp>
+			<cp>343.56</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>602.5</hp>
+			<mp>273.0</mp>
+			<cp>361.5</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>632.66</hp>
+			<mp>286.92</mp>
+			<cp>379.596</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>663.08</hp>
+			<mp>300.96</mp>
+			<cp>397.848</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>693.76</hp>
+			<mp>315.12</mp>
+			<cp>416.256</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>724.7</hp>
+			<mp>329.4</mp>
+			<cp>434.82</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>755.9</hp>
+			<mp>343.8</mp>
+			<cp>453.54</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>787.36</hp>
+			<mp>358.32</mp>
+			<cp>472.416</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>819.08</hp>
+			<mp>372.96</mp>
+			<cp>491.448</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>851.06</hp>
+			<mp>387.72</mp>
+			<cp>510.636</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>883.3</hp>
+			<mp>402.6</mp>
+			<cp>529.98</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>915.8</hp>
+			<mp>417.6</mp>
+			<cp>549.48</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>948.56</hp>
+			<mp>432.72</mp>
+			<cp>569.136</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>981.58</hp>
+			<mp>447.96</mp>
+			<cp>588.948</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1014.86</hp>
+			<mp>463.32</mp>
+			<cp>608.916</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1048.4</hp>
+			<mp>478.8</mp>
+			<cp>629.04</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1096.5</hp>
+			<mp>504.8</mp>
+			<cp>657.9</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1144.97</hp>
+			<mp>531.0</mp>
+			<cp>686.982</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1193.81</hp>
+			<mp>557.4</mp>
+			<cp>716.286</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1243.02</hp>
+			<mp>584.0</mp>
+			<cp>745.812</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1292.6</hp>
+			<mp>610.8</mp>
+			<cp>775.56</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1342.55</hp>
+			<mp>637.8</mp>
+			<cp>805.53</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1392.87</hp>
+			<mp>665.0</mp>
+			<cp>835.722</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1443.56</hp>
+			<mp>692.4</mp>
+			<cp>866.136</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1494.62</hp>
+			<mp>720.0</mp>
+			<cp>896.772</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1546.05</hp>
+			<mp>747.8</mp>
+			<cp>927.63</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1597.85</hp>
+			<mp>775.8</mp>
+			<cp>958.71</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1650.02</hp>
+			<mp>804.0</mp>
+			<cp>990.012</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1702.56</hp>
+			<mp>832.4</mp>
+			<cp>1021.536</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1755.47</hp>
+			<mp>861.0</mp>
+			<cp>1053.282</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1808.75</hp>
+			<mp>889.8</mp>
+			<cp>1085.25</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1862.4</hp>
+			<mp>918.8</mp>
+			<cp>1117.44</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1916.42</hp>
+			<mp>948.0</mp>
+			<cp>1149.852</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1970.81</hp>
+			<mp>977.4</mp>
+			<cp>1182.486</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2025.57</hp>
+			<mp>1007.0</mp>
+			<cp>1215.342</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2080.7</hp>
+			<mp>1036.8</mp>
+			<cp>1248.42</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2136.2</hp>
+			<mp>1066.8</mp>
+			<cp>1281.72</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2192.07</hp>
+			<mp>1097.0</mp>
+			<cp>1315.242</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2248.31</hp>
+			<mp>1127.4</mp>
+			<cp>1348.986</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2304.92</hp>
+			<mp>1158.0</mp>
+			<cp>1382.952</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2361.9</hp>
+			<mp>1188.8</mp>
+			<cp>1417.14</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2419.25</hp>
+			<mp>1219.8</mp>
+			<cp>1451.55</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2476.97</hp>
+			<mp>1251.0</mp>
+			<cp>1486.182</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2535.06</hp>
+			<mp>1282.4</mp>
+			<cp>1521.036</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2593.52</hp>
+			<mp>1314.0</mp>
+			<cp>1556.112</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2652.35</hp>
+			<mp>1345.8</mp>
+			<cp>1591.41</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2711.55</hp>
+			<mp>1377.8</mp>
+			<cp>1626.93</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2771.12</hp>
+			<mp>1410.0</mp>
+			<cp>1662.672</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2831.06</hp>
+			<mp>1442.4</mp>
+			<cp>1698.636</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2891.37</hp>
+			<mp>1475.0</mp>
+			<cp>1734.822</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2952.05</hp>
+			<mp>1507.8</mp>
+			<cp>1771.23</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3013.1</hp>
+			<mp>1540.8</mp>
+			<cp>1807.86</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3074.52</hp>
+			<mp>1574.0</mp>
+			<cp>1844.712</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3136.31</hp>
+			<mp>1607.4</mp>
+			<cp>1881.786</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3198.47</hp>
+			<mp>1641.0</mp>
+			<cp>1919.082</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3261.0</hp>
+			<mp>1674.8</mp>
+			<cp>1956.6</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3323.9</hp>
+			<mp>1708.8</mp>
+			<cp>1994.34</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3387.17</hp>
+			<mp>1743.0</mp>
+			<cp>2032.302</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3450.81</hp>
+			<mp>1777.4</mp>
+			<cp>2070.486</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3514.82</hp>
+			<mp>1812.0</mp>
+			<cp>2108.892</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3579.2</hp>
+			<mp>1846.8</mp>
+			<cp>2147.52</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3643.95</hp>
+			<mp>1881.8</mp>
+			<cp>2186.37</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3709.07</hp>
+			<mp>1917.0</mp>
+			<cp>2225.442</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3774.56</hp>
+			<mp>1952.4</mp>
+			<cp>2264.736</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3840.42</hp>
+			<mp>1988.0</mp>
+			<cp>2304.252</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3906.65</hp>
+			<mp>2023.8</mp>
+			<cp>2343.99</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3973.25</hp>
+			<mp>2059.8</mp>
+			<cp>2383.95</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4040.22</hp>
+			<mp>2096.0</mp>
+			<cp>2424.132</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4107.56</hp>
+			<mp>2132.4</mp>
+			<cp>2464.536</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4175.27</hp>
+			<mp>2169.0</mp>
+			<cp>2505.162</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4243.35</hp>
+			<mp>2205.8</mp>
+			<cp>2546.01</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4311.8</hp>
+			<mp>2242.8</mp>
+			<cp>2587.08</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4380.62</hp>
+			<mp>2280.0</mp>
+			<cp>2628.372</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4449.81</hp>
+			<mp>2317.4</mp>
+			<cp>2669.886</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4519.37</hp>
+			<mp>2355.0</mp>
+			<cp>2711.622</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4589.3</hp>
+			<mp>2392.8</mp>
+			<cp>2753.58</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4659.6</hp>
+			<mp>2430.8</mp>
+			<cp>2795.75</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4730.27</hp>
+			<mp>2469</mp>
+			<cp>2838.15</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4801.31</hp>
+			<mp>2507.4</mp>
+			<cp>2880.77</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4872.72</hp>
+			<mp>2546</mp>
+			<cp>2923.6</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>4944.5</hp>
+			<mp>2584.8</mp>
+			<cp>2966.66</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5016.65</hp>
+			<mp>2623.8</mp>
+			<cp>3009.93</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5089.17</hp>
+			<mp>2663</mp>
+			<cp>3053.502</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/StormBlaster.xml
+++ b/data/stats/chars/baseStats/StormBlaster.xml
@@ -1,0 +1,923 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
+    <classId>211</classId>
+    <staticData>
+        <baseINT>20</baseINT>
+        <baseSTR>40</baseSTR>
+        <baseCON>40</baseCON>
+        <baseMEN>25</baseMEN>
+        <baseDEX>35</baseDEX>
+        <baseWIT>10</baseWIT>
+        <physicalAbnormalResist>10</physicalAbnormalResist>
+        <magicAbnormalResist>10</magicAbnormalResist>
+        <creationPoints>
+            <node x="102612" y="59473" z="-3773" />
+        </creationPoints>
+        <basePAtk>4</basePAtk>
+        <baseCritRate>4</baseCritRate>
+        <baseMCritRate>5</baseMCritRate>
+        <baseAtkType>FIST</baseAtkType>
+        <basePAtkSpd>300</basePAtkSpd>
+        <baseMAtkSpd>333</baseMAtkSpd>
+        <basePDef>
+            <chest>31</chest>
+            <legs>18</legs>
+            <head>12</head>
+            <feet>7</feet>
+            <gloves>8</gloves>
+            <underwear>3</underwear>
+            <cloak>1</cloak>
+        </basePDef>
+        <baseMAtk>6</baseMAtk>
+        <baseMDef>
+            <rear>9</rear>
+            <lear>9</lear>
+            <rfinger>5</rfinger>
+            <lfinger>5</lfinger>
+            <neck>13</neck>
+        </baseMDef>
+        <baseCanPenetrate>0</baseCanPenetrate>
+        <baseAtkRange>20</baseAtkRange>
+        <baseDamRange>
+            <verticalDirection>0</verticalDirection>
+            <horizontalDirection>0</horizontalDirection>
+            <distance>26</distance>
+            <width>120</width>
+        </baseDamRange>
+        <baseRndDam>10</baseRndDam>
+        <baseMoveSpd>
+            <walk>88</walk>
+            <run>141</run>
+            <slowSwim>50</slowSwim>
+            <fastSwim>50</fastSwim>
+        </baseMoveSpd>
+        <baseBreath>150</baseBreath>
+        <baseSafeFall>350</baseSafeFall>
+        <collisionMale>
+            <radius>6</radius>
+            <height>18.1</height>
+        </collisionMale>
+        <collisionFemale>
+            <radius>6.5</radius>
+            <height>19.2</height>
+        </collisionFemale>
+    </staticData>
+    <lvlUpgainData>
+        <level val="1">
+            <hp>80.0</hp>
+            <mp>30.0</mp>
+            <cp>40.0</cp>
+            <hpRegen>2.0</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2.0</cpRegen>
+        </level>
+        <level val="2">
+            <hp>97</hp>
+            <mp>36.5</mp>
+            <cp>48.5</cp>
+            <hpRegen>2.05</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2.0</cpRegen>
+        </level>
+        <level val="3">
+            <hp>114</hp>
+            <mp>44</mp>
+            <cp>57</cp>
+            <hpRegen>2.1</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2.0</cpRegen>
+        </level>
+        <level val="4">
+            <hp>131</hp>
+            <mp>52.5</mp>
+            <cp>65.5</cp>
+            <hpRegen>2.15</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2</cpRegen>
+        </level>
+        <level val="5">
+            <hp>148</hp>
+            <mp>62</mp>
+            <cp>74</cp>
+            <hpRegen>2.2</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2</cpRegen>
+        </level>
+        <level val="6">
+            <hp>165</hp>
+            <mp>72.5</mp>
+            <cp>82.5</cp>
+            <hpRegen>2.25</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2</cpRegen>
+        </level>
+        <level val="7">
+            <hp>182</hp>
+            <mp>84</mp>
+            <cp>91</cp>
+            <hpRegen>2.3</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2</cpRegen>
+        </level>
+        <level val="8">
+            <hp>199</hp>
+            <mp>96.5</mp>
+            <cp>99.5</cp>
+            <hpRegen>2.35</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2</cpRegen>
+        </level>
+        <level val="9">
+            <hp>216</hp>
+            <mp>110</mp>
+            <cp>108</cp>
+            <hpRegen>2.4</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2</cpRegen>
+        </level>
+        <level val="10">
+            <hp>233</hp>
+            <mp>124.5</mp>
+            <cp>116.5</cp>
+            <hpRegen>2.45</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2</cpRegen>
+        </level>
+        <level val="11">
+            <hp>250</hp>
+            <mp>140</mp>
+            <cp>125</cp>
+            <hpRegen>2.55</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="12">
+            <hp>267</hp>
+            <mp>156.5</mp>
+            <cp>133.5</cp>
+            <hpRegen>2.65</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="13">
+            <hp>284</hp>
+            <mp>174</mp>
+            <cp>142</cp>
+            <hpRegen>2.75</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="14">
+            <hp>301</hp>
+            <mp>192.5</mp>
+            <cp>150.5</cp>
+            <hpRegen>2.85</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="15">
+            <hp>318</hp>
+            <mp>212</mp>
+            <cp>159</cp>
+            <hpRegen>2.95</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="16">
+            <hp>335</hp>
+            <mp>232.5</mp>
+            <cp>167.5</cp>
+            <hpRegen>3.05</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="17">
+            <hp>352</hp>
+            <mp>254</mp>
+            <cp>176</cp>
+            <hpRegen>3.15</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="18">
+            <hp>369</hp>
+            <mp>276.5</mp>
+            <cp>184.5</cp>
+            <hpRegen>3.25</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="19">
+            <hp>386</hp>
+            <mp>300</mp>
+            <cp>193</cp>
+            <hpRegen>3.35</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="20">
+            <hp>403</hp>
+            <mp>324.5</mp>
+            <cp>201.5</cp>
+            <hpRegen>3.45</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="21">
+            <hp>420</hp>
+            <mp>350</mp>
+            <cp>210</cp>
+            <hpRegen>3.55</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="22">
+            <hp>437</hp>
+            <mp>376.5</mp>
+            <cp>218.5</cp>
+            <hpRegen>3.65</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="23">
+            <hp>454</hp>
+            <mp>404</mp>
+            <cp>227</cp>
+            <hpRegen>3.75</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="24">
+            <hp>471</hp>
+            <mp>432.5</mp>
+            <cp>235.5</cp>
+            <hpRegen>3.85</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="25">
+            <hp>488</hp>
+            <mp>462</mp>
+            <cp>244</cp>
+            <hpRegen>3.95</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="26">
+            <hp>505</hp>
+            <mp>492.5</mp>
+            <cp>252.5</cp>
+            <hpRegen>4.05</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="27">
+            <hp>522</hp>
+            <mp>524</mp>
+            <cp>261</cp>
+            <hpRegen>4.15</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="28">
+            <hp>539</hp>
+            <mp>556.5</mp>
+            <cp>269.5</cp>
+            <hpRegen>4.25</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="29">
+            <hp>556</hp>
+            <mp>590</mp>
+            <cp>278</cp>
+            <hpRegen>4.35</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="30">
+            <hp>573</hp>
+            <mp>624.5</mp>
+            <cp>286.5</cp>
+            <hpRegen>4.45</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="31">
+            <hp>590</hp>
+            <mp>660</mp>
+            <cp>295</cp>
+            <hpRegen>4.55</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="32">
+            <hp>607</hp>
+            <mp>696.5</mp>
+            <cp>303.5</cp>
+            <hpRegen>4.65</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="33">
+            <hp>624</hp>
+            <mp>734</mp>
+            <cp>312</cp>
+            <hpRegen>4.75</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="34">
+            <hp>641</hp>
+            <mp>772.5</mp>
+            <cp>320.5</cp>
+            <hpRegen>4.85</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="35">
+            <hp>658</hp>
+            <mp>812</mp>
+            <cp>329</cp>
+            <hpRegen>4.95</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="36">
+            <hp>675</hp>
+            <mp>852.5</mp>
+            <cp>337.5</cp>
+            <hpRegen>5.05</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="37">
+            <hp>692</hp>
+            <mp>894</mp>
+            <cp>346</cp>
+            <hpRegen>5.15</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="38">
+            <hp>709</hp>
+            <mp>936.5</mp>
+            <cp>354.5</cp>
+            <hpRegen>5.25</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="39">
+            <hp>726</hp>
+            <mp>980</mp>
+            <cp>363</cp>
+            <hpRegen>5.35</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="40">
+            <hp>895</hp>
+            <mp>147.5</mp>
+            <cp>626</cp>
+            <hpRegen>5.45</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="41">
+            <hp>943</hp>
+            <mp>196</mp>
+            <cp>660</cp>
+            <hpRegen>5.55</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="42">
+            <hp>991</hp>
+            <mp>244.5</mp>
+            <cp>694</cp>
+            <hpRegen>5.65</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="43">
+            <hp>1039</hp>
+            <mp>293</mp>
+            <cp>728</cp>
+            <hpRegen>5.75</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="44">
+            <hp>1087</hp>
+            <mp>341.5</mp>
+            <cp>762</cp>
+            <hpRegen>5.85</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="45">
+            <hp>1135</hp>
+            <mp>390</mp>
+            <cp>796</cp>
+            <hpRegen>5.95</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="46">
+            <hp>1183</hp>
+            <mp>438.5</mp>
+            <cp>830</cp>
+            <hpRegen>6.05</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="47">
+            <hp>1231</hp>
+            <mp>487</mp>
+            <cp>864</cp>
+            <hpRegen>6.15</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="48">
+            <hp>1279</hp>
+            <mp>535.5</mp>
+            <cp>898</cp>
+            <hpRegen>6.25</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="49">
+            <hp>1327</hp>
+            <mp>584</mp>
+            <cp>932</cp>
+            <hpRegen>6.35</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="50">
+            <hp>1375</hp>
+            <mp>632.5</mp>
+            <cp>966</cp>
+            <hpRegen>6.45</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="51">
+            <hp>1423</hp>
+            <mp>681</mp>
+            <cp>1000</cp>
+            <hpRegen>6.55</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="52">
+            <hp>1471</hp>
+            <mp>729.5</mp>
+            <cp>1034</cp>
+            <hpRegen>6.65</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="53">
+            <hp>1519</hp>
+            <mp>778</mp>
+            <cp>1068</cp>
+            <hpRegen>6.75</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="54">
+            <hp>1567</hp>
+            <mp>826.5</mp>
+            <cp>1102</cp>
+            <hpRegen>6.85</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="55">
+            <hp>1615</hp>
+            <mp>875</mp>
+            <cp>1136</cp>
+            <hpRegen>6.95</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="56">
+            <hp>1663</hp>
+            <mp>923.5</mp>
+            <cp>1170</cp>
+            <hpRegen>7.05</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="57">
+            <hp>1711</hp>
+            <mp>972</mp>
+            <cp>1204</cp>
+            <hpRegen>7.15</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="58">
+            <hp>1759</hp>
+            <mp>1020.5</mp>
+            <cp>1238</cp>
+            <hpRegen>7.25</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="59">
+            <hp>1807</hp>
+            <mp>1069</mp>
+            <cp>1272</cp>
+            <hpRegen>7.35</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="60">
+            <hp>1855</hp>
+            <mp>1117.5</mp>
+            <cp>1306</cp>
+            <hpRegen>7.45</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="61">
+            <hp>1903</hp>
+            <mp>1166</mp>
+            <cp>1340</cp>
+            <hpRegen>7.55</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="62">
+            <hp>1951</hp>
+            <mp>1214.5</mp>
+            <cp>1374</cp>
+            <hpRegen>7.65</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="63">
+            <hp>1999</hp>
+            <mp>1263</mp>
+            <cp>1408</cp>
+            <hpRegen>7.75</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="64">
+            <hp>2047</hp>
+            <mp>1311.5</mp>
+            <cp>1442</cp>
+            <hpRegen>7.85</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="65">
+            <hp>2095</hp>
+            <mp>1360</mp>
+            <cp>1476</cp>
+            <hpRegen>7.95</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="66">
+            <hp>2143</hp>
+            <mp>1408.5</mp>
+            <cp>1510</cp>
+            <hpRegen>8.05</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="67">
+            <hp>2191</hp>
+            <mp>1457</mp>
+            <cp>1544</cp>
+            <hpRegen>8.15</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="68">
+            <hp>2239</hp>
+            <mp>1505.5</mp>
+            <cp>1578</cp>
+            <hpRegen>8.25</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="69">
+            <hp>2287</hp>
+            <mp>1554</mp>
+            <cp>1612</cp>
+            <hpRegen>8.35</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="70">
+            <hp>2335</hp>
+            <mp>1602.5</mp>
+            <cp>1646</cp>
+            <hpRegen>8.45</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="71">
+            <hp>2383</hp>
+            <mp>1651</mp>
+            <cp>1680</cp>
+            <hpRegen>8.55</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="72">
+            <hp>2431</hp>
+            <mp>1699.5</mp>
+            <cp>1714</cp>
+            <hpRegen>8.65</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="73">
+            <hp>2479</hp>
+            <mp>1748</mp>
+            <cp>1748</cp>
+            <hpRegen>8.75</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="74">
+            <hp>2527</hp>
+            <mp>1796.5</mp>
+            <cp>1782</cp>
+            <hpRegen>8.85</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="75">
+            <hp>2575</hp>
+            <mp>1845</mp>
+            <cp>1816</cp>
+            <hpRegen>8.95</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="76">
+            <hp>2879</hp>
+            <mp>988</mp>
+            <cp>2001</cp>
+            <hpRegen>9.05</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="77">
+            <hp>2920</hp>
+            <mp>1008.5</mp>
+            <cp>2044</cp>
+            <hpRegen>9.15</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="78">
+            <hp>2982</hp>
+            <mp>1030</mp>
+            <cp>2088</cp>
+            <hpRegen>9.25</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="79">
+            <hp>3065</hp>
+            <mp>1052.5</mp>
+            <cp>2133</cp>
+            <hpRegen>9.35</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="80">
+            <hp>3169</hp>
+            <mp>1076</mp>
+            <cp>2179</cp>
+            <hpRegen>9.45</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="81">
+            <hp>3294</hp>
+            <mp>1100.5</mp>
+            <cp>2226</cp>
+            <hpRegen>9.55</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="82">
+            <hp>3440</hp>
+            <mp>1126</mp>
+            <cp>2274</cp>
+            <hpRegen>9.65</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="83">
+            <hp>3607</hp>
+            <mp>1152.5</mp>
+            <cp>2323</cp>
+            <hpRegen>9.75</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="84">
+            <hp>3795</hp>
+            <mp>1180</mp>
+            <cp>2373</cp>
+            <hpRegen>9.85</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="85">
+            <hp>5052</hp>
+            <mp>1846</mp>
+            <cp>5454</cp>
+            <hpRegen>9.95</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="86">
+            <hp>5100.5</hp>
+            <mp>1881</mp>
+            <cp>5508</cp>
+            <hpRegen>10.05</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="87">
+            <hp>5152</hp>
+            <mp>1916</mp>
+            <cp>5562</cp>
+            <hpRegen>10.15</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="88">
+            <hp>5206.5</hp>
+            <mp>1951</mp>
+            <cp>5616</cp>
+            <hpRegen>10.25</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="89">
+            <hp>5264</hp>
+            <mp>1986</mp>
+            <cp>5670</cp>
+            <hpRegen>10.35</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="90">
+            <hp>5324.5</hp>
+            <mp>2021</mp>
+            <cp>5724</cp>
+            <hpRegen>10.45</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="91">
+            <hp>5388</hp>
+            <mp>2056</mp>
+            <cp>5778</cp>
+            <hpRegen>10.55</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="92">
+            <hp>5454.5</hp>
+            <mp>2091</mp>
+            <cp>5832</cp>
+            <hpRegen>10.65</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="93">
+            <hp>5524</hp>
+            <mp>2126</mp>
+            <cp>5886</cp>
+            <hpRegen>10.75</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="94">
+            <hp>5596.5</hp>
+            <mp>2161</mp>
+            <cp>5940</cp>
+            <hpRegen>10.85</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="95">
+            <hp>5672</hp>
+            <mp>2196</mp>
+            <cp>5994</cp>
+            <hpRegen>10.95</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="96">
+            <hp>5750.5</hp>
+            <mp>2231</mp>
+            <cp>6048</cp>
+            <hpRegen>11.05</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="97">
+            <hp>5832</hp>
+            <mp>2266</mp>
+            <cp>6102</cp>
+            <hpRegen>11.15</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="98">
+            <hp>5916.5</hp>
+            <mp>2301</mp>
+            <cp>6156</cp>
+            <hpRegen>11.25</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="99">
+            <hp>6004</hp>
+            <mp>2336</mp>
+            <cp>6210</cp>
+            <hpRegen>11.35</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="100">
+            <hp>6094.5</hp>
+            <mp>2371</mp>
+            <cp>6264</cp>
+            <hpRegen>11.45</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="101">
+            <hp>6188</hp>
+            <mp>2406</mp>
+            <cp>6318</cp>
+            <hpRegen>11.55</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="102">
+            <hp>6284.5</hp>
+            <mp>2441</mp>
+            <cp>6372</cp>
+            <hpRegen>11.65</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="103">
+            <hp>6384</hp>
+            <mp>2476</mp>
+            <cp>6426</cp>
+            <hpRegen>11.75</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="104">
+            <hp>6486.5</hp>
+            <mp>2511</mp>
+            <cp>6480</cp>
+            <hpRegen>11.85</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="105">
+            <hp>6592</hp>
+            <mp>2546</mp>
+            <cp>6534</cp>
+            <hpRegen>11.95</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="106">
+            <hp>6700.5</hp>
+            <mp>2581</mp>
+            <cp>6588</cp>
+            <hpRegen>12.05</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="107">
+            <hp>6812</hp>
+            <mp>2616</mp>
+            <cp>6642</cp>
+            <hpRegen>12.15</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+    </lvlUpgainData>
+</list>

--- a/data/stats/chars/baseStats/StormScreamer.xml
+++ b/data/stats/chars/baseStats/StormScreamer.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>110</classId>
-    <staticData>
-        <baseINT>44</baseINT>
-        <baseSTR>23</baseSTR>
-        <baseCON>24</baseCON>
-        <baseMEN>37</baseMEN>
-        <baseDEX>23</baseDEX>
-        <baseWIT>19</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>15</magicAbnormalResist>
-        <creationPoints>
-            <node x="28295" y="11063" z="-4224"/>
-            <node x="28302" y="11008" z="-4224"/>
-            <node x="28377" y="10916" z="-4224"/>
-            <node x="28456" y="10997" z="-4224"/>
-            <node x="28461" y="11044" z="-4224"/>
-            <node x="28395" y="11127" z="-4224"/>
-        </creationPoints>
-        <basePAtk>3</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>15</chest>
-            <legs>8</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>85</walk>
-            <run>128</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>150</baseBreath>
-        <baseSafeFall>300</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>24</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.0</radius>
-            <height>23.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>106.0</hp>
-            <mp>40.0</mp>
-            <cp>63.6</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>121.47</hp>
-            <mp>47.28</mp>
-            <cp>72.882</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>137.11</hp>
-            <mp>54.64</mp>
-            <cp>82.266</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>152.92</hp>
-            <mp>62.08</mp>
-            <cp>91.752</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>168.9</hp>
-            <mp>69.6</mp>
-            <cp>101.34</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>185.05</hp>
-            <mp>77.2</mp>
-            <cp>111.03</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>201.37</hp>
-            <mp>84.88</mp>
-            <cp>120.822</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>217.86</hp>
-            <mp>92.64</mp>
-            <cp>130.716</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>234.52</hp>
-            <mp>100.48</mp>
-            <cp>140.712</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>251.35</hp>
-            <mp>108.4</mp>
-            <cp>150.81</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>268.35</hp>
-            <mp>116.4</mp>
-            <cp>161.01</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>285.52</hp>
-            <mp>124.48</mp>
-            <cp>171.312</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>302.86</hp>
-            <mp>132.64</mp>
-            <cp>181.716</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>320.37</hp>
-            <mp>140.88</mp>
-            <cp>192.222</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>338.05</hp>
-            <mp>149.2</mp>
-            <cp>202.83</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>355.9</hp>
-            <mp>157.6</mp>
-            <cp>213.54</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>373.92</hp>
-            <mp>166.08</mp>
-            <cp>224.352</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>392.11</hp>
-            <mp>174.64</mp>
-            <cp>235.266</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>410.47</hp>
-            <mp>183.28</mp>
-            <cp>246.282</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>429.0</hp>
-            <mp>192.0</mp>
-            <cp>257.4</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>458.7</hp>
-            <mp>205.2</mp>
-            <cp>275.22</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>488.67</hp>
-            <mp>218.52</mp>
-            <cp>293.202</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>518.91</hp>
-            <mp>231.96</mp>
-            <cp>311.346</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>549.42</hp>
-            <mp>245.52</mp>
-            <cp>329.652</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>580.2</hp>
-            <mp>259.2</mp>
-            <cp>348.12</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>611.25</hp>
-            <mp>273.0</mp>
-            <cp>366.75</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>642.57</hp>
-            <mp>286.92</mp>
-            <cp>385.542</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>674.16</hp>
-            <mp>300.96</mp>
-            <cp>404.496</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>706.02</hp>
-            <mp>315.12</mp>
-            <cp>423.612</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>738.15</hp>
-            <mp>329.4</mp>
-            <cp>442.89</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>770.55</hp>
-            <mp>343.8</mp>
-            <cp>462.33</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>803.22</hp>
-            <mp>358.32</mp>
-            <cp>481.932</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>836.16</hp>
-            <mp>372.96</mp>
-            <cp>501.696</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>869.37</hp>
-            <mp>387.72</mp>
-            <cp>521.622</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>902.85</hp>
-            <mp>402.6</mp>
-            <cp>541.71</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>936.6</hp>
-            <mp>417.6</mp>
-            <cp>561.96</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>970.62</hp>
-            <mp>432.72</mp>
-            <cp>582.372</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1004.91</hp>
-            <mp>447.96</mp>
-            <cp>602.946</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1039.47</hp>
-            <mp>463.32</mp>
-            <cp>623.682</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1074.3</hp>
-            <mp>478.8</mp>
-            <cp>644.58</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1122.4</hp>
-            <mp>504.8</mp>
-            <cp>673.44</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1170.87</hp>
-            <mp>531.0</mp>
-            <cp>702.522</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1219.71</hp>
-            <mp>557.4</mp>
-            <cp>731.826</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1268.92</hp>
-            <mp>584.0</mp>
-            <cp>761.352</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1318.5</hp>
-            <mp>610.8</mp>
-            <cp>791.1</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1368.45</hp>
-            <mp>637.8</mp>
-            <cp>821.07</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1418.77</hp>
-            <mp>665.0</mp>
-            <cp>851.262</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1469.46</hp>
-            <mp>692.4</mp>
-            <cp>881.676</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1520.52</hp>
-            <mp>720.0</mp>
-            <cp>912.312</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1571.95</hp>
-            <mp>747.8</mp>
-            <cp>943.17</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1623.75</hp>
-            <mp>775.8</mp>
-            <cp>974.25</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1675.92</hp>
-            <mp>804.0</mp>
-            <cp>1005.552</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1728.46</hp>
-            <mp>832.4</mp>
-            <cp>1037.076</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1781.37</hp>
-            <mp>861.0</mp>
-            <cp>1068.822</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1834.65</hp>
-            <mp>889.8</mp>
-            <cp>1100.79</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1888.3</hp>
-            <mp>918.8</mp>
-            <cp>1132.98</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1942.32</hp>
-            <mp>948.0</mp>
-            <cp>1165.392</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1996.71</hp>
-            <mp>977.4</mp>
-            <cp>1198.026</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2051.47</hp>
-            <mp>1007.0</mp>
-            <cp>1230.882</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2106.6</hp>
-            <mp>1036.8</mp>
-            <cp>1263.96</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2162.1</hp>
-            <mp>1066.8</mp>
-            <cp>1297.26</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2217.97</hp>
-            <mp>1097.0</mp>
-            <cp>1330.782</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2274.21</hp>
-            <mp>1127.4</mp>
-            <cp>1364.526</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2330.82</hp>
-            <mp>1158.0</mp>
-            <cp>1398.492</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2387.8</hp>
-            <mp>1188.8</mp>
-            <cp>1432.68</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2445.15</hp>
-            <mp>1219.8</mp>
-            <cp>1467.09</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2502.87</hp>
-            <mp>1251.0</mp>
-            <cp>1501.722</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2560.96</hp>
-            <mp>1282.4</mp>
-            <cp>1536.576</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2619.42</hp>
-            <mp>1314.0</mp>
-            <cp>1571.652</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2678.25</hp>
-            <mp>1345.8</mp>
-            <cp>1606.95</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2737.45</hp>
-            <mp>1377.8</mp>
-            <cp>1642.47</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2797.02</hp>
-            <mp>1410.0</mp>
-            <cp>1678.212</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2856.96</hp>
-            <mp>1442.4</mp>
-            <cp>1714.176</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2917.27</hp>
-            <mp>1475.0</mp>
-            <cp>1750.362</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2977.95</hp>
-            <mp>1507.8</mp>
-            <cp>1786.77</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3039.0</hp>
-            <mp>1540.8</mp>
-            <cp>1823.4</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3100.42</hp>
-            <mp>1574.0</mp>
-            <cp>1860.252</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3162.21</hp>
-            <mp>1607.4</mp>
-            <cp>1897.326</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3224.37</hp>
-            <mp>1641.0</mp>
-            <cp>1934.622</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3286.9</hp>
-            <mp>1674.8</mp>
-            <cp>1972.14</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3349.8</hp>
-            <mp>1708.8</mp>
-            <cp>2009.88</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3413.07</hp>
-            <mp>1743.0</mp>
-            <cp>2047.842</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3476.71</hp>
-            <mp>1777.4</mp>
-            <cp>2086.026</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3540.72</hp>
-            <mp>1812.0</mp>
-            <cp>2124.432</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3605.1</hp>
-            <mp>1846.8</mp>
-            <cp>2163.06</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3669.85</hp>
-            <mp>1881.8</mp>
-            <cp>2201.91</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3734.97</hp>
-            <mp>1917.0</mp>
-            <cp>2240.982</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3800.46</hp>
-            <mp>1952.4</mp>
-            <cp>2280.276</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3866.32</hp>
-            <mp>1988.0</mp>
-            <cp>2319.792</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3932.55</hp>
-            <mp>2023.8</mp>
-            <cp>2359.53</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>3999.15</hp>
-            <mp>2059.8</mp>
-            <cp>2399.49</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>110</classId>
+	<staticData>
+		<baseINT>44</baseINT>
+		<baseSTR>23</baseSTR>
+		<baseCON>24</baseCON>
+		<baseMEN>37</baseMEN>
+		<baseDEX>23</baseDEX>
+		<baseWIT>19</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="28295" y="11063" z="-4224" />
+			<node x="28302" y="11008" z="-4224" />
+			<node x="28377" y="10916" z="-4224" />
+			<node x="28456" y="10997" z="-4224" />
+			<node x="28461" y="11044" z="-4224" />
+			<node x="28395" y="11127" z="-4224" />
+		</creationPoints>
+		<basePAtk>3</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>15</chest>
+			<legs>8</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>85</walk>
+			<run>128</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>300</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>106.0</hp>
+			<mp>40.0</mp>
+			<cp>63.6</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>121.47</hp>
+			<mp>47.28</mp>
+			<cp>72.882</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>137.11</hp>
+			<mp>54.64</mp>
+			<cp>82.266</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>152.92</hp>
+			<mp>62.08</mp>
+			<cp>91.752</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>168.9</hp>
+			<mp>69.6</mp>
+			<cp>101.34</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>185.05</hp>
+			<mp>77.2</mp>
+			<cp>111.03</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>201.37</hp>
+			<mp>84.88</mp>
+			<cp>120.822</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>217.86</hp>
+			<mp>92.64</mp>
+			<cp>130.716</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>234.52</hp>
+			<mp>100.48</mp>
+			<cp>140.712</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>251.35</hp>
+			<mp>108.4</mp>
+			<cp>150.81</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>268.35</hp>
+			<mp>116.4</mp>
+			<cp>161.01</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>285.52</hp>
+			<mp>124.48</mp>
+			<cp>171.312</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>302.86</hp>
+			<mp>132.64</mp>
+			<cp>181.716</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>320.37</hp>
+			<mp>140.88</mp>
+			<cp>192.222</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>338.05</hp>
+			<mp>149.2</mp>
+			<cp>202.83</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>355.9</hp>
+			<mp>157.6</mp>
+			<cp>213.54</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>373.92</hp>
+			<mp>166.08</mp>
+			<cp>224.352</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>392.11</hp>
+			<mp>174.64</mp>
+			<cp>235.266</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>410.47</hp>
+			<mp>183.28</mp>
+			<cp>246.282</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>429.0</hp>
+			<mp>192.0</mp>
+			<cp>257.4</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>458.7</hp>
+			<mp>205.2</mp>
+			<cp>275.22</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>488.67</hp>
+			<mp>218.52</mp>
+			<cp>293.202</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>518.91</hp>
+			<mp>231.96</mp>
+			<cp>311.346</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>549.42</hp>
+			<mp>245.52</mp>
+			<cp>329.652</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>580.2</hp>
+			<mp>259.2</mp>
+			<cp>348.12</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>611.25</hp>
+			<mp>273.0</mp>
+			<cp>366.75</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>642.57</hp>
+			<mp>286.92</mp>
+			<cp>385.542</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>674.16</hp>
+			<mp>300.96</mp>
+			<cp>404.496</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>706.02</hp>
+			<mp>315.12</mp>
+			<cp>423.612</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>738.15</hp>
+			<mp>329.4</mp>
+			<cp>442.89</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>770.55</hp>
+			<mp>343.8</mp>
+			<cp>462.33</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>803.22</hp>
+			<mp>358.32</mp>
+			<cp>481.932</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>836.16</hp>
+			<mp>372.96</mp>
+			<cp>501.696</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>869.37</hp>
+			<mp>387.72</mp>
+			<cp>521.622</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>902.85</hp>
+			<mp>402.6</mp>
+			<cp>541.71</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>936.6</hp>
+			<mp>417.6</mp>
+			<cp>561.96</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>970.62</hp>
+			<mp>432.72</mp>
+			<cp>582.372</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1004.91</hp>
+			<mp>447.96</mp>
+			<cp>602.946</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1039.47</hp>
+			<mp>463.32</mp>
+			<cp>623.682</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1074.3</hp>
+			<mp>478.8</mp>
+			<cp>644.58</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1122.4</hp>
+			<mp>504.8</mp>
+			<cp>673.44</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1170.87</hp>
+			<mp>531.0</mp>
+			<cp>702.522</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1219.71</hp>
+			<mp>557.4</mp>
+			<cp>731.826</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1268.92</hp>
+			<mp>584.0</mp>
+			<cp>761.352</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1318.5</hp>
+			<mp>610.8</mp>
+			<cp>791.1</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1368.45</hp>
+			<mp>637.8</mp>
+			<cp>821.07</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1418.77</hp>
+			<mp>665.0</mp>
+			<cp>851.262</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1469.46</hp>
+			<mp>692.4</mp>
+			<cp>881.676</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1520.52</hp>
+			<mp>720.0</mp>
+			<cp>912.312</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1571.95</hp>
+			<mp>747.8</mp>
+			<cp>943.17</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1623.75</hp>
+			<mp>775.8</mp>
+			<cp>974.25</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1675.92</hp>
+			<mp>804.0</mp>
+			<cp>1005.552</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1728.46</hp>
+			<mp>832.4</mp>
+			<cp>1037.076</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1781.37</hp>
+			<mp>861.0</mp>
+			<cp>1068.822</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1834.65</hp>
+			<mp>889.8</mp>
+			<cp>1100.79</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1888.3</hp>
+			<mp>918.8</mp>
+			<cp>1132.98</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1942.32</hp>
+			<mp>948.0</mp>
+			<cp>1165.392</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1996.71</hp>
+			<mp>977.4</mp>
+			<cp>1198.026</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2051.47</hp>
+			<mp>1007.0</mp>
+			<cp>1230.882</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2106.6</hp>
+			<mp>1036.8</mp>
+			<cp>1263.96</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2162.1</hp>
+			<mp>1066.8</mp>
+			<cp>1297.26</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2217.97</hp>
+			<mp>1097.0</mp>
+			<cp>1330.782</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2274.21</hp>
+			<mp>1127.4</mp>
+			<cp>1364.526</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2330.82</hp>
+			<mp>1158.0</mp>
+			<cp>1398.492</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2387.8</hp>
+			<mp>1188.8</mp>
+			<cp>1432.68</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2445.15</hp>
+			<mp>1219.8</mp>
+			<cp>1467.09</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2502.87</hp>
+			<mp>1251.0</mp>
+			<cp>1501.722</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2560.96</hp>
+			<mp>1282.4</mp>
+			<cp>1536.576</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2619.42</hp>
+			<mp>1314.0</mp>
+			<cp>1571.652</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2678.25</hp>
+			<mp>1345.8</mp>
+			<cp>1606.95</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2737.45</hp>
+			<mp>1377.8</mp>
+			<cp>1642.47</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2797.02</hp>
+			<mp>1410.0</mp>
+			<cp>1678.212</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2856.96</hp>
+			<mp>1442.4</mp>
+			<cp>1714.176</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2917.27</hp>
+			<mp>1475.0</mp>
+			<cp>1750.362</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2977.95</hp>
+			<mp>1507.8</mp>
+			<cp>1786.77</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3039.0</hp>
+			<mp>1540.8</mp>
+			<cp>1823.4</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3100.42</hp>
+			<mp>1574.0</mp>
+			<cp>1860.252</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3162.21</hp>
+			<mp>1607.4</mp>
+			<cp>1897.326</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3224.37</hp>
+			<mp>1641.0</mp>
+			<cp>1934.622</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3286.9</hp>
+			<mp>1674.8</mp>
+			<cp>1972.14</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3349.8</hp>
+			<mp>1708.8</mp>
+			<cp>2009.88</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3413.07</hp>
+			<mp>1743.0</mp>
+			<cp>2047.842</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3476.71</hp>
+			<mp>1777.4</mp>
+			<cp>2086.026</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3540.72</hp>
+			<mp>1812.0</mp>
+			<cp>2124.432</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3605.1</hp>
+			<mp>1846.8</mp>
+			<cp>2163.06</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3669.85</hp>
+			<mp>1881.8</mp>
+			<cp>2201.91</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3734.97</hp>
+			<mp>1917.0</mp>
+			<cp>2240.982</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3800.46</hp>
+			<mp>1952.4</mp>
+			<cp>2280.276</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3866.32</hp>
+			<mp>1988.0</mp>
+			<cp>2319.792</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3932.55</hp>
+			<mp>2023.8</mp>
+			<cp>2359.53</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3999.15</hp>
+			<mp>2059.8</mp>
+			<cp>2399.49</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4066.12</hp>
+			<mp>2096.0</mp>
+			<cp>2439.672</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4133.46</hp>
+			<mp>2132.4</mp>
+			<cp>2480.076</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4201.17</hp>
+			<mp>2169.0</mp>
+			<cp>2520.702</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4269.25</hp>
+			<mp>2205.8</mp>
+			<cp>2561.55</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4337.7</hp>
+			<mp>2242.8</mp>
+			<cp>2602.62</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4406.52</hp>
+			<mp>2280.0</mp>
+			<cp>2643.912</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4475.71</hp>
+			<mp>2317.4</mp>
+			<cp>2685.426</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4545.27</hp>
+			<mp>2355.0</mp>
+			<cp>2727.162</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4615.2</hp>
+			<mp>2392.8</mp>
+			<cp>2769.12</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4685.5</hp>
+			<mp>2430.8</mp>
+			<cp>2811.29</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4756.17</hp>
+			<mp>2469</mp>
+			<cp>2853.69</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4827.21</hp>
+			<mp>2507.4</mp>
+			<cp>2896.31</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4898.62</hp>
+			<mp>2546</mp>
+			<cp>2939.14</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>4970.4</hp>
+			<mp>2584.8</mp>
+			<cp>2982.2</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5042.55</hp>
+			<mp>2623.8</mp>
+			<cp>3025.47</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5115.07</hp>
+			<mp>2663</mp>
+			<cp>3069.042</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/SwordMuse.xml
+++ b/data/stats/chars/baseStats/SwordMuse.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>100</classId>
-    <staticData>
-        <baseINT>23</baseINT>
-        <baseSTR>36</baseSTR>
-        <baseCON>36</baseCON>
-        <baseMEN>26</baseMEN>
-        <baseDEX>35</baseDEX>
-        <baseWIT>14</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>15</magicAbnormalResist>
-        <creationPoints>
-            <node x="46045" y="41251" z="-3440"/>
-            <node x="46117" y="41247" z="-3440"/>
-            <node x="46182" y="41198" z="-3440"/>
-            <node x="46115" y="41141" z="-3440"/>
-            <node x="46048" y="41141" z="-3440"/>
-            <node x="45978" y="41196" z="-3440"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>90</walk>
-            <run>143</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>150</baseBreath>
-        <baseSafeFall>350</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>24</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.5</radius>
-            <height>23</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>89.0</hp>
-            <mp>30.0</mp>
-            <cp>44.5</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>101.74</hp>
-            <mp>35.46</mp>
-            <cp>50.87</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>114.62</hp>
-            <mp>40.98</mp>
-            <cp>57.31</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>127.64</hp>
-            <mp>46.56</mp>
-            <cp>63.82</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>140.8</hp>
-            <mp>52.2</mp>
-            <cp>70.4</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>154.1</hp>
-            <mp>57.9</mp>
-            <cp>77.05</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>167.54</hp>
-            <mp>63.66</mp>
-            <cp>83.77</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>181.12</hp>
-            <mp>69.48</mp>
-            <cp>90.56</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>194.84</hp>
-            <mp>75.36</mp>
-            <cp>97.42</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>208.7</hp>
-            <mp>81.3</mp>
-            <cp>104.35</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>222.7</hp>
-            <mp>87.3</mp>
-            <cp>111.35</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>236.84</hp>
-            <mp>93.36</mp>
-            <cp>118.42</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>251.12</hp>
-            <mp>99.48</mp>
-            <cp>125.56</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>265.54</hp>
-            <mp>105.66</mp>
-            <cp>132.77</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>280.1</hp>
-            <mp>111.9</mp>
-            <cp>140.05</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>294.8</hp>
-            <mp>118.2</mp>
-            <cp>147.4</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>309.64</hp>
-            <mp>124.56</mp>
-            <cp>154.82</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>324.62</hp>
-            <mp>130.98</mp>
-            <cp>162.31</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>339.74</hp>
-            <mp>137.46</mp>
-            <cp>169.87</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>355.0</hp>
-            <mp>144.0</mp>
-            <cp>177.5</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>388.0</hp>
-            <mp>153.9</mp>
-            <cp>194.0</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>421.3</hp>
-            <mp>163.89</mp>
-            <cp>210.65</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>454.9</hp>
-            <mp>173.97</mp>
-            <cp>227.45</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>488.8</hp>
-            <mp>184.14</mp>
-            <cp>244.4</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>523.0</hp>
-            <mp>194.4</mp>
-            <cp>261.5</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>557.5</hp>
-            <mp>204.75</mp>
-            <cp>278.75</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>592.3</hp>
-            <mp>215.19</mp>
-            <cp>296.15</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>627.4</hp>
-            <mp>225.72</mp>
-            <cp>313.7</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>662.8</hp>
-            <mp>236.34</mp>
-            <cp>331.4</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>698.5</hp>
-            <mp>247.05</mp>
-            <cp>349.25</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>734.5</hp>
-            <mp>257.85</mp>
-            <cp>367.25</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>770.8</hp>
-            <mp>268.74</mp>
-            <cp>385.4</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>807.4</hp>
-            <mp>279.72</mp>
-            <cp>403.7</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>844.3</hp>
-            <mp>290.79</mp>
-            <cp>422.15</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>881.5</hp>
-            <mp>301.95</mp>
-            <cp>440.75</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>919.0</hp>
-            <mp>313.2</mp>
-            <cp>459.5</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>956.8</hp>
-            <mp>324.54</mp>
-            <cp>478.4</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>994.9</hp>
-            <mp>335.97</mp>
-            <cp>497.45</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1033.3</hp>
-            <mp>347.49</mp>
-            <cp>516.65</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1072.0</hp>
-            <mp>359.1</mp>
-            <cp>536.0</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1126.6</hp>
-            <mp>378.6</mp>
-            <cp>563.3</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1181.62</hp>
-            <mp>398.25</mp>
-            <cp>590.81</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1237.06</hp>
-            <mp>418.05</mp>
-            <cp>618.53</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1292.92</hp>
-            <mp>438.0</mp>
-            <cp>646.46</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1349.2</hp>
-            <mp>458.1</mp>
-            <cp>674.6</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1405.9</hp>
-            <mp>478.35</mp>
-            <cp>702.95</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1463.02</hp>
-            <mp>498.75</mp>
-            <cp>731.51</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1520.56</hp>
-            <mp>519.3</mp>
-            <cp>760.28</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1578.52</hp>
-            <mp>540.0</mp>
-            <cp>789.26</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1636.9</hp>
-            <mp>560.85</mp>
-            <cp>818.45</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1695.7</hp>
-            <mp>581.85</mp>
-            <cp>847.85</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1754.92</hp>
-            <mp>603.0</mp>
-            <cp>877.46</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1814.56</hp>
-            <mp>624.3</mp>
-            <cp>907.28</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1874.62</hp>
-            <mp>645.75</mp>
-            <cp>937.31</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1935.1</hp>
-            <mp>667.35</mp>
-            <cp>967.55</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1996.0</hp>
-            <mp>689.1</mp>
-            <cp>998.0</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>2057.32</hp>
-            <mp>711.0</mp>
-            <cp>1028.66</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2119.06</hp>
-            <mp>733.05</mp>
-            <cp>1059.53</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2181.22</hp>
-            <mp>755.25</mp>
-            <cp>1090.61</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2243.8</hp>
-            <mp>777.6</mp>
-            <cp>1121.9</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2306.8</hp>
-            <mp>800.1</mp>
-            <cp>1153.4</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2370.22</hp>
-            <mp>822.75</mp>
-            <cp>1185.11</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2434.06</hp>
-            <mp>845.55</mp>
-            <cp>1217.03</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2498.32</hp>
-            <mp>868.5</mp>
-            <cp>1249.16</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2563.0</hp>
-            <mp>891.6</mp>
-            <cp>1281.5</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2628.1</hp>
-            <mp>914.85</mp>
-            <cp>1314.05</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2693.62</hp>
-            <mp>938.25</mp>
-            <cp>1346.81</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2759.56</hp>
-            <mp>961.8</mp>
-            <cp>1379.78</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2825.92</hp>
-            <mp>985.5</mp>
-            <cp>1412.96</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2892.7</hp>
-            <mp>1009.35</mp>
-            <cp>1446.35</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2959.9</hp>
-            <mp>1033.35</mp>
-            <cp>1479.95</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>3027.52</hp>
-            <mp>1057.5</mp>
-            <cp>1513.76</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>3095.56</hp>
-            <mp>1081.8</mp>
-            <cp>1547.78</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>3164.02</hp>
-            <mp>1106.25</mp>
-            <cp>1582.01</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3232.9</hp>
-            <mp>1130.85</mp>
-            <cp>1616.45</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3302.2</hp>
-            <mp>1155.6</mp>
-            <cp>1651.1</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3371.92</hp>
-            <mp>1180.5</mp>
-            <cp>1685.96</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3442.06</hp>
-            <mp>1205.55</mp>
-            <cp>1721.03</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3512.62</hp>
-            <mp>1230.75</mp>
-            <cp>1756.31</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3583.6</hp>
-            <mp>1256.1</mp>
-            <cp>1791.8</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3655.0</hp>
-            <mp>1281.6</mp>
-            <cp>1827.5</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3726.82</hp>
-            <mp>1307.25</mp>
-            <cp>1863.41</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3799.06</hp>
-            <mp>1333.05</mp>
-            <cp>1899.53</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3871.72</hp>
-            <mp>1359.0</mp>
-            <cp>1935.86</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3944.8</hp>
-            <mp>1385.1</mp>
-            <cp>1972.4</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>4018.3</hp>
-            <mp>1411.35</mp>
-            <cp>2009.15</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>4092.22</hp>
-            <mp>1437.75</mp>
-            <cp>2046.11</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>4166.56</hp>
-            <mp>1464.3</mp>
-            <cp>2083.28</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>4241.32</hp>
-            <mp>1491.0</mp>
-            <cp>2120.66</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4316.5</hp>
-            <mp>1517.85</mp>
-            <cp>2158.25</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4392.1</hp>
-            <mp>1544.85</mp>
-            <cp>2196.05</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>100</classId>
+	<staticData>
+		<baseINT>23</baseINT>
+		<baseSTR>36</baseSTR>
+		<baseCON>36</baseCON>
+		<baseMEN>26</baseMEN>
+		<baseDEX>35</baseDEX>
+		<baseWIT>14</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="46045" y="41251" z="-3440" />
+			<node x="46117" y="41247" z="-3440" />
+			<node x="46182" y="41198" z="-3440" />
+			<node x="46115" y="41141" z="-3440" />
+			<node x="46048" y="41141" z="-3440" />
+			<node x="45978" y="41196" z="-3440" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>90</walk>
+			<run>143</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>350</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.5</radius>
+			<height>23</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>89.0</hp>
+			<mp>30.0</mp>
+			<cp>44.5</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>101.74</hp>
+			<mp>35.46</mp>
+			<cp>50.87</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>114.62</hp>
+			<mp>40.98</mp>
+			<cp>57.31</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>127.64</hp>
+			<mp>46.56</mp>
+			<cp>63.82</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>140.8</hp>
+			<mp>52.2</mp>
+			<cp>70.4</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>154.1</hp>
+			<mp>57.9</mp>
+			<cp>77.05</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>167.54</hp>
+			<mp>63.66</mp>
+			<cp>83.77</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>181.12</hp>
+			<mp>69.48</mp>
+			<cp>90.56</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>194.84</hp>
+			<mp>75.36</mp>
+			<cp>97.42</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>208.7</hp>
+			<mp>81.3</mp>
+			<cp>104.35</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>222.7</hp>
+			<mp>87.3</mp>
+			<cp>111.35</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>236.84</hp>
+			<mp>93.36</mp>
+			<cp>118.42</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>251.12</hp>
+			<mp>99.48</mp>
+			<cp>125.56</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>265.54</hp>
+			<mp>105.66</mp>
+			<cp>132.77</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>280.1</hp>
+			<mp>111.9</mp>
+			<cp>140.05</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>294.8</hp>
+			<mp>118.2</mp>
+			<cp>147.4</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>309.64</hp>
+			<mp>124.56</mp>
+			<cp>154.82</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>324.62</hp>
+			<mp>130.98</mp>
+			<cp>162.31</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>339.74</hp>
+			<mp>137.46</mp>
+			<cp>169.87</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>355.0</hp>
+			<mp>144.0</mp>
+			<cp>177.5</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>388.0</hp>
+			<mp>153.9</mp>
+			<cp>194.0</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>421.3</hp>
+			<mp>163.89</mp>
+			<cp>210.65</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>454.9</hp>
+			<mp>173.97</mp>
+			<cp>227.45</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>488.8</hp>
+			<mp>184.14</mp>
+			<cp>244.4</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>523.0</hp>
+			<mp>194.4</mp>
+			<cp>261.5</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>557.5</hp>
+			<mp>204.75</mp>
+			<cp>278.75</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>592.3</hp>
+			<mp>215.19</mp>
+			<cp>296.15</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>627.4</hp>
+			<mp>225.72</mp>
+			<cp>313.7</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>662.8</hp>
+			<mp>236.34</mp>
+			<cp>331.4</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>698.5</hp>
+			<mp>247.05</mp>
+			<cp>349.25</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>734.5</hp>
+			<mp>257.85</mp>
+			<cp>367.25</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>770.8</hp>
+			<mp>268.74</mp>
+			<cp>385.4</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>807.4</hp>
+			<mp>279.72</mp>
+			<cp>403.7</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>844.3</hp>
+			<mp>290.79</mp>
+			<cp>422.15</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>881.5</hp>
+			<mp>301.95</mp>
+			<cp>440.75</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>919.0</hp>
+			<mp>313.2</mp>
+			<cp>459.5</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>956.8</hp>
+			<mp>324.54</mp>
+			<cp>478.4</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>994.9</hp>
+			<mp>335.97</mp>
+			<cp>497.45</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1033.3</hp>
+			<mp>347.49</mp>
+			<cp>516.65</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1072.0</hp>
+			<mp>359.1</mp>
+			<cp>536.0</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1126.6</hp>
+			<mp>378.6</mp>
+			<cp>563.3</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1181.62</hp>
+			<mp>398.25</mp>
+			<cp>590.81</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1237.06</hp>
+			<mp>418.05</mp>
+			<cp>618.53</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1292.92</hp>
+			<mp>438.0</mp>
+			<cp>646.46</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1349.2</hp>
+			<mp>458.1</mp>
+			<cp>674.6</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1405.9</hp>
+			<mp>478.35</mp>
+			<cp>702.95</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1463.02</hp>
+			<mp>498.75</mp>
+			<cp>731.51</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1520.56</hp>
+			<mp>519.3</mp>
+			<cp>760.28</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1578.52</hp>
+			<mp>540.0</mp>
+			<cp>789.26</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1636.9</hp>
+			<mp>560.85</mp>
+			<cp>818.45</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1695.7</hp>
+			<mp>581.85</mp>
+			<cp>847.85</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1754.92</hp>
+			<mp>603.0</mp>
+			<cp>877.46</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1814.56</hp>
+			<mp>624.3</mp>
+			<cp>907.28</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1874.62</hp>
+			<mp>645.75</mp>
+			<cp>937.31</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1935.1</hp>
+			<mp>667.35</mp>
+			<cp>967.55</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1996.0</hp>
+			<mp>689.1</mp>
+			<cp>998.0</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2057.32</hp>
+			<mp>711.0</mp>
+			<cp>1028.66</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2119.06</hp>
+			<mp>733.05</mp>
+			<cp>1059.53</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2181.22</hp>
+			<mp>755.25</mp>
+			<cp>1090.61</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2243.8</hp>
+			<mp>777.6</mp>
+			<cp>1121.9</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2306.8</hp>
+			<mp>800.1</mp>
+			<cp>1153.4</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2370.22</hp>
+			<mp>822.75</mp>
+			<cp>1185.11</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2434.06</hp>
+			<mp>845.55</mp>
+			<cp>1217.03</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2498.32</hp>
+			<mp>868.5</mp>
+			<cp>1249.16</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2563.0</hp>
+			<mp>891.6</mp>
+			<cp>1281.5</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2628.1</hp>
+			<mp>914.85</mp>
+			<cp>1314.05</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2693.62</hp>
+			<mp>938.25</mp>
+			<cp>1346.81</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2759.56</hp>
+			<mp>961.8</mp>
+			<cp>1379.78</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2825.92</hp>
+			<mp>985.5</mp>
+			<cp>1412.96</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2892.7</hp>
+			<mp>1009.35</mp>
+			<cp>1446.35</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2959.9</hp>
+			<mp>1033.35</mp>
+			<cp>1479.95</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>3027.52</hp>
+			<mp>1057.5</mp>
+			<cp>1513.76</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>3095.56</hp>
+			<mp>1081.8</mp>
+			<cp>1547.78</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3164.02</hp>
+			<mp>1106.25</mp>
+			<cp>1582.01</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3232.9</hp>
+			<mp>1130.85</mp>
+			<cp>1616.45</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3302.2</hp>
+			<mp>1155.6</mp>
+			<cp>1651.1</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3371.92</hp>
+			<mp>1180.5</mp>
+			<cp>1685.96</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3442.06</hp>
+			<mp>1205.55</mp>
+			<cp>1721.03</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3512.62</hp>
+			<mp>1230.75</mp>
+			<cp>1756.31</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3583.6</hp>
+			<mp>1256.1</mp>
+			<cp>1791.8</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3655.0</hp>
+			<mp>1281.6</mp>
+			<cp>1827.5</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3726.82</hp>
+			<mp>1307.25</mp>
+			<cp>1863.41</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3799.06</hp>
+			<mp>1333.05</mp>
+			<cp>1899.53</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3871.72</hp>
+			<mp>1359.0</mp>
+			<cp>1935.86</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3944.8</hp>
+			<mp>1385.1</mp>
+			<cp>1972.4</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>4018.3</hp>
+			<mp>1411.35</mp>
+			<cp>2009.15</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>4092.22</hp>
+			<mp>1437.75</mp>
+			<cp>2046.11</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4166.56</hp>
+			<mp>1464.3</mp>
+			<cp>2083.28</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4241.32</hp>
+			<mp>1491.0</mp>
+			<cp>2120.66</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4316.5</hp>
+			<mp>1517.85</mp>
+			<cp>2158.25</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4392.1</hp>
+			<mp>1544.85</mp>
+			<cp>2196.05</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4468.12</hp>
+			<mp>1572.0</mp>
+			<cp>2234.06</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4544.56</hp>
+			<mp>1599.3</mp>
+			<cp>2272.28</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4621.42</hp>
+			<mp>1626.75</mp>
+			<cp>2310.71</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4698.7</hp>
+			<mp>1654.35</mp>
+			<cp>2349.35</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4776.4</hp>
+			<mp>1682.1</mp>
+			<cp>2388.2</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4854.52</hp>
+			<mp>1710.0</mp>
+			<cp>2427.26</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4933.06</hp>
+			<mp>1738.05</mp>
+			<cp>2466.53</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>5012.02</hp>
+			<mp>1766.25</mp>
+			<cp>2506.01</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>5091.4</hp>
+			<mp>1794.6</mp>
+			<cp>2545.7</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>5171.2</hp>
+			<mp>1823.1</mp>
+			<cp>2585.6</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5251.42</hp>
+			<mp>1851.75</mp>
+			<cp>2625.71</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5332.06</hp>
+			<mp>1880.55</mp>
+			<cp>2666.03</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5413.12</hp>
+			<mp>1909.5</mp>
+			<cp>2706.56</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5494.6</hp>
+			<mp>1938.6</mp>
+			<cp>2747.3</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5576.5</hp>
+			<mp>1967.85</mp>
+			<cp>2788.25</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5658.82</hp>
+			<mp>1997.25</mp>
+			<cp>2829.41</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/SwordSinger.xml
+++ b/data/stats/chars/baseStats/SwordSinger.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>21</classId>
-    <staticData>
-        <baseINT>23</baseINT>
-        <baseSTR>36</baseSTR>
-        <baseCON>36</baseCON>
-        <baseMEN>26</baseMEN>
-        <baseDEX>35</baseDEX>
-        <baseWIT>14</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>15</magicAbnormalResist>
-        <creationPoints>
-            <node x="46045" y="41251" z="-3440"/>
-            <node x="46117" y="41247" z="-3440"/>
-            <node x="46182" y="41198" z="-3440"/>
-            <node x="46115" y="41141" z="-3440"/>
-            <node x="46048" y="41141" z="-3440"/>
-            <node x="45978" y="41196" z="-3440"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>90</walk>
-            <run>143</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>150</baseBreath>
-        <baseSafeFall>350</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>24</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.5</radius>
-            <height>23</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>89.0</hp>
-            <mp>30.0</mp>
-            <cp>44.5</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>101.74</hp>
-            <mp>35.46</mp>
-            <cp>50.87</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>114.62</hp>
-            <mp>40.98</mp>
-            <cp>57.31</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>127.64</hp>
-            <mp>46.56</mp>
-            <cp>63.82</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>140.8</hp>
-            <mp>52.2</mp>
-            <cp>70.4</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>154.1</hp>
-            <mp>57.9</mp>
-            <cp>77.05</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>167.54</hp>
-            <mp>63.66</mp>
-            <cp>83.77</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>181.12</hp>
-            <mp>69.48</mp>
-            <cp>90.56</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>194.84</hp>
-            <mp>75.36</mp>
-            <cp>97.42</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>208.7</hp>
-            <mp>81.3</mp>
-            <cp>104.35</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>222.7</hp>
-            <mp>87.3</mp>
-            <cp>111.35</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>236.84</hp>
-            <mp>93.36</mp>
-            <cp>118.42</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>251.12</hp>
-            <mp>99.48</mp>
-            <cp>125.56</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>265.54</hp>
-            <mp>105.66</mp>
-            <cp>132.77</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>280.1</hp>
-            <mp>111.9</mp>
-            <cp>140.05</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>294.8</hp>
-            <mp>118.2</mp>
-            <cp>147.4</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>309.64</hp>
-            <mp>124.56</mp>
-            <cp>154.82</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>324.62</hp>
-            <mp>130.98</mp>
-            <cp>162.31</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>339.74</hp>
-            <mp>137.46</mp>
-            <cp>169.87</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>355.0</hp>
-            <mp>144.0</mp>
-            <cp>177.5</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>388.0</hp>
-            <mp>153.9</mp>
-            <cp>194.0</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>421.3</hp>
-            <mp>163.89</mp>
-            <cp>210.65</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>454.9</hp>
-            <mp>173.97</mp>
-            <cp>227.45</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>488.8</hp>
-            <mp>184.14</mp>
-            <cp>244.4</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>523.0</hp>
-            <mp>194.4</mp>
-            <cp>261.5</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>557.5</hp>
-            <mp>204.75</mp>
-            <cp>278.75</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>592.3</hp>
-            <mp>215.19</mp>
-            <cp>296.15</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>627.4</hp>
-            <mp>225.72</mp>
-            <cp>313.7</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>662.8</hp>
-            <mp>236.34</mp>
-            <cp>331.4</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>698.5</hp>
-            <mp>247.05</mp>
-            <cp>349.25</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>734.5</hp>
-            <mp>257.85</mp>
-            <cp>367.25</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>770.8</hp>
-            <mp>268.74</mp>
-            <cp>385.4</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>807.4</hp>
-            <mp>279.72</mp>
-            <cp>403.7</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>844.3</hp>
-            <mp>290.79</mp>
-            <cp>422.15</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>881.5</hp>
-            <mp>301.95</mp>
-            <cp>440.75</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>919.0</hp>
-            <mp>313.2</mp>
-            <cp>459.5</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>956.8</hp>
-            <mp>324.54</mp>
-            <cp>478.4</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>994.9</hp>
-            <mp>335.97</mp>
-            <cp>497.45</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1033.3</hp>
-            <mp>347.49</mp>
-            <cp>516.65</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1072.0</hp>
-            <mp>359.1</mp>
-            <cp>536.0</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1126.6</hp>
-            <mp>378.6</mp>
-            <cp>563.3</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1181.62</hp>
-            <mp>398.25</mp>
-            <cp>590.81</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1237.06</hp>
-            <mp>418.05</mp>
-            <cp>618.53</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1292.92</hp>
-            <mp>438.0</mp>
-            <cp>646.46</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1349.2</hp>
-            <mp>458.1</mp>
-            <cp>674.6</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1405.9</hp>
-            <mp>478.35</mp>
-            <cp>702.95</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1463.02</hp>
-            <mp>498.75</mp>
-            <cp>731.51</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1520.56</hp>
-            <mp>519.3</mp>
-            <cp>760.28</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1578.52</hp>
-            <mp>540.0</mp>
-            <cp>789.26</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1636.9</hp>
-            <mp>560.85</mp>
-            <cp>818.45</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1695.7</hp>
-            <mp>581.85</mp>
-            <cp>847.85</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1754.92</hp>
-            <mp>603.0</mp>
-            <cp>877.46</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1814.56</hp>
-            <mp>624.3</mp>
-            <cp>907.28</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1874.62</hp>
-            <mp>645.75</mp>
-            <cp>937.31</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1935.1</hp>
-            <mp>667.35</mp>
-            <cp>967.55</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1996.0</hp>
-            <mp>689.1</mp>
-            <cp>998.0</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>2057.32</hp>
-            <mp>711.0</mp>
-            <cp>1028.66</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2119.06</hp>
-            <mp>733.05</mp>
-            <cp>1059.53</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2181.22</hp>
-            <mp>755.25</mp>
-            <cp>1090.61</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2243.8</hp>
-            <mp>777.6</mp>
-            <cp>1121.9</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2306.8</hp>
-            <mp>800.1</mp>
-            <cp>1153.4</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2370.22</hp>
-            <mp>822.75</mp>
-            <cp>1185.11</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2434.06</hp>
-            <mp>845.55</mp>
-            <cp>1217.03</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2498.32</hp>
-            <mp>868.5</mp>
-            <cp>1249.16</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2563.0</hp>
-            <mp>891.6</mp>
-            <cp>1281.5</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2628.1</hp>
-            <mp>914.85</mp>
-            <cp>1314.05</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2693.62</hp>
-            <mp>938.25</mp>
-            <cp>1346.81</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2759.56</hp>
-            <mp>961.8</mp>
-            <cp>1379.78</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2825.92</hp>
-            <mp>985.5</mp>
-            <cp>1412.96</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2892.7</hp>
-            <mp>1009.35</mp>
-            <cp>1446.35</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2959.9</hp>
-            <mp>1033.35</mp>
-            <cp>1479.95</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>3027.52</hp>
-            <mp>1057.5</mp>
-            <cp>1513.76</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>3095.56</hp>
-            <mp>1081.8</mp>
-            <cp>1547.78</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>3164.02</hp>
-            <mp>1106.25</mp>
-            <cp>1582.01</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3232.9</hp>
-            <mp>1130.85</mp>
-            <cp>1616.45</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3302.2</hp>
-            <mp>1155.6</mp>
-            <cp>1651.1</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3371.92</hp>
-            <mp>1180.5</mp>
-            <cp>1685.96</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3442.06</hp>
-            <mp>1205.55</mp>
-            <cp>1721.03</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3512.62</hp>
-            <mp>1230.75</mp>
-            <cp>1756.31</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3583.6</hp>
-            <mp>1256.1</mp>
-            <cp>1791.8</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3655.0</hp>
-            <mp>1281.6</mp>
-            <cp>1827.5</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3726.82</hp>
-            <mp>1307.25</mp>
-            <cp>1863.41</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3799.06</hp>
-            <mp>1333.05</mp>
-            <cp>1899.53</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3871.72</hp>
-            <mp>1359.0</mp>
-            <cp>1935.86</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3944.8</hp>
-            <mp>1385.1</mp>
-            <cp>1972.4</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>4018.3</hp>
-            <mp>1411.35</mp>
-            <cp>2009.15</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>4092.22</hp>
-            <mp>1437.75</mp>
-            <cp>2046.11</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>4166.56</hp>
-            <mp>1464.3</mp>
-            <cp>2083.28</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>4241.32</hp>
-            <mp>1491.0</mp>
-            <cp>2120.66</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4316.5</hp>
-            <mp>1517.85</mp>
-            <cp>2158.25</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4392.1</hp>
-            <mp>1544.85</mp>
-            <cp>2196.05</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>21</classId>
+	<staticData>
+		<baseINT>23</baseINT>
+		<baseSTR>36</baseSTR>
+		<baseCON>36</baseCON>
+		<baseMEN>26</baseMEN>
+		<baseDEX>35</baseDEX>
+		<baseWIT>14</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="46045" y="41251" z="-3440" />
+			<node x="46117" y="41247" z="-3440" />
+			<node x="46182" y="41198" z="-3440" />
+			<node x="46115" y="41141" z="-3440" />
+			<node x="46048" y="41141" z="-3440" />
+			<node x="45978" y="41196" z="-3440" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>90</walk>
+			<run>143</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>350</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.5</radius>
+			<height>23</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>89.0</hp>
+			<mp>30.0</mp>
+			<cp>44.5</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>101.74</hp>
+			<mp>35.46</mp>
+			<cp>50.87</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>114.62</hp>
+			<mp>40.98</mp>
+			<cp>57.31</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>127.64</hp>
+			<mp>46.56</mp>
+			<cp>63.82</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>140.8</hp>
+			<mp>52.2</mp>
+			<cp>70.4</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>154.1</hp>
+			<mp>57.9</mp>
+			<cp>77.05</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>167.54</hp>
+			<mp>63.66</mp>
+			<cp>83.77</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>181.12</hp>
+			<mp>69.48</mp>
+			<cp>90.56</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>194.84</hp>
+			<mp>75.36</mp>
+			<cp>97.42</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>208.7</hp>
+			<mp>81.3</mp>
+			<cp>104.35</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>222.7</hp>
+			<mp>87.3</mp>
+			<cp>111.35</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>236.84</hp>
+			<mp>93.36</mp>
+			<cp>118.42</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>251.12</hp>
+			<mp>99.48</mp>
+			<cp>125.56</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>265.54</hp>
+			<mp>105.66</mp>
+			<cp>132.77</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>280.1</hp>
+			<mp>111.9</mp>
+			<cp>140.05</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>294.8</hp>
+			<mp>118.2</mp>
+			<cp>147.4</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>309.64</hp>
+			<mp>124.56</mp>
+			<cp>154.82</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>324.62</hp>
+			<mp>130.98</mp>
+			<cp>162.31</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>339.74</hp>
+			<mp>137.46</mp>
+			<cp>169.87</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>355.0</hp>
+			<mp>144.0</mp>
+			<cp>177.5</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>388.0</hp>
+			<mp>153.9</mp>
+			<cp>194.0</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>421.3</hp>
+			<mp>163.89</mp>
+			<cp>210.65</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>454.9</hp>
+			<mp>173.97</mp>
+			<cp>227.45</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>488.8</hp>
+			<mp>184.14</mp>
+			<cp>244.4</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>523.0</hp>
+			<mp>194.4</mp>
+			<cp>261.5</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>557.5</hp>
+			<mp>204.75</mp>
+			<cp>278.75</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>592.3</hp>
+			<mp>215.19</mp>
+			<cp>296.15</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>627.4</hp>
+			<mp>225.72</mp>
+			<cp>313.7</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>662.8</hp>
+			<mp>236.34</mp>
+			<cp>331.4</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>698.5</hp>
+			<mp>247.05</mp>
+			<cp>349.25</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>734.5</hp>
+			<mp>257.85</mp>
+			<cp>367.25</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>770.8</hp>
+			<mp>268.74</mp>
+			<cp>385.4</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>807.4</hp>
+			<mp>279.72</mp>
+			<cp>403.7</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>844.3</hp>
+			<mp>290.79</mp>
+			<cp>422.15</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>881.5</hp>
+			<mp>301.95</mp>
+			<cp>440.75</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>919.0</hp>
+			<mp>313.2</mp>
+			<cp>459.5</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>956.8</hp>
+			<mp>324.54</mp>
+			<cp>478.4</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>994.9</hp>
+			<mp>335.97</mp>
+			<cp>497.45</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1033.3</hp>
+			<mp>347.49</mp>
+			<cp>516.65</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1072.0</hp>
+			<mp>359.1</mp>
+			<cp>536.0</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1126.6</hp>
+			<mp>378.6</mp>
+			<cp>563.3</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1181.62</hp>
+			<mp>398.25</mp>
+			<cp>590.81</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1237.06</hp>
+			<mp>418.05</mp>
+			<cp>618.53</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1292.92</hp>
+			<mp>438.0</mp>
+			<cp>646.46</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1349.2</hp>
+			<mp>458.1</mp>
+			<cp>674.6</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1405.9</hp>
+			<mp>478.35</mp>
+			<cp>702.95</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1463.02</hp>
+			<mp>498.75</mp>
+			<cp>731.51</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1520.56</hp>
+			<mp>519.3</mp>
+			<cp>760.28</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1578.52</hp>
+			<mp>540.0</mp>
+			<cp>789.26</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1636.9</hp>
+			<mp>560.85</mp>
+			<cp>818.45</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1695.7</hp>
+			<mp>581.85</mp>
+			<cp>847.85</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1754.92</hp>
+			<mp>603.0</mp>
+			<cp>877.46</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1814.56</hp>
+			<mp>624.3</mp>
+			<cp>907.28</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1874.62</hp>
+			<mp>645.75</mp>
+			<cp>937.31</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1935.1</hp>
+			<mp>667.35</mp>
+			<cp>967.55</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1996.0</hp>
+			<mp>689.1</mp>
+			<cp>998.0</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2057.32</hp>
+			<mp>711.0</mp>
+			<cp>1028.66</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2119.06</hp>
+			<mp>733.05</mp>
+			<cp>1059.53</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2181.22</hp>
+			<mp>755.25</mp>
+			<cp>1090.61</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2243.8</hp>
+			<mp>777.6</mp>
+			<cp>1121.9</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2306.8</hp>
+			<mp>800.1</mp>
+			<cp>1153.4</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2370.22</hp>
+			<mp>822.75</mp>
+			<cp>1185.11</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2434.06</hp>
+			<mp>845.55</mp>
+			<cp>1217.03</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2498.32</hp>
+			<mp>868.5</mp>
+			<cp>1249.16</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2563.0</hp>
+			<mp>891.6</mp>
+			<cp>1281.5</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2628.1</hp>
+			<mp>914.85</mp>
+			<cp>1314.05</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2693.62</hp>
+			<mp>938.25</mp>
+			<cp>1346.81</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2759.56</hp>
+			<mp>961.8</mp>
+			<cp>1379.78</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2825.92</hp>
+			<mp>985.5</mp>
+			<cp>1412.96</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2892.7</hp>
+			<mp>1009.35</mp>
+			<cp>1446.35</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2959.9</hp>
+			<mp>1033.35</mp>
+			<cp>1479.95</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>3027.52</hp>
+			<mp>1057.5</mp>
+			<cp>1513.76</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>3095.56</hp>
+			<mp>1081.8</mp>
+			<cp>1547.78</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3164.02</hp>
+			<mp>1106.25</mp>
+			<cp>1582.01</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3232.9</hp>
+			<mp>1130.85</mp>
+			<cp>1616.45</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3302.2</hp>
+			<mp>1155.6</mp>
+			<cp>1651.1</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3371.92</hp>
+			<mp>1180.5</mp>
+			<cp>1685.96</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3442.06</hp>
+			<mp>1205.55</mp>
+			<cp>1721.03</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3512.62</hp>
+			<mp>1230.75</mp>
+			<cp>1756.31</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3583.6</hp>
+			<mp>1256.1</mp>
+			<cp>1791.8</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3655.0</hp>
+			<mp>1281.6</mp>
+			<cp>1827.5</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3726.82</hp>
+			<mp>1307.25</mp>
+			<cp>1863.41</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3799.06</hp>
+			<mp>1333.05</mp>
+			<cp>1899.53</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3871.72</hp>
+			<mp>1359.0</mp>
+			<cp>1935.86</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3944.8</hp>
+			<mp>1385.1</mp>
+			<cp>1972.4</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>4018.3</hp>
+			<mp>1411.35</mp>
+			<cp>2009.15</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>4092.22</hp>
+			<mp>1437.75</mp>
+			<cp>2046.11</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4166.56</hp>
+			<mp>1464.3</mp>
+			<cp>2083.28</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4241.32</hp>
+			<mp>1491.0</mp>
+			<cp>2120.66</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4316.5</hp>
+			<mp>1517.85</mp>
+			<cp>2158.25</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4392.1</hp>
+			<mp>1544.85</mp>
+			<cp>2196.05</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4468.12</hp>
+			<mp>1572.0</mp>
+			<cp>2234.06</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4544.56</hp>
+			<mp>1599.3</mp>
+			<cp>2272.28</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4621.42</hp>
+			<mp>1626.75</mp>
+			<cp>2310.71</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4698.7</hp>
+			<mp>1654.35</mp>
+			<cp>2349.35</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4776.4</hp>
+			<mp>1682.1</mp>
+			<cp>2388.2</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4854.52</hp>
+			<mp>1710.0</mp>
+			<cp>2427.26</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4933.06</hp>
+			<mp>1738.05</mp>
+			<cp>2466.53</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>5012.02</hp>
+			<mp>1766.25</mp>
+			<cp>2506.01</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>5091.4</hp>
+			<mp>1794.6</mp>
+			<cp>2545.7</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>5171.2</hp>
+			<mp>1823.1</mp>
+			<cp>2585.6</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5251.42</hp>
+			<mp>1851.75</mp>
+			<cp>2625.71</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5332.06</hp>
+			<mp>1880.55</mp>
+			<cp>2666.03</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5413.12</hp>
+			<mp>1909.5</mp>
+			<cp>2706.56</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5494.6</hp>
+			<mp>1938.6</mp>
+			<cp>2747.3</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5576.5</hp>
+			<mp>1967.85</mp>
+			<cp>2788.25</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5658.82</hp>
+			<mp>1997.25</mp>
+			<cp>2829.41</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Sylph_Gunner.xml
+++ b/data/stats/chars/baseStats/Sylph_Gunner.xml
@@ -1,0 +1,923 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
+    <classId>209</classId>
+    <staticData>
+        <baseINT>20</baseINT>
+        <baseSTR>40</baseSTR>
+        <baseCON>40</baseCON>
+        <baseMEN>25</baseMEN>
+        <baseDEX>35</baseDEX>
+        <baseWIT>10</baseWIT>
+        <physicalAbnormalResist>10</physicalAbnormalResist>
+        <magicAbnormalResist>10</magicAbnormalResist>
+        <creationPoints>
+            <node x="102612" y="59473" z="-3773" />
+        </creationPoints>
+        <basePAtk>4</basePAtk>
+        <baseCritRate>4</baseCritRate>
+        <baseMCritRate>5</baseMCritRate>
+        <baseAtkType>FIST</baseAtkType>
+        <basePAtkSpd>300</basePAtkSpd>
+        <baseMAtkSpd>333</baseMAtkSpd>
+        <basePDef>
+            <chest>31</chest>
+            <legs>18</legs>
+            <head>12</head>
+            <feet>7</feet>
+            <gloves>8</gloves>
+            <underwear>3</underwear>
+            <cloak>1</cloak>
+        </basePDef>
+        <baseMAtk>6</baseMAtk>
+        <baseMDef>
+            <rear>9</rear>
+            <lear>9</lear>
+            <rfinger>5</rfinger>
+            <lfinger>5</lfinger>
+            <neck>13</neck>
+        </baseMDef>
+        <baseCanPenetrate>0</baseCanPenetrate>
+        <baseAtkRange>20</baseAtkRange>
+        <baseDamRange>
+            <verticalDirection>0</verticalDirection>
+            <horizontalDirection>0</horizontalDirection>
+            <distance>26</distance>
+            <width>120</width>
+        </baseDamRange>
+        <baseRndDam>10</baseRndDam>
+        <baseMoveSpd>
+            <walk>88</walk>
+            <run>141</run>
+            <slowSwim>50</slowSwim>
+            <fastSwim>50</fastSwim>
+        </baseMoveSpd>
+        <baseBreath>150</baseBreath>
+        <baseSafeFall>350</baseSafeFall>
+        <collisionMale>
+            <radius>6</radius>
+            <height>18.1</height>
+        </collisionMale>
+        <collisionFemale>
+            <radius>6.5</radius>
+            <height>19.2</height>
+        </collisionFemale>
+    </staticData>
+    <lvlUpgainData>
+        <level val="1">
+            <hp>80.0</hp>
+            <mp>30.0</mp>
+            <cp>40.0</cp>
+            <hpRegen>2.0</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2.0</cpRegen>
+        </level>
+        <level val="2">
+            <hp>97</hp>
+            <mp>36.5</mp>
+            <cp>48.5</cp>
+            <hpRegen>2.05</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2.0</cpRegen>
+        </level>
+        <level val="3">
+            <hp>114</hp>
+            <mp>44</mp>
+            <cp>57</cp>
+            <hpRegen>2.1</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2.0</cpRegen>
+        </level>
+        <level val="4">
+            <hp>131</hp>
+            <mp>52.5</mp>
+            <cp>65.5</cp>
+            <hpRegen>2.15</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2</cpRegen>
+        </level>
+        <level val="5">
+            <hp>148</hp>
+            <mp>62</mp>
+            <cp>74</cp>
+            <hpRegen>2.2</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2</cpRegen>
+        </level>
+        <level val="6">
+            <hp>165</hp>
+            <mp>72.5</mp>
+            <cp>82.5</cp>
+            <hpRegen>2.25</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2</cpRegen>
+        </level>
+        <level val="7">
+            <hp>182</hp>
+            <mp>84</mp>
+            <cp>91</cp>
+            <hpRegen>2.3</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2</cpRegen>
+        </level>
+        <level val="8">
+            <hp>199</hp>
+            <mp>96.5</mp>
+            <cp>99.5</cp>
+            <hpRegen>2.35</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2</cpRegen>
+        </level>
+        <level val="9">
+            <hp>216</hp>
+            <mp>110</mp>
+            <cp>108</cp>
+            <hpRegen>2.4</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2</cpRegen>
+        </level>
+        <level val="10">
+            <hp>233</hp>
+            <mp>124.5</mp>
+            <cp>116.5</cp>
+            <hpRegen>2.45</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2</cpRegen>
+        </level>
+        <level val="11">
+            <hp>250</hp>
+            <mp>140</mp>
+            <cp>125</cp>
+            <hpRegen>2.55</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="12">
+            <hp>267</hp>
+            <mp>156.5</mp>
+            <cp>133.5</cp>
+            <hpRegen>2.65</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="13">
+            <hp>284</hp>
+            <mp>174</mp>
+            <cp>142</cp>
+            <hpRegen>2.75</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="14">
+            <hp>301</hp>
+            <mp>192.5</mp>
+            <cp>150.5</cp>
+            <hpRegen>2.85</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="15">
+            <hp>318</hp>
+            <mp>212</mp>
+            <cp>159</cp>
+            <hpRegen>2.95</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="16">
+            <hp>335</hp>
+            <mp>232.5</mp>
+            <cp>167.5</cp>
+            <hpRegen>3.05</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="17">
+            <hp>352</hp>
+            <mp>254</mp>
+            <cp>176</cp>
+            <hpRegen>3.15</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="18">
+            <hp>369</hp>
+            <mp>276.5</mp>
+            <cp>184.5</cp>
+            <hpRegen>3.25</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="19">
+            <hp>386</hp>
+            <mp>300</mp>
+            <cp>193</cp>
+            <hpRegen>3.35</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="20">
+            <hp>403</hp>
+            <mp>324.5</mp>
+            <cp>201.5</cp>
+            <hpRegen>3.45</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="21">
+            <hp>420</hp>
+            <mp>350</mp>
+            <cp>210</cp>
+            <hpRegen>3.55</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="22">
+            <hp>437</hp>
+            <mp>376.5</mp>
+            <cp>218.5</cp>
+            <hpRegen>3.65</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="23">
+            <hp>454</hp>
+            <mp>404</mp>
+            <cp>227</cp>
+            <hpRegen>3.75</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="24">
+            <hp>471</hp>
+            <mp>432.5</mp>
+            <cp>235.5</cp>
+            <hpRegen>3.85</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="25">
+            <hp>488</hp>
+            <mp>462</mp>
+            <cp>244</cp>
+            <hpRegen>3.95</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="26">
+            <hp>505</hp>
+            <mp>492.5</mp>
+            <cp>252.5</cp>
+            <hpRegen>4.05</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="27">
+            <hp>522</hp>
+            <mp>524</mp>
+            <cp>261</cp>
+            <hpRegen>4.15</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="28">
+            <hp>539</hp>
+            <mp>556.5</mp>
+            <cp>269.5</cp>
+            <hpRegen>4.25</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="29">
+            <hp>556</hp>
+            <mp>590</mp>
+            <cp>278</cp>
+            <hpRegen>4.35</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="30">
+            <hp>573</hp>
+            <mp>624.5</mp>
+            <cp>286.5</cp>
+            <hpRegen>4.45</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="31">
+            <hp>590</hp>
+            <mp>660</mp>
+            <cp>295</cp>
+            <hpRegen>4.55</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="32">
+            <hp>607</hp>
+            <mp>696.5</mp>
+            <cp>303.5</cp>
+            <hpRegen>4.65</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="33">
+            <hp>624</hp>
+            <mp>734</mp>
+            <cp>312</cp>
+            <hpRegen>4.75</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="34">
+            <hp>641</hp>
+            <mp>772.5</mp>
+            <cp>320.5</cp>
+            <hpRegen>4.85</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="35">
+            <hp>658</hp>
+            <mp>812</mp>
+            <cp>329</cp>
+            <hpRegen>4.95</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="36">
+            <hp>675</hp>
+            <mp>852.5</mp>
+            <cp>337.5</cp>
+            <hpRegen>5.05</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="37">
+            <hp>692</hp>
+            <mp>894</mp>
+            <cp>346</cp>
+            <hpRegen>5.15</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="38">
+            <hp>709</hp>
+            <mp>936.5</mp>
+            <cp>354.5</cp>
+            <hpRegen>5.25</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="39">
+            <hp>726</hp>
+            <mp>980</mp>
+            <cp>363</cp>
+            <hpRegen>5.35</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="40">
+            <hp>895</hp>
+            <mp>147.5</mp>
+            <cp>626</cp>
+            <hpRegen>5.45</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="41">
+            <hp>943</hp>
+            <mp>196</mp>
+            <cp>660</cp>
+            <hpRegen>5.55</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="42">
+            <hp>991</hp>
+            <mp>244.5</mp>
+            <cp>694</cp>
+            <hpRegen>5.65</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="43">
+            <hp>1039</hp>
+            <mp>293</mp>
+            <cp>728</cp>
+            <hpRegen>5.75</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="44">
+            <hp>1087</hp>
+            <mp>341.5</mp>
+            <cp>762</cp>
+            <hpRegen>5.85</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="45">
+            <hp>1135</hp>
+            <mp>390</mp>
+            <cp>796</cp>
+            <hpRegen>5.95</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="46">
+            <hp>1183</hp>
+            <mp>438.5</mp>
+            <cp>830</cp>
+            <hpRegen>6.05</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="47">
+            <hp>1231</hp>
+            <mp>487</mp>
+            <cp>864</cp>
+            <hpRegen>6.15</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="48">
+            <hp>1279</hp>
+            <mp>535.5</mp>
+            <cp>898</cp>
+            <hpRegen>6.25</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="49">
+            <hp>1327</hp>
+            <mp>584</mp>
+            <cp>932</cp>
+            <hpRegen>6.35</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="50">
+            <hp>1375</hp>
+            <mp>632.5</mp>
+            <cp>966</cp>
+            <hpRegen>6.45</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="51">
+            <hp>1423</hp>
+            <mp>681</mp>
+            <cp>1000</cp>
+            <hpRegen>6.55</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="52">
+            <hp>1471</hp>
+            <mp>729.5</mp>
+            <cp>1034</cp>
+            <hpRegen>6.65</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="53">
+            <hp>1519</hp>
+            <mp>778</mp>
+            <cp>1068</cp>
+            <hpRegen>6.75</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="54">
+            <hp>1567</hp>
+            <mp>826.5</mp>
+            <cp>1102</cp>
+            <hpRegen>6.85</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="55">
+            <hp>1615</hp>
+            <mp>875</mp>
+            <cp>1136</cp>
+            <hpRegen>6.95</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="56">
+            <hp>1663</hp>
+            <mp>923.5</mp>
+            <cp>1170</cp>
+            <hpRegen>7.05</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="57">
+            <hp>1711</hp>
+            <mp>972</mp>
+            <cp>1204</cp>
+            <hpRegen>7.15</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="58">
+            <hp>1759</hp>
+            <mp>1020.5</mp>
+            <cp>1238</cp>
+            <hpRegen>7.25</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="59">
+            <hp>1807</hp>
+            <mp>1069</mp>
+            <cp>1272</cp>
+            <hpRegen>7.35</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="60">
+            <hp>1855</hp>
+            <mp>1117.5</mp>
+            <cp>1306</cp>
+            <hpRegen>7.45</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="61">
+            <hp>1903</hp>
+            <mp>1166</mp>
+            <cp>1340</cp>
+            <hpRegen>7.55</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="62">
+            <hp>1951</hp>
+            <mp>1214.5</mp>
+            <cp>1374</cp>
+            <hpRegen>7.65</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="63">
+            <hp>1999</hp>
+            <mp>1263</mp>
+            <cp>1408</cp>
+            <hpRegen>7.75</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="64">
+            <hp>2047</hp>
+            <mp>1311.5</mp>
+            <cp>1442</cp>
+            <hpRegen>7.85</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="65">
+            <hp>2095</hp>
+            <mp>1360</mp>
+            <cp>1476</cp>
+            <hpRegen>7.95</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="66">
+            <hp>2143</hp>
+            <mp>1408.5</mp>
+            <cp>1510</cp>
+            <hpRegen>8.05</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="67">
+            <hp>2191</hp>
+            <mp>1457</mp>
+            <cp>1544</cp>
+            <hpRegen>8.15</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="68">
+            <hp>2239</hp>
+            <mp>1505.5</mp>
+            <cp>1578</cp>
+            <hpRegen>8.25</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="69">
+            <hp>2287</hp>
+            <mp>1554</mp>
+            <cp>1612</cp>
+            <hpRegen>8.35</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="70">
+            <hp>2335</hp>
+            <mp>1602.5</mp>
+            <cp>1646</cp>
+            <hpRegen>8.45</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="71">
+            <hp>2383</hp>
+            <mp>1651</mp>
+            <cp>1680</cp>
+            <hpRegen>8.55</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="72">
+            <hp>2431</hp>
+            <mp>1699.5</mp>
+            <cp>1714</cp>
+            <hpRegen>8.65</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="73">
+            <hp>2479</hp>
+            <mp>1748</mp>
+            <cp>1748</cp>
+            <hpRegen>8.75</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="74">
+            <hp>2527</hp>
+            <mp>1796.5</mp>
+            <cp>1782</cp>
+            <hpRegen>8.85</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="75">
+            <hp>2575</hp>
+            <mp>1845</mp>
+            <cp>1816</cp>
+            <hpRegen>8.95</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="76">
+            <hp>2623</hp>
+            <mp>1893.5</mp>
+            <cp>1850</cp>
+            <hpRegen>9.05</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="77">
+            <hp>2671</hp>
+            <mp>1942</mp>
+            <cp>1884</cp>
+            <hpRegen>9.15</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="78">
+            <hp>2719</hp>
+            <mp>1990.5</mp>
+            <cp>1918</cp>
+            <hpRegen>9.25</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="79">
+            <hp>2767</hp>
+            <mp>2039</mp>
+            <cp>1952</cp>
+            <hpRegen>9.35</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="80">
+            <hp>2815</hp>
+            <mp>2087.5</mp>
+            <cp>1986</cp>
+            <hpRegen>9.45</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="81">
+            <hp>2863</hp>
+            <mp>2136</mp>
+            <cp>2020</cp>
+            <hpRegen>9.55</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="82">
+            <hp>2911</hp>
+            <mp>2184.5</mp>
+            <cp>2054</cp>
+            <hpRegen>9.65</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="83">
+            <hp>2959</hp>
+            <mp>2233</mp>
+            <cp>2088</cp>
+            <hpRegen>9.75</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="84">
+            <hp>3007</hp>
+            <mp>2281.5</mp>
+            <cp>2122</cp>
+            <hpRegen>9.85</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="85">
+            <hp>3055</hp>
+            <mp>2330</mp>
+            <cp>2156</cp>
+            <hpRegen>9.95</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="86">
+            <hp>3103</hp>
+            <mp>2378.5</mp>
+            <cp>2190</cp>
+            <hpRegen>10.05</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="87">
+            <hp>3151</hp>
+            <mp>2427</mp>
+            <cp>2224</cp>
+            <hpRegen>10.15</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="88">
+            <hp>3199</hp>
+            <mp>2475.5</mp>
+            <cp>2258</cp>
+            <hpRegen>10.25</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="89">
+            <hp>3247</hp>
+            <mp>2524</mp>
+            <cp>2292</cp>
+            <hpRegen>10.35</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="90">
+            <hp>3295</hp>
+            <mp>2572.5</mp>
+            <cp>2326</cp>
+            <hpRegen>10.45</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="91">
+            <hp>3343</hp>
+            <mp>2621</mp>
+            <cp>2360</cp>
+            <hpRegen>10.55</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="92">
+            <hp>3391</hp>
+            <mp>2669.5</mp>
+            <cp>2394</cp>
+            <hpRegen>10.65</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="93">
+            <hp>3439</hp>
+            <mp>2718</mp>
+            <cp>2428</cp>
+            <hpRegen>10.75</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="94">
+            <hp>3487</hp>
+            <mp>2766.5</mp>
+            <cp>2462</cp>
+            <hpRegen>10.85</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="95">
+            <hp>3535</hp>
+            <mp>2815</mp>
+            <cp>2496</cp>
+            <hpRegen>10.95</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="96">
+            <hp>3583</hp>
+            <mp>2863.5</mp>
+            <cp>2530</cp>
+            <hpRegen>11.05</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="97">
+            <hp>3631</hp>
+            <mp>2912</mp>
+            <cp>2564</cp>
+            <hpRegen>11.15</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="98">
+            <hp>3679</hp>
+            <mp>2960.5</mp>
+            <cp>2598</cp>
+            <hpRegen>11.25</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="99">
+            <hp>3727</hp>
+            <mp>3009</mp>
+            <cp>2632</cp>
+            <hpRegen>11.35</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="100">
+            <hp>3775</hp>
+            <mp>3057.5</mp>
+            <cp>2666</cp>
+            <hpRegen>11.45</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="101">
+            <hp>3823</hp>
+            <mp>3106</mp>
+            <cp>2700</cp>
+            <hpRegen>11.55</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="102">
+            <hp>3871</hp>
+            <mp>3154.5</mp>
+            <cp>2734</cp>
+            <hpRegen>11.65</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="103">
+            <hp>3919</hp>
+            <mp>3203</mp>
+            <cp>2768</cp>
+            <hpRegen>11.75</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="104">
+            <hp>3967</hp>
+            <mp>3251.5</mp>
+            <cp>2802</cp>
+            <hpRegen>11.85</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="105">
+            <hp>4015</hp>
+            <mp>3300</mp>
+            <cp>2836</cp>
+            <hpRegen>11.95</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="106">
+            <hp>4063</hp>
+            <mp>3348.5</mp>
+            <cp>2870</cp>
+            <hpRegen>12.05</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="107">
+            <hp>4111</hp>
+            <mp>3397</mp>
+            <cp>2904</cp>
+            <hpRegen>12.15</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+    </lvlUpgainData>
+</list>

--- a/data/stats/chars/baseStats/Sylphid.xml
+++ b/data/stats/chars/baseStats/Sylphid.xml
@@ -1,0 +1,923 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
+    <classId>208</classId>
+    <staticData>
+        <baseINT>20</baseINT>
+        <baseSTR>40</baseSTR>
+        <baseCON>40</baseCON>
+        <baseMEN>25</baseMEN>
+        <baseDEX>35</baseDEX>
+        <baseWIT>10</baseWIT>
+        <physicalAbnormalResist>10</physicalAbnormalResist>
+        <magicAbnormalResist>10</magicAbnormalResist>
+        <creationPoints>
+            <node x="102612" y="59473" z="-3773" />
+        </creationPoints>
+        <basePAtk>4</basePAtk>
+        <baseCritRate>4</baseCritRate>
+        <baseMCritRate>5</baseMCritRate>
+        <baseAtkType>FIST</baseAtkType>
+        <basePAtkSpd>300</basePAtkSpd>
+        <baseMAtkSpd>333</baseMAtkSpd>
+        <basePDef>
+            <chest>31</chest>
+            <legs>18</legs>
+            <head>12</head>
+            <feet>7</feet>
+            <gloves>8</gloves>
+            <underwear>3</underwear>
+            <cloak>1</cloak>
+        </basePDef>
+        <baseMAtk>6</baseMAtk>
+        <baseMDef>
+            <rear>9</rear>
+            <lear>9</lear>
+            <rfinger>5</rfinger>
+            <lfinger>5</lfinger>
+            <neck>13</neck>
+        </baseMDef>
+        <baseCanPenetrate>0</baseCanPenetrate>
+        <baseAtkRange>20</baseAtkRange>
+        <baseDamRange>
+            <verticalDirection>0</verticalDirection>
+            <horizontalDirection>0</horizontalDirection>
+            <distance>26</distance>
+            <width>120</width>
+        </baseDamRange>
+        <baseRndDam>10</baseRndDam>
+        <baseMoveSpd>
+            <walk>88</walk>
+            <run>141</run>
+            <slowSwim>50</slowSwim>
+            <fastSwim>50</fastSwim>
+        </baseMoveSpd>
+        <baseBreath>150</baseBreath>
+        <baseSafeFall>350</baseSafeFall>
+        <collisionMale>
+            <radius>6</radius>
+            <height>18.1</height>
+        </collisionMale>
+        <collisionFemale>
+            <radius>6.5</radius>
+            <height>19.2</height>
+        </collisionFemale>
+    </staticData>
+    <lvlUpgainData>
+        <level val="1">
+            <hp>80.0</hp>
+            <mp>30.0</mp>
+            <cp>40.0</cp>
+            <hpRegen>2.0</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2.0</cpRegen>
+        </level>
+        <level val="2">
+            <hp>97</hp>
+            <mp>36.5</mp>
+            <cp>48.5</cp>
+            <hpRegen>2.05</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2.0</cpRegen>
+        </level>
+        <level val="3">
+            <hp>114</hp>
+            <mp>44</mp>
+            <cp>57</cp>
+            <hpRegen>2.1</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2.0</cpRegen>
+        </level>
+        <level val="4">
+            <hp>131</hp>
+            <mp>52.5</mp>
+            <cp>65.5</cp>
+            <hpRegen>2.15</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2</cpRegen>
+        </level>
+        <level val="5">
+            <hp>148</hp>
+            <mp>62</mp>
+            <cp>74</cp>
+            <hpRegen>2.2</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2</cpRegen>
+        </level>
+        <level val="6">
+            <hp>165</hp>
+            <mp>72.5</mp>
+            <cp>82.5</cp>
+            <hpRegen>2.25</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2</cpRegen>
+        </level>
+        <level val="7">
+            <hp>182</hp>
+            <mp>84</mp>
+            <cp>91</cp>
+            <hpRegen>2.3</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2</cpRegen>
+        </level>
+        <level val="8">
+            <hp>199</hp>
+            <mp>96.5</mp>
+            <cp>99.5</cp>
+            <hpRegen>2.35</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2</cpRegen>
+        </level>
+        <level val="9">
+            <hp>216</hp>
+            <mp>110</mp>
+            <cp>108</cp>
+            <hpRegen>2.4</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2</cpRegen>
+        </level>
+        <level val="10">
+            <hp>233</hp>
+            <mp>124.5</mp>
+            <cp>116.5</cp>
+            <hpRegen>2.45</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2</cpRegen>
+        </level>
+        <level val="11">
+            <hp>250</hp>
+            <mp>140</mp>
+            <cp>125</cp>
+            <hpRegen>2.55</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="12">
+            <hp>267</hp>
+            <mp>156.5</mp>
+            <cp>133.5</cp>
+            <hpRegen>2.65</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="13">
+            <hp>284</hp>
+            <mp>174</mp>
+            <cp>142</cp>
+            <hpRegen>2.75</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="14">
+            <hp>301</hp>
+            <mp>192.5</mp>
+            <cp>150.5</cp>
+            <hpRegen>2.85</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="15">
+            <hp>318</hp>
+            <mp>212</mp>
+            <cp>159</cp>
+            <hpRegen>2.95</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="16">
+            <hp>335</hp>
+            <mp>232.5</mp>
+            <cp>167.5</cp>
+            <hpRegen>3.05</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="17">
+            <hp>352</hp>
+            <mp>254</mp>
+            <cp>176</cp>
+            <hpRegen>3.15</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="18">
+            <hp>369</hp>
+            <mp>276.5</mp>
+            <cp>184.5</cp>
+            <hpRegen>3.25</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="19">
+            <hp>386</hp>
+            <mp>300</mp>
+            <cp>193</cp>
+            <hpRegen>3.35</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="20">
+            <hp>403</hp>
+            <mp>324.5</mp>
+            <cp>201.5</cp>
+            <hpRegen>3.45</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="21">
+            <hp>420</hp>
+            <mp>350</mp>
+            <cp>210</cp>
+            <hpRegen>3.55</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="22">
+            <hp>437</hp>
+            <mp>376.5</mp>
+            <cp>218.5</cp>
+            <hpRegen>3.65</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="23">
+            <hp>454</hp>
+            <mp>404</mp>
+            <cp>227</cp>
+            <hpRegen>3.75</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="24">
+            <hp>471</hp>
+            <mp>432.5</mp>
+            <cp>235.5</cp>
+            <hpRegen>3.85</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="25">
+            <hp>488</hp>
+            <mp>462</mp>
+            <cp>244</cp>
+            <hpRegen>3.95</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="26">
+            <hp>505</hp>
+            <mp>492.5</mp>
+            <cp>252.5</cp>
+            <hpRegen>4.05</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="27">
+            <hp>522</hp>
+            <mp>524</mp>
+            <cp>261</cp>
+            <hpRegen>4.15</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="28">
+            <hp>539</hp>
+            <mp>556.5</mp>
+            <cp>269.5</cp>
+            <hpRegen>4.25</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="29">
+            <hp>556</hp>
+            <mp>590</mp>
+            <cp>278</cp>
+            <hpRegen>4.35</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="30">
+            <hp>573</hp>
+            <mp>624.5</mp>
+            <cp>286.5</cp>
+            <hpRegen>4.45</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="31">
+            <hp>590</hp>
+            <mp>660</mp>
+            <cp>295</cp>
+            <hpRegen>4.55</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="32">
+            <hp>607</hp>
+            <mp>696.5</mp>
+            <cp>303.5</cp>
+            <hpRegen>4.65</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="33">
+            <hp>624</hp>
+            <mp>734</mp>
+            <cp>312</cp>
+            <hpRegen>4.75</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="34">
+            <hp>641</hp>
+            <mp>772.5</mp>
+            <cp>320.5</cp>
+            <hpRegen>4.85</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="35">
+            <hp>658</hp>
+            <mp>812</mp>
+            <cp>329</cp>
+            <hpRegen>4.95</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="36">
+            <hp>675</hp>
+            <mp>852.5</mp>
+            <cp>337.5</cp>
+            <hpRegen>5.05</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="37">
+            <hp>692</hp>
+            <mp>894</mp>
+            <cp>346</cp>
+            <hpRegen>5.15</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="38">
+            <hp>709</hp>
+            <mp>936.5</mp>
+            <cp>354.5</cp>
+            <hpRegen>5.25</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="39">
+            <hp>726</hp>
+            <mp>980</mp>
+            <cp>363</cp>
+            <hpRegen>5.35</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="40">
+            <hp>743</hp>
+            <mp>1024.5</mp>
+            <cp>371.5</cp>
+            <hpRegen>5.45</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="41">
+            <hp>760</hp>
+            <mp>1070</mp>
+            <cp>380</cp>
+            <hpRegen>5.55</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="42">
+            <hp>777</hp>
+            <mp>1116.5</mp>
+            <cp>388.5</cp>
+            <hpRegen>5.65</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="43">
+            <hp>794</hp>
+            <mp>1164</mp>
+            <cp>397</cp>
+            <hpRegen>5.75</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="44">
+            <hp>811</hp>
+            <mp>1212.5</mp>
+            <cp>405.5</cp>
+            <hpRegen>5.85</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="45">
+            <hp>828</hp>
+            <mp>1262</mp>
+            <cp>414</cp>
+            <hpRegen>5.95</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="46">
+            <hp>845</hp>
+            <mp>1312.5</mp>
+            <cp>422.5</cp>
+            <hpRegen>6.05</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="47">
+            <hp>862</hp>
+            <mp>1364</mp>
+            <cp>431</cp>
+            <hpRegen>6.15</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="48">
+            <hp>879</hp>
+            <mp>1416.5</mp>
+            <cp>439.5</cp>
+            <hpRegen>6.25</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="49">
+            <hp>896</hp>
+            <mp>1470</mp>
+            <cp>448</cp>
+            <hpRegen>6.35</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="50">
+            <hp>913</hp>
+            <mp>1524.5</mp>
+            <cp>456.5</cp>
+            <hpRegen>6.45</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="51">
+            <hp>930</hp>
+            <mp>1580</mp>
+            <cp>465</cp>
+            <hpRegen>6.55</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="52">
+            <hp>947</hp>
+            <mp>1636.5</mp>
+            <cp>473.5</cp>
+            <hpRegen>6.65</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="53">
+            <hp>964</hp>
+            <mp>1694</mp>
+            <cp>482</cp>
+            <hpRegen>6.75</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="54">
+            <hp>981</hp>
+            <mp>1752.5</mp>
+            <cp>490.5</cp>
+            <hpRegen>6.85</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="55">
+            <hp>998</hp>
+            <mp>1812</mp>
+            <cp>499</cp>
+            <hpRegen>6.95</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="56">
+            <hp>1015</hp>
+            <mp>1872.5</mp>
+            <cp>507.5</cp>
+            <hpRegen>7.05</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="57">
+            <hp>1032</hp>
+            <mp>1934</mp>
+            <cp>516</cp>
+            <hpRegen>7.15</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="58">
+            <hp>1049</hp>
+            <mp>1996.5</mp>
+            <cp>524.5</cp>
+            <hpRegen>7.25</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="59">
+            <hp>1066</hp>
+            <mp>2060</mp>
+            <cp>533</cp>
+            <hpRegen>7.35</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="60">
+            <hp>1083</hp>
+            <mp>2124.5</mp>
+            <cp>541.5</cp>
+            <hpRegen>7.45</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="61">
+            <hp>1100</hp>
+            <mp>2190</mp>
+            <cp>550</cp>
+            <hpRegen>7.55</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="62">
+            <hp>1117</hp>
+            <mp>2256.5</mp>
+            <cp>558.5</cp>
+            <hpRegen>7.65</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="63">
+            <hp>1134</hp>
+            <mp>2324</mp>
+            <cp>567</cp>
+            <hpRegen>7.75</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="64">
+            <hp>1151</hp>
+            <mp>2392.5</mp>
+            <cp>575.5</cp>
+            <hpRegen>7.85</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="65">
+            <hp>1168</hp>
+            <mp>2462</mp>
+            <cp>584</cp>
+            <hpRegen>7.95</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="66">
+            <hp>1185</hp>
+            <mp>2532.5</mp>
+            <cp>592.5</cp>
+            <hpRegen>8.05</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="67">
+            <hp>1202</hp>
+            <mp>2604</mp>
+            <cp>601</cp>
+            <hpRegen>8.15</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="68">
+            <hp>1219</hp>
+            <mp>2676.5</mp>
+            <cp>609.5</cp>
+            <hpRegen>8.25</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="69">
+            <hp>1236</hp>
+            <mp>2750</mp>
+            <cp>618</cp>
+            <hpRegen>8.35</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="70">
+            <hp>1253</hp>
+            <mp>2824.5</mp>
+            <cp>626.5</cp>
+            <hpRegen>8.45</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="71">
+            <hp>1270</hp>
+            <mp>2900</mp>
+            <cp>635</cp>
+            <hpRegen>8.55</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="72">
+            <hp>1287</hp>
+            <mp>2976.5</mp>
+            <cp>643.5</cp>
+            <hpRegen>8.65</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="73">
+            <hp>1304</hp>
+            <mp>3054</mp>
+            <cp>652</cp>
+            <hpRegen>8.75</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="74">
+            <hp>1321</hp>
+            <mp>3132.5</mp>
+            <cp>660.5</cp>
+            <hpRegen>8.85</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="75">
+            <hp>1338</hp>
+            <mp>3212</mp>
+            <cp>669</cp>
+            <hpRegen>8.95</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="76">
+            <hp>1355</hp>
+            <mp>3292.5</mp>
+            <cp>677.5</cp>
+            <hpRegen>9.05</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="77">
+            <hp>1372</hp>
+            <mp>3374</mp>
+            <cp>686</cp>
+            <hpRegen>9.15</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="78">
+            <hp>1389</hp>
+            <mp>3456.5</mp>
+            <cp>694.5</cp>
+            <hpRegen>9.25</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="79">
+            <hp>1406</hp>
+            <mp>3540</mp>
+            <cp>703</cp>
+            <hpRegen>9.35</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="80">
+            <hp>1423</hp>
+            <mp>3624.5</mp>
+            <cp>711.5</cp>
+            <hpRegen>9.45</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="81">
+            <hp>1440</hp>
+            <mp>3710</mp>
+            <cp>720</cp>
+            <hpRegen>9.55</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="82">
+            <hp>1457</hp>
+            <mp>3796.5</mp>
+            <cp>728.5</cp>
+            <hpRegen>9.65</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="83">
+            <hp>1474</hp>
+            <mp>3884</mp>
+            <cp>737</cp>
+            <hpRegen>9.75</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="84">
+            <hp>1491</hp>
+            <mp>3972.5</mp>
+            <cp>745.5</cp>
+            <hpRegen>9.85</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="85">
+            <hp>1508</hp>
+            <mp>4062</mp>
+            <cp>754</cp>
+            <hpRegen>9.95</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="86">
+            <hp>1525</hp>
+            <mp>4152.5</mp>
+            <cp>762.5</cp>
+            <hpRegen>10.05</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="87">
+            <hp>1542</hp>
+            <mp>4244</mp>
+            <cp>771</cp>
+            <hpRegen>10.15</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="88">
+            <hp>1559</hp>
+            <mp>4336.5</mp>
+            <cp>779.5</cp>
+            <hpRegen>10.25</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="89">
+            <hp>1576</hp>
+            <mp>4430</mp>
+            <cp>788</cp>
+            <hpRegen>10.35</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="90">
+            <hp>1593</hp>
+            <mp>4524.5</mp>
+            <cp>796.5</cp>
+            <hpRegen>10.45</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="91">
+            <hp>1610</hp>
+            <mp>4620</mp>
+            <cp>805</cp>
+            <hpRegen>10.55</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="92">
+            <hp>1627</hp>
+            <mp>4716.5</mp>
+            <cp>813.5</cp>
+            <hpRegen>10.65</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="93">
+            <hp>1644</hp>
+            <mp>4814</mp>
+            <cp>822</cp>
+            <hpRegen>10.75</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="94">
+            <hp>1661</hp>
+            <mp>4912.5</mp>
+            <cp>830.5</cp>
+            <hpRegen>10.85</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="95">
+            <hp>1678</hp>
+            <mp>5012</mp>
+            <cp>839</cp>
+            <hpRegen>10.95</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="96">
+            <hp>1695</hp>
+            <mp>5112.5</mp>
+            <cp>847.5</cp>
+            <hpRegen>11.05</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="97">
+            <hp>1712</hp>
+            <mp>5214</mp>
+            <cp>856</cp>
+            <hpRegen>11.15</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="98">
+            <hp>1729</hp>
+            <mp>5316.5</mp>
+            <cp>864.5</cp>
+            <hpRegen>11.25</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="99">
+            <hp>1746</hp>
+            <mp>5420</mp>
+            <cp>873</cp>
+            <hpRegen>11.35</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="100">
+            <hp>1763</hp>
+            <mp>5524.5</mp>
+            <cp>881.5</cp>
+            <hpRegen>11.45</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="101">
+            <hp>1780</hp>
+            <mp>5630</mp>
+            <cp>890</cp>
+            <hpRegen>11.55</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="102">
+            <hp>1797</hp>
+            <mp>5736.5</mp>
+            <cp>898.5</cp>
+            <hpRegen>11.65</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="103">
+            <hp>1814</hp>
+            <mp>5844</mp>
+            <cp>907</cp>
+            <hpRegen>11.75</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="104">
+            <hp>1831</hp>
+            <mp>5952.5</mp>
+            <cp>915.5</cp>
+            <hpRegen>11.85</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="105">
+            <hp>1848</hp>
+            <mp>6062</mp>
+            <cp>924</cp>
+            <hpRegen>11.95</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="106">
+            <hp>1865</hp>
+            <mp>6172.5</mp>
+            <cp>932.5</cp>
+            <hpRegen>12.05</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="107">
+            <hp>1882</hp>
+            <mp>6284</mp>
+            <cp>941</cp>
+            <hpRegen>12.15</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+    </lvlUpgainData>
+</list>

--- a/data/stats/chars/baseStats/TempleKnight.xml
+++ b/data/stats/chars/baseStats/TempleKnight.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>20</classId>
-    <staticData>
-        <baseINT>23</baseINT>
-        <baseSTR>36</baseSTR>
-        <baseCON>36</baseCON>
-        <baseMEN>26</baseMEN>
-        <baseDEX>35</baseDEX>
-        <baseWIT>14</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>15</magicAbnormalResist>
-        <creationPoints>
-            <node x="46045" y="41251" z="-3440"/>
-            <node x="46117" y="41247" z="-3440"/>
-            <node x="46182" y="41198" z="-3440"/>
-            <node x="46115" y="41141" z="-3440"/>
-            <node x="46048" y="41141" z="-3440"/>
-            <node x="45978" y="41196" z="-3440"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>90</walk>
-            <run>143</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>150</baseBreath>
-        <baseSafeFall>350</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>24</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.5</radius>
-            <height>23</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>89.0</hp>
-            <mp>30.0</mp>
-            <cp>53.4</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>101.74</hp>
-            <mp>35.46</mp>
-            <cp>61.044</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>114.62</hp>
-            <mp>40.98</mp>
-            <cp>68.772</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>127.64</hp>
-            <mp>46.56</mp>
-            <cp>76.584</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>140.8</hp>
-            <mp>52.2</mp>
-            <cp>84.48</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>154.1</hp>
-            <mp>57.9</mp>
-            <cp>92.46</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>167.54</hp>
-            <mp>63.66</mp>
-            <cp>100.524</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>181.12</hp>
-            <mp>69.48</mp>
-            <cp>108.672</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>194.84</hp>
-            <mp>75.36</mp>
-            <cp>116.904</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>208.7</hp>
-            <mp>81.3</mp>
-            <cp>125.22</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>222.7</hp>
-            <mp>87.3</mp>
-            <cp>133.62</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>236.84</hp>
-            <mp>93.36</mp>
-            <cp>142.104</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>251.12</hp>
-            <mp>99.48</mp>
-            <cp>150.672</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>265.54</hp>
-            <mp>105.66</mp>
-            <cp>159.324</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>280.1</hp>
-            <mp>111.9</mp>
-            <cp>168.06</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>294.8</hp>
-            <mp>118.2</mp>
-            <cp>176.88</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>309.64</hp>
-            <mp>124.56</mp>
-            <cp>185.784</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>324.62</hp>
-            <mp>130.98</mp>
-            <cp>194.772</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>339.74</hp>
-            <mp>137.46</mp>
-            <cp>203.844</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>355.0</hp>
-            <mp>144.0</mp>
-            <cp>213.0</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>388.0</hp>
-            <mp>153.9</mp>
-            <cp>232.8</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>421.3</hp>
-            <mp>163.89</mp>
-            <cp>252.78</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>454.9</hp>
-            <mp>173.97</mp>
-            <cp>272.94</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>488.8</hp>
-            <mp>184.14</mp>
-            <cp>293.28</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>523.0</hp>
-            <mp>194.4</mp>
-            <cp>313.8</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>557.5</hp>
-            <mp>204.75</mp>
-            <cp>334.5</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>592.3</hp>
-            <mp>215.19</mp>
-            <cp>355.38</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>627.4</hp>
-            <mp>225.72</mp>
-            <cp>376.44</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>662.8</hp>
-            <mp>236.34</mp>
-            <cp>397.68</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>698.5</hp>
-            <mp>247.05</mp>
-            <cp>419.1</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>734.5</hp>
-            <mp>257.85</mp>
-            <cp>440.7</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>770.8</hp>
-            <mp>268.74</mp>
-            <cp>462.48</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>807.4</hp>
-            <mp>279.72</mp>
-            <cp>484.44</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>844.3</hp>
-            <mp>290.79</mp>
-            <cp>506.58</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>881.5</hp>
-            <mp>301.95</mp>
-            <cp>528.9</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>919.0</hp>
-            <mp>313.2</mp>
-            <cp>551.4</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>956.8</hp>
-            <mp>324.54</mp>
-            <cp>574.08</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>994.9</hp>
-            <mp>335.97</mp>
-            <cp>596.94</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1033.3</hp>
-            <mp>347.49</mp>
-            <cp>619.98</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1072.0</hp>
-            <mp>359.1</mp>
-            <cp>643.2</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1124.0</hp>
-            <mp>378.6</mp>
-            <cp>674.4</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1176.4</hp>
-            <mp>398.25</mp>
-            <cp>705.84</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1229.2</hp>
-            <mp>418.05</mp>
-            <cp>737.52</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1282.4</hp>
-            <mp>438.0</mp>
-            <cp>769.44</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1336.0</hp>
-            <mp>458.1</mp>
-            <cp>801.6</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1390.0</hp>
-            <mp>478.35</mp>
-            <cp>834.0</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1444.4</hp>
-            <mp>498.75</mp>
-            <cp>866.64</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1499.2</hp>
-            <mp>519.3</mp>
-            <cp>899.52</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1554.4</hp>
-            <mp>540.0</mp>
-            <cp>932.64</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1610.0</hp>
-            <mp>560.85</mp>
-            <cp>966.0</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1666.0</hp>
-            <mp>581.85</mp>
-            <cp>999.6</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1722.4</hp>
-            <mp>603.0</mp>
-            <cp>1033.44</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1779.2</hp>
-            <mp>624.3</mp>
-            <cp>1067.52</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1836.4</hp>
-            <mp>645.75</mp>
-            <cp>1101.84</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1894.0</hp>
-            <mp>667.35</mp>
-            <cp>1136.4</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1952.0</hp>
-            <mp>689.1</mp>
-            <cp>1171.2</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>2010.4</hp>
-            <mp>711.0</mp>
-            <cp>1206.24</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2069.2</hp>
-            <mp>733.05</mp>
-            <cp>1241.52</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2128.4</hp>
-            <mp>755.25</mp>
-            <cp>1277.04</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2188.0</hp>
-            <mp>777.6</mp>
-            <cp>1312.8</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2248.0</hp>
-            <mp>800.1</mp>
-            <cp>1348.8</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2308.4</hp>
-            <mp>822.75</mp>
-            <cp>1385.04</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2369.2</hp>
-            <mp>845.55</mp>
-            <cp>1421.52</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2430.4</hp>
-            <mp>868.5</mp>
-            <cp>1458.24</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2492.0</hp>
-            <mp>891.6</mp>
-            <cp>1495.2</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2554.0</hp>
-            <mp>914.85</mp>
-            <cp>1532.4</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2616.4</hp>
-            <mp>938.25</mp>
-            <cp>1569.84</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2679.2</hp>
-            <mp>961.8</mp>
-            <cp>1607.52</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2742.4</hp>
-            <mp>985.5</mp>
-            <cp>1645.44</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2806.0</hp>
-            <mp>1009.35</mp>
-            <cp>1683.6</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2870.0</hp>
-            <mp>1033.35</mp>
-            <cp>1722.0</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2934.4</hp>
-            <mp>1057.5</mp>
-            <cp>1760.64</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2999.2</hp>
-            <mp>1081.8</mp>
-            <cp>1799.52</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>3064.4</hp>
-            <mp>1106.25</mp>
-            <cp>1838.64</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3130.0</hp>
-            <mp>1130.85</mp>
-            <cp>1878.0</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3196.0</hp>
-            <mp>1155.6</mp>
-            <cp>1917.6</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3262.4</hp>
-            <mp>1180.5</mp>
-            <cp>1957.44</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3329.2</hp>
-            <mp>1205.55</mp>
-            <cp>1997.52</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3396.4</hp>
-            <mp>1230.75</mp>
-            <cp>2037.84</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3464.0</hp>
-            <mp>1256.1</mp>
-            <cp>2078.4</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3532.0</hp>
-            <mp>1281.6</mp>
-            <cp>2119.2</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3600.4</hp>
-            <mp>1307.25</mp>
-            <cp>2160.24</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3669.2</hp>
-            <mp>1333.05</mp>
-            <cp>2201.52</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3738.4</hp>
-            <mp>1359.0</mp>
-            <cp>2243.04</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3808.0</hp>
-            <mp>1385.1</mp>
-            <cp>2284.8</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3878.0</hp>
-            <mp>1411.35</mp>
-            <cp>2326.8</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3948.4</hp>
-            <mp>1437.75</mp>
-            <cp>2369.04</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>4019.2</hp>
-            <mp>1464.3</mp>
-            <cp>2411.52</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>4090.4</hp>
-            <mp>1491.0</mp>
-            <cp>2454.24</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4162.0</hp>
-            <mp>1517.85</mp>
-            <cp>2497.2</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4234.0</hp>
-            <mp>1544.85</mp>
-            <cp>2540.4</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>20</classId>
+	<staticData>
+		<baseINT>23</baseINT>
+		<baseSTR>36</baseSTR>
+		<baseCON>36</baseCON>
+		<baseMEN>26</baseMEN>
+		<baseDEX>35</baseDEX>
+		<baseWIT>14</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="46045" y="41251" z="-3440" />
+			<node x="46117" y="41247" z="-3440" />
+			<node x="46182" y="41198" z="-3440" />
+			<node x="46115" y="41141" z="-3440" />
+			<node x="46048" y="41141" z="-3440" />
+			<node x="45978" y="41196" z="-3440" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>90</walk>
+			<run>143</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>350</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.5</radius>
+			<height>23</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>89.0</hp>
+			<mp>30.0</mp>
+			<cp>53.4</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>101.74</hp>
+			<mp>35.46</mp>
+			<cp>61.044</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>114.62</hp>
+			<mp>40.98</mp>
+			<cp>68.772</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>127.64</hp>
+			<mp>46.56</mp>
+			<cp>76.584</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>140.8</hp>
+			<mp>52.2</mp>
+			<cp>84.48</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>154.1</hp>
+			<mp>57.9</mp>
+			<cp>92.46</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>167.54</hp>
+			<mp>63.66</mp>
+			<cp>100.524</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>181.12</hp>
+			<mp>69.48</mp>
+			<cp>108.672</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>194.84</hp>
+			<mp>75.36</mp>
+			<cp>116.904</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>208.7</hp>
+			<mp>81.3</mp>
+			<cp>125.22</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>222.7</hp>
+			<mp>87.3</mp>
+			<cp>133.62</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>236.84</hp>
+			<mp>93.36</mp>
+			<cp>142.104</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>251.12</hp>
+			<mp>99.48</mp>
+			<cp>150.672</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>265.54</hp>
+			<mp>105.66</mp>
+			<cp>159.324</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>280.1</hp>
+			<mp>111.9</mp>
+			<cp>168.06</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>294.8</hp>
+			<mp>118.2</mp>
+			<cp>176.88</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>309.64</hp>
+			<mp>124.56</mp>
+			<cp>185.784</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>324.62</hp>
+			<mp>130.98</mp>
+			<cp>194.772</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>339.74</hp>
+			<mp>137.46</mp>
+			<cp>203.844</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>355.0</hp>
+			<mp>144.0</mp>
+			<cp>213.0</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>388.0</hp>
+			<mp>153.9</mp>
+			<cp>232.8</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>421.3</hp>
+			<mp>163.89</mp>
+			<cp>252.78</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>454.9</hp>
+			<mp>173.97</mp>
+			<cp>272.94</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>488.8</hp>
+			<mp>184.14</mp>
+			<cp>293.28</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>523.0</hp>
+			<mp>194.4</mp>
+			<cp>313.8</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>557.5</hp>
+			<mp>204.75</mp>
+			<cp>334.5</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>592.3</hp>
+			<mp>215.19</mp>
+			<cp>355.38</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>627.4</hp>
+			<mp>225.72</mp>
+			<cp>376.44</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>662.8</hp>
+			<mp>236.34</mp>
+			<cp>397.68</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>698.5</hp>
+			<mp>247.05</mp>
+			<cp>419.1</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>734.5</hp>
+			<mp>257.85</mp>
+			<cp>440.7</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>770.8</hp>
+			<mp>268.74</mp>
+			<cp>462.48</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>807.4</hp>
+			<mp>279.72</mp>
+			<cp>484.44</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>844.3</hp>
+			<mp>290.79</mp>
+			<cp>506.58</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>881.5</hp>
+			<mp>301.95</mp>
+			<cp>528.9</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>919.0</hp>
+			<mp>313.2</mp>
+			<cp>551.4</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>956.8</hp>
+			<mp>324.54</mp>
+			<cp>574.08</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>994.9</hp>
+			<mp>335.97</mp>
+			<cp>596.94</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1033.3</hp>
+			<mp>347.49</mp>
+			<cp>619.98</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1072.0</hp>
+			<mp>359.1</mp>
+			<cp>643.2</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1124.0</hp>
+			<mp>378.6</mp>
+			<cp>674.4</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1176.4</hp>
+			<mp>398.25</mp>
+			<cp>705.84</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1229.2</hp>
+			<mp>418.05</mp>
+			<cp>737.52</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1282.4</hp>
+			<mp>438.0</mp>
+			<cp>769.44</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1336.0</hp>
+			<mp>458.1</mp>
+			<cp>801.6</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1390.0</hp>
+			<mp>478.35</mp>
+			<cp>834.0</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1444.4</hp>
+			<mp>498.75</mp>
+			<cp>866.64</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1499.2</hp>
+			<mp>519.3</mp>
+			<cp>899.52</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1554.4</hp>
+			<mp>540.0</mp>
+			<cp>932.64</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1610.0</hp>
+			<mp>560.85</mp>
+			<cp>966.0</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1666.0</hp>
+			<mp>581.85</mp>
+			<cp>999.6</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1722.4</hp>
+			<mp>603.0</mp>
+			<cp>1033.44</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1779.2</hp>
+			<mp>624.3</mp>
+			<cp>1067.52</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1836.4</hp>
+			<mp>645.75</mp>
+			<cp>1101.84</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1894.0</hp>
+			<mp>667.35</mp>
+			<cp>1136.4</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1952.0</hp>
+			<mp>689.1</mp>
+			<cp>1171.2</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2010.4</hp>
+			<mp>711.0</mp>
+			<cp>1206.24</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2069.2</hp>
+			<mp>733.05</mp>
+			<cp>1241.52</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2128.4</hp>
+			<mp>755.25</mp>
+			<cp>1277.04</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2188.0</hp>
+			<mp>777.6</mp>
+			<cp>1312.8</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2248.0</hp>
+			<mp>800.1</mp>
+			<cp>1348.8</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2308.4</hp>
+			<mp>822.75</mp>
+			<cp>1385.04</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2369.2</hp>
+			<mp>845.55</mp>
+			<cp>1421.52</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2430.4</hp>
+			<mp>868.5</mp>
+			<cp>1458.24</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2492.0</hp>
+			<mp>891.6</mp>
+			<cp>1495.2</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2554.0</hp>
+			<mp>914.85</mp>
+			<cp>1532.4</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2616.4</hp>
+			<mp>938.25</mp>
+			<cp>1569.84</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2679.2</hp>
+			<mp>961.8</mp>
+			<cp>1607.52</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2742.4</hp>
+			<mp>985.5</mp>
+			<cp>1645.44</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2806.0</hp>
+			<mp>1009.35</mp>
+			<cp>1683.6</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2870.0</hp>
+			<mp>1033.35</mp>
+			<cp>1722.0</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2934.4</hp>
+			<mp>1057.5</mp>
+			<cp>1760.64</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2999.2</hp>
+			<mp>1081.8</mp>
+			<cp>1799.52</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3064.4</hp>
+			<mp>1106.25</mp>
+			<cp>1838.64</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3130.0</hp>
+			<mp>1130.85</mp>
+			<cp>1878.0</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3196.0</hp>
+			<mp>1155.6</mp>
+			<cp>1917.6</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3262.4</hp>
+			<mp>1180.5</mp>
+			<cp>1957.44</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3329.2</hp>
+			<mp>1205.55</mp>
+			<cp>1997.52</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3396.4</hp>
+			<mp>1230.75</mp>
+			<cp>2037.84</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3464.0</hp>
+			<mp>1256.1</mp>
+			<cp>2078.4</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3532.0</hp>
+			<mp>1281.6</mp>
+			<cp>2119.2</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3600.4</hp>
+			<mp>1307.25</mp>
+			<cp>2160.24</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3669.2</hp>
+			<mp>1333.05</mp>
+			<cp>2201.52</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3738.4</hp>
+			<mp>1359.0</mp>
+			<cp>2243.04</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3808.0</hp>
+			<mp>1385.1</mp>
+			<cp>2284.8</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3878.0</hp>
+			<mp>1411.35</mp>
+			<cp>2326.8</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3948.4</hp>
+			<mp>1437.75</mp>
+			<cp>2369.04</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4019.2</hp>
+			<mp>1464.3</mp>
+			<cp>2411.52</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4090.4</hp>
+			<mp>1491.0</mp>
+			<cp>2454.24</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4162.0</hp>
+			<mp>1517.85</mp>
+			<cp>2497.2</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4234.0</hp>
+			<mp>1544.85</mp>
+			<cp>2540.4</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4306.4</hp>
+			<mp>1572.0</mp>
+			<cp>2583.84</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4379.2</hp>
+			<mp>1599.3</mp>
+			<cp>2627.52</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4452.4</hp>
+			<mp>1626.75</mp>
+			<cp>2671.44</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4526.0</hp>
+			<mp>1654.35</mp>
+			<cp>2715.6</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4600.0</hp>
+			<mp>1682.1</mp>
+			<cp>2760.0</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4674.4</hp>
+			<mp>1710.0</mp>
+			<cp>2804.64</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4749.2</hp>
+			<mp>1738.05</mp>
+			<cp>2849.52</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4824.4</hp>
+			<mp>1766.25</mp>
+			<cp>2894.64</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4900</hp>
+			<mp>1794.6</mp>
+			<cp>2940</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4976</hp>
+			<mp>1823.1</mp>
+			<cp>2985.6</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5052.4</hp>
+			<mp>1851.75</mp>
+			<cp>3031.44</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5129.2</hp>
+			<mp>1880.55</mp>
+			<cp>3077.52</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5206.4</hp>
+			<mp>1909.5</mp>
+			<cp>3123.84</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5284</hp>
+			<mp>1938.6</mp>
+			<cp>3170.4</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5362</hp>
+			<mp>1967.85</mp>
+			<cp>3217.2</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5440.4</hp>
+			<mp>1997.25</mp>
+			<cp>3264.24</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Titan.xml
+++ b/data/stats/chars/baseStats/Titan.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>113</classId>
-    <staticData>
-        <baseINT>18</baseINT>
-        <baseSTR>40</baseSTR>
-        <baseCON>47</baseCON>
-        <baseMEN>27</baseMEN>
-        <baseDEX>26</baseDEX>
-        <baseWIT>12</baseWIT>
-        <physicalAbnormalResist>15</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-56733" y="-113459" z="-690"/>
-            <node x="-56686" y="-113470" z="-690"/>
-            <node x="-56728" y="-113610" z="-690"/>
-            <node x="-56693" y="-113610" z="-690"/>
-            <node x="-56743" y="-113757" z="-690"/>
-            <node x="-56682" y="-113730" z="-690"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>25</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>70</walk>
-            <run>130</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>90</baseBreath>
-        <baseSafeFall>200</baseSafeFall>
-        <collisionMale>
-            <radius>11</radius>
-            <height>28.0</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7</radius>
-            <height>27.0</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>80.0</hp>
-            <mp>30.0</mp>
-            <cp>56.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>92.74</hp>
-            <mp>35.46</mp>
-            <cp>64.918</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>105.62</hp>
-            <mp>40.98</mp>
-            <cp>73.934</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>118.64</hp>
-            <mp>46.56</mp>
-            <cp>83.048</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>131.8</hp>
-            <mp>52.2</mp>
-            <cp>92.26</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>145.1</hp>
-            <mp>57.9</mp>
-            <cp>101.57</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>158.54</hp>
-            <mp>63.66</mp>
-            <cp>110.978</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>172.12</hp>
-            <mp>69.48</mp>
-            <cp>120.484</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>185.84</hp>
-            <mp>75.36</mp>
-            <cp>130.088</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>199.7</hp>
-            <mp>81.3</mp>
-            <cp>139.79</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>213.7</hp>
-            <mp>87.3</mp>
-            <cp>149.59</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>227.84</hp>
-            <mp>93.36</mp>
-            <cp>159.488</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>242.12</hp>
-            <mp>99.48</mp>
-            <cp>169.484</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>256.54</hp>
-            <mp>105.66</mp>
-            <cp>179.578</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>271.1</hp>
-            <mp>111.9</mp>
-            <cp>189.77</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>285.8</hp>
-            <mp>118.2</mp>
-            <cp>200.06</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>300.64</hp>
-            <mp>124.56</mp>
-            <cp>210.448</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>315.62</hp>
-            <mp>130.98</mp>
-            <cp>220.934</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>330.74</hp>
-            <mp>137.46</mp>
-            <cp>231.518</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>346.0</hp>
-            <mp>144.0</mp>
-            <cp>242.2</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>381.2</hp>
-            <mp>153.9</mp>
-            <cp>266.84</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>416.72</hp>
-            <mp>163.89</mp>
-            <cp>291.704</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>452.56</hp>
-            <mp>173.97</mp>
-            <cp>316.792</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>488.72</hp>
-            <mp>184.14</mp>
-            <cp>342.104</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>525.2</hp>
-            <mp>194.4</mp>
-            <cp>367.64</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>562.0</hp>
-            <mp>204.75</mp>
-            <cp>393.4</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>599.12</hp>
-            <mp>215.19</mp>
-            <cp>419.384</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>636.56</hp>
-            <mp>225.72</mp>
-            <cp>445.592</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>674.32</hp>
-            <mp>236.34</mp>
-            <cp>472.024</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>712.4</hp>
-            <mp>247.05</mp>
-            <cp>498.68</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>750.8</hp>
-            <mp>257.85</mp>
-            <cp>525.56</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>789.52</hp>
-            <mp>268.74</mp>
-            <cp>552.664</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>828.56</hp>
-            <mp>279.72</mp>
-            <cp>579.992</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>867.92</hp>
-            <mp>290.79</mp>
-            <cp>607.544</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>907.6</hp>
-            <mp>301.95</mp>
-            <cp>635.32</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>947.6</hp>
-            <mp>313.2</mp>
-            <cp>663.32</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>987.92</hp>
-            <mp>324.54</mp>
-            <cp>691.544</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1028.56</hp>
-            <mp>335.97</mp>
-            <cp>719.992</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1069.52</hp>
-            <mp>347.49</mp>
-            <cp>748.664</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1110.8</hp>
-            <mp>359.1</mp>
-            <cp>777.56</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1168.0</hp>
-            <mp>378.6</mp>
-            <cp>817.6</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1225.64</hp>
-            <mp>398.25</mp>
-            <cp>857.948</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1283.72</hp>
-            <mp>418.05</mp>
-            <cp>898.604</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1342.24</hp>
-            <mp>438.0</mp>
-            <cp>939.568</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1401.2</hp>
-            <mp>458.1</mp>
-            <cp>980.84</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1460.6</hp>
-            <mp>478.35</mp>
-            <cp>1022.42</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1520.44</hp>
-            <mp>498.75</mp>
-            <cp>1064.308</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1580.72</hp>
-            <mp>519.3</mp>
-            <cp>1106.504</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1641.44</hp>
-            <mp>540.0</mp>
-            <cp>1149.008</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1702.6</hp>
-            <mp>560.85</mp>
-            <cp>1191.82</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1764.2</hp>
-            <mp>581.85</mp>
-            <cp>1234.94</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1826.24</hp>
-            <mp>603.0</mp>
-            <cp>1278.368</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1888.72</hp>
-            <mp>624.3</mp>
-            <cp>1322.104</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1951.64</hp>
-            <mp>645.75</mp>
-            <cp>1366.148</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>2015.0</hp>
-            <mp>667.35</mp>
-            <cp>1410.5</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>2078.8</hp>
-            <mp>689.1</mp>
-            <cp>1455.16</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>2143.04</hp>
-            <mp>711.0</mp>
-            <cp>1500.128</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2207.72</hp>
-            <mp>733.05</mp>
-            <cp>1545.404</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2272.84</hp>
-            <mp>755.25</mp>
-            <cp>1590.988</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2338.4</hp>
-            <mp>777.6</mp>
-            <cp>1636.88</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2404.4</hp>
-            <mp>800.1</mp>
-            <cp>1683.08</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2470.84</hp>
-            <mp>822.75</mp>
-            <cp>1729.588</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2537.72</hp>
-            <mp>845.55</mp>
-            <cp>1776.404</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2605.04</hp>
-            <mp>868.5</mp>
-            <cp>1823.528</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2672.8</hp>
-            <mp>891.6</mp>
-            <cp>1870.96</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2741.0</hp>
-            <mp>914.85</mp>
-            <cp>1918.7</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2809.64</hp>
-            <mp>938.25</mp>
-            <cp>1966.748</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2878.72</hp>
-            <mp>961.8</mp>
-            <cp>2015.104</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2948.24</hp>
-            <mp>985.5</mp>
-            <cp>2063.768</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>3018.2</hp>
-            <mp>1009.35</mp>
-            <cp>2112.74</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>3088.6</hp>
-            <mp>1033.35</mp>
-            <cp>2162.02</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>3159.44</hp>
-            <mp>1057.5</mp>
-            <cp>2211.608</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>3230.72</hp>
-            <mp>1081.8</mp>
-            <cp>2261.504</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>3302.44</hp>
-            <mp>1106.25</mp>
-            <cp>2311.708</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3374.6</hp>
-            <mp>1130.85</mp>
-            <cp>2362.22</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3447.2</hp>
-            <mp>1155.6</mp>
-            <cp>2413.04</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3520.24</hp>
-            <mp>1180.5</mp>
-            <cp>2464.168</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3593.72</hp>
-            <mp>1205.55</mp>
-            <cp>2515.604</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3667.64</hp>
-            <mp>1230.75</mp>
-            <cp>2567.348</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3742.0</hp>
-            <mp>1256.1</mp>
-            <cp>2619.4</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3816.8</hp>
-            <mp>1281.6</mp>
-            <cp>2671.76</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3892.04</hp>
-            <mp>1307.25</mp>
-            <cp>2724.428</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3967.72</hp>
-            <mp>1333.05</mp>
-            <cp>2777.404</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>4043.84</hp>
-            <mp>1359.0</mp>
-            <cp>2830.688</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>4120.4</hp>
-            <mp>1385.1</mp>
-            <cp>2884.28</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>4197.4</hp>
-            <mp>1411.35</mp>
-            <cp>2938.18</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>4274.84</hp>
-            <mp>1437.75</mp>
-            <cp>2992.388</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>4352.72</hp>
-            <mp>1464.3</mp>
-            <cp>3046.904</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>4431.04</hp>
-            <mp>1491.0</mp>
-            <cp>3101.728</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4509.8</hp>
-            <mp>1517.85</mp>
-            <cp>3156.86</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4589.0</hp>
-            <mp>1544.85</mp>
-            <cp>3212.3</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>113</classId>
+	<staticData>
+		<baseINT>18</baseINT>
+		<baseSTR>40</baseSTR>
+		<baseCON>47</baseCON>
+		<baseMEN>27</baseMEN>
+		<baseDEX>26</baseDEX>
+		<baseWIT>12</baseWIT>
+		<physicalAbnormalResist>15</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-56733" y="-113459" z="-690" />
+			<node x="-56686" y="-113470" z="-690" />
+			<node x="-56728" y="-113610" z="-690" />
+			<node x="-56693" y="-113610" z="-690" />
+			<node x="-56743" y="-113757" z="-690" />
+			<node x="-56682" y="-113730" z="-690" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>25</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>70</walk>
+			<run>130</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>90</baseBreath>
+		<baseSafeFall>200</baseSafeFall>
+		<collisionMale>
+			<radius>11</radius>
+			<height>28.0</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7</radius>
+			<height>27.0</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>80.0</hp>
+			<mp>30.0</mp>
+			<cp>56.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>92.74</hp>
+			<mp>35.46</mp>
+			<cp>64.918</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>105.62</hp>
+			<mp>40.98</mp>
+			<cp>73.934</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>118.64</hp>
+			<mp>46.56</mp>
+			<cp>83.048</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>131.8</hp>
+			<mp>52.2</mp>
+			<cp>92.26</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>145.1</hp>
+			<mp>57.9</mp>
+			<cp>101.57</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>158.54</hp>
+			<mp>63.66</mp>
+			<cp>110.978</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>172.12</hp>
+			<mp>69.48</mp>
+			<cp>120.484</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>185.84</hp>
+			<mp>75.36</mp>
+			<cp>130.088</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>199.7</hp>
+			<mp>81.3</mp>
+			<cp>139.79</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>213.7</hp>
+			<mp>87.3</mp>
+			<cp>149.59</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>227.84</hp>
+			<mp>93.36</mp>
+			<cp>159.488</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>242.12</hp>
+			<mp>99.48</mp>
+			<cp>169.484</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>256.54</hp>
+			<mp>105.66</mp>
+			<cp>179.578</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>271.1</hp>
+			<mp>111.9</mp>
+			<cp>189.77</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>285.8</hp>
+			<mp>118.2</mp>
+			<cp>200.06</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>300.64</hp>
+			<mp>124.56</mp>
+			<cp>210.448</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>315.62</hp>
+			<mp>130.98</mp>
+			<cp>220.934</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>330.74</hp>
+			<mp>137.46</mp>
+			<cp>231.518</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>346.0</hp>
+			<mp>144.0</mp>
+			<cp>242.2</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>381.2</hp>
+			<mp>153.9</mp>
+			<cp>266.84</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>416.72</hp>
+			<mp>163.89</mp>
+			<cp>291.704</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>452.56</hp>
+			<mp>173.97</mp>
+			<cp>316.792</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>488.72</hp>
+			<mp>184.14</mp>
+			<cp>342.104</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>525.2</hp>
+			<mp>194.4</mp>
+			<cp>367.64</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>562.0</hp>
+			<mp>204.75</mp>
+			<cp>393.4</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>599.12</hp>
+			<mp>215.19</mp>
+			<cp>419.384</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>636.56</hp>
+			<mp>225.72</mp>
+			<cp>445.592</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>674.32</hp>
+			<mp>236.34</mp>
+			<cp>472.024</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>712.4</hp>
+			<mp>247.05</mp>
+			<cp>498.68</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>750.8</hp>
+			<mp>257.85</mp>
+			<cp>525.56</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>789.52</hp>
+			<mp>268.74</mp>
+			<cp>552.664</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>828.56</hp>
+			<mp>279.72</mp>
+			<cp>579.992</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>867.92</hp>
+			<mp>290.79</mp>
+			<cp>607.544</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>907.6</hp>
+			<mp>301.95</mp>
+			<cp>635.32</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>947.6</hp>
+			<mp>313.2</mp>
+			<cp>663.32</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>987.92</hp>
+			<mp>324.54</mp>
+			<cp>691.544</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1028.56</hp>
+			<mp>335.97</mp>
+			<cp>719.992</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1069.52</hp>
+			<mp>347.49</mp>
+			<cp>748.664</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1110.8</hp>
+			<mp>359.1</mp>
+			<cp>777.56</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1168.0</hp>
+			<mp>378.6</mp>
+			<cp>817.6</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1225.64</hp>
+			<mp>398.25</mp>
+			<cp>857.948</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1283.72</hp>
+			<mp>418.05</mp>
+			<cp>898.604</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1342.24</hp>
+			<mp>438.0</mp>
+			<cp>939.568</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1401.2</hp>
+			<mp>458.1</mp>
+			<cp>980.84</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1460.6</hp>
+			<mp>478.35</mp>
+			<cp>1022.42</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1520.44</hp>
+			<mp>498.75</mp>
+			<cp>1064.308</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1580.72</hp>
+			<mp>519.3</mp>
+			<cp>1106.504</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1641.44</hp>
+			<mp>540.0</mp>
+			<cp>1149.008</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1702.6</hp>
+			<mp>560.85</mp>
+			<cp>1191.82</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1764.2</hp>
+			<mp>581.85</mp>
+			<cp>1234.94</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1826.24</hp>
+			<mp>603.0</mp>
+			<cp>1278.368</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1888.72</hp>
+			<mp>624.3</mp>
+			<cp>1322.104</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1951.64</hp>
+			<mp>645.75</mp>
+			<cp>1366.148</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>2015.0</hp>
+			<mp>667.35</mp>
+			<cp>1410.5</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>2078.8</hp>
+			<mp>689.1</mp>
+			<cp>1455.16</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2143.04</hp>
+			<mp>711.0</mp>
+			<cp>1500.128</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2207.72</hp>
+			<mp>733.05</mp>
+			<cp>1545.404</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2272.84</hp>
+			<mp>755.25</mp>
+			<cp>1590.988</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2338.4</hp>
+			<mp>777.6</mp>
+			<cp>1636.88</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2404.4</hp>
+			<mp>800.1</mp>
+			<cp>1683.08</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2470.84</hp>
+			<mp>822.75</mp>
+			<cp>1729.588</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2537.72</hp>
+			<mp>845.55</mp>
+			<cp>1776.404</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2605.04</hp>
+			<mp>868.5</mp>
+			<cp>1823.528</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2672.8</hp>
+			<mp>891.6</mp>
+			<cp>1870.96</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2741.0</hp>
+			<mp>914.85</mp>
+			<cp>1918.7</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2809.64</hp>
+			<mp>938.25</mp>
+			<cp>1966.748</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2878.72</hp>
+			<mp>961.8</mp>
+			<cp>2015.104</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2948.24</hp>
+			<mp>985.5</mp>
+			<cp>2063.768</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>3018.2</hp>
+			<mp>1009.35</mp>
+			<cp>2112.74</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>3088.6</hp>
+			<mp>1033.35</mp>
+			<cp>2162.02</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>3159.44</hp>
+			<mp>1057.5</mp>
+			<cp>2211.608</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>3230.72</hp>
+			<mp>1081.8</mp>
+			<cp>2261.504</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3302.44</hp>
+			<mp>1106.25</mp>
+			<cp>2311.708</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3374.6</hp>
+			<mp>1130.85</mp>
+			<cp>2362.22</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3447.2</hp>
+			<mp>1155.6</mp>
+			<cp>2413.04</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3520.24</hp>
+			<mp>1180.5</mp>
+			<cp>2464.168</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3593.72</hp>
+			<mp>1205.55</mp>
+			<cp>2515.604</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3667.64</hp>
+			<mp>1230.75</mp>
+			<cp>2567.348</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3742.0</hp>
+			<mp>1256.1</mp>
+			<cp>2619.4</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3816.8</hp>
+			<mp>1281.6</mp>
+			<cp>2671.76</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3892.04</hp>
+			<mp>1307.25</mp>
+			<cp>2724.428</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3967.72</hp>
+			<mp>1333.05</mp>
+			<cp>2777.404</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>4043.84</hp>
+			<mp>1359.0</mp>
+			<cp>2830.688</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>4120.4</hp>
+			<mp>1385.1</mp>
+			<cp>2884.28</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>4197.4</hp>
+			<mp>1411.35</mp>
+			<cp>2938.18</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>4274.84</hp>
+			<mp>1437.75</mp>
+			<cp>2992.388</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4352.72</hp>
+			<mp>1464.3</mp>
+			<cp>3046.904</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4431.04</hp>
+			<mp>1491.0</mp>
+			<cp>3101.728</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4509.8</hp>
+			<mp>1517.85</mp>
+			<cp>3156.86</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4589.0</hp>
+			<mp>1544.85</mp>
+			<cp>3212.3</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4668.64</hp>
+			<mp>1572.0</mp>
+			<cp>3268.048</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4748.72</hp>
+			<mp>1599.3</mp>
+			<cp>3324.104</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4829.24</hp>
+			<mp>1626.75</mp>
+			<cp>3380.468</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4910.2</hp>
+			<mp>1654.35</mp>
+			<cp>3437.14</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4991.6</hp>
+			<mp>1682.1</mp>
+			<cp>3494.12</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>5073.44</hp>
+			<mp>1710.0</mp>
+			<cp>3551.408</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>5155.72</hp>
+			<mp>1738.05</mp>
+			<cp>3609.004</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>5238.44</hp>
+			<mp>1766.25</mp>
+			<cp>3666.908</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>5321.6</hp>
+			<mp>1794.6</mp>
+			<cp>3725.12</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>5405.2</hp>
+			<mp>1823.1</mp>
+			<cp>3783.65</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5489.24</hp>
+			<mp>1851.75</mp>
+			<cp>3842.48</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5573.72</hp>
+			<mp>1880.55</mp>
+			<cp>3901.62</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5658.64</hp>
+			<mp>1909.5</mp>
+			<cp>3961.08</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5744</hp>
+			<mp>1938.6</mp>
+			<cp>4020.84</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5829.8</hp>
+			<mp>1967.85</mp>
+			<cp>4080.92</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5916.04</hp>
+			<mp>1997.25</mp>
+			<cp>4141.228</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/TreasureHunter.xml
+++ b/data/stats/chars/baseStats/TreasureHunter.xml
@@ -1,798 +1,926 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>8</classId>
-    <staticData>
-        <baseINT>21</baseINT>
-        <baseSTR>40</baseSTR>
-        <baseCON>43</baseCON>
-        <baseMEN>25</baseMEN>
-        <baseDEX>30</baseDEX>
-        <baseWIT>11</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-71338" y="258271" z="-3104"/>
-            <node x="-71417" y="258270" z="-3104"/>
-            <node x="-71453" y="258305" z="-3104"/>
-            <node x="-71467" y="258378" z="-3104"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>80</walk>
-            <run>132</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>100</baseBreath>
-        <baseSafeFall>250</baseSafeFall>
-        <collisionMale>
-            <radius>9.0</radius>
-            <height>23</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>8.0</radius>
-            <height>23.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>80.0</hp>
-            <mp>30.0</mp>
-            <cp>44.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>91.83</hp>
-            <mp>35.46</mp>
-            <cp>50.5065</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>103.79</hp>
-            <mp>40.98</mp>
-            <cp>57.0845</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>115.88</hp>
-            <mp>46.56</mp>
-            <cp>63.734</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>128.1</hp>
-            <mp>52.2</mp>
-            <cp>70.455</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>140.45</hp>
-            <mp>57.9</mp>
-            <cp>77.2475</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>152.93</hp>
-            <mp>63.66</mp>
-            <cp>84.1115</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>165.54</hp>
-            <mp>69.48</mp>
-            <cp>91.047</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>178.28</hp>
-            <mp>75.36</mp>
-            <cp>98.054</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>191.15</hp>
-            <mp>81.3</mp>
-            <cp>105.1325</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>204.15</hp>
-            <mp>87.3</mp>
-            <cp>112.2825</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>217.28</hp>
-            <mp>93.36</mp>
-            <cp>119.504</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>230.54</hp>
-            <mp>99.48</mp>
-            <cp>126.797</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>243.93</hp>
-            <mp>105.66</mp>
-            <cp>134.1615</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>257.45</hp>
-            <mp>111.9</mp>
-            <cp>141.5975</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>271.1</hp>
-            <mp>118.2</mp>
-            <cp>149.105</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>284.88</hp>
-            <mp>124.56</mp>
-            <cp>156.684</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>298.79</hp>
-            <mp>130.98</mp>
-            <cp>164.3345</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>312.83</hp>
-            <mp>137.46</mp>
-            <cp>172.0565</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>327.0</hp>
-            <mp>144.0</mp>
-            <cp>179.85</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>354.5</hp>
-            <mp>153.9</mp>
-            <cp>194.975</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>382.25</hp>
-            <mp>163.89</mp>
-            <cp>210.2375</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>410.25</hp>
-            <mp>173.97</mp>
-            <cp>225.6375</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>438.5</hp>
-            <mp>184.14</mp>
-            <cp>241.175</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>467.0</hp>
-            <mp>194.4</mp>
-            <cp>256.85</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>495.75</hp>
-            <mp>204.75</mp>
-            <cp>272.6625</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>524.75</hp>
-            <mp>215.19</mp>
-            <cp>288.6125</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>554.0</hp>
-            <mp>225.72</mp>
-            <cp>304.7</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>583.5</hp>
-            <mp>236.34</mp>
-            <cp>320.925</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>613.25</hp>
-            <mp>247.05</mp>
-            <cp>337.2875</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>643.25</hp>
-            <mp>257.85</mp>
-            <cp>353.7875</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>673.5</hp>
-            <mp>268.74</mp>
-            <cp>370.425</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>704.0</hp>
-            <mp>279.72</mp>
-            <cp>387.2</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>734.75</hp>
-            <mp>290.79</mp>
-            <cp>404.1125</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>765.75</hp>
-            <mp>301.95</mp>
-            <cp>421.1625</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>797.0</hp>
-            <mp>313.2</mp>
-            <cp>438.35</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>828.5</hp>
-            <mp>324.54</mp>
-            <cp>455.675</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>860.25</hp>
-            <mp>335.97</mp>
-            <cp>473.1375</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>892.25</hp>
-            <mp>347.49</mp>
-            <cp>490.7375</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>924.5</hp>
-            <mp>359.1</mp>
-            <cp>508.475</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>966.1</hp>
-            <mp>378.6</mp>
-            <cp>531.355</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1008.02</hp>
-            <mp>398.25</mp>
-            <cp>554.411</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1050.26</hp>
-            <mp>418.05</mp>
-            <cp>577.643</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1092.82</hp>
-            <mp>438.0</mp>
-            <cp>601.051</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1135.7</hp>
-            <mp>458.1</mp>
-            <cp>624.635</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1178.9</hp>
-            <mp>478.35</mp>
-            <cp>648.395</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1222.42</hp>
-            <mp>498.75</mp>
-            <cp>672.331</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1266.26</hp>
-            <mp>519.3</mp>
-            <cp>696.443</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1310.42</hp>
-            <mp>540.0</mp>
-            <cp>720.731</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1354.9</hp>
-            <mp>560.85</mp>
-            <cp>745.195</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1399.7</hp>
-            <mp>581.85</mp>
-            <cp>769.835</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1444.82</hp>
-            <mp>603.0</mp>
-            <cp>794.651</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1490.26</hp>
-            <mp>624.3</mp>
-            <cp>819.643</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1536.02</hp>
-            <mp>645.75</mp>
-            <cp>844.811</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1582.1</hp>
-            <mp>667.35</mp>
-            <cp>870.155</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1628.5</hp>
-            <mp>689.1</mp>
-            <cp>895.675</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1675.22</hp>
-            <mp>711.0</mp>
-            <cp>921.371</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1722.26</hp>
-            <mp>733.05</mp>
-            <cp>947.243</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>1769.62</hp>
-            <mp>755.25</mp>
-            <cp>973.291</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>1817.3</hp>
-            <mp>777.6</mp>
-            <cp>999.515</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>1865.3</hp>
-            <mp>800.1</mp>
-            <cp>1025.915</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>1913.62</hp>
-            <mp>822.75</mp>
-            <cp>1052.491</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>1962.26</hp>
-            <mp>845.55</mp>
-            <cp>1079.243</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2011.22</hp>
-            <mp>868.5</mp>
-            <cp>1106.171</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2060.5</hp>
-            <mp>891.6</mp>
-            <cp>1133.275</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2110.1</hp>
-            <mp>914.85</mp>
-            <cp>1160.555</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2160.02</hp>
-            <mp>938.25</mp>
-            <cp>1188.011</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2210.26</hp>
-            <mp>961.8</mp>
-            <cp>1215.643</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2260.82</hp>
-            <mp>985.5</mp>
-            <cp>1243.451</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2311.7</hp>
-            <mp>1009.35</mp>
-            <cp>1271.435</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2362.9</hp>
-            <mp>1033.35</mp>
-            <cp>1299.595</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2414.42</hp>
-            <mp>1057.5</mp>
-            <cp>1327.931</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2466.26</hp>
-            <mp>1081.8</mp>
-            <cp>1356.443</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2518.42</hp>
-            <mp>1106.25</mp>
-            <cp>1385.131</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2570.9</hp>
-            <mp>1130.85</mp>
-            <cp>1413.995</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>2623.7</hp>
-            <mp>1155.6</mp>
-            <cp>1443.035</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>2676.82</hp>
-            <mp>1180.5</mp>
-            <cp>1472.251</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>2730.26</hp>
-            <mp>1205.55</mp>
-            <cp>1501.643</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>2784.02</hp>
-            <mp>1230.75</mp>
-            <cp>1531.211</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>2838.1</hp>
-            <mp>1256.1</mp>
-            <cp>1560.955</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>2892.5</hp>
-            <mp>1281.6</mp>
-            <cp>1590.875</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>2947.22</hp>
-            <mp>1307.25</mp>
-            <cp>1620.971</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3002.26</hp>
-            <mp>1333.05</mp>
-            <cp>1651.243</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3057.62</hp>
-            <mp>1359.0</mp>
-            <cp>1681.691</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3113.3</hp>
-            <mp>1385.1</mp>
-            <cp>1712.315</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3169.3</hp>
-            <mp>1411.35</mp>
-            <cp>1743.115</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3225.62</hp>
-            <mp>1437.75</mp>
-            <cp>1774.091</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3282.26</hp>
-            <mp>1464.3</mp>
-            <cp>1805.243</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3339.22</hp>
-            <mp>1491.0</mp>
-            <cp>1836.571</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3396.5</hp>
-            <mp>1517.85</mp>
-            <cp>1868.075</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>3454.1</hp>
-            <mp>1544.85</mp>
-            <cp>1899.755</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>8</classId>
+	<staticData>
+		<baseINT>21</baseINT>
+		<baseSTR>40</baseSTR>
+		<baseCON>43</baseCON>
+		<baseMEN>25</baseMEN>
+		<baseDEX>30</baseDEX>
+		<baseWIT>11</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-71338" y="258271" z="-3104" />
+			<node x="-71417" y="258270" z="-3104" />
+			<node x="-71453" y="258305" z="-3104" />
+			<node x="-71467" y="258378" z="-3104" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>80</walk>
+			<run>132</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>250</baseSafeFall>
+		<collisionMale>
+			<radius>9.0</radius>
+			<height>23</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>8.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>80.0</hp>
+			<mp>30.0</mp>
+			<cp>44.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>91.83</hp>
+			<mp>35.46</mp>
+			<cp>50.5065</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>103.79</hp>
+			<mp>40.98</mp>
+			<cp>57.0845</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>115.88</hp>
+			<mp>46.56</mp>
+			<cp>63.734</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>128.1</hp>
+			<mp>52.2</mp>
+			<cp>70.455</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>140.45</hp>
+			<mp>57.9</mp>
+			<cp>77.2475</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>152.93</hp>
+			<mp>63.66</mp>
+			<cp>84.1115</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>165.54</hp>
+			<mp>69.48</mp>
+			<cp>91.047</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>178.28</hp>
+			<mp>75.36</mp>
+			<cp>98.054</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>191.15</hp>
+			<mp>81.3</mp>
+			<cp>105.1325</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>204.15</hp>
+			<mp>87.3</mp>
+			<cp>112.2825</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>217.28</hp>
+			<mp>93.36</mp>
+			<cp>119.504</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>230.54</hp>
+			<mp>99.48</mp>
+			<cp>126.797</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>243.93</hp>
+			<mp>105.66</mp>
+			<cp>134.1615</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>257.45</hp>
+			<mp>111.9</mp>
+			<cp>141.5975</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>271.1</hp>
+			<mp>118.2</mp>
+			<cp>149.105</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>284.88</hp>
+			<mp>124.56</mp>
+			<cp>156.684</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>298.79</hp>
+			<mp>130.98</mp>
+			<cp>164.3345</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>312.83</hp>
+			<mp>137.46</mp>
+			<cp>172.0565</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>327.0</hp>
+			<mp>144.0</mp>
+			<cp>179.85</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>354.5</hp>
+			<mp>153.9</mp>
+			<cp>194.975</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>382.25</hp>
+			<mp>163.89</mp>
+			<cp>210.2375</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>410.25</hp>
+			<mp>173.97</mp>
+			<cp>225.6375</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>438.5</hp>
+			<mp>184.14</mp>
+			<cp>241.175</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>467.0</hp>
+			<mp>194.4</mp>
+			<cp>256.85</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>495.75</hp>
+			<mp>204.75</mp>
+			<cp>272.6625</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>524.75</hp>
+			<mp>215.19</mp>
+			<cp>288.6125</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>554.0</hp>
+			<mp>225.72</mp>
+			<cp>304.7</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>583.5</hp>
+			<mp>236.34</mp>
+			<cp>320.925</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>613.25</hp>
+			<mp>247.05</mp>
+			<cp>337.2875</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>643.25</hp>
+			<mp>257.85</mp>
+			<cp>353.7875</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>673.5</hp>
+			<mp>268.74</mp>
+			<cp>370.425</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>704.0</hp>
+			<mp>279.72</mp>
+			<cp>387.2</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>734.75</hp>
+			<mp>290.79</mp>
+			<cp>404.1125</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>765.75</hp>
+			<mp>301.95</mp>
+			<cp>421.1625</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>797.0</hp>
+			<mp>313.2</mp>
+			<cp>438.35</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>828.5</hp>
+			<mp>324.54</mp>
+			<cp>455.675</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>860.25</hp>
+			<mp>335.97</mp>
+			<cp>473.1375</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>892.25</hp>
+			<mp>347.49</mp>
+			<cp>490.7375</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>924.5</hp>
+			<mp>359.1</mp>
+			<cp>508.475</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>966.1</hp>
+			<mp>378.6</mp>
+			<cp>531.355</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1008.02</hp>
+			<mp>398.25</mp>
+			<cp>554.411</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1050.26</hp>
+			<mp>418.05</mp>
+			<cp>577.643</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1092.82</hp>
+			<mp>438.0</mp>
+			<cp>601.051</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1135.7</hp>
+			<mp>458.1</mp>
+			<cp>624.635</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1178.9</hp>
+			<mp>478.35</mp>
+			<cp>648.395</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1222.42</hp>
+			<mp>498.75</mp>
+			<cp>672.331</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1266.26</hp>
+			<mp>519.3</mp>
+			<cp>696.443</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1310.42</hp>
+			<mp>540.0</mp>
+			<cp>720.731</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1354.9</hp>
+			<mp>560.85</mp>
+			<cp>745.195</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1399.7</hp>
+			<mp>581.85</mp>
+			<cp>769.835</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1444.82</hp>
+			<mp>603.0</mp>
+			<cp>794.651</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1490.26</hp>
+			<mp>624.3</mp>
+			<cp>819.643</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1536.02</hp>
+			<mp>645.75</mp>
+			<cp>844.811</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1582.1</hp>
+			<mp>667.35</mp>
+			<cp>870.155</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1628.5</hp>
+			<mp>689.1</mp>
+			<cp>895.675</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1675.22</hp>
+			<mp>711.0</mp>
+			<cp>921.371</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1722.26</hp>
+			<mp>733.05</mp>
+			<cp>947.243</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1769.62</hp>
+			<mp>755.25</mp>
+			<cp>973.291</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1817.3</hp>
+			<mp>777.6</mp>
+			<cp>999.515</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>1865.3</hp>
+			<mp>800.1</mp>
+			<cp>1025.915</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>1913.62</hp>
+			<mp>822.75</mp>
+			<cp>1052.491</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>1962.26</hp>
+			<mp>845.55</mp>
+			<cp>1079.243</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2011.22</hp>
+			<mp>868.5</mp>
+			<cp>1106.171</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2060.5</hp>
+			<mp>891.6</mp>
+			<cp>1133.275</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2110.1</hp>
+			<mp>914.85</mp>
+			<cp>1160.555</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2160.02</hp>
+			<mp>938.25</mp>
+			<cp>1188.011</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2210.26</hp>
+			<mp>961.8</mp>
+			<cp>1215.643</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2260.82</hp>
+			<mp>985.5</mp>
+			<cp>1243.451</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2311.7</hp>
+			<mp>1009.35</mp>
+			<cp>1271.435</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2362.9</hp>
+			<mp>1033.35</mp>
+			<cp>1299.595</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2414.42</hp>
+			<mp>1057.5</mp>
+			<cp>1327.931</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2466.26</hp>
+			<mp>1081.8</mp>
+			<cp>1356.443</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2518.42</hp>
+			<mp>1106.25</mp>
+			<cp>1385.131</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2570.9</hp>
+			<mp>1130.85</mp>
+			<cp>1413.995</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>2623.7</hp>
+			<mp>1155.6</mp>
+			<cp>1443.035</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>2676.82</hp>
+			<mp>1180.5</mp>
+			<cp>1472.251</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>2730.26</hp>
+			<mp>1205.55</mp>
+			<cp>1501.643</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>2784.02</hp>
+			<mp>1230.75</mp>
+			<cp>1531.211</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>2838.1</hp>
+			<mp>1256.1</mp>
+			<cp>1560.955</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>2892.5</hp>
+			<mp>1281.6</mp>
+			<cp>1590.875</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>2947.22</hp>
+			<mp>1307.25</mp>
+			<cp>1620.971</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3002.26</hp>
+			<mp>1333.05</mp>
+			<cp>1651.243</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3057.62</hp>
+			<mp>1359.0</mp>
+			<cp>1681.691</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3113.3</hp>
+			<mp>1385.1</mp>
+			<cp>1712.315</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3169.3</hp>
+			<mp>1411.35</mp>
+			<cp>1743.115</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3225.62</hp>
+			<mp>1437.75</mp>
+			<cp>1774.091</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3282.26</hp>
+			<mp>1464.3</mp>
+			<cp>1805.243</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3339.22</hp>
+			<mp>1491.0</mp>
+			<cp>1836.571</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3396.5</hp>
+			<mp>1517.85</mp>
+			<cp>1868.075</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3454.1</hp>
+			<mp>1544.85</mp>
+			<cp>1899.755</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>3512.02</hp>
+			<mp>1572.0</mp>
+			<cp>1931.611</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>3570.26</hp>
+			<mp>1599.3</mp>
+			<cp>1963.643</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>3628.82</hp>
+			<mp>1626.75</mp>
+			<cp>1995.851</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>3687.7</hp>
+			<mp>1654.35</mp>
+			<cp>2028.235</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>3746.9</hp>
+			<mp>1682.1</mp>
+			<cp>2060.795</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>3806.42</hp>
+			<mp>1710.0</mp>
+			<cp>2093.531</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>3866.26</hp>
+			<mp>1738.05</mp>
+			<cp>2126.443</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>3926.42</hp>
+			<mp>1766.25</mp>
+			<cp>2159.531</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>3986.9</hp>
+			<mp>1794.6</mp>
+			<cp>2192.8</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4047.7</hp>
+			<mp>1823.1</mp>
+			<cp>2226.25</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4108.82</hp>
+			<mp>1851.75</mp>
+			<cp>2259.88</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4170.26</hp>
+			<mp>1880.55</mp>
+			<cp>2293.68</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4232.02</hp>
+			<mp>1909.5</mp>
+			<cp>2327.67</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>4294.1</hp>
+			<mp>1938.6</mp>
+			<cp>2361.84</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>4356.5</hp>
+			<mp>1967.85</mp>
+			<cp>2396.19</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>4419.22</hp>
+			<mp>1997.25</mp>
+			<cp>2430.571</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Trickster.xml
+++ b/data/stats/chars/baseStats/Trickster.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>134</classId> <!-- TODO update data -->
-    <staticData>
-        <baseINT>25</baseINT>
-        <baseSTR>41</baseSTR>
-        <baseCON>27</baseCON>
-        <baseMEN>22</baseMEN>
-        <baseDEX>35</baseDEX>
-        <baseWIT>20</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-125607" y="38452" z="1152"/>
-            <node x="-125472" y="38450" z="1152"/>
-            <node x="-125615" y="37771" z="1152"/>
-            <node x="-125464" y="37776" z="1152"/>
-            <node x="-125517" y="38267" z="1155"/>
-            <node x="-125531" y="37944" z="1155"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>87</walk>
-            <run>140</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>100</baseBreath>
-        <baseSafeFall>500</baseSafeFall>
-        <collisionMale>
-            <radius>8.0</radius>
-            <height>25.2</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.0</radius>
-            <height>22.6</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>97.0</hp>
-            <mp>40.0</mp>
-            <cp>48.5</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>113.38</hp>
-            <mp>47.28</mp>
-            <cp>56.69</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>129.94</hp>
-            <mp>54.64</mp>
-            <cp>64.97</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>146.68</hp>
-            <mp>62.08</mp>
-            <cp>73.34</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>163.6</hp>
-            <mp>69.6</mp>
-            <cp>81.8</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>180.7</hp>
-            <mp>77.2</mp>
-            <cp>90.35</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>197.98</hp>
-            <mp>84.88</mp>
-            <cp>98.99</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>215.44</hp>
-            <mp>92.64</mp>
-            <cp>107.72</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>233.08</hp>
-            <mp>100.48</mp>
-            <cp>116.54</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>250.9</hp>
-            <mp>108.4</mp>
-            <cp>125.45</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>268.9</hp>
-            <mp>116.4</mp>
-            <cp>134.45</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>287.08</hp>
-            <mp>124.48</mp>
-            <cp>143.54</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>305.44</hp>
-            <mp>132.64</mp>
-            <cp>152.72</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>323.98</hp>
-            <mp>140.88</mp>
-            <cp>161.99</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>342.7</hp>
-            <mp>149.2</mp>
-            <cp>171.35</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>361.6</hp>
-            <mp>157.6</mp>
-            <cp>180.8</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>380.68</hp>
-            <mp>166.08</mp>
-            <cp>190.34</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>399.94</hp>
-            <mp>174.64</mp>
-            <cp>199.97</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>419.38</hp>
-            <mp>183.28</mp>
-            <cp>209.69</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>449.9</hp>
-            <mp>196.36</mp>
-            <cp>224.95</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>480.7</hp>
-            <mp>209.56</mp>
-            <cp>240.35</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>511.78</hp>
-            <mp>222.88</mp>
-            <cp>255.89</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>543.14</hp>
-            <mp>236.32</mp>
-            <cp>271.57</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>574.78</hp>
-            <mp>249.88</mp>
-            <cp>287.39</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>606.7</hp>
-            <mp>263.56</mp>
-            <cp>303.35</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>638.9</hp>
-            <mp>277.36</mp>
-            <cp>319.45</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>671.38</hp>
-            <mp>291.28</mp>
-            <cp>335.69</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>704.14</hp>
-            <mp>305.32</mp>
-            <cp>352.07</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>737.18</hp>
-            <mp>319.48</mp>
-            <cp>368.59</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>770.5</hp>
-            <mp>333.76</mp>
-            <cp>385.25</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>804.1</hp>
-            <mp>348.16</mp>
-            <cp>402.05</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>837.98</hp>
-            <mp>362.68</mp>
-            <cp>418.99</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>872.14</hp>
-            <mp>377.32</mp>
-            <cp>436.07</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>906.58</hp>
-            <mp>392.08</mp>
-            <cp>453.29</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>941.3</hp>
-            <mp>406.96</mp>
-            <cp>470.65</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>976.3</hp>
-            <mp>421.96</mp>
-            <cp>488.15</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>1011.58</hp>
-            <mp>437.08</mp>
-            <cp>505.79</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1047.14</hp>
-            <mp>452.32</mp>
-            <cp>523.57</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1082.98</hp>
-            <mp>467.68</mp>
-            <cp>541.49</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1139.74</hp>
-            <mp>487.03</mp>
-            <cp>569.87</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1196.94</hp>
-            <mp>506.53</mp>
-            <cp>598.47</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1254.58</hp>
-            <mp>526.18</mp>
-            <cp>627.29</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1312.66</hp>
-            <mp>545.98</mp>
-            <cp>656.33</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1371.18</hp>
-            <mp>565.93</mp>
-            <cp>685.59</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1430.14</hp>
-            <mp>586.03</mp>
-            <cp>715.07</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1489.54</hp>
-            <mp>606.28</mp>
-            <cp>744.77</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1549.38</hp>
-            <mp>626.68</mp>
-            <cp>774.69</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1609.66</hp>
-            <mp>647.23</mp>
-            <cp>804.83</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1670.38</hp>
-            <mp>667.93</mp>
-            <cp>835.19</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1731.54</hp>
-            <mp>688.78</mp>
-            <cp>865.77</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1793.14</hp>
-            <mp>709.78</mp>
-            <cp>896.57</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1855.18</hp>
-            <mp>730.93</mp>
-            <cp>927.59</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1917.66</hp>
-            <mp>752.23</mp>
-            <cp>958.83</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1980.58</hp>
-            <mp>773.68</mp>
-            <cp>990.29</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>2043.94</hp>
-            <mp>795.28</mp>
-            <cp>1021.97</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>2107.74</hp>
-            <mp>817.03</mp>
-            <cp>1053.87</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>2171.98</hp>
-            <mp>838.93</mp>
-            <cp>1085.99</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2236.66</hp>
-            <mp>860.98</mp>
-            <cp>1118.33</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2301.78</hp>
-            <mp>883.18</mp>
-            <cp>1150.89</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2367.34</hp>
-            <mp>905.53</mp>
-            <cp>1183.67</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2433.34</hp>
-            <mp>928.03</mp>
-            <cp>1216.67</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2499.78</hp>
-            <mp>950.68</mp>
-            <cp>1249.89</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2566.66</hp>
-            <mp>973.48</mp>
-            <cp>1283.33</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2633.98</hp>
-            <mp>996.43</mp>
-            <cp>1316.99</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2701.74</hp>
-            <mp>1019.53</mp>
-            <cp>1350.87</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2769.94</hp>
-            <mp>1042.78</mp>
-            <cp>1384.97</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2838.58</hp>
-            <mp>1066.18</mp>
-            <cp>1419.29</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2907.66</hp>
-            <mp>1089.73</mp>
-            <cp>1453.83</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2977.18</hp>
-            <mp>1113.43</mp>
-            <cp>1488.59</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>3047.14</hp>
-            <mp>1137.28</mp>
-            <cp>1523.57</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>3117.54</hp>
-            <mp>1161.28</mp>
-            <cp>1558.77</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>3188.38</hp>
-            <mp>1185.43</mp>
-            <cp>1594.19</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>3259.66</hp>
-            <mp>1209.73</mp>
-            <cp>1629.83</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>3331.38</hp>
-            <mp>1234.18</mp>
-            <cp>1665.69</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3403.54</hp>
-            <mp>1258.78</mp>
-            <cp>1701.77</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3476.14</hp>
-            <mp>1283.53</mp>
-            <cp>1738.07</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3549.18</hp>
-            <mp>1308.43</mp>
-            <cp>1774.59</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3622.66</hp>
-            <mp>1333.48</mp>
-            <cp>1811.33</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3696.58</hp>
-            <mp>1358.68</mp>
-            <cp>1848.29</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3770.94</hp>
-            <mp>1384.03</mp>
-            <cp>1885.47</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3845.74</hp>
-            <mp>1409.53</mp>
-            <cp>1922.87</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3920.98</hp>
-            <mp>1435.18</mp>
-            <cp>1960.49</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3996.66</hp>
-            <mp>1460.98</mp>
-            <cp>1998.33</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>4072.78</hp>
-            <mp>1486.93</mp>
-            <cp>2036.39</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>4149.34</hp>
-            <mp>1513.03</mp>
-            <cp>2074.67</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>4226.34</hp>
-            <mp>1539.28</mp>
-            <cp>2113.17</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>4303.78</hp>
-            <mp>1565.68</mp>
-            <cp>2151.89</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>4381.66</hp>
-            <mp>1592.23</mp>
-            <cp>2190.83</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>4459.98</hp>
-            <mp>1618.93</mp>
-            <cp>2229.99</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4538.74</hp>
-            <mp>1645.78</mp>
-            <cp>2269.37</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4617.94</hp>
-            <mp>1672.78</mp>
-            <cp>2308.97</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>134</classId>
+	<staticData>
+		<baseINT>25</baseINT>
+		<baseSTR>41</baseSTR>
+		<baseCON>27</baseCON>
+		<baseMEN>22</baseMEN>
+		<baseDEX>35</baseDEX>
+		<baseWIT>20</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-125607" y="38452" z="1152" />
+			<node x="-125472" y="38450" z="1152" />
+			<node x="-125615" y="37771" z="1152" />
+			<node x="-125464" y="37776" z="1152" />
+			<node x="-125517" y="38267" z="1155" />
+			<node x="-125531" y="37944" z="1155" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>87</walk>
+			<run>140</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>500</baseSafeFall>
+		<collisionMale>
+			<radius>8.0</radius>
+			<height>25.2</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.0</radius>
+			<height>22.6</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>97.0</hp>
+			<mp>40.0</mp>
+			<cp>48.5</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>113.38</hp>
+			<mp>47.28</mp>
+			<cp>56.69</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>129.94</hp>
+			<mp>54.64</mp>
+			<cp>64.97</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>146.68</hp>
+			<mp>62.08</mp>
+			<cp>73.34</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>163.6</hp>
+			<mp>69.6</mp>
+			<cp>81.8</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>180.7</hp>
+			<mp>77.2</mp>
+			<cp>90.35</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>197.98</hp>
+			<mp>84.88</mp>
+			<cp>98.99</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>215.44</hp>
+			<mp>92.64</mp>
+			<cp>107.72</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>233.08</hp>
+			<mp>100.48</mp>
+			<cp>116.54</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>250.9</hp>
+			<mp>108.4</mp>
+			<cp>125.45</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>268.9</hp>
+			<mp>116.4</mp>
+			<cp>134.45</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>287.08</hp>
+			<mp>124.48</mp>
+			<cp>143.54</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>305.44</hp>
+			<mp>132.64</mp>
+			<cp>152.72</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>323.98</hp>
+			<mp>140.88</mp>
+			<cp>161.99</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>342.7</hp>
+			<mp>149.2</mp>
+			<cp>171.35</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>361.6</hp>
+			<mp>157.6</mp>
+			<cp>180.8</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>380.68</hp>
+			<mp>166.08</mp>
+			<cp>190.34</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>399.94</hp>
+			<mp>174.64</mp>
+			<cp>199.97</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>419.38</hp>
+			<mp>183.28</mp>
+			<cp>209.69</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>449.9</hp>
+			<mp>196.36</mp>
+			<cp>224.95</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>480.7</hp>
+			<mp>209.56</mp>
+			<cp>240.35</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>511.78</hp>
+			<mp>222.88</mp>
+			<cp>255.89</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>543.14</hp>
+			<mp>236.32</mp>
+			<cp>271.57</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>574.78</hp>
+			<mp>249.88</mp>
+			<cp>287.39</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>606.7</hp>
+			<mp>263.56</mp>
+			<cp>303.35</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>638.9</hp>
+			<mp>277.36</mp>
+			<cp>319.45</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>671.38</hp>
+			<mp>291.28</mp>
+			<cp>335.69</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>704.14</hp>
+			<mp>305.32</mp>
+			<cp>352.07</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>737.18</hp>
+			<mp>319.48</mp>
+			<cp>368.59</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>770.5</hp>
+			<mp>333.76</mp>
+			<cp>385.25</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>804.1</hp>
+			<mp>348.16</mp>
+			<cp>402.05</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>837.98</hp>
+			<mp>362.68</mp>
+			<cp>418.99</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>872.14</hp>
+			<mp>377.32</mp>
+			<cp>436.07</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>906.58</hp>
+			<mp>392.08</mp>
+			<cp>453.29</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>941.3</hp>
+			<mp>406.96</mp>
+			<cp>470.65</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>976.3</hp>
+			<mp>421.96</mp>
+			<cp>488.15</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>1011.58</hp>
+			<mp>437.08</mp>
+			<cp>505.79</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1047.14</hp>
+			<mp>452.32</mp>
+			<cp>523.57</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1082.98</hp>
+			<mp>467.68</mp>
+			<cp>541.49</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1139.74</hp>
+			<mp>487.03</mp>
+			<cp>569.87</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1196.94</hp>
+			<mp>506.53</mp>
+			<cp>598.47</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1254.58</hp>
+			<mp>526.18</mp>
+			<cp>627.29</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1312.66</hp>
+			<mp>545.98</mp>
+			<cp>656.33</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1371.18</hp>
+			<mp>565.93</mp>
+			<cp>685.59</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1430.14</hp>
+			<mp>586.03</mp>
+			<cp>715.07</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1489.54</hp>
+			<mp>606.28</mp>
+			<cp>744.77</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1549.38</hp>
+			<mp>626.68</mp>
+			<cp>774.69</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1609.66</hp>
+			<mp>647.23</mp>
+			<cp>804.83</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1670.38</hp>
+			<mp>667.93</mp>
+			<cp>835.19</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1731.54</hp>
+			<mp>688.78</mp>
+			<cp>865.77</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1793.14</hp>
+			<mp>709.78</mp>
+			<cp>896.57</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1855.18</hp>
+			<mp>730.93</mp>
+			<cp>927.59</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1917.66</hp>
+			<mp>752.23</mp>
+			<cp>958.83</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1980.58</hp>
+			<mp>773.68</mp>
+			<cp>990.29</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>2043.94</hp>
+			<mp>795.28</mp>
+			<cp>1021.97</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>2107.74</hp>
+			<mp>817.03</mp>
+			<cp>1053.87</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2171.98</hp>
+			<mp>838.93</mp>
+			<cp>1085.99</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2236.66</hp>
+			<mp>860.98</mp>
+			<cp>1118.33</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2301.78</hp>
+			<mp>883.18</mp>
+			<cp>1150.89</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2367.34</hp>
+			<mp>905.53</mp>
+			<cp>1183.67</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2433.34</hp>
+			<mp>928.03</mp>
+			<cp>1216.67</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2499.78</hp>
+			<mp>950.68</mp>
+			<cp>1249.89</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2566.66</hp>
+			<mp>973.48</mp>
+			<cp>1283.33</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2633.98</hp>
+			<mp>996.43</mp>
+			<cp>1316.99</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2701.74</hp>
+			<mp>1019.53</mp>
+			<cp>1350.87</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2769.94</hp>
+			<mp>1042.78</mp>
+			<cp>1384.97</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2838.58</hp>
+			<mp>1066.18</mp>
+			<cp>1419.29</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2907.66</hp>
+			<mp>1089.73</mp>
+			<cp>1453.83</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2977.18</hp>
+			<mp>1113.43</mp>
+			<cp>1488.59</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>3047.14</hp>
+			<mp>1137.28</mp>
+			<cp>1523.57</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>3117.54</hp>
+			<mp>1161.28</mp>
+			<cp>1558.77</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>3188.38</hp>
+			<mp>1185.43</mp>
+			<cp>1594.19</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>3259.66</hp>
+			<mp>1209.73</mp>
+			<cp>1629.83</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3331.38</hp>
+			<mp>1234.18</mp>
+			<cp>1665.69</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3403.54</hp>
+			<mp>1258.78</mp>
+			<cp>1701.77</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3476.14</hp>
+			<mp>1283.53</mp>
+			<cp>1738.07</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3549.18</hp>
+			<mp>1308.43</mp>
+			<cp>1774.59</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3622.66</hp>
+			<mp>1333.48</mp>
+			<cp>1811.33</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3696.58</hp>
+			<mp>1358.68</mp>
+			<cp>1848.29</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3770.94</hp>
+			<mp>1384.03</mp>
+			<cp>1885.47</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3845.74</hp>
+			<mp>1409.53</mp>
+			<cp>1922.87</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3920.98</hp>
+			<mp>1435.18</mp>
+			<cp>1960.49</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3996.66</hp>
+			<mp>1460.98</mp>
+			<cp>1998.33</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>4072.78</hp>
+			<mp>1486.93</mp>
+			<cp>2036.39</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>4149.34</hp>
+			<mp>1513.03</mp>
+			<cp>2074.67</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>4226.34</hp>
+			<mp>1539.28</mp>
+			<cp>2113.17</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>4303.78</hp>
+			<mp>1565.68</mp>
+			<cp>2151.89</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4381.66</hp>
+			<mp>1592.23</mp>
+			<cp>2190.83</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4459.98</hp>
+			<mp>1618.93</mp>
+			<cp>2229.99</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4538.74</hp>
+			<mp>1645.78</mp>
+			<cp>2269.37</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4617.94</hp>
+			<mp>1672.78</mp>
+			<cp>2308.97</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4697.58</hp>
+			<mp>1699.93</mp>
+			<cp>2348.79</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4777.66</hp>
+			<mp>1727.23</mp>
+			<cp>2388.83</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4858.18</hp>
+			<mp>1754.68</mp>
+			<cp>2429.09</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4939.14</hp>
+			<mp>1782.28</mp>
+			<cp>2469.57</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>5020.54</hp>
+			<mp>1810.03</mp>
+			<cp>2510.27</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>5102.38</hp>
+			<mp>1837.93</mp>
+			<cp>2551.19</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>5184.66</hp>
+			<mp>1865.98</mp>
+			<cp>2592.33</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>5267.38</hp>
+			<mp>1894.18</mp>
+			<cp>2633.69</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>5350.54</hp>
+			<mp>1922.53</mp>
+			<cp>2675.27</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>5434.14</hp>
+			<mp>1951.03</mp>
+			<cp>2717.07</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5518.18</hp>
+			<mp>1979.68</mp>
+			<cp>2759.09</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5602.66</hp>
+			<mp>2008.48</mp>
+			<cp>2801.33</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5687.58</hp>
+			<mp>2037.43</mp>
+			<cp>2843.79</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5772.94</hp>
+			<mp>2066.53</mp>
+			<cp>2886.47</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5858.74</hp>
+			<mp>2095.78</mp>
+			<cp>2929.37</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5944.98</hp>
+			<mp>2125.18</mp>
+			<cp>2972.49</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Trooper.xml
+++ b/data/stats/chars/baseStats/Trooper.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>125</classId> <!-- TODO update data -->
-    <staticData>
-        <baseINT>25</baseINT>
-        <baseSTR>41</baseSTR>
-        <baseCON>27</baseCON>
-        <baseMEN>22</baseMEN>
-        <baseDEX>35</baseDEX>
-        <baseWIT>20</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-125607" y="38452" z="1152"/>
-            <node x="-125472" y="38450" z="1152"/>
-            <node x="-125615" y="37771" z="1152"/>
-            <node x="-125464" y="37776" z="1152"/>
-            <node x="-125517" y="38267" z="1155"/>
-            <node x="-125531" y="37944" z="1155"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>87</walk>
-            <run>140</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>100</baseBreath>
-        <baseSafeFall>500</baseSafeFall>
-        <collisionMale>
-            <radius>8.0</radius>
-            <height>25.2</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.0</radius>
-            <height>22.6</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>95.0</hp>
-            <mp>30.0</mp>
-            <cp>47.5</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>108.65</hp>
-            <mp>35.46</mp>
-            <cp>54.325</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>122.45</hp>
-            <mp>40.98</mp>
-            <cp>61.225</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>136.4</hp>
-            <mp>46.56</mp>
-            <cp>68.2</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>150.5</hp>
-            <mp>52.2</mp>
-            <cp>75.25</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>164.75</hp>
-            <mp>57.9</mp>
-            <cp>82.375</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>179.15</hp>
-            <mp>63.66</mp>
-            <cp>89.575</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>193.7</hp>
-            <mp>69.48</mp>
-            <cp>96.85</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>208.4</hp>
-            <mp>75.36</mp>
-            <cp>104.2</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>223.25</hp>
-            <mp>81.3</mp>
-            <cp>111.625</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>238.25</hp>
-            <mp>87.3</mp>
-            <cp>119.125</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>253.4</hp>
-            <mp>93.36</mp>
-            <cp>126.7</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>268.7</hp>
-            <mp>99.48</mp>
-            <cp>134.35</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>284.15</hp>
-            <mp>105.66</mp>
-            <cp>142.075</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>299.75</hp>
-            <mp>111.9</mp>
-            <cp>149.875</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>315.5</hp>
-            <mp>118.2</mp>
-            <cp>157.75</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>331.4</hp>
-            <mp>124.56</mp>
-            <cp>165.7</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>347.45</hp>
-            <mp>130.98</mp>
-            <cp>173.725</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>363.65</hp>
-            <mp>137.46</mp>
-            <cp>181.825</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>398.53</hp>
-            <mp>147.27</mp>
-            <cp>199.265</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>433.73</hp>
-            <mp>157.17</mp>
-            <cp>216.865</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>469.25</hp>
-            <mp>167.16</mp>
-            <cp>234.625</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>505.09</hp>
-            <mp>177.24</mp>
-            <cp>252.545</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>541.25</hp>
-            <mp>187.41</mp>
-            <cp>270.625</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>577.73</hp>
-            <mp>197.67</mp>
-            <cp>288.865</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>614.53</hp>
-            <mp>208.02</mp>
-            <cp>307.265</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>651.65</hp>
-            <mp>218.46</mp>
-            <cp>325.825</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>689.09</hp>
-            <mp>228.99</mp>
-            <cp>344.545</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>726.85</hp>
-            <mp>239.61</mp>
-            <cp>363.425</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>764.93</hp>
-            <mp>250.32</mp>
-            <cp>382.465</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>803.33</hp>
-            <mp>261.12</mp>
-            <cp>401.665</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>842.05</hp>
-            <mp>272.01</mp>
-            <cp>421.025</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>881.09</hp>
-            <mp>282.99</mp>
-            <cp>440.545</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>920.45</hp>
-            <mp>294.06</mp>
-            <cp>460.225</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>960.13</hp>
-            <mp>305.22</mp>
-            <cp>480.065</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>1000.13</hp>
-            <mp>316.47</mp>
-            <cp>500.065</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>1040.45</hp>
-            <mp>327.81</mp>
-            <cp>520.225</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1081.09</hp>
-            <mp>339.24</mp>
-            <cp>540.545</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1122.05</hp>
-            <mp>350.76</mp>
-            <cp>561.025</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1163.33</hp>
-            <mp>362.37</mp>
-            <cp>581.665</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1204.93</hp>
-            <mp>374.07</mp>
-            <cp>602.465</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1246.85</hp>
-            <mp>385.86</mp>
-            <cp>623.425</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1289.09</hp>
-            <mp>397.74</mp>
-            <cp>644.545</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1331.65</hp>
-            <mp>409.71</mp>
-            <cp>665.825</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1374.53</hp>
-            <mp>421.77</mp>
-            <cp>687.265</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1417.73</hp>
-            <mp>433.92</mp>
-            <cp>708.865</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1461.25</hp>
-            <mp>446.16</mp>
-            <cp>730.625</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1505.09</hp>
-            <mp>458.49</mp>
-            <cp>752.545</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1549.25</hp>
-            <mp>470.91</mp>
-            <cp>774.625</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1593.73</hp>
-            <mp>483.42</mp>
-            <cp>796.865</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1638.53</hp>
-            <mp>496.02</mp>
-            <cp>819.265</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1683.65</hp>
-            <mp>508.71</mp>
-            <cp>841.825</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1729.09</hp>
-            <mp>521.49</mp>
-            <cp>864.545</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1774.85</hp>
-            <mp>534.36</mp>
-            <cp>887.425</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1820.93</hp>
-            <mp>547.32</mp>
-            <cp>910.465</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1867.33</hp>
-            <mp>560.37</mp>
-            <cp>933.665</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1914.05</hp>
-            <mp>573.51</mp>
-            <cp>957.025</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1961.09</hp>
-            <mp>586.74</mp>
-            <cp>980.545</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2008.45</hp>
-            <mp>600.06</mp>
-            <cp>1004.225</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2056.13</hp>
-            <mp>613.47</mp>
-            <cp>1028.065</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2104.13</hp>
-            <mp>626.97</mp>
-            <cp>1052.065</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2152.45</hp>
-            <mp>640.56</mp>
-            <cp>1076.225</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2201.09</hp>
-            <mp>654.24</mp>
-            <cp>1100.545</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2250.05</hp>
-            <mp>668.01</mp>
-            <cp>1125.025</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2299.33</hp>
-            <mp>681.87</mp>
-            <cp>1149.665</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2348.93</hp>
-            <mp>695.82</mp>
-            <cp>1174.465</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2398.85</hp>
-            <mp>709.86</mp>
-            <cp>1199.425</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2449.09</hp>
-            <mp>723.99</mp>
-            <cp>1224.545</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2499.65</hp>
-            <mp>738.21</mp>
-            <cp>1249.825</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2550.53</hp>
-            <mp>752.52</mp>
-            <cp>1275.265</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2601.73</hp>
-            <mp>766.92</mp>
-            <cp>1300.865</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2653.25</hp>
-            <mp>781.41</mp>
-            <cp>1326.625</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2705.09</hp>
-            <mp>795.99</mp>
-            <cp>1352.545</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2757.25</hp>
-            <mp>810.66</mp>
-            <cp>1378.625</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2809.73</hp>
-            <mp>825.42</mp>
-            <cp>1404.865</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>2862.53</hp>
-            <mp>840.27</mp>
-            <cp>1431.265</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>2915.65</hp>
-            <mp>855.21</mp>
-            <cp>1457.825</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>2969.09</hp>
-            <mp>870.24</mp>
-            <cp>1484.545</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3022.85</hp>
-            <mp>885.36</mp>
-            <cp>1511.425</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3076.93</hp>
-            <mp>900.57</mp>
-            <cp>1538.465</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3131.33</hp>
-            <mp>915.87</mp>
-            <cp>1565.665</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3186.05</hp>
-            <mp>931.26</mp>
-            <cp>1593.025</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3241.09</hp>
-            <mp>946.74</mp>
-            <cp>1620.545</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3296.45</hp>
-            <mp>962.31</mp>
-            <cp>1648.225</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3352.13</hp>
-            <mp>977.97</mp>
-            <cp>1676.065</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3408.13</hp>
-            <mp>993.72</mp>
-            <cp>1704.065</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3464.45</hp>
-            <mp>1009.56</mp>
-            <cp>1732.225</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3521.09</hp>
-            <mp>1025.49</mp>
-            <cp>1760.545</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3578.05</hp>
-            <mp>1041.51</mp>
-            <cp>1789.025</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3635.33</hp>
-            <mp>1057.62</mp>
-            <cp>1817.665</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>3692.93</hp>
-            <mp>1073.82</mp>
-            <cp>1846.465</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>125</classId>
+	<staticData>
+		<baseINT>25</baseINT>
+		<baseSTR>41</baseSTR>
+		<baseCON>27</baseCON>
+		<baseMEN>22</baseMEN>
+		<baseDEX>35</baseDEX>
+		<baseWIT>20</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-125607" y="38452" z="1152" />
+			<node x="-125472" y="38450" z="1152" />
+			<node x="-125615" y="37771" z="1152" />
+			<node x="-125464" y="37776" z="1152" />
+			<node x="-125517" y="38267" z="1155" />
+			<node x="-125531" y="37944" z="1155" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>87</walk>
+			<run>140</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>500</baseSafeFall>
+		<collisionMale>
+			<radius>8.0</radius>
+			<height>25.2</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.0</radius>
+			<height>22.6</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>95.0</hp>
+			<mp>30.0</mp>
+			<cp>47.5</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>108.65</hp>
+			<mp>35.46</mp>
+			<cp>54.325</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>122.45</hp>
+			<mp>40.98</mp>
+			<cp>61.225</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>136.4</hp>
+			<mp>46.56</mp>
+			<cp>68.2</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>150.5</hp>
+			<mp>52.2</mp>
+			<cp>75.25</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>164.75</hp>
+			<mp>57.9</mp>
+			<cp>82.375</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>179.15</hp>
+			<mp>63.66</mp>
+			<cp>89.575</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>193.7</hp>
+			<mp>69.48</mp>
+			<cp>96.85</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>208.4</hp>
+			<mp>75.36</mp>
+			<cp>104.2</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>223.25</hp>
+			<mp>81.3</mp>
+			<cp>111.625</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>238.25</hp>
+			<mp>87.3</mp>
+			<cp>119.125</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>253.4</hp>
+			<mp>93.36</mp>
+			<cp>126.7</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>268.7</hp>
+			<mp>99.48</mp>
+			<cp>134.35</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>284.15</hp>
+			<mp>105.66</mp>
+			<cp>142.075</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>299.75</hp>
+			<mp>111.9</mp>
+			<cp>149.875</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>315.5</hp>
+			<mp>118.2</mp>
+			<cp>157.75</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>331.4</hp>
+			<mp>124.56</mp>
+			<cp>165.7</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>347.45</hp>
+			<mp>130.98</mp>
+			<cp>173.725</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>363.65</hp>
+			<mp>137.46</mp>
+			<cp>181.825</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>398.53</hp>
+			<mp>147.27</mp>
+			<cp>199.265</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>433.73</hp>
+			<mp>157.17</mp>
+			<cp>216.865</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>469.25</hp>
+			<mp>167.16</mp>
+			<cp>234.625</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>505.09</hp>
+			<mp>177.24</mp>
+			<cp>252.545</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>541.25</hp>
+			<mp>187.41</mp>
+			<cp>270.625</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>577.73</hp>
+			<mp>197.67</mp>
+			<cp>288.865</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>614.53</hp>
+			<mp>208.02</mp>
+			<cp>307.265</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>651.65</hp>
+			<mp>218.46</mp>
+			<cp>325.825</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>689.09</hp>
+			<mp>228.99</mp>
+			<cp>344.545</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>726.85</hp>
+			<mp>239.61</mp>
+			<cp>363.425</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>764.93</hp>
+			<mp>250.32</mp>
+			<cp>382.465</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>803.33</hp>
+			<mp>261.12</mp>
+			<cp>401.665</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>842.05</hp>
+			<mp>272.01</mp>
+			<cp>421.025</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>881.09</hp>
+			<mp>282.99</mp>
+			<cp>440.545</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>920.45</hp>
+			<mp>294.06</mp>
+			<cp>460.225</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>960.13</hp>
+			<mp>305.22</mp>
+			<cp>480.065</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>1000.13</hp>
+			<mp>316.47</mp>
+			<cp>500.065</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>1040.45</hp>
+			<mp>327.81</mp>
+			<cp>520.225</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1081.09</hp>
+			<mp>339.24</mp>
+			<cp>540.545</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1122.05</hp>
+			<mp>350.76</mp>
+			<cp>561.025</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1163.33</hp>
+			<mp>362.37</mp>
+			<cp>581.665</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1204.93</hp>
+			<mp>374.07</mp>
+			<cp>602.465</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1246.85</hp>
+			<mp>385.86</mp>
+			<cp>623.425</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1289.09</hp>
+			<mp>397.74</mp>
+			<cp>644.545</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1331.65</hp>
+			<mp>409.71</mp>
+			<cp>665.825</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1374.53</hp>
+			<mp>421.77</mp>
+			<cp>687.265</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1417.73</hp>
+			<mp>433.92</mp>
+			<cp>708.865</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1461.25</hp>
+			<mp>446.16</mp>
+			<cp>730.625</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1505.09</hp>
+			<mp>458.49</mp>
+			<cp>752.545</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1549.25</hp>
+			<mp>470.91</mp>
+			<cp>774.625</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1593.73</hp>
+			<mp>483.42</mp>
+			<cp>796.865</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1638.53</hp>
+			<mp>496.02</mp>
+			<cp>819.265</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1683.65</hp>
+			<mp>508.71</mp>
+			<cp>841.825</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1729.09</hp>
+			<mp>521.49</mp>
+			<cp>864.545</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1774.85</hp>
+			<mp>534.36</mp>
+			<cp>887.425</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1820.93</hp>
+			<mp>547.32</mp>
+			<cp>910.465</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1867.33</hp>
+			<mp>560.37</mp>
+			<cp>933.665</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1914.05</hp>
+			<mp>573.51</mp>
+			<cp>957.025</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1961.09</hp>
+			<mp>586.74</mp>
+			<cp>980.545</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2008.45</hp>
+			<mp>600.06</mp>
+			<cp>1004.225</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2056.13</hp>
+			<mp>613.47</mp>
+			<cp>1028.065</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2104.13</hp>
+			<mp>626.97</mp>
+			<cp>1052.065</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2152.45</hp>
+			<mp>640.56</mp>
+			<cp>1076.225</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2201.09</hp>
+			<mp>654.24</mp>
+			<cp>1100.545</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2250.05</hp>
+			<mp>668.01</mp>
+			<cp>1125.025</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2299.33</hp>
+			<mp>681.87</mp>
+			<cp>1149.665</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2348.93</hp>
+			<mp>695.82</mp>
+			<cp>1174.465</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2398.85</hp>
+			<mp>709.86</mp>
+			<cp>1199.425</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2449.09</hp>
+			<mp>723.99</mp>
+			<cp>1224.545</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2499.65</hp>
+			<mp>738.21</mp>
+			<cp>1249.825</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2550.53</hp>
+			<mp>752.52</mp>
+			<cp>1275.265</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2601.73</hp>
+			<mp>766.92</mp>
+			<cp>1300.865</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2653.25</hp>
+			<mp>781.41</mp>
+			<cp>1326.625</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2705.09</hp>
+			<mp>795.99</mp>
+			<cp>1352.545</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2757.25</hp>
+			<mp>810.66</mp>
+			<cp>1378.625</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2809.73</hp>
+			<mp>825.42</mp>
+			<cp>1404.865</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>2862.53</hp>
+			<mp>840.27</mp>
+			<cp>1431.265</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>2915.65</hp>
+			<mp>855.21</mp>
+			<cp>1457.825</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>2969.09</hp>
+			<mp>870.24</mp>
+			<cp>1484.545</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3022.85</hp>
+			<mp>885.36</mp>
+			<cp>1511.425</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3076.93</hp>
+			<mp>900.57</mp>
+			<cp>1538.465</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3131.33</hp>
+			<mp>915.87</mp>
+			<cp>1565.665</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3186.05</hp>
+			<mp>931.26</mp>
+			<cp>1593.025</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3241.09</hp>
+			<mp>946.74</mp>
+			<cp>1620.545</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3296.45</hp>
+			<mp>962.31</mp>
+			<cp>1648.225</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3352.13</hp>
+			<mp>977.97</mp>
+			<cp>1676.065</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3408.13</hp>
+			<mp>993.72</mp>
+			<cp>1704.065</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3464.45</hp>
+			<mp>1009.56</mp>
+			<cp>1732.225</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3521.09</hp>
+			<mp>1025.49</mp>
+			<cp>1760.545</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3578.05</hp>
+			<mp>1041.51</mp>
+			<cp>1789.025</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3635.33</hp>
+			<mp>1057.62</mp>
+			<cp>1817.665</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3692.93</hp>
+			<mp>1073.82</mp>
+			<cp>1846.465</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>3750.85</hp>
+			<mp>1090.11</mp>
+			<cp>1875.425</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>3809.09</hp>
+			<mp>1106.49</mp>
+			<cp>1904.545</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>3867.65</hp>
+			<mp>1122.96</mp>
+			<cp>1933.825</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>3926.53</hp>
+			<mp>1139.52</mp>
+			<cp>1963.265</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>3985.73</hp>
+			<mp>1156.17</mp>
+			<cp>1992.865</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4045.25</hp>
+			<mp>1172.91</mp>
+			<cp>2022.625</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4105.09</hp>
+			<mp>1189.74</mp>
+			<cp>2052.545</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4165.25</hp>
+			<mp>1206.66</mp>
+			<cp>2082.625</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4225.73</hp>
+			<mp>1223.67</mp>
+			<cp>2112.87</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4286.53</hp>
+			<mp>1240.77</mp>
+			<cp>2143.27</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4347.65</hp>
+			<mp>1257.96</mp>
+			<cp>2173.83</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4409.09</hp>
+			<mp>1275.24</mp>
+			<cp>2204.55</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4470.85</hp>
+			<mp>1292.61</mp>
+			<cp>2235.43</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>4532.93</hp>
+			<mp>1310.07</mp>
+			<cp>2266.47</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>4595.33</hp>
+			<mp>1327.62</mp>
+			<cp>2297.67</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>4658.05</hp>
+			<mp>1345.26</mp>
+			<cp>2329.025</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Tyrant.xml
+++ b/data/stats/chars/baseStats/Tyrant.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>48</classId>
-    <staticData>
-        <baseINT>18</baseINT>
-        <baseSTR>40</baseSTR>
-        <baseCON>47</baseCON>
-        <baseMEN>27</baseMEN>
-        <baseDEX>26</baseDEX>
-        <baseWIT>12</baseWIT>
-        <physicalAbnormalResist>15</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-56733" y="-113459" z="-690"/>
-            <node x="-56686" y="-113470" z="-690"/>
-            <node x="-56728" y="-113610" z="-690"/>
-            <node x="-56693" y="-113610" z="-690"/>
-            <node x="-56743" y="-113757" z="-690"/>
-            <node x="-56682" y="-113730" z="-690"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>25</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>70</walk>
-            <run>130</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>90</baseBreath>
-        <baseSafeFall>200</baseSafeFall>
-        <collisionMale>
-            <radius>11</radius>
-            <height>28.0</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7</radius>
-            <height>27.0</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>80.0</hp>
-            <mp>30.0</mp>
-            <cp>40.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>92.74</hp>
-            <mp>35.46</mp>
-            <cp>46.37</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>105.62</hp>
-            <mp>40.98</mp>
-            <cp>52.81</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>118.64</hp>
-            <mp>46.56</mp>
-            <cp>59.32</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>131.8</hp>
-            <mp>52.2</mp>
-            <cp>65.9</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>145.1</hp>
-            <mp>57.9</mp>
-            <cp>72.55</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>158.54</hp>
-            <mp>63.66</mp>
-            <cp>79.27</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>172.12</hp>
-            <mp>69.48</mp>
-            <cp>86.06</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>185.84</hp>
-            <mp>75.36</mp>
-            <cp>92.92</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>199.7</hp>
-            <mp>81.3</mp>
-            <cp>99.85</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>213.7</hp>
-            <mp>87.3</mp>
-            <cp>106.85</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>227.84</hp>
-            <mp>93.36</mp>
-            <cp>113.92</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>242.12</hp>
-            <mp>99.48</mp>
-            <cp>121.06</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>256.54</hp>
-            <mp>105.66</mp>
-            <cp>128.27</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>271.1</hp>
-            <mp>111.9</mp>
-            <cp>135.55</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>285.8</hp>
-            <mp>118.2</mp>
-            <cp>142.9</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>300.64</hp>
-            <mp>124.56</mp>
-            <cp>150.32</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>315.62</hp>
-            <mp>130.98</mp>
-            <cp>157.81</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>330.74</hp>
-            <mp>137.46</mp>
-            <cp>165.37</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>346.0</hp>
-            <mp>144.0</mp>
-            <cp>173.0</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>379.0</hp>
-            <mp>153.9</mp>
-            <cp>189.5</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>412.3</hp>
-            <mp>163.89</mp>
-            <cp>206.15</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>445.9</hp>
-            <mp>173.97</mp>
-            <cp>222.95</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>479.8</hp>
-            <mp>184.14</mp>
-            <cp>239.9</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>514.0</hp>
-            <mp>194.4</mp>
-            <cp>257.0</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>548.5</hp>
-            <mp>204.75</mp>
-            <cp>274.25</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>583.3</hp>
-            <mp>215.19</mp>
-            <cp>291.65</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>618.4</hp>
-            <mp>225.72</mp>
-            <cp>309.2</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>653.8</hp>
-            <mp>236.34</mp>
-            <cp>326.9</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>689.5</hp>
-            <mp>247.05</mp>
-            <cp>344.75</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>725.5</hp>
-            <mp>257.85</mp>
-            <cp>362.75</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>761.8</hp>
-            <mp>268.74</mp>
-            <cp>380.9</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>798.4</hp>
-            <mp>279.72</mp>
-            <cp>399.2</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>835.3</hp>
-            <mp>290.79</mp>
-            <cp>417.65</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>872.5</hp>
-            <mp>301.95</mp>
-            <cp>436.25</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>910.0</hp>
-            <mp>313.2</mp>
-            <cp>455.0</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>947.8</hp>
-            <mp>324.54</mp>
-            <cp>473.9</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>985.9</hp>
-            <mp>335.97</mp>
-            <cp>492.95</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1024.3</hp>
-            <mp>347.49</mp>
-            <cp>512.15</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1063.0</hp>
-            <mp>359.1</mp>
-            <cp>531.5</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1117.6</hp>
-            <mp>378.6</mp>
-            <cp>558.8</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1172.62</hp>
-            <mp>398.25</mp>
-            <cp>586.31</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1228.06</hp>
-            <mp>418.05</mp>
-            <cp>614.03</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1283.92</hp>
-            <mp>438.0</mp>
-            <cp>641.96</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1340.2</hp>
-            <mp>458.1</mp>
-            <cp>670.1</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1396.9</hp>
-            <mp>478.35</mp>
-            <cp>698.45</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1454.02</hp>
-            <mp>498.75</mp>
-            <cp>727.01</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1511.56</hp>
-            <mp>519.3</mp>
-            <cp>755.78</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1569.52</hp>
-            <mp>540.0</mp>
-            <cp>784.76</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1627.9</hp>
-            <mp>560.85</mp>
-            <cp>813.95</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1686.7</hp>
-            <mp>581.85</mp>
-            <cp>843.35</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1745.92</hp>
-            <mp>603.0</mp>
-            <cp>872.96</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1805.56</hp>
-            <mp>624.3</mp>
-            <cp>902.78</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1865.62</hp>
-            <mp>645.75</mp>
-            <cp>932.81</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1926.1</hp>
-            <mp>667.35</mp>
-            <cp>963.05</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1987.0</hp>
-            <mp>689.1</mp>
-            <cp>993.5</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>2048.32</hp>
-            <mp>711.0</mp>
-            <cp>1024.16</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2110.06</hp>
-            <mp>733.05</mp>
-            <cp>1055.03</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2172.22</hp>
-            <mp>755.25</mp>
-            <cp>1086.11</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2234.8</hp>
-            <mp>777.6</mp>
-            <cp>1117.4</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2297.8</hp>
-            <mp>800.1</mp>
-            <cp>1148.9</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2361.22</hp>
-            <mp>822.75</mp>
-            <cp>1180.61</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2425.06</hp>
-            <mp>845.55</mp>
-            <cp>1212.53</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2489.32</hp>
-            <mp>868.5</mp>
-            <cp>1244.66</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2554.0</hp>
-            <mp>891.6</mp>
-            <cp>1277.0</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2619.1</hp>
-            <mp>914.85</mp>
-            <cp>1309.55</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2684.62</hp>
-            <mp>938.25</mp>
-            <cp>1342.31</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2750.56</hp>
-            <mp>961.8</mp>
-            <cp>1375.28</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2816.92</hp>
-            <mp>985.5</mp>
-            <cp>1408.46</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2883.7</hp>
-            <mp>1009.35</mp>
-            <cp>1441.85</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2950.9</hp>
-            <mp>1033.35</mp>
-            <cp>1475.45</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>3018.52</hp>
-            <mp>1057.5</mp>
-            <cp>1509.26</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>3086.56</hp>
-            <mp>1081.8</mp>
-            <cp>1543.28</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>3155.02</hp>
-            <mp>1106.25</mp>
-            <cp>1577.51</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3223.9</hp>
-            <mp>1130.85</mp>
-            <cp>1611.95</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3293.2</hp>
-            <mp>1155.6</mp>
-            <cp>1646.6</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3362.92</hp>
-            <mp>1180.5</mp>
-            <cp>1681.46</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3433.06</hp>
-            <mp>1205.55</mp>
-            <cp>1716.53</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3503.62</hp>
-            <mp>1230.75</mp>
-            <cp>1751.81</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3574.6</hp>
-            <mp>1256.1</mp>
-            <cp>1787.3</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3646.0</hp>
-            <mp>1281.6</mp>
-            <cp>1823.0</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3717.82</hp>
-            <mp>1307.25</mp>
-            <cp>1858.91</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3790.06</hp>
-            <mp>1333.05</mp>
-            <cp>1895.03</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3862.72</hp>
-            <mp>1359.0</mp>
-            <cp>1931.36</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3935.8</hp>
-            <mp>1385.1</mp>
-            <cp>1967.9</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>4009.3</hp>
-            <mp>1411.35</mp>
-            <cp>2004.65</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>4083.22</hp>
-            <mp>1437.75</mp>
-            <cp>2041.61</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>4157.56</hp>
-            <mp>1464.3</mp>
-            <cp>2078.78</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>4232.32</hp>
-            <mp>1491.0</mp>
-            <cp>2116.16</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4307.5</hp>
-            <mp>1517.85</mp>
-            <cp>2153.75</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4383.1</hp>
-            <mp>1544.85</mp>
-            <cp>2191.55</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>48</classId>
+	<staticData>
+		<baseINT>18</baseINT>
+		<baseSTR>40</baseSTR>
+		<baseCON>47</baseCON>
+		<baseMEN>27</baseMEN>
+		<baseDEX>26</baseDEX>
+		<baseWIT>12</baseWIT>
+		<physicalAbnormalResist>15</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-56733" y="-113459" z="-690" />
+			<node x="-56686" y="-113470" z="-690" />
+			<node x="-56728" y="-113610" z="-690" />
+			<node x="-56693" y="-113610" z="-690" />
+			<node x="-56743" y="-113757" z="-690" />
+			<node x="-56682" y="-113730" z="-690" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>25</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>70</walk>
+			<run>130</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>90</baseBreath>
+		<baseSafeFall>200</baseSafeFall>
+		<collisionMale>
+			<radius>11</radius>
+			<height>28.0</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7</radius>
+			<height>27.0</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>80.0</hp>
+			<mp>30.0</mp>
+			<cp>40.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>92.74</hp>
+			<mp>35.46</mp>
+			<cp>46.37</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>105.62</hp>
+			<mp>40.98</mp>
+			<cp>52.81</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>118.64</hp>
+			<mp>46.56</mp>
+			<cp>59.32</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>131.8</hp>
+			<mp>52.2</mp>
+			<cp>65.9</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>145.1</hp>
+			<mp>57.9</mp>
+			<cp>72.55</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>158.54</hp>
+			<mp>63.66</mp>
+			<cp>79.27</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>172.12</hp>
+			<mp>69.48</mp>
+			<cp>86.06</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>185.84</hp>
+			<mp>75.36</mp>
+			<cp>92.92</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>199.7</hp>
+			<mp>81.3</mp>
+			<cp>99.85</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>213.7</hp>
+			<mp>87.3</mp>
+			<cp>106.85</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>227.84</hp>
+			<mp>93.36</mp>
+			<cp>113.92</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>242.12</hp>
+			<mp>99.48</mp>
+			<cp>121.06</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>256.54</hp>
+			<mp>105.66</mp>
+			<cp>128.27</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>271.1</hp>
+			<mp>111.9</mp>
+			<cp>135.55</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>285.8</hp>
+			<mp>118.2</mp>
+			<cp>142.9</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>300.64</hp>
+			<mp>124.56</mp>
+			<cp>150.32</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>315.62</hp>
+			<mp>130.98</mp>
+			<cp>157.81</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>330.74</hp>
+			<mp>137.46</mp>
+			<cp>165.37</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>346.0</hp>
+			<mp>144.0</mp>
+			<cp>173.0</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>379.0</hp>
+			<mp>153.9</mp>
+			<cp>189.5</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>412.3</hp>
+			<mp>163.89</mp>
+			<cp>206.15</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>445.9</hp>
+			<mp>173.97</mp>
+			<cp>222.95</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>479.8</hp>
+			<mp>184.14</mp>
+			<cp>239.9</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>514.0</hp>
+			<mp>194.4</mp>
+			<cp>257.0</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>548.5</hp>
+			<mp>204.75</mp>
+			<cp>274.25</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>583.3</hp>
+			<mp>215.19</mp>
+			<cp>291.65</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>618.4</hp>
+			<mp>225.72</mp>
+			<cp>309.2</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>653.8</hp>
+			<mp>236.34</mp>
+			<cp>326.9</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>689.5</hp>
+			<mp>247.05</mp>
+			<cp>344.75</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>725.5</hp>
+			<mp>257.85</mp>
+			<cp>362.75</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>761.8</hp>
+			<mp>268.74</mp>
+			<cp>380.9</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>798.4</hp>
+			<mp>279.72</mp>
+			<cp>399.2</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>835.3</hp>
+			<mp>290.79</mp>
+			<cp>417.65</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>872.5</hp>
+			<mp>301.95</mp>
+			<cp>436.25</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>910.0</hp>
+			<mp>313.2</mp>
+			<cp>455.0</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>947.8</hp>
+			<mp>324.54</mp>
+			<cp>473.9</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>985.9</hp>
+			<mp>335.97</mp>
+			<cp>492.95</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1024.3</hp>
+			<mp>347.49</mp>
+			<cp>512.15</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1063.0</hp>
+			<mp>359.1</mp>
+			<cp>531.5</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1117.6</hp>
+			<mp>378.6</mp>
+			<cp>558.8</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1172.62</hp>
+			<mp>398.25</mp>
+			<cp>586.31</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1228.06</hp>
+			<mp>418.05</mp>
+			<cp>614.03</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1283.92</hp>
+			<mp>438.0</mp>
+			<cp>641.96</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1340.2</hp>
+			<mp>458.1</mp>
+			<cp>670.1</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1396.9</hp>
+			<mp>478.35</mp>
+			<cp>698.45</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1454.02</hp>
+			<mp>498.75</mp>
+			<cp>727.01</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1511.56</hp>
+			<mp>519.3</mp>
+			<cp>755.78</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1569.52</hp>
+			<mp>540.0</mp>
+			<cp>784.76</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1627.9</hp>
+			<mp>560.85</mp>
+			<cp>813.95</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1686.7</hp>
+			<mp>581.85</mp>
+			<cp>843.35</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1745.92</hp>
+			<mp>603.0</mp>
+			<cp>872.96</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1805.56</hp>
+			<mp>624.3</mp>
+			<cp>902.78</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1865.62</hp>
+			<mp>645.75</mp>
+			<cp>932.81</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1926.1</hp>
+			<mp>667.35</mp>
+			<cp>963.05</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1987.0</hp>
+			<mp>689.1</mp>
+			<cp>993.5</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2048.32</hp>
+			<mp>711.0</mp>
+			<cp>1024.16</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2110.06</hp>
+			<mp>733.05</mp>
+			<cp>1055.03</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2172.22</hp>
+			<mp>755.25</mp>
+			<cp>1086.11</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2234.8</hp>
+			<mp>777.6</mp>
+			<cp>1117.4</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2297.8</hp>
+			<mp>800.1</mp>
+			<cp>1148.9</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2361.22</hp>
+			<mp>822.75</mp>
+			<cp>1180.61</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2425.06</hp>
+			<mp>845.55</mp>
+			<cp>1212.53</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2489.32</hp>
+			<mp>868.5</mp>
+			<cp>1244.66</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2554.0</hp>
+			<mp>891.6</mp>
+			<cp>1277.0</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2619.1</hp>
+			<mp>914.85</mp>
+			<cp>1309.55</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2684.62</hp>
+			<mp>938.25</mp>
+			<cp>1342.31</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2750.56</hp>
+			<mp>961.8</mp>
+			<cp>1375.28</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2816.92</hp>
+			<mp>985.5</mp>
+			<cp>1408.46</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2883.7</hp>
+			<mp>1009.35</mp>
+			<cp>1441.85</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2950.9</hp>
+			<mp>1033.35</mp>
+			<cp>1475.45</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>3018.52</hp>
+			<mp>1057.5</mp>
+			<cp>1509.26</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>3086.56</hp>
+			<mp>1081.8</mp>
+			<cp>1543.28</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3155.02</hp>
+			<mp>1106.25</mp>
+			<cp>1577.51</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3223.9</hp>
+			<mp>1130.85</mp>
+			<cp>1611.95</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3293.2</hp>
+			<mp>1155.6</mp>
+			<cp>1646.6</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3362.92</hp>
+			<mp>1180.5</mp>
+			<cp>1681.46</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3433.06</hp>
+			<mp>1205.55</mp>
+			<cp>1716.53</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3503.62</hp>
+			<mp>1230.75</mp>
+			<cp>1751.81</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3574.6</hp>
+			<mp>1256.1</mp>
+			<cp>1787.3</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3646.0</hp>
+			<mp>1281.6</mp>
+			<cp>1823.0</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3717.82</hp>
+			<mp>1307.25</mp>
+			<cp>1858.91</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3790.06</hp>
+			<mp>1333.05</mp>
+			<cp>1895.03</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3862.72</hp>
+			<mp>1359.0</mp>
+			<cp>1931.36</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3935.8</hp>
+			<mp>1385.1</mp>
+			<cp>1967.9</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>4009.3</hp>
+			<mp>1411.35</mp>
+			<cp>2004.65</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>4083.22</hp>
+			<mp>1437.75</mp>
+			<cp>2041.61</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4157.56</hp>
+			<mp>1464.3</mp>
+			<cp>2078.78</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4232.32</hp>
+			<mp>1491.0</mp>
+			<cp>2116.16</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4307.5</hp>
+			<mp>1517.85</mp>
+			<cp>2153.75</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4383.1</hp>
+			<mp>1544.85</mp>
+			<cp>2191.55</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4459.12</hp>
+			<mp>1572.0</mp>
+			<cp>2229.56</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4535.56</hp>
+			<mp>1599.3</mp>
+			<cp>2267.78</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4612.42</hp>
+			<mp>1626.75</mp>
+			<cp>2306.21</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4689.7</hp>
+			<mp>1654.35</mp>
+			<cp>2344.85</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4767.4</hp>
+			<mp>1682.1</mp>
+			<cp>2383.7</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4845.52</hp>
+			<mp>1710.0</mp>
+			<cp>2422.76</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4924.06</hp>
+			<mp>1738.05</mp>
+			<cp>2462.03</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>5003.02</hp>
+			<mp>1766.25</mp>
+			<cp>2501.51</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>5082.4</hp>
+			<mp>1794.6</mp>
+			<cp>2541.2</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>5162.2</hp>
+			<mp>1823.1</mp>
+			<cp>2581.1</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5242.42</hp>
+			<mp>1851.75</mp>
+			<cp>2621.21</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5323.06</hp>
+			<mp>1880.55</mp>
+			<cp>2661.53</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5404.12</hp>
+			<mp>1909.5</mp>
+			<cp>2702.06</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5485.6</hp>
+			<mp>1938.6</mp>
+			<cp>2742.8</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5567.5</hp>
+			<mp>1967.85</mp>
+			<cp>2783.75</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5649.82</hp>
+			<mp>1997.25</mp>
+			<cp>2824.91</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Warcryer.xml
+++ b/data/stats/chars/baseStats/Warcryer.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>52</classId>
-    <staticData>
-        <baseINT>31</baseINT>
-        <baseSTR>27</baseSTR>
-        <baseCON>31</baseCON>
-        <baseMEN>42</baseMEN>
-        <baseDEX>24</baseDEX>
-        <baseWIT>15</baseWIT>
-        <physicalAbnormalResist>15</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-56733" y="-113459" z="-690"/>
-            <node x="-56686" y="-113470" z="-690"/>
-            <node x="-56728" y="-113610" z="-690"/>
-            <node x="-56693" y="-113610" z="-690"/>
-            <node x="-56743" y="-113757" z="-690"/>
-            <node x="-56682" y="-113730" z="-690"/>
-        </creationPoints>
-        <basePAtk>3</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>15</chest>
-            <legs>8</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>25</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>70</walk>
-            <run>128</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>90</baseBreath>
-        <baseSafeFall>250</baseSafeFall>
-        <collisionMale>
-            <radius>7.0</radius>
-            <height>27.5</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>8.0</radius>
-            <height>25.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>95.0</hp>
-            <mp>40.0</mp>
-            <cp>47.5</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>110.47</hp>
-            <mp>47.28</mp>
-            <cp>55.235</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>126.11</hp>
-            <mp>54.64</mp>
-            <cp>63.055</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>141.92</hp>
-            <mp>62.08</mp>
-            <cp>70.96</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>157.9</hp>
-            <mp>69.6</mp>
-            <cp>78.95</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>174.05</hp>
-            <mp>77.2</mp>
-            <cp>87.025</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>190.37</hp>
-            <mp>84.88</mp>
-            <cp>95.185</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>206.86</hp>
-            <mp>92.64</mp>
-            <cp>103.43</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>223.52</hp>
-            <mp>100.48</mp>
-            <cp>111.76</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>240.35</hp>
-            <mp>108.4</mp>
-            <cp>120.175</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>257.35</hp>
-            <mp>116.4</mp>
-            <cp>128.675</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>274.52</hp>
-            <mp>124.48</mp>
-            <cp>137.26</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>291.86</hp>
-            <mp>132.64</mp>
-            <cp>145.93</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>309.37</hp>
-            <mp>140.88</mp>
-            <cp>154.685</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>327.05</hp>
-            <mp>149.2</mp>
-            <cp>163.525</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>344.9</hp>
-            <mp>157.6</mp>
-            <cp>172.45</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>362.92</hp>
-            <mp>166.08</mp>
-            <cp>181.46</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>381.11</hp>
-            <mp>174.64</mp>
-            <cp>190.555</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>399.47</hp>
-            <mp>183.28</mp>
-            <cp>199.735</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>418.0</hp>
-            <mp>192.0</mp>
-            <cp>209.0</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>453.2</hp>
-            <mp>205.2</mp>
-            <cp>226.6</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>488.72</hp>
-            <mp>218.52</mp>
-            <cp>244.36</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>524.56</hp>
-            <mp>231.96</mp>
-            <cp>262.28</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>560.72</hp>
-            <mp>245.52</mp>
-            <cp>280.36</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>597.2</hp>
-            <mp>259.2</mp>
-            <cp>298.6</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>634.0</hp>
-            <mp>273.0</mp>
-            <cp>317.0</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>671.12</hp>
-            <mp>286.92</mp>
-            <cp>335.56</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>708.56</hp>
-            <mp>300.96</mp>
-            <cp>354.28</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>746.32</hp>
-            <mp>315.12</mp>
-            <cp>373.16</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>784.4</hp>
-            <mp>329.4</mp>
-            <cp>392.2</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>822.8</hp>
-            <mp>343.8</mp>
-            <cp>411.4</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>861.52</hp>
-            <mp>358.32</mp>
-            <cp>430.76</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>900.56</hp>
-            <mp>372.96</mp>
-            <cp>450.28</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>939.92</hp>
-            <mp>387.72</mp>
-            <cp>469.96</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>979.6</hp>
-            <mp>402.6</mp>
-            <cp>489.8</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>1019.6</hp>
-            <mp>417.6</mp>
-            <cp>509.8</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>1059.92</hp>
-            <mp>432.72</mp>
-            <cp>529.96</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>1100.56</hp>
-            <mp>447.96</mp>
-            <cp>550.28</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1141.52</hp>
-            <mp>463.32</mp>
-            <cp>570.76</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1182.8</hp>
-            <mp>478.8</mp>
-            <cp>591.4</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1236.1</hp>
-            <mp>504.8</mp>
-            <cp>618.05</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1289.81</hp>
-            <mp>531.0</mp>
-            <cp>644.905</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1343.93</hp>
-            <mp>557.4</mp>
-            <cp>671.965</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1398.46</hp>
-            <mp>584.0</mp>
-            <cp>699.23</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1453.4</hp>
-            <mp>610.8</mp>
-            <cp>726.7</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1508.75</hp>
-            <mp>637.8</mp>
-            <cp>754.375</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1564.51</hp>
-            <mp>665.0</mp>
-            <cp>782.255</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1620.68</hp>
-            <mp>692.4</mp>
-            <cp>810.34</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1677.26</hp>
-            <mp>720.0</mp>
-            <cp>838.63</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1734.25</hp>
-            <mp>747.8</mp>
-            <cp>867.125</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1791.65</hp>
-            <mp>775.8</mp>
-            <cp>895.825</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1849.46</hp>
-            <mp>804.0</mp>
-            <cp>924.73</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1907.68</hp>
-            <mp>832.4</mp>
-            <cp>953.84</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1966.31</hp>
-            <mp>861.0</mp>
-            <cp>983.155</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>2025.35</hp>
-            <mp>889.8</mp>
-            <cp>1012.675</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>2084.8</hp>
-            <mp>918.8</mp>
-            <cp>1042.4</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>2144.66</hp>
-            <mp>948.0</mp>
-            <cp>1072.33</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2204.93</hp>
-            <mp>977.4</mp>
-            <cp>1102.465</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2265.61</hp>
-            <mp>1007.0</mp>
-            <cp>1132.805</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2326.7</hp>
-            <mp>1036.8</mp>
-            <cp>1163.35</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2388.2</hp>
-            <mp>1066.8</mp>
-            <cp>1194.1</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2450.11</hp>
-            <mp>1097.0</mp>
-            <cp>1225.055</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2512.43</hp>
-            <mp>1127.4</mp>
-            <cp>1256.215</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2575.16</hp>
-            <mp>1158.0</mp>
-            <cp>1287.58</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2638.3</hp>
-            <mp>1188.8</mp>
-            <cp>1319.15</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2701.85</hp>
-            <mp>1219.8</mp>
-            <cp>1350.925</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2765.81</hp>
-            <mp>1251.0</mp>
-            <cp>1382.905</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2830.18</hp>
-            <mp>1282.4</mp>
-            <cp>1415.09</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2894.96</hp>
-            <mp>1314.0</mp>
-            <cp>1447.48</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2960.15</hp>
-            <mp>1345.8</mp>
-            <cp>1480.075</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>3025.75</hp>
-            <mp>1377.8</mp>
-            <cp>1512.875</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>3091.76</hp>
-            <mp>1410.0</mp>
-            <cp>1545.88</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>3158.18</hp>
-            <mp>1442.4</mp>
-            <cp>1579.09</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>3225.01</hp>
-            <mp>1475.0</mp>
-            <cp>1612.505</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3292.25</hp>
-            <mp>1507.8</mp>
-            <cp>1646.125</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3359.9</hp>
-            <mp>1540.8</mp>
-            <cp>1679.95</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3427.96</hp>
-            <mp>1574.0</mp>
-            <cp>1713.98</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3496.43</hp>
-            <mp>1607.4</mp>
-            <cp>1748.215</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3565.31</hp>
-            <mp>1641.0</mp>
-            <cp>1782.655</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3634.6</hp>
-            <mp>1674.8</mp>
-            <cp>1817.3</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3704.3</hp>
-            <mp>1708.8</mp>
-            <cp>1852.15</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3774.41</hp>
-            <mp>1743.0</mp>
-            <cp>1887.205</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3844.93</hp>
-            <mp>1777.4</mp>
-            <cp>1922.465</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3915.86</hp>
-            <mp>1812.0</mp>
-            <cp>1957.93</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3987.2</hp>
-            <mp>1846.8</mp>
-            <cp>1993.6</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>4058.95</hp>
-            <mp>1881.8</mp>
-            <cp>2029.475</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>4131.11</hp>
-            <mp>1917.0</mp>
-            <cp>2065.555</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>4203.68</hp>
-            <mp>1952.4</mp>
-            <cp>2101.84</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>4276.66</hp>
-            <mp>1988.0</mp>
-            <cp>2138.33</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4350.05</hp>
-            <mp>2023.8</mp>
-            <cp>2175.025</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4423.85</hp>
-            <mp>2059.8</mp>
-            <cp>2211.925</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>52</classId>
+	<staticData>
+		<baseINT>31</baseINT>
+		<baseSTR>27</baseSTR>
+		<baseCON>31</baseCON>
+		<baseMEN>42</baseMEN>
+		<baseDEX>24</baseDEX>
+		<baseWIT>15</baseWIT>
+		<physicalAbnormalResist>15</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-56733" y="-113459" z="-690" />
+			<node x="-56686" y="-113470" z="-690" />
+			<node x="-56728" y="-113610" z="-690" />
+			<node x="-56693" y="-113610" z="-690" />
+			<node x="-56743" y="-113757" z="-690" />
+			<node x="-56682" y="-113730" z="-690" />
+		</creationPoints>
+		<basePAtk>3</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>15</chest>
+			<legs>8</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>25</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>70</walk>
+			<run>128</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>90</baseBreath>
+		<baseSafeFall>250</baseSafeFall>
+		<collisionMale>
+			<radius>7.0</radius>
+			<height>27.5</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>8.0</radius>
+			<height>25.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>95.0</hp>
+			<mp>40.0</mp>
+			<cp>47.5</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>110.47</hp>
+			<mp>47.28</mp>
+			<cp>55.235</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>126.11</hp>
+			<mp>54.64</mp>
+			<cp>63.055</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>141.92</hp>
+			<mp>62.08</mp>
+			<cp>70.96</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>157.9</hp>
+			<mp>69.6</mp>
+			<cp>78.95</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>174.05</hp>
+			<mp>77.2</mp>
+			<cp>87.025</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>190.37</hp>
+			<mp>84.88</mp>
+			<cp>95.185</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>206.86</hp>
+			<mp>92.64</mp>
+			<cp>103.43</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>223.52</hp>
+			<mp>100.48</mp>
+			<cp>111.76</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>240.35</hp>
+			<mp>108.4</mp>
+			<cp>120.175</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>257.35</hp>
+			<mp>116.4</mp>
+			<cp>128.675</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>274.52</hp>
+			<mp>124.48</mp>
+			<cp>137.26</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>291.86</hp>
+			<mp>132.64</mp>
+			<cp>145.93</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>309.37</hp>
+			<mp>140.88</mp>
+			<cp>154.685</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>327.05</hp>
+			<mp>149.2</mp>
+			<cp>163.525</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>344.9</hp>
+			<mp>157.6</mp>
+			<cp>172.45</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>362.92</hp>
+			<mp>166.08</mp>
+			<cp>181.46</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>381.11</hp>
+			<mp>174.64</mp>
+			<cp>190.555</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>399.47</hp>
+			<mp>183.28</mp>
+			<cp>199.735</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>418.0</hp>
+			<mp>192.0</mp>
+			<cp>209.0</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>453.2</hp>
+			<mp>205.2</mp>
+			<cp>226.6</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>488.72</hp>
+			<mp>218.52</mp>
+			<cp>244.36</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>524.56</hp>
+			<mp>231.96</mp>
+			<cp>262.28</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>560.72</hp>
+			<mp>245.52</mp>
+			<cp>280.36</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>597.2</hp>
+			<mp>259.2</mp>
+			<cp>298.6</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>634.0</hp>
+			<mp>273.0</mp>
+			<cp>317.0</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>671.12</hp>
+			<mp>286.92</mp>
+			<cp>335.56</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>708.56</hp>
+			<mp>300.96</mp>
+			<cp>354.28</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>746.32</hp>
+			<mp>315.12</mp>
+			<cp>373.16</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>784.4</hp>
+			<mp>329.4</mp>
+			<cp>392.2</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>822.8</hp>
+			<mp>343.8</mp>
+			<cp>411.4</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>861.52</hp>
+			<mp>358.32</mp>
+			<cp>430.76</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>900.56</hp>
+			<mp>372.96</mp>
+			<cp>450.28</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>939.92</hp>
+			<mp>387.72</mp>
+			<cp>469.96</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>979.6</hp>
+			<mp>402.6</mp>
+			<cp>489.8</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>1019.6</hp>
+			<mp>417.6</mp>
+			<cp>509.8</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>1059.92</hp>
+			<mp>432.72</mp>
+			<cp>529.96</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>1100.56</hp>
+			<mp>447.96</mp>
+			<cp>550.28</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1141.52</hp>
+			<mp>463.32</mp>
+			<cp>570.76</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1182.8</hp>
+			<mp>478.8</mp>
+			<cp>591.4</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1236.1</hp>
+			<mp>504.8</mp>
+			<cp>618.05</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1289.81</hp>
+			<mp>531.0</mp>
+			<cp>644.905</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1343.93</hp>
+			<mp>557.4</mp>
+			<cp>671.965</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1398.46</hp>
+			<mp>584.0</mp>
+			<cp>699.23</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1453.4</hp>
+			<mp>610.8</mp>
+			<cp>726.7</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1508.75</hp>
+			<mp>637.8</mp>
+			<cp>754.375</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1564.51</hp>
+			<mp>665.0</mp>
+			<cp>782.255</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1620.68</hp>
+			<mp>692.4</mp>
+			<cp>810.34</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1677.26</hp>
+			<mp>720.0</mp>
+			<cp>838.63</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1734.25</hp>
+			<mp>747.8</mp>
+			<cp>867.125</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1791.65</hp>
+			<mp>775.8</mp>
+			<cp>895.825</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1849.46</hp>
+			<mp>804.0</mp>
+			<cp>924.73</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1907.68</hp>
+			<mp>832.4</mp>
+			<cp>953.84</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1966.31</hp>
+			<mp>861.0</mp>
+			<cp>983.155</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>2025.35</hp>
+			<mp>889.8</mp>
+			<cp>1012.675</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>2084.8</hp>
+			<mp>918.8</mp>
+			<cp>1042.4</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2144.66</hp>
+			<mp>948.0</mp>
+			<cp>1072.33</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2204.93</hp>
+			<mp>977.4</mp>
+			<cp>1102.465</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2265.61</hp>
+			<mp>1007.0</mp>
+			<cp>1132.805</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2326.7</hp>
+			<mp>1036.8</mp>
+			<cp>1163.35</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2388.2</hp>
+			<mp>1066.8</mp>
+			<cp>1194.1</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2450.11</hp>
+			<mp>1097.0</mp>
+			<cp>1225.055</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2512.43</hp>
+			<mp>1127.4</mp>
+			<cp>1256.215</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2575.16</hp>
+			<mp>1158.0</mp>
+			<cp>1287.58</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2638.3</hp>
+			<mp>1188.8</mp>
+			<cp>1319.15</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2701.85</hp>
+			<mp>1219.8</mp>
+			<cp>1350.925</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2765.81</hp>
+			<mp>1251.0</mp>
+			<cp>1382.905</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2830.18</hp>
+			<mp>1282.4</mp>
+			<cp>1415.09</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2894.96</hp>
+			<mp>1314.0</mp>
+			<cp>1447.48</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2960.15</hp>
+			<mp>1345.8</mp>
+			<cp>1480.075</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>3025.75</hp>
+			<mp>1377.8</mp>
+			<cp>1512.875</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>3091.76</hp>
+			<mp>1410.0</mp>
+			<cp>1545.88</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>3158.18</hp>
+			<mp>1442.4</mp>
+			<cp>1579.09</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3225.01</hp>
+			<mp>1475.0</mp>
+			<cp>1612.505</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3292.25</hp>
+			<mp>1507.8</mp>
+			<cp>1646.125</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3359.9</hp>
+			<mp>1540.8</mp>
+			<cp>1679.95</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3427.96</hp>
+			<mp>1574.0</mp>
+			<cp>1713.98</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3496.43</hp>
+			<mp>1607.4</mp>
+			<cp>1748.215</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3565.31</hp>
+			<mp>1641.0</mp>
+			<cp>1782.655</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3634.6</hp>
+			<mp>1674.8</mp>
+			<cp>1817.3</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3704.3</hp>
+			<mp>1708.8</mp>
+			<cp>1852.15</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3774.41</hp>
+			<mp>1743.0</mp>
+			<cp>1887.205</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3844.93</hp>
+			<mp>1777.4</mp>
+			<cp>1922.465</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3915.86</hp>
+			<mp>1812.0</mp>
+			<cp>1957.93</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3987.2</hp>
+			<mp>1846.8</mp>
+			<cp>1993.6</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>4058.95</hp>
+			<mp>1881.8</mp>
+			<cp>2029.475</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>4131.11</hp>
+			<mp>1917.0</mp>
+			<cp>2065.555</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4203.68</hp>
+			<mp>1952.4</mp>
+			<cp>2101.84</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4276.66</hp>
+			<mp>1988.0</mp>
+			<cp>2138.33</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4350.05</hp>
+			<mp>2023.8</mp>
+			<cp>2175.025</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4423.85</hp>
+			<mp>2059.8</mp>
+			<cp>2211.925</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4498.06</hp>
+			<mp>2096.0</mp>
+			<cp>2249.03</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4572.68</hp>
+			<mp>2132.4</mp>
+			<cp>2286.34</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4647.71</hp>
+			<mp>2169.0</mp>
+			<cp>2323.855</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4723.15</hp>
+			<mp>2205.8</mp>
+			<cp>2361.575</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4799.0</hp>
+			<mp>2242.8</mp>
+			<cp>2399.5</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4875.26</hp>
+			<mp>2280.0</mp>
+			<cp>2437.63</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4951.93</hp>
+			<mp>2317.4</mp>
+			<cp>2475.965</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>5029.01</hp>
+			<mp>2355.0</mp>
+			<cp>2514.505</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>5106.5</hp>
+			<mp>2392.8</mp>
+			<cp>2553.25</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>5184.4</hp>
+			<mp>2430.8</mp>
+			<cp>2592.19</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5262.71</hp>
+			<mp>2469</mp>
+			<cp>2631.33</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5341.43</hp>
+			<mp>2507.4</mp>
+			<cp>2670.67</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5420.56</hp>
+			<mp>2546</mp>
+			<cp>2710.21</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5500.1</hp>
+			<mp>2584.8</mp>
+			<cp>2749.95</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5580.05</hp>
+			<mp>2623.8</mp>
+			<cp>2789.89</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5660.41</hp>
+			<mp>2663</mp>
+			<cp>2830.205</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Warder.xml
+++ b/data/stats/chars/baseStats/Warder.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>126</classId> <!-- TODO update data -->
+    <classId>126</classId>
     <staticData>
         <baseINT>25</baseINT>
         <baseSTR>41</baseSTR>
@@ -11,12 +11,12 @@
         <physicalAbnormalResist>10</physicalAbnormalResist>
         <magicAbnormalResist>10</magicAbnormalResist>
         <creationPoints>
-            <node x="-125607" y="38452" z="1152"/>
-            <node x="-125472" y="38450" z="1152"/>
-            <node x="-125615" y="37771" z="1152"/>
-            <node x="-125464" y="37776" z="1152"/>
-            <node x="-125517" y="38267" z="1155"/>
-            <node x="-125531" y="37944" z="1155"/>
+            <node x="-125607" y="38452" z="1152" />
+            <node x="-125472" y="38450" z="1152" />
+            <node x="-125615" y="37771" z="1152" />
+            <node x="-125464" y="37776" z="1152" />
+            <node x="-125517" y="38267" z="1155" />
+            <node x="-125531" y="37944" z="1155" />
         </creationPoints>
         <basePAtk>4</basePAtk>
         <baseCritRate>4</baseCritRate>
@@ -793,6 +793,134 @@
             <mp>1431.76</mp>
             <cp>1666.25</cp>
             <hpRegen>10.5</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="92">
+            <hp>3383.18</hp>
+            <mp>1453.48</mp>
+            <cp>1691.59</cp>
+            <hpRegen>10.6</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="93">
+            <hp>3434.14</hp>
+            <mp>1475.32</mp>
+            <cp>1717.07</cp>
+            <hpRegen>10.7</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="94">
+            <hp>3485.38</hp>
+            <mp>1497.28</mp>
+            <cp>1742.69</cp>
+            <hpRegen>10.8</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="95">
+            <hp>3536.9</hp>
+            <mp>1519.36</mp>
+            <cp>1768.45</cp>
+            <hpRegen>10.9</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="96">
+            <hp>3588.7</hp>
+            <mp>1541.56</mp>
+            <cp>1794.35</cp>
+            <hpRegen>11</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="97">
+            <hp>3640.78</hp>
+            <mp>1563.88</mp>
+            <cp>1820.39</cp>
+            <hpRegen>11.1</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="98">
+            <hp>3693.14</hp>
+            <mp>1586.32</mp>
+            <cp>1846.57</cp>
+            <hpRegen>11.2</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="99">
+            <hp>3745.78</hp>
+            <mp>1608.88</mp>
+            <cp>1872.89</cp>
+            <hpRegen>11.3</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="100">
+            <hp>3798.7</hp>
+            <mp>1631.56</mp>
+            <cp>1899.35</cp>
+            <hpRegen>11.4</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="101">
+            <hp>3851.9</hp>
+            <mp>1654.36</mp>
+            <cp>1925.95</cp>
+            <hpRegen>11.5</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="102">
+            <hp>3905.38</hp>
+            <mp>1677.28</mp>
+            <cp>1952.69</cp>
+            <hpRegen>11.6</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="103">
+            <hp>3959.14</hp>
+            <mp>1700.32</mp>
+            <cp>1979.57</cp>
+            <hpRegen>11.7</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="104">
+            <hp>4013.18</hp>
+            <mp>1723.48</mp>
+            <cp>2006.59</cp>
+            <hpRegen>11.8</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="105">
+            <hp>4067.5</hp>
+            <mp>1746.76</mp>
+            <cp>2033.75</cp>
+            <hpRegen>11.9</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="106">
+            <hp>4122.1</hp>
+            <mp>1770.16</mp>
+            <cp>2061.05</cp>
+            <hpRegen>12</hpRegen>
+            <mpRegen>3.0</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="107">
+            <hp>4176.98</hp>
+            <mp>1793.68</mp>
+            <cp>2088.49</cp>
+            <hpRegen>12.1</hpRegen>
             <mpRegen>3.0</mpRegen>
             <cpRegen>8.5</cpRegen>
         </level>

--- a/data/stats/chars/baseStats/Warlock.xml
+++ b/data/stats/chars/baseStats/Warlock.xml
@@ -1,798 +1,926 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>14</classId>
-    <staticData>
-        <baseINT>41</baseINT>
-        <baseSTR>22</baseSTR>
-        <baseCON>27</baseCON>
-        <baseMEN>39</baseMEN>
-        <baseDEX>21</baseDEX>
-        <baseWIT>20</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-90875" y="248162" z="-3570"/>
-            <node x="-90954" y="248118" z="-3570"/>
-            <node x="-90918" y="248070" z="-3570"/>
-            <node x="-90890" y="248027" z="-3570"/>
-        </creationPoints>
-        <basePAtk>3</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>15</chest>
-            <legs>8</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>78</walk>
-            <run>124</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>100</baseBreath>
-        <baseSafeFall>200</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>22.8</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>6.5</radius>
-            <height>22.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>101.0</hp>
-            <mp>40.0</mp>
-            <cp>60.6</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>116.47</hp>
-            <mp>47.28</mp>
-            <cp>69.882</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>132.11</hp>
-            <mp>54.64</mp>
-            <cp>79.266</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>147.92</hp>
-            <mp>62.08</mp>
-            <cp>88.752</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>163.9</hp>
-            <mp>69.6</mp>
-            <cp>98.34</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>180.05</hp>
-            <mp>77.2</mp>
-            <cp>108.03</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>196.37</hp>
-            <mp>84.88</mp>
-            <cp>117.822</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>212.86</hp>
-            <mp>92.64</mp>
-            <cp>127.716</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>229.52</hp>
-            <mp>100.48</mp>
-            <cp>137.712</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>246.35</hp>
-            <mp>108.4</mp>
-            <cp>147.81</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>263.35</hp>
-            <mp>116.4</mp>
-            <cp>158.01</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>280.52</hp>
-            <mp>124.48</mp>
-            <cp>168.312</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>297.86</hp>
-            <mp>132.64</mp>
-            <cp>178.716</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>315.37</hp>
-            <mp>140.88</mp>
-            <cp>189.222</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>333.05</hp>
-            <mp>149.2</mp>
-            <cp>199.83</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>350.9</hp>
-            <mp>157.6</mp>
-            <cp>210.54</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>368.92</hp>
-            <mp>166.08</mp>
-            <cp>221.352</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>387.11</hp>
-            <mp>174.64</mp>
-            <cp>232.266</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>405.47</hp>
-            <mp>183.28</mp>
-            <cp>243.282</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>424.0</hp>
-            <mp>192.0</mp>
-            <cp>254.4</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>451.5</hp>
-            <mp>205.2</mp>
-            <cp>270.9</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>479.25</hp>
-            <mp>218.52</mp>
-            <cp>287.55</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>507.25</hp>
-            <mp>231.96</mp>
-            <cp>304.35</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>535.5</hp>
-            <mp>245.52</mp>
-            <cp>321.3</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>564.0</hp>
-            <mp>259.2</mp>
-            <cp>338.4</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>592.75</hp>
-            <mp>273.0</mp>
-            <cp>355.65</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>621.75</hp>
-            <mp>286.92</mp>
-            <cp>373.05</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>651.0</hp>
-            <mp>300.96</mp>
-            <cp>390.6</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>680.5</hp>
-            <mp>315.12</mp>
-            <cp>408.3</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>710.25</hp>
-            <mp>329.4</mp>
-            <cp>426.15</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>740.25</hp>
-            <mp>343.8</mp>
-            <cp>444.15</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>770.5</hp>
-            <mp>358.32</mp>
-            <cp>462.3</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>801.0</hp>
-            <mp>372.96</mp>
-            <cp>480.6</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>831.75</hp>
-            <mp>387.72</mp>
-            <cp>499.05</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>862.75</hp>
-            <mp>402.6</mp>
-            <cp>517.65</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>894.0</hp>
-            <mp>417.6</mp>
-            <cp>536.4</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>925.5</hp>
-            <mp>432.72</mp>
-            <cp>555.3</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>957.25</hp>
-            <mp>447.96</mp>
-            <cp>574.35</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>989.25</hp>
-            <mp>463.32</mp>
-            <cp>593.55</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1021.5</hp>
-            <mp>478.8</mp>
-            <cp>612.9</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1070.9</hp>
-            <mp>504.8</mp>
-            <cp>642.54</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1120.68</hp>
-            <mp>531.0</mp>
-            <cp>672.408</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1170.84</hp>
-            <mp>557.4</mp>
-            <cp>702.504</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1221.38</hp>
-            <mp>584.0</mp>
-            <cp>732.828</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1272.3</hp>
-            <mp>610.8</mp>
-            <cp>763.38</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1323.6</hp>
-            <mp>637.8</mp>
-            <cp>794.16</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1375.28</hp>
-            <mp>665.0</mp>
-            <cp>825.168</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1427.34</hp>
-            <mp>692.4</mp>
-            <cp>856.404</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1479.78</hp>
-            <mp>720.0</mp>
-            <cp>887.868</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1532.6</hp>
-            <mp>747.8</mp>
-            <cp>919.56</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1585.8</hp>
-            <mp>775.8</mp>
-            <cp>951.48</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1639.38</hp>
-            <mp>804.0</mp>
-            <cp>983.628</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1693.34</hp>
-            <mp>832.4</mp>
-            <cp>1016.004</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1747.68</hp>
-            <mp>861.0</mp>
-            <cp>1048.608</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1802.4</hp>
-            <mp>889.8</mp>
-            <cp>1081.44</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1857.5</hp>
-            <mp>918.8</mp>
-            <cp>1114.5</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1912.98</hp>
-            <mp>948.0</mp>
-            <cp>1147.788</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1968.84</hp>
-            <mp>977.4</mp>
-            <cp>1181.304</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2025.08</hp>
-            <mp>1007.0</mp>
-            <cp>1215.048</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2081.7</hp>
-            <mp>1036.8</mp>
-            <cp>1249.02</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2138.7</hp>
-            <mp>1066.8</mp>
-            <cp>1283.22</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2196.08</hp>
-            <mp>1097.0</mp>
-            <cp>1317.648</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2253.84</hp>
-            <mp>1127.4</mp>
-            <cp>1352.304</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2311.98</hp>
-            <mp>1158.0</mp>
-            <cp>1387.188</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2370.5</hp>
-            <mp>1188.8</mp>
-            <cp>1422.3</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2429.4</hp>
-            <mp>1219.8</mp>
-            <cp>1457.64</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2488.68</hp>
-            <mp>1251.0</mp>
-            <cp>1493.208</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2548.34</hp>
-            <mp>1282.4</mp>
-            <cp>1529.004</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2608.38</hp>
-            <mp>1314.0</mp>
-            <cp>1565.028</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2668.8</hp>
-            <mp>1345.8</mp>
-            <cp>1601.28</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2729.6</hp>
-            <mp>1377.8</mp>
-            <cp>1637.76</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2790.78</hp>
-            <mp>1410.0</mp>
-            <cp>1674.468</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2852.34</hp>
-            <mp>1442.4</mp>
-            <cp>1711.404</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2914.28</hp>
-            <mp>1475.0</mp>
-            <cp>1748.568</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2976.6</hp>
-            <mp>1507.8</mp>
-            <cp>1785.96</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3039.3</hp>
-            <mp>1540.8</mp>
-            <cp>1823.58</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3102.38</hp>
-            <mp>1574.0</mp>
-            <cp>1861.428</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3165.84</hp>
-            <mp>1607.4</mp>
-            <cp>1899.504</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3229.68</hp>
-            <mp>1641.0</mp>
-            <cp>1937.808</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3293.9</hp>
-            <mp>1674.8</mp>
-            <cp>1976.34</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3358.5</hp>
-            <mp>1708.8</mp>
-            <cp>2015.1</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3423.48</hp>
-            <mp>1743.0</mp>
-            <cp>2054.088</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3488.84</hp>
-            <mp>1777.4</mp>
-            <cp>2093.304</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3554.58</hp>
-            <mp>1812.0</mp>
-            <cp>2132.748</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3620.7</hp>
-            <mp>1846.8</mp>
-            <cp>2172.42</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3687.2</hp>
-            <mp>1881.8</mp>
-            <cp>2212.32</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3754.08</hp>
-            <mp>1917.0</mp>
-            <cp>2252.448</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3821.34</hp>
-            <mp>1952.4</mp>
-            <cp>2292.804</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3888.98</hp>
-            <mp>1988.0</mp>
-            <cp>2333.388</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3957.0</hp>
-            <mp>2023.8</mp>
-            <cp>2374.2</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4025.4</hp>
-            <mp>2059.8</mp>
-            <cp>2415.24</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>14</classId>
+	<staticData>
+		<baseINT>41</baseINT>
+		<baseSTR>22</baseSTR>
+		<baseCON>27</baseCON>
+		<baseMEN>39</baseMEN>
+		<baseDEX>21</baseDEX>
+		<baseWIT>20</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-90875" y="248162" z="-3570" />
+			<node x="-90954" y="248118" z="-3570" />
+			<node x="-90918" y="248070" z="-3570" />
+			<node x="-90890" y="248027" z="-3570" />
+		</creationPoints>
+		<basePAtk>3</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>15</chest>
+			<legs>8</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>78</walk>
+			<run>124</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>200</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>22.8</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>6.5</radius>
+			<height>22.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>101.0</hp>
+			<mp>40.0</mp>
+			<cp>60.6</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>116.47</hp>
+			<mp>47.28</mp>
+			<cp>69.882</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>132.11</hp>
+			<mp>54.64</mp>
+			<cp>79.266</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>147.92</hp>
+			<mp>62.08</mp>
+			<cp>88.752</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>163.9</hp>
+			<mp>69.6</mp>
+			<cp>98.34</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>180.05</hp>
+			<mp>77.2</mp>
+			<cp>108.03</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>196.37</hp>
+			<mp>84.88</mp>
+			<cp>117.822</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>212.86</hp>
+			<mp>92.64</mp>
+			<cp>127.716</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>229.52</hp>
+			<mp>100.48</mp>
+			<cp>137.712</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>246.35</hp>
+			<mp>108.4</mp>
+			<cp>147.81</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>263.35</hp>
+			<mp>116.4</mp>
+			<cp>158.01</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>280.52</hp>
+			<mp>124.48</mp>
+			<cp>168.312</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>297.86</hp>
+			<mp>132.64</mp>
+			<cp>178.716</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>315.37</hp>
+			<mp>140.88</mp>
+			<cp>189.222</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>333.05</hp>
+			<mp>149.2</mp>
+			<cp>199.83</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>350.9</hp>
+			<mp>157.6</mp>
+			<cp>210.54</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>368.92</hp>
+			<mp>166.08</mp>
+			<cp>221.352</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>387.11</hp>
+			<mp>174.64</mp>
+			<cp>232.266</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>405.47</hp>
+			<mp>183.28</mp>
+			<cp>243.282</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>424.0</hp>
+			<mp>192.0</mp>
+			<cp>254.4</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>451.5</hp>
+			<mp>205.2</mp>
+			<cp>270.9</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>479.25</hp>
+			<mp>218.52</mp>
+			<cp>287.55</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>507.25</hp>
+			<mp>231.96</mp>
+			<cp>304.35</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>535.5</hp>
+			<mp>245.52</mp>
+			<cp>321.3</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>564.0</hp>
+			<mp>259.2</mp>
+			<cp>338.4</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>592.75</hp>
+			<mp>273.0</mp>
+			<cp>355.65</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>621.75</hp>
+			<mp>286.92</mp>
+			<cp>373.05</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>651.0</hp>
+			<mp>300.96</mp>
+			<cp>390.6</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>680.5</hp>
+			<mp>315.12</mp>
+			<cp>408.3</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>710.25</hp>
+			<mp>329.4</mp>
+			<cp>426.15</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>740.25</hp>
+			<mp>343.8</mp>
+			<cp>444.15</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>770.5</hp>
+			<mp>358.32</mp>
+			<cp>462.3</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>801.0</hp>
+			<mp>372.96</mp>
+			<cp>480.6</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>831.75</hp>
+			<mp>387.72</mp>
+			<cp>499.05</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>862.75</hp>
+			<mp>402.6</mp>
+			<cp>517.65</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>894.0</hp>
+			<mp>417.6</mp>
+			<cp>536.4</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>925.5</hp>
+			<mp>432.72</mp>
+			<cp>555.3</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>957.25</hp>
+			<mp>447.96</mp>
+			<cp>574.35</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>989.25</hp>
+			<mp>463.32</mp>
+			<cp>593.55</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1021.5</hp>
+			<mp>478.8</mp>
+			<cp>612.9</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1070.9</hp>
+			<mp>504.8</mp>
+			<cp>642.54</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1120.68</hp>
+			<mp>531.0</mp>
+			<cp>672.408</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1170.84</hp>
+			<mp>557.4</mp>
+			<cp>702.504</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1221.38</hp>
+			<mp>584.0</mp>
+			<cp>732.828</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1272.3</hp>
+			<mp>610.8</mp>
+			<cp>763.38</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1323.6</hp>
+			<mp>637.8</mp>
+			<cp>794.16</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1375.28</hp>
+			<mp>665.0</mp>
+			<cp>825.168</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1427.34</hp>
+			<mp>692.4</mp>
+			<cp>856.404</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1479.78</hp>
+			<mp>720.0</mp>
+			<cp>887.868</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1532.6</hp>
+			<mp>747.8</mp>
+			<cp>919.56</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1585.8</hp>
+			<mp>775.8</mp>
+			<cp>951.48</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1639.38</hp>
+			<mp>804.0</mp>
+			<cp>983.628</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1693.34</hp>
+			<mp>832.4</mp>
+			<cp>1016.004</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1747.68</hp>
+			<mp>861.0</mp>
+			<cp>1048.608</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1802.4</hp>
+			<mp>889.8</mp>
+			<cp>1081.44</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1857.5</hp>
+			<mp>918.8</mp>
+			<cp>1114.5</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1912.98</hp>
+			<mp>948.0</mp>
+			<cp>1147.788</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1968.84</hp>
+			<mp>977.4</mp>
+			<cp>1181.304</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2025.08</hp>
+			<mp>1007.0</mp>
+			<cp>1215.048</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2081.7</hp>
+			<mp>1036.8</mp>
+			<cp>1249.02</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2138.7</hp>
+			<mp>1066.8</mp>
+			<cp>1283.22</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2196.08</hp>
+			<mp>1097.0</mp>
+			<cp>1317.648</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2253.84</hp>
+			<mp>1127.4</mp>
+			<cp>1352.304</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2311.98</hp>
+			<mp>1158.0</mp>
+			<cp>1387.188</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2370.5</hp>
+			<mp>1188.8</mp>
+			<cp>1422.3</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2429.4</hp>
+			<mp>1219.8</mp>
+			<cp>1457.64</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2488.68</hp>
+			<mp>1251.0</mp>
+			<cp>1493.208</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2548.34</hp>
+			<mp>1282.4</mp>
+			<cp>1529.004</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2608.38</hp>
+			<mp>1314.0</mp>
+			<cp>1565.028</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2668.8</hp>
+			<mp>1345.8</mp>
+			<cp>1601.28</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2729.6</hp>
+			<mp>1377.8</mp>
+			<cp>1637.76</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2790.78</hp>
+			<mp>1410.0</mp>
+			<cp>1674.468</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2852.34</hp>
+			<mp>1442.4</mp>
+			<cp>1711.404</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2914.28</hp>
+			<mp>1475.0</mp>
+			<cp>1748.568</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2976.6</hp>
+			<mp>1507.8</mp>
+			<cp>1785.96</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3039.3</hp>
+			<mp>1540.8</mp>
+			<cp>1823.58</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3102.38</hp>
+			<mp>1574.0</mp>
+			<cp>1861.428</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3165.84</hp>
+			<mp>1607.4</mp>
+			<cp>1899.504</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3229.68</hp>
+			<mp>1641.0</mp>
+			<cp>1937.808</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3293.9</hp>
+			<mp>1674.8</mp>
+			<cp>1976.34</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3358.5</hp>
+			<mp>1708.8</mp>
+			<cp>2015.1</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3423.48</hp>
+			<mp>1743.0</mp>
+			<cp>2054.088</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3488.84</hp>
+			<mp>1777.4</mp>
+			<cp>2093.304</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3554.58</hp>
+			<mp>1812.0</mp>
+			<cp>2132.748</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3620.7</hp>
+			<mp>1846.8</mp>
+			<cp>2172.42</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3687.2</hp>
+			<mp>1881.8</mp>
+			<cp>2212.32</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3754.08</hp>
+			<mp>1917.0</mp>
+			<cp>2252.448</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3821.34</hp>
+			<mp>1952.4</mp>
+			<cp>2292.804</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3888.98</hp>
+			<mp>1988.0</mp>
+			<cp>2333.388</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3957.0</hp>
+			<mp>2023.8</mp>
+			<cp>2374.2</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4025.4</hp>
+			<mp>2059.8</mp>
+			<cp>2415.24</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4094.18</hp>
+			<mp>2096.0</mp>
+			<cp>2456.508</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4163.34</hp>
+			<mp>2132.4</mp>
+			<cp>2498.004</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4232.88</hp>
+			<mp>2169.0</mp>
+			<cp>2539.728</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4302.8</hp>
+			<mp>2205.8</mp>
+			<cp>2581.68</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4373.1</hp>
+			<mp>2242.8</mp>
+			<cp>2623.86</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4443.78</hp>
+			<mp>2280.0</mp>
+			<cp>2666.268</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4514.84</hp>
+			<mp>2317.4</mp>
+			<cp>2708.904</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4586.28</hp>
+			<mp>2355.0</mp>
+			<cp>2751.768</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4658.1</hp>
+			<mp>2392.8</mp>
+			<cp>2794.86</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4730.3</hp>
+			<mp>2430.8</mp>
+			<cp>2838.19</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4802.88</hp>
+			<mp>2469</mp>
+			<cp>2881.74</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4875.84</hp>
+			<mp>2507.4</mp>
+			<cp>2925.52</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4949.18</hp>
+			<mp>2546</mp>
+			<cp>2969.54</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5022.9</hp>
+			<mp>2584.8</mp>
+			<cp>3013.78</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5097</hp>
+			<mp>2623.8</mp>
+			<cp>3058.26</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5171.48</hp>
+			<mp>2663</mp>
+			<cp>3102.888</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Warlord.xml
+++ b/data/stats/chars/baseStats/Warlord.xml
@@ -1,798 +1,926 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>3</classId>
-    <staticData>
-        <baseINT>21</baseINT>
-        <baseSTR>40</baseSTR>
-        <baseCON>43</baseCON>
-        <baseMEN>25</baseMEN>
-        <baseDEX>30</baseDEX>
-        <baseWIT>11</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-71338" y="258271" z="-3104"/>
-            <node x="-71417" y="258270" z="-3104"/>
-            <node x="-71453" y="258305" z="-3104"/>
-            <node x="-71467" y="258378" z="-3104"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>80</walk>
-            <run>132</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>100</baseBreath>
-        <baseSafeFall>250</baseSafeFall>
-        <collisionMale>
-            <radius>9.0</radius>
-            <height>23</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>8.0</radius>
-            <height>23.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>80.0</hp>
-            <mp>30.0</mp>
-            <cp>64.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>91.83</hp>
-            <mp>35.46</mp>
-            <cp>73.464</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>103.79</hp>
-            <mp>40.98</mp>
-            <cp>83.032</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>115.88</hp>
-            <mp>46.56</mp>
-            <cp>92.704</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>128.1</hp>
-            <mp>52.2</mp>
-            <cp>102.48</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>140.45</hp>
-            <mp>57.9</mp>
-            <cp>112.36</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>152.93</hp>
-            <mp>63.66</mp>
-            <cp>122.344</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>165.54</hp>
-            <mp>69.48</mp>
-            <cp>132.432</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>178.28</hp>
-            <mp>75.36</mp>
-            <cp>142.624</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>191.15</hp>
-            <mp>81.3</mp>
-            <cp>152.92</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>204.15</hp>
-            <mp>87.3</mp>
-            <cp>163.32</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>217.28</hp>
-            <mp>93.36</mp>
-            <cp>173.824</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>230.54</hp>
-            <mp>99.48</mp>
-            <cp>184.432</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>243.93</hp>
-            <mp>105.66</mp>
-            <cp>195.144</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>257.45</hp>
-            <mp>111.9</mp>
-            <cp>205.96</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>271.1</hp>
-            <mp>118.2</mp>
-            <cp>216.88</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>284.88</hp>
-            <mp>124.56</mp>
-            <cp>227.904</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>298.79</hp>
-            <mp>130.98</mp>
-            <cp>239.032</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>312.83</hp>
-            <mp>137.46</mp>
-            <cp>250.264</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>327.0</hp>
-            <mp>144.0</mp>
-            <cp>261.6</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>360.0</hp>
-            <mp>153.9</mp>
-            <cp>288.0</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>393.3</hp>
-            <mp>163.89</mp>
-            <cp>314.64</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>426.9</hp>
-            <mp>173.97</mp>
-            <cp>341.52</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>460.8</hp>
-            <mp>184.14</mp>
-            <cp>368.64</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>495.0</hp>
-            <mp>194.4</mp>
-            <cp>396.0</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>529.5</hp>
-            <mp>204.75</mp>
-            <cp>423.6</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>564.3</hp>
-            <mp>215.19</mp>
-            <cp>451.44</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>599.4</hp>
-            <mp>225.72</mp>
-            <cp>479.52</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>634.8</hp>
-            <mp>236.34</mp>
-            <cp>507.84</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>670.5</hp>
-            <mp>247.05</mp>
-            <cp>536.4</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>706.5</hp>
-            <mp>257.85</mp>
-            <cp>565.2</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>742.8</hp>
-            <mp>268.74</mp>
-            <cp>594.24</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>779.4</hp>
-            <mp>279.72</mp>
-            <cp>623.52</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>816.3</hp>
-            <mp>290.79</mp>
-            <cp>653.04</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>853.5</hp>
-            <mp>301.95</mp>
-            <cp>682.8</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>891.0</hp>
-            <mp>313.2</mp>
-            <cp>712.8</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>928.8</hp>
-            <mp>324.54</mp>
-            <cp>743.04</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>966.9</hp>
-            <mp>335.97</mp>
-            <cp>773.52</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1005.3</hp>
-            <mp>347.49</mp>
-            <cp>804.24</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1044.0</hp>
-            <mp>359.1</mp>
-            <cp>835.2</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1098.6</hp>
-            <mp>378.6</mp>
-            <cp>878.88</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1153.62</hp>
-            <mp>398.25</mp>
-            <cp>922.896</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1209.06</hp>
-            <mp>418.05</mp>
-            <cp>967.248</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1264.92</hp>
-            <mp>438.0</mp>
-            <cp>1011.936</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1321.2</hp>
-            <mp>458.1</mp>
-            <cp>1056.96</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1377.9</hp>
-            <mp>478.35</mp>
-            <cp>1102.32</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1435.02</hp>
-            <mp>498.75</mp>
-            <cp>1148.016</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1492.56</hp>
-            <mp>519.3</mp>
-            <cp>1194.048</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1550.52</hp>
-            <mp>540.0</mp>
-            <cp>1240.416</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1608.9</hp>
-            <mp>560.85</mp>
-            <cp>1287.12</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1667.7</hp>
-            <mp>581.85</mp>
-            <cp>1334.16</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1726.92</hp>
-            <mp>603.0</mp>
-            <cp>1381.536</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1786.56</hp>
-            <mp>624.3</mp>
-            <cp>1429.248</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1846.62</hp>
-            <mp>645.75</mp>
-            <cp>1477.296</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1907.1</hp>
-            <mp>667.35</mp>
-            <cp>1525.68</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1968.0</hp>
-            <mp>689.1</mp>
-            <cp>1574.4</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>2029.32</hp>
-            <mp>711.0</mp>
-            <cp>1623.456</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2091.06</hp>
-            <mp>733.05</mp>
-            <cp>1672.848</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2153.22</hp>
-            <mp>755.25</mp>
-            <cp>1722.576</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2215.8</hp>
-            <mp>777.6</mp>
-            <cp>1772.64</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2278.8</hp>
-            <mp>800.1</mp>
-            <cp>1823.04</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2342.22</hp>
-            <mp>822.75</mp>
-            <cp>1873.776</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2406.06</hp>
-            <mp>845.55</mp>
-            <cp>1924.848</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2470.32</hp>
-            <mp>868.5</mp>
-            <cp>1976.256</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2535.0</hp>
-            <mp>891.6</mp>
-            <cp>2028.0</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2600.1</hp>
-            <mp>914.85</mp>
-            <cp>2080.08</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2665.62</hp>
-            <mp>938.25</mp>
-            <cp>2132.496</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2731.56</hp>
-            <mp>961.8</mp>
-            <cp>2185.248</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2797.92</hp>
-            <mp>985.5</mp>
-            <cp>2238.336</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2864.7</hp>
-            <mp>1009.35</mp>
-            <cp>2291.76</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2931.9</hp>
-            <mp>1033.35</mp>
-            <cp>2345.52</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2999.52</hp>
-            <mp>1057.5</mp>
-            <cp>2399.616</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>3067.56</hp>
-            <mp>1081.8</mp>
-            <cp>2454.048</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>3136.02</hp>
-            <mp>1106.25</mp>
-            <cp>2508.816</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3204.9</hp>
-            <mp>1130.85</mp>
-            <cp>2563.92</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3274.2</hp>
-            <mp>1155.6</mp>
-            <cp>2619.36</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3343.92</hp>
-            <mp>1180.5</mp>
-            <cp>2675.136</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3414.06</hp>
-            <mp>1205.55</mp>
-            <cp>2731.248</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3484.62</hp>
-            <mp>1230.75</mp>
-            <cp>2787.696</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3555.6</hp>
-            <mp>1256.1</mp>
-            <cp>2844.48</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3627.0</hp>
-            <mp>1281.6</mp>
-            <cp>2901.6</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3698.82</hp>
-            <mp>1307.25</mp>
-            <cp>2959.056</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3771.06</hp>
-            <mp>1333.05</mp>
-            <cp>3016.848</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3843.72</hp>
-            <mp>1359.0</mp>
-            <cp>3074.976</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3916.8</hp>
-            <mp>1385.1</mp>
-            <cp>3133.44</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3990.3</hp>
-            <mp>1411.35</mp>
-            <cp>3192.24</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>4064.22</hp>
-            <mp>1437.75</mp>
-            <cp>3251.376</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>4138.56</hp>
-            <mp>1464.3</mp>
-            <cp>3310.848</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>4213.32</hp>
-            <mp>1491.0</mp>
-            <cp>3370.656</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4288.5</hp>
-            <mp>1517.85</mp>
-            <cp>3430.8</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4364.1</hp>
-            <mp>1544.85</mp>
-            <cp>3491.28</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>3</classId>
+	<staticData>
+		<baseINT>21</baseINT>
+		<baseSTR>40</baseSTR>
+		<baseCON>43</baseCON>
+		<baseMEN>25</baseMEN>
+		<baseDEX>30</baseDEX>
+		<baseWIT>11</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-71338" y="258271" z="-3104" />
+			<node x="-71417" y="258270" z="-3104" />
+			<node x="-71453" y="258305" z="-3104" />
+			<node x="-71467" y="258378" z="-3104" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>80</walk>
+			<run>132</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>250</baseSafeFall>
+		<collisionMale>
+			<radius>9.0</radius>
+			<height>23</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>8.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>80.0</hp>
+			<mp>30.0</mp>
+			<cp>64.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>91.83</hp>
+			<mp>35.46</mp>
+			<cp>73.464</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>103.79</hp>
+			<mp>40.98</mp>
+			<cp>83.032</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>115.88</hp>
+			<mp>46.56</mp>
+			<cp>92.704</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>128.1</hp>
+			<mp>52.2</mp>
+			<cp>102.48</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>140.45</hp>
+			<mp>57.9</mp>
+			<cp>112.36</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>152.93</hp>
+			<mp>63.66</mp>
+			<cp>122.344</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>165.54</hp>
+			<mp>69.48</mp>
+			<cp>132.432</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>178.28</hp>
+			<mp>75.36</mp>
+			<cp>142.624</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>191.15</hp>
+			<mp>81.3</mp>
+			<cp>152.92</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>204.15</hp>
+			<mp>87.3</mp>
+			<cp>163.32</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>217.28</hp>
+			<mp>93.36</mp>
+			<cp>173.824</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>230.54</hp>
+			<mp>99.48</mp>
+			<cp>184.432</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>243.93</hp>
+			<mp>105.66</mp>
+			<cp>195.144</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>257.45</hp>
+			<mp>111.9</mp>
+			<cp>205.96</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>271.1</hp>
+			<mp>118.2</mp>
+			<cp>216.88</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>284.88</hp>
+			<mp>124.56</mp>
+			<cp>227.904</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>298.79</hp>
+			<mp>130.98</mp>
+			<cp>239.032</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>312.83</hp>
+			<mp>137.46</mp>
+			<cp>250.264</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>327.0</hp>
+			<mp>144.0</mp>
+			<cp>261.6</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>360.0</hp>
+			<mp>153.9</mp>
+			<cp>288.0</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>393.3</hp>
+			<mp>163.89</mp>
+			<cp>314.64</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>426.9</hp>
+			<mp>173.97</mp>
+			<cp>341.52</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>460.8</hp>
+			<mp>184.14</mp>
+			<cp>368.64</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>495.0</hp>
+			<mp>194.4</mp>
+			<cp>396.0</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>529.5</hp>
+			<mp>204.75</mp>
+			<cp>423.6</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>564.3</hp>
+			<mp>215.19</mp>
+			<cp>451.44</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>599.4</hp>
+			<mp>225.72</mp>
+			<cp>479.52</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>634.8</hp>
+			<mp>236.34</mp>
+			<cp>507.84</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>670.5</hp>
+			<mp>247.05</mp>
+			<cp>536.4</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>706.5</hp>
+			<mp>257.85</mp>
+			<cp>565.2</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>742.8</hp>
+			<mp>268.74</mp>
+			<cp>594.24</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>779.4</hp>
+			<mp>279.72</mp>
+			<cp>623.52</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>816.3</hp>
+			<mp>290.79</mp>
+			<cp>653.04</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>853.5</hp>
+			<mp>301.95</mp>
+			<cp>682.8</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>891.0</hp>
+			<mp>313.2</mp>
+			<cp>712.8</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>928.8</hp>
+			<mp>324.54</mp>
+			<cp>743.04</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>966.9</hp>
+			<mp>335.97</mp>
+			<cp>773.52</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1005.3</hp>
+			<mp>347.49</mp>
+			<cp>804.24</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1044.0</hp>
+			<mp>359.1</mp>
+			<cp>835.2</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1098.6</hp>
+			<mp>378.6</mp>
+			<cp>878.88</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1153.62</hp>
+			<mp>398.25</mp>
+			<cp>922.896</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1209.06</hp>
+			<mp>418.05</mp>
+			<cp>967.248</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1264.92</hp>
+			<mp>438.0</mp>
+			<cp>1011.936</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1321.2</hp>
+			<mp>458.1</mp>
+			<cp>1056.96</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1377.9</hp>
+			<mp>478.35</mp>
+			<cp>1102.32</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1435.02</hp>
+			<mp>498.75</mp>
+			<cp>1148.016</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1492.56</hp>
+			<mp>519.3</mp>
+			<cp>1194.048</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1550.52</hp>
+			<mp>540.0</mp>
+			<cp>1240.416</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1608.9</hp>
+			<mp>560.85</mp>
+			<cp>1287.12</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1667.7</hp>
+			<mp>581.85</mp>
+			<cp>1334.16</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1726.92</hp>
+			<mp>603.0</mp>
+			<cp>1381.536</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1786.56</hp>
+			<mp>624.3</mp>
+			<cp>1429.248</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1846.62</hp>
+			<mp>645.75</mp>
+			<cp>1477.296</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1907.1</hp>
+			<mp>667.35</mp>
+			<cp>1525.68</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1968.0</hp>
+			<mp>689.1</mp>
+			<cp>1574.4</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2029.32</hp>
+			<mp>711.0</mp>
+			<cp>1623.456</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2091.06</hp>
+			<mp>733.05</mp>
+			<cp>1672.848</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2153.22</hp>
+			<mp>755.25</mp>
+			<cp>1722.576</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2215.8</hp>
+			<mp>777.6</mp>
+			<cp>1772.64</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2278.8</hp>
+			<mp>800.1</mp>
+			<cp>1823.04</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2342.22</hp>
+			<mp>822.75</mp>
+			<cp>1873.776</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2406.06</hp>
+			<mp>845.55</mp>
+			<cp>1924.848</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2470.32</hp>
+			<mp>868.5</mp>
+			<cp>1976.256</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2535.0</hp>
+			<mp>891.6</mp>
+			<cp>2028.0</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2600.1</hp>
+			<mp>914.85</mp>
+			<cp>2080.08</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2665.62</hp>
+			<mp>938.25</mp>
+			<cp>2132.496</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2731.56</hp>
+			<mp>961.8</mp>
+			<cp>2185.248</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2797.92</hp>
+			<mp>985.5</mp>
+			<cp>2238.336</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2864.7</hp>
+			<mp>1009.35</mp>
+			<cp>2291.76</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2931.9</hp>
+			<mp>1033.35</mp>
+			<cp>2345.52</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2999.52</hp>
+			<mp>1057.5</mp>
+			<cp>2399.616</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>3067.56</hp>
+			<mp>1081.8</mp>
+			<cp>2454.048</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3136.02</hp>
+			<mp>1106.25</mp>
+			<cp>2508.816</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3204.9</hp>
+			<mp>1130.85</mp>
+			<cp>2563.92</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3274.2</hp>
+			<mp>1155.6</mp>
+			<cp>2619.36</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3343.92</hp>
+			<mp>1180.5</mp>
+			<cp>2675.136</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3414.06</hp>
+			<mp>1205.55</mp>
+			<cp>2731.248</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3484.62</hp>
+			<mp>1230.75</mp>
+			<cp>2787.696</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3555.6</hp>
+			<mp>1256.1</mp>
+			<cp>2844.48</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3627.0</hp>
+			<mp>1281.6</mp>
+			<cp>2901.6</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3698.82</hp>
+			<mp>1307.25</mp>
+			<cp>2959.056</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3771.06</hp>
+			<mp>1333.05</mp>
+			<cp>3016.848</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3843.72</hp>
+			<mp>1359.0</mp>
+			<cp>3074.976</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3916.8</hp>
+			<mp>1385.1</mp>
+			<cp>3133.44</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3990.3</hp>
+			<mp>1411.35</mp>
+			<cp>3192.24</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>4064.22</hp>
+			<mp>1437.75</mp>
+			<cp>3251.376</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4138.56</hp>
+			<mp>1464.3</mp>
+			<cp>3310.848</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4213.32</hp>
+			<mp>1491.0</mp>
+			<cp>3370.656</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4288.5</hp>
+			<mp>1517.85</mp>
+			<cp>3430.8</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4364.1</hp>
+			<mp>1544.85</mp>
+			<cp>3491.28</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4440.12</hp>
+			<mp>1572.0</mp>
+			<cp>3552.096</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4516.56</hp>
+			<mp>1599.3</mp>
+			<cp>3613.248</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4593.42</hp>
+			<mp>1626.75</mp>
+			<cp>3674.736</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4670.7</hp>
+			<mp>1654.35</mp>
+			<cp>3736.56</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4748.4</hp>
+			<mp>1682.1</mp>
+			<cp>3798.72</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4826.52</hp>
+			<mp>1710.0</mp>
+			<cp>3861.216</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4905.06</hp>
+			<mp>1738.05</mp>
+			<cp>3924.048</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4984.02</hp>
+			<mp>1766.25</mp>
+			<cp>3987.216</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>5063.4</hp>
+			<mp>1794.6</mp>
+			<cp>4050.72</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>5143.2</hp>
+			<mp>1823.1</mp>
+			<cp>4114.57</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5223.42</hp>
+			<mp>1851.75</mp>
+			<cp>4178.76</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5304.06</hp>
+			<mp>1880.55</mp>
+			<cp>4243.29</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5385.12</hp>
+			<mp>1909.5</mp>
+			<cp>4308.16</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5466.6</hp>
+			<mp>1938.6</mp>
+			<cp>4373.36</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5548.5</hp>
+			<mp>1967.85</mp>
+			<cp>4438.91</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5630.82</hp>
+			<mp>1997.25</mp>
+			<cp>4504.656</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Warrior.xml
+++ b/data/stats/chars/baseStats/Warrior.xml
@@ -1,798 +1,926 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>1</classId>
-    <staticData>
-        <baseINT>21</baseINT>
-        <baseSTR>40</baseSTR>
-        <baseCON>43</baseCON>
-        <baseMEN>25</baseMEN>
-        <baseDEX>30</baseDEX>
-        <baseWIT>11</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="-71338" y="258271" z="-3104"/>
-            <node x="-71417" y="258270" z="-3104"/>
-            <node x="-71453" y="258305" z="-3104"/>
-            <node x="-71467" y="258378" z="-3104"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>80</walk>
-            <run>132</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>100</baseBreath>
-        <baseSafeFall>250</baseSafeFall>
-        <collisionMale>
-            <radius>9.0</radius>
-            <height>23</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>8.0</radius>
-            <height>23.5</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>80.0</hp>
-            <mp>30.0</mp>
-            <cp>64.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>91.83</hp>
-            <mp>35.46</mp>
-            <cp>73.464</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>103.79</hp>
-            <mp>40.98</mp>
-            <cp>83.032</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>115.88</hp>
-            <mp>46.56</mp>
-            <cp>92.704</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>128.1</hp>
-            <mp>52.2</mp>
-            <cp>102.48</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>140.45</hp>
-            <mp>57.9</mp>
-            <cp>112.36</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>152.93</hp>
-            <mp>63.66</mp>
-            <cp>122.344</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>165.54</hp>
-            <mp>69.48</mp>
-            <cp>132.432</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>178.28</hp>
-            <mp>75.36</mp>
-            <cp>142.624</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>191.15</hp>
-            <mp>81.3</mp>
-            <cp>152.92</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>204.15</hp>
-            <mp>87.3</mp>
-            <cp>163.32</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>217.28</hp>
-            <mp>93.36</mp>
-            <cp>173.824</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>230.54</hp>
-            <mp>99.48</mp>
-            <cp>184.432</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>243.93</hp>
-            <mp>105.66</mp>
-            <cp>195.144</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>257.45</hp>
-            <mp>111.9</mp>
-            <cp>205.96</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>271.1</hp>
-            <mp>118.2</mp>
-            <cp>216.88</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>284.88</hp>
-            <mp>124.56</mp>
-            <cp>227.904</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>298.79</hp>
-            <mp>130.98</mp>
-            <cp>239.032</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>312.83</hp>
-            <mp>137.46</mp>
-            <cp>250.264</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>327.0</hp>
-            <mp>144.0</mp>
-            <cp>261.6</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>360.0</hp>
-            <mp>153.9</mp>
-            <cp>288.0</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>393.3</hp>
-            <mp>163.89</mp>
-            <cp>314.64</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>426.9</hp>
-            <mp>173.97</mp>
-            <cp>341.52</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>460.8</hp>
-            <mp>184.14</mp>
-            <cp>368.64</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>495.0</hp>
-            <mp>194.4</mp>
-            <cp>396.0</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>529.5</hp>
-            <mp>204.75</mp>
-            <cp>423.6</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>564.3</hp>
-            <mp>215.19</mp>
-            <cp>451.44</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>599.4</hp>
-            <mp>225.72</mp>
-            <cp>479.52</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>634.8</hp>
-            <mp>236.34</mp>
-            <cp>507.84</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>670.5</hp>
-            <mp>247.05</mp>
-            <cp>536.4</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>706.5</hp>
-            <mp>257.85</mp>
-            <cp>565.2</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>742.8</hp>
-            <mp>268.74</mp>
-            <cp>594.24</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>779.4</hp>
-            <mp>279.72</mp>
-            <cp>623.52</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>816.3</hp>
-            <mp>290.79</mp>
-            <cp>653.04</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>853.5</hp>
-            <mp>301.95</mp>
-            <cp>682.8</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>891.0</hp>
-            <mp>313.2</mp>
-            <cp>712.8</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>928.8</hp>
-            <mp>324.54</mp>
-            <cp>743.04</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>966.9</hp>
-            <mp>335.97</mp>
-            <cp>773.52</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1005.3</hp>
-            <mp>347.49</mp>
-            <cp>804.24</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1044.0</hp>
-            <mp>359.1</mp>
-            <cp>835.2</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1083.0</hp>
-            <mp>370.8</mp>
-            <cp>866.4</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1122.3</hp>
-            <mp>382.59</mp>
-            <cp>897.84</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1161.9</hp>
-            <mp>394.47</mp>
-            <cp>929.52</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1201.8</hp>
-            <mp>406.44</mp>
-            <cp>961.44</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1242.0</hp>
-            <mp>418.5</mp>
-            <cp>993.6</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1282.5</hp>
-            <mp>430.65</mp>
-            <cp>1026.0</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1323.3</hp>
-            <mp>442.89</mp>
-            <cp>1058.64</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1364.4</hp>
-            <mp>455.22</mp>
-            <cp>1091.52</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1405.8</hp>
-            <mp>467.64</mp>
-            <cp>1124.64</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1447.5</hp>
-            <mp>480.15</mp>
-            <cp>1158.0</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1489.5</hp>
-            <mp>492.75</mp>
-            <cp>1191.6</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1531.8</hp>
-            <mp>505.44</mp>
-            <cp>1225.44</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1574.4</hp>
-            <mp>518.22</mp>
-            <cp>1259.52</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1617.3</hp>
-            <mp>531.09</mp>
-            <cp>1293.84</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1660.5</hp>
-            <mp>544.05</mp>
-            <cp>1328.4</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1704.0</hp>
-            <mp>557.1</mp>
-            <cp>1363.2</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1747.8</hp>
-            <mp>570.24</mp>
-            <cp>1398.24</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1791.9</hp>
-            <mp>583.47</mp>
-            <cp>1433.52</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>1836.3</hp>
-            <mp>596.79</mp>
-            <cp>1469.04</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>1881.0</hp>
-            <mp>610.2</mp>
-            <cp>1504.8</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>1926.0</hp>
-            <mp>623.7</mp>
-            <cp>1540.8</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>1971.3</hp>
-            <mp>637.29</mp>
-            <cp>1577.04</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2016.9</hp>
-            <mp>650.97</mp>
-            <cp>1613.52</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2062.8</hp>
-            <mp>664.74</mp>
-            <cp>1650.24</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2109.0</hp>
-            <mp>678.6</mp>
-            <cp>1687.2</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2155.5</hp>
-            <mp>692.55</mp>
-            <cp>1724.4</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2202.3</hp>
-            <mp>706.59</mp>
-            <cp>1761.84</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2249.4</hp>
-            <mp>720.72</mp>
-            <cp>1799.52</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2296.8</hp>
-            <mp>734.94</mp>
-            <cp>1837.44</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2344.5</hp>
-            <mp>749.25</mp>
-            <cp>1875.6</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2392.5</hp>
-            <mp>763.65</mp>
-            <cp>1914.0</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2440.8</hp>
-            <mp>778.14</mp>
-            <cp>1952.64</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2489.4</hp>
-            <mp>792.72</mp>
-            <cp>1991.52</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2538.3</hp>
-            <mp>807.39</mp>
-            <cp>2030.64</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2587.5</hp>
-            <mp>822.15</mp>
-            <cp>2070.0</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>2637.0</hp>
-            <mp>837.0</mp>
-            <cp>2109.6</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>2686.8</hp>
-            <mp>851.94</mp>
-            <cp>2149.44</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>2736.9</hp>
-            <mp>866.97</mp>
-            <cp>2189.52</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>2787.3</hp>
-            <mp>882.09</mp>
-            <cp>2229.84</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>2838.0</hp>
-            <mp>897.3</mp>
-            <cp>2270.4</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>2889.0</hp>
-            <mp>912.6</mp>
-            <cp>2311.2</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>2940.3</hp>
-            <mp>927.99</mp>
-            <cp>2352.24</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>2991.9</hp>
-            <mp>943.47</mp>
-            <cp>2393.52</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3043.8</hp>
-            <mp>959.04</mp>
-            <cp>2435.04</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3096.0</hp>
-            <mp>974.7</mp>
-            <cp>2476.8</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3148.5</hp>
-            <mp>990.45</mp>
-            <cp>2518.8</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3201.3</hp>
-            <mp>1006.3</mp>
-            <cp>2561.04</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3254.4</hp>
-            <mp>1022.22</mp>
-            <cp>2603.52</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3307.8</hp>
-            <mp>1038.24</mp>
-            <cp>2646.24</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3361.5</hp>
-            <mp>1054.35</mp>
-            <cp>2689.2</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>3415.5</hp>
-            <mp>1070.55</mp>
-            <cp>2732.4</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>1</classId>
+	<staticData>
+		<baseINT>21</baseINT>
+		<baseSTR>40</baseSTR>
+		<baseCON>43</baseCON>
+		<baseMEN>25</baseMEN>
+		<baseDEX>30</baseDEX>
+		<baseWIT>11</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="-71338" y="258271" z="-3104" />
+			<node x="-71417" y="258270" z="-3104" />
+			<node x="-71453" y="258305" z="-3104" />
+			<node x="-71467" y="258378" z="-3104" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>80</walk>
+			<run>132</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>100</baseBreath>
+		<baseSafeFall>250</baseSafeFall>
+		<collisionMale>
+			<radius>9.0</radius>
+			<height>23</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>8.0</radius>
+			<height>23.5</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>80.0</hp>
+			<mp>30.0</mp>
+			<cp>64.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>91.83</hp>
+			<mp>35.46</mp>
+			<cp>73.464</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>103.79</hp>
+			<mp>40.98</mp>
+			<cp>83.032</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>115.88</hp>
+			<mp>46.56</mp>
+			<cp>92.704</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>128.1</hp>
+			<mp>52.2</mp>
+			<cp>102.48</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>140.45</hp>
+			<mp>57.9</mp>
+			<cp>112.36</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>152.93</hp>
+			<mp>63.66</mp>
+			<cp>122.344</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>165.54</hp>
+			<mp>69.48</mp>
+			<cp>132.432</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>178.28</hp>
+			<mp>75.36</mp>
+			<cp>142.624</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>191.15</hp>
+			<mp>81.3</mp>
+			<cp>152.92</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>204.15</hp>
+			<mp>87.3</mp>
+			<cp>163.32</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>217.28</hp>
+			<mp>93.36</mp>
+			<cp>173.824</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>230.54</hp>
+			<mp>99.48</mp>
+			<cp>184.432</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>243.93</hp>
+			<mp>105.66</mp>
+			<cp>195.144</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>257.45</hp>
+			<mp>111.9</mp>
+			<cp>205.96</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>271.1</hp>
+			<mp>118.2</mp>
+			<cp>216.88</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>284.88</hp>
+			<mp>124.56</mp>
+			<cp>227.904</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>298.79</hp>
+			<mp>130.98</mp>
+			<cp>239.032</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>312.83</hp>
+			<mp>137.46</mp>
+			<cp>250.264</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>327.0</hp>
+			<mp>144.0</mp>
+			<cp>261.6</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>360.0</hp>
+			<mp>153.9</mp>
+			<cp>288.0</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>393.3</hp>
+			<mp>163.89</mp>
+			<cp>314.64</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>426.9</hp>
+			<mp>173.97</mp>
+			<cp>341.52</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>460.8</hp>
+			<mp>184.14</mp>
+			<cp>368.64</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>495.0</hp>
+			<mp>194.4</mp>
+			<cp>396.0</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>529.5</hp>
+			<mp>204.75</mp>
+			<cp>423.6</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>564.3</hp>
+			<mp>215.19</mp>
+			<cp>451.44</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>599.4</hp>
+			<mp>225.72</mp>
+			<cp>479.52</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>634.8</hp>
+			<mp>236.34</mp>
+			<cp>507.84</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>670.5</hp>
+			<mp>247.05</mp>
+			<cp>536.4</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>706.5</hp>
+			<mp>257.85</mp>
+			<cp>565.2</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>742.8</hp>
+			<mp>268.74</mp>
+			<cp>594.24</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>779.4</hp>
+			<mp>279.72</mp>
+			<cp>623.52</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>816.3</hp>
+			<mp>290.79</mp>
+			<cp>653.04</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>853.5</hp>
+			<mp>301.95</mp>
+			<cp>682.8</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>891.0</hp>
+			<mp>313.2</mp>
+			<cp>712.8</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>928.8</hp>
+			<mp>324.54</mp>
+			<cp>743.04</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>966.9</hp>
+			<mp>335.97</mp>
+			<cp>773.52</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1005.3</hp>
+			<mp>347.49</mp>
+			<cp>804.24</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1044.0</hp>
+			<mp>359.1</mp>
+			<cp>835.2</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1083.0</hp>
+			<mp>370.8</mp>
+			<cp>866.4</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1122.3</hp>
+			<mp>382.59</mp>
+			<cp>897.84</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1161.9</hp>
+			<mp>394.47</mp>
+			<cp>929.52</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1201.8</hp>
+			<mp>406.44</mp>
+			<cp>961.44</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1242.0</hp>
+			<mp>418.5</mp>
+			<cp>993.6</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1282.5</hp>
+			<mp>430.65</mp>
+			<cp>1026.0</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1323.3</hp>
+			<mp>442.89</mp>
+			<cp>1058.64</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1364.4</hp>
+			<mp>455.22</mp>
+			<cp>1091.52</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1405.8</hp>
+			<mp>467.64</mp>
+			<cp>1124.64</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1447.5</hp>
+			<mp>480.15</mp>
+			<cp>1158.0</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1489.5</hp>
+			<mp>492.75</mp>
+			<cp>1191.6</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1531.8</hp>
+			<mp>505.44</mp>
+			<cp>1225.44</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1574.4</hp>
+			<mp>518.22</mp>
+			<cp>1259.52</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1617.3</hp>
+			<mp>531.09</mp>
+			<cp>1293.84</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1660.5</hp>
+			<mp>544.05</mp>
+			<cp>1328.4</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1704.0</hp>
+			<mp>557.1</mp>
+			<cp>1363.2</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1747.8</hp>
+			<mp>570.24</mp>
+			<cp>1398.24</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1791.9</hp>
+			<mp>583.47</mp>
+			<cp>1433.52</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1836.3</hp>
+			<mp>596.79</mp>
+			<cp>1469.04</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>1881.0</hp>
+			<mp>610.2</mp>
+			<cp>1504.8</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>1926.0</hp>
+			<mp>623.7</mp>
+			<cp>1540.8</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>1971.3</hp>
+			<mp>637.29</mp>
+			<cp>1577.04</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2016.9</hp>
+			<mp>650.97</mp>
+			<cp>1613.52</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2062.8</hp>
+			<mp>664.74</mp>
+			<cp>1650.24</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2109.0</hp>
+			<mp>678.6</mp>
+			<cp>1687.2</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2155.5</hp>
+			<mp>692.55</mp>
+			<cp>1724.4</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2202.3</hp>
+			<mp>706.59</mp>
+			<cp>1761.84</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2249.4</hp>
+			<mp>720.72</mp>
+			<cp>1799.52</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2296.8</hp>
+			<mp>734.94</mp>
+			<cp>1837.44</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2344.5</hp>
+			<mp>749.25</mp>
+			<cp>1875.6</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2392.5</hp>
+			<mp>763.65</mp>
+			<cp>1914.0</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2440.8</hp>
+			<mp>778.14</mp>
+			<cp>1952.64</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2489.4</hp>
+			<mp>792.72</mp>
+			<cp>1991.52</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2538.3</hp>
+			<mp>807.39</mp>
+			<cp>2030.64</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2587.5</hp>
+			<mp>822.15</mp>
+			<cp>2070.0</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>2637.0</hp>
+			<mp>837.0</mp>
+			<cp>2109.6</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>2686.8</hp>
+			<mp>851.94</mp>
+			<cp>2149.44</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>2736.9</hp>
+			<mp>866.97</mp>
+			<cp>2189.52</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>2787.3</hp>
+			<mp>882.09</mp>
+			<cp>2229.84</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>2838.0</hp>
+			<mp>897.3</mp>
+			<cp>2270.4</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>2889.0</hp>
+			<mp>912.6</mp>
+			<cp>2311.2</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>2940.3</hp>
+			<mp>927.99</mp>
+			<cp>2352.24</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>2991.9</hp>
+			<mp>943.47</mp>
+			<cp>2393.52</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3043.8</hp>
+			<mp>959.04</mp>
+			<cp>2435.04</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3096.0</hp>
+			<mp>974.7</mp>
+			<cp>2476.8</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3148.5</hp>
+			<mp>990.45</mp>
+			<cp>2518.8</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3201.3</hp>
+			<mp>1006.3</mp>
+			<cp>2561.04</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3254.4</hp>
+			<mp>1022.22</mp>
+			<cp>2603.52</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3307.8</hp>
+			<mp>1038.24</mp>
+			<cp>2646.24</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3361.5</hp>
+			<mp>1054.35</mp>
+			<cp>2689.2</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3415.5</hp>
+			<mp>1070.55</mp>
+			<cp>2732.4</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>3469.8</hp>
+			<mp>1086.84</mp>
+			<cp>2775.84</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>3524.4</hp>
+			<mp>1103.22</mp>
+			<cp>2819.52</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>3579.3</hp>
+			<mp>1119.69</mp>
+			<cp>2863.44</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>3634.5</hp>
+			<mp>1136.25</mp>
+			<cp>2907.6</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>3690</hp>
+			<mp>1152.9</mp>
+			<cp>2952.0</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>3745.8</hp>
+			<mp>1169.64</mp>
+			<cp>2996.64</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>3801.9</hp>
+			<mp>1186.47</mp>
+			<cp>3041.52</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>3858.3</hp>
+			<mp>1203.39</mp>
+			<cp>3086.64</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>3915</hp>
+			<mp>1220.4</mp>
+			<cp>3132</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>3972</hp>
+			<mp>1237.5</mp>
+			<cp>3177.6</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4029.3</hp>
+			<mp>1254.69</mp>
+			<cp>3223.44</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4086.9</hp>
+			<mp>1271.97</mp>
+			<cp>3269.52</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4144.8</hp>
+			<mp>1289.34</mp>
+			<cp>3315.84</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>4203</hp>
+			<mp>1306.8</mp>
+			<cp>3362.4</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>4261.5</hp>
+			<mp>1324.35</mp>
+			<cp>3409.2</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>4320.3</hp>
+			<mp>1341.99</mp>
+			<cp>3456.24</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/Warsmith.xml
+++ b/data/stats/chars/baseStats/Warsmith.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>57</classId>
-    <staticData>
-        <baseINT>20</baseINT>
-        <baseSTR>39</baseSTR>
-        <baseCON>45</baseCON>
-        <baseMEN>27</baseMEN>
-        <baseDEX>29</baseDEX>
-        <baseWIT>10</baseWIT>
-        <physicalAbnormalResist>15</physicalAbnormalResist>
-        <magicAbnormalResist>10</magicAbnormalResist>
-        <creationPoints>
-            <node x="108644" y="-173947" z="-400"/>
-            <node x="108678" y="-174002" z="-400"/>
-            <node x="108505" y="-173964" z="-400"/>
-            <node x="108512" y="-174026" z="-400"/>
-            <node x="108549" y="-174075" z="-400"/>
-            <node x="108576" y="-174122" z="-400"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>80</walk>
-            <run>131</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>80</baseBreath>
-        <baseSafeFall>180</baseSafeFall>
-        <collisionMale>
-            <radius>9.0</radius>
-            <height>18.0</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>5.0</radius>
-            <height>19.0</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>80.0</hp>
-            <mp>30.0</mp>
-            <cp>64.0</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>92.74</hp>
-            <mp>35.46</mp>
-            <cp>74.192</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>105.62</hp>
-            <mp>40.98</mp>
-            <cp>84.496</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>118.64</hp>
-            <mp>46.56</mp>
-            <cp>94.912</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>131.8</hp>
-            <mp>52.2</mp>
-            <cp>105.44</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>145.1</hp>
-            <mp>57.9</mp>
-            <cp>116.08</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>158.54</hp>
-            <mp>63.66</mp>
-            <cp>126.832</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>172.12</hp>
-            <mp>69.48</mp>
-            <cp>137.696</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>185.84</hp>
-            <mp>75.36</mp>
-            <cp>148.672</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>199.7</hp>
-            <mp>81.3</mp>
-            <cp>159.76</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>213.7</hp>
-            <mp>87.3</mp>
-            <cp>170.96</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>227.84</hp>
-            <mp>93.36</mp>
-            <cp>182.272</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>242.12</hp>
-            <mp>99.48</mp>
-            <cp>193.696</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>256.54</hp>
-            <mp>105.66</mp>
-            <cp>205.232</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>271.1</hp>
-            <mp>111.9</mp>
-            <cp>216.88</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>285.8</hp>
-            <mp>118.2</mp>
-            <cp>228.64</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>300.64</hp>
-            <mp>124.56</mp>
-            <cp>240.512</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>315.62</hp>
-            <mp>130.98</mp>
-            <cp>252.496</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>330.74</hp>
-            <mp>137.46</mp>
-            <cp>264.592</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>346.0</hp>
-            <mp>144.0</mp>
-            <cp>276.8</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>379.0</hp>
-            <mp>153.9</mp>
-            <cp>303.2</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>412.3</hp>
-            <mp>163.89</mp>
-            <cp>329.84</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>445.9</hp>
-            <mp>173.97</mp>
-            <cp>356.72</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>479.8</hp>
-            <mp>184.14</mp>
-            <cp>383.84</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>514.0</hp>
-            <mp>194.4</mp>
-            <cp>411.2</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>548.5</hp>
-            <mp>204.75</mp>
-            <cp>438.8</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>583.3</hp>
-            <mp>215.19</mp>
-            <cp>466.64</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>618.4</hp>
-            <mp>225.72</mp>
-            <cp>494.72</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>653.8</hp>
-            <mp>236.34</mp>
-            <cp>523.04</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>689.5</hp>
-            <mp>247.05</mp>
-            <cp>551.6</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>725.5</hp>
-            <mp>257.85</mp>
-            <cp>580.4</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>761.8</hp>
-            <mp>268.74</mp>
-            <cp>609.44</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>798.4</hp>
-            <mp>279.72</mp>
-            <cp>638.72</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>835.3</hp>
-            <mp>290.79</mp>
-            <cp>668.24</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>872.5</hp>
-            <mp>301.95</mp>
-            <cp>698.0</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>910.0</hp>
-            <mp>313.2</mp>
-            <cp>728.0</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>947.8</hp>
-            <mp>324.54</mp>
-            <cp>758.24</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>985.9</hp>
-            <mp>335.97</mp>
-            <cp>788.72</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>1024.3</hp>
-            <mp>347.49</mp>
-            <cp>819.44</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1063.0</hp>
-            <mp>359.1</mp>
-            <cp>850.4</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1117.6</hp>
-            <mp>378.6</mp>
-            <cp>894.08</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1172.62</hp>
-            <mp>398.25</mp>
-            <cp>938.096</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1228.06</hp>
-            <mp>418.05</mp>
-            <cp>982.448</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1283.92</hp>
-            <mp>438.0</mp>
-            <cp>1027.136</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1340.2</hp>
-            <mp>458.1</mp>
-            <cp>1072.16</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1396.9</hp>
-            <mp>478.35</mp>
-            <cp>1117.52</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1454.02</hp>
-            <mp>498.75</mp>
-            <cp>1163.216</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1511.56</hp>
-            <mp>519.3</mp>
-            <cp>1209.248</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1569.52</hp>
-            <mp>540.0</mp>
-            <cp>1255.616</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1627.9</hp>
-            <mp>560.85</mp>
-            <cp>1302.32</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1686.7</hp>
-            <mp>581.85</mp>
-            <cp>1349.36</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1745.92</hp>
-            <mp>603.0</mp>
-            <cp>1396.736</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1805.56</hp>
-            <mp>624.3</mp>
-            <cp>1444.448</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1865.62</hp>
-            <mp>645.75</mp>
-            <cp>1492.496</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1926.1</hp>
-            <mp>667.35</mp>
-            <cp>1540.88</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1987.0</hp>
-            <mp>689.1</mp>
-            <cp>1589.6</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>2048.32</hp>
-            <mp>711.0</mp>
-            <cp>1638.656</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>2110.06</hp>
-            <mp>733.05</mp>
-            <cp>1688.048</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>2172.22</hp>
-            <mp>755.25</mp>
-            <cp>1737.776</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2234.8</hp>
-            <mp>777.6</mp>
-            <cp>1787.84</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2297.8</hp>
-            <mp>800.1</mp>
-            <cp>1838.24</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2361.22</hp>
-            <mp>822.75</mp>
-            <cp>1888.976</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2425.06</hp>
-            <mp>845.55</mp>
-            <cp>1940.048</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2489.32</hp>
-            <mp>868.5</mp>
-            <cp>1991.456</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2554.0</hp>
-            <mp>891.6</mp>
-            <cp>2043.2</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2619.1</hp>
-            <mp>914.85</mp>
-            <cp>2095.28</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2684.62</hp>
-            <mp>938.25</mp>
-            <cp>2147.696</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2750.56</hp>
-            <mp>961.8</mp>
-            <cp>2200.448</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2816.92</hp>
-            <mp>985.5</mp>
-            <cp>2253.536</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2883.7</hp>
-            <mp>1009.35</mp>
-            <cp>2306.96</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2950.9</hp>
-            <mp>1033.35</mp>
-            <cp>2360.72</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>3018.52</hp>
-            <mp>1057.5</mp>
-            <cp>2414.816</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>3086.56</hp>
-            <mp>1081.8</mp>
-            <cp>2469.248</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>3155.02</hp>
-            <mp>1106.25</mp>
-            <cp>2524.016</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>3223.9</hp>
-            <mp>1130.85</mp>
-            <cp>2579.12</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>3293.2</hp>
-            <mp>1155.6</mp>
-            <cp>2634.56</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>3362.92</hp>
-            <mp>1180.5</mp>
-            <cp>2690.336</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3433.06</hp>
-            <mp>1205.55</mp>
-            <cp>2746.448</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3503.62</hp>
-            <mp>1230.75</mp>
-            <cp>2802.896</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3574.6</hp>
-            <mp>1256.1</mp>
-            <cp>2859.68</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3646.0</hp>
-            <mp>1281.6</mp>
-            <cp>2916.8</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3717.82</hp>
-            <mp>1307.25</mp>
-            <cp>2974.256</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3790.06</hp>
-            <mp>1333.05</mp>
-            <cp>3032.048</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3862.72</hp>
-            <mp>1359.0</mp>
-            <cp>3090.176</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3935.8</hp>
-            <mp>1385.1</mp>
-            <cp>3148.64</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>4009.3</hp>
-            <mp>1411.35</mp>
-            <cp>3207.44</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>4083.22</hp>
-            <mp>1437.75</mp>
-            <cp>3266.576</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>4157.56</hp>
-            <mp>1464.3</mp>
-            <cp>3326.048</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>4232.32</hp>
-            <mp>1491.0</mp>
-            <cp>3385.856</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>4307.5</hp>
-            <mp>1517.85</mp>
-            <cp>3446.0</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>4383.1</hp>
-            <mp>1544.85</mp>
-            <cp>3506.48</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>57</classId>
+	<staticData>
+		<baseINT>20</baseINT>
+		<baseSTR>39</baseSTR>
+		<baseCON>45</baseCON>
+		<baseMEN>27</baseMEN>
+		<baseDEX>29</baseDEX>
+		<baseWIT>10</baseWIT>
+		<physicalAbnormalResist>15</physicalAbnormalResist>
+		<magicAbnormalResist>10</magicAbnormalResist>
+		<creationPoints>
+			<node x="108644" y="-173947" z="-400" />
+			<node x="108678" y="-174002" z="-400" />
+			<node x="108505" y="-173964" z="-400" />
+			<node x="108512" y="-174026" z="-400" />
+			<node x="108549" y="-174075" z="-400" />
+			<node x="108576" y="-174122" z="-400" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>80</walk>
+			<run>131</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>80</baseBreath>
+		<baseSafeFall>180</baseSafeFall>
+		<collisionMale>
+			<radius>9.0</radius>
+			<height>18.0</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>5.0</radius>
+			<height>19.0</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>80.0</hp>
+			<mp>30.0</mp>
+			<cp>64.0</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>92.74</hp>
+			<mp>35.46</mp>
+			<cp>74.192</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>105.62</hp>
+			<mp>40.98</mp>
+			<cp>84.496</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>118.64</hp>
+			<mp>46.56</mp>
+			<cp>94.912</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>131.8</hp>
+			<mp>52.2</mp>
+			<cp>105.44</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>145.1</hp>
+			<mp>57.9</mp>
+			<cp>116.08</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>158.54</hp>
+			<mp>63.66</mp>
+			<cp>126.832</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>172.12</hp>
+			<mp>69.48</mp>
+			<cp>137.696</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>185.84</hp>
+			<mp>75.36</mp>
+			<cp>148.672</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>199.7</hp>
+			<mp>81.3</mp>
+			<cp>159.76</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>213.7</hp>
+			<mp>87.3</mp>
+			<cp>170.96</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>227.84</hp>
+			<mp>93.36</mp>
+			<cp>182.272</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>242.12</hp>
+			<mp>99.48</mp>
+			<cp>193.696</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>256.54</hp>
+			<mp>105.66</mp>
+			<cp>205.232</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>271.1</hp>
+			<mp>111.9</mp>
+			<cp>216.88</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>285.8</hp>
+			<mp>118.2</mp>
+			<cp>228.64</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>300.64</hp>
+			<mp>124.56</mp>
+			<cp>240.512</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>315.62</hp>
+			<mp>130.98</mp>
+			<cp>252.496</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>330.74</hp>
+			<mp>137.46</mp>
+			<cp>264.592</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>346.0</hp>
+			<mp>144.0</mp>
+			<cp>276.8</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>379.0</hp>
+			<mp>153.9</mp>
+			<cp>303.2</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>412.3</hp>
+			<mp>163.89</mp>
+			<cp>329.84</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>445.9</hp>
+			<mp>173.97</mp>
+			<cp>356.72</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>479.8</hp>
+			<mp>184.14</mp>
+			<cp>383.84</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>514.0</hp>
+			<mp>194.4</mp>
+			<cp>411.2</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>548.5</hp>
+			<mp>204.75</mp>
+			<cp>438.8</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>583.3</hp>
+			<mp>215.19</mp>
+			<cp>466.64</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>618.4</hp>
+			<mp>225.72</mp>
+			<cp>494.72</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>653.8</hp>
+			<mp>236.34</mp>
+			<cp>523.04</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>689.5</hp>
+			<mp>247.05</mp>
+			<cp>551.6</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>725.5</hp>
+			<mp>257.85</mp>
+			<cp>580.4</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>761.8</hp>
+			<mp>268.74</mp>
+			<cp>609.44</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>798.4</hp>
+			<mp>279.72</mp>
+			<cp>638.72</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>835.3</hp>
+			<mp>290.79</mp>
+			<cp>668.24</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>872.5</hp>
+			<mp>301.95</mp>
+			<cp>698.0</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>910.0</hp>
+			<mp>313.2</mp>
+			<cp>728.0</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>947.8</hp>
+			<mp>324.54</mp>
+			<cp>758.24</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>985.9</hp>
+			<mp>335.97</mp>
+			<cp>788.72</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>1024.3</hp>
+			<mp>347.49</mp>
+			<cp>819.44</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1063.0</hp>
+			<mp>359.1</mp>
+			<cp>850.4</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1117.6</hp>
+			<mp>378.6</mp>
+			<cp>894.08</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1172.62</hp>
+			<mp>398.25</mp>
+			<cp>938.096</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1228.06</hp>
+			<mp>418.05</mp>
+			<cp>982.448</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1283.92</hp>
+			<mp>438.0</mp>
+			<cp>1027.136</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1340.2</hp>
+			<mp>458.1</mp>
+			<cp>1072.16</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1396.9</hp>
+			<mp>478.35</mp>
+			<cp>1117.52</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1454.02</hp>
+			<mp>498.75</mp>
+			<cp>1163.216</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1511.56</hp>
+			<mp>519.3</mp>
+			<cp>1209.248</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1569.52</hp>
+			<mp>540.0</mp>
+			<cp>1255.616</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1627.9</hp>
+			<mp>560.85</mp>
+			<cp>1302.32</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1686.7</hp>
+			<mp>581.85</mp>
+			<cp>1349.36</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1745.92</hp>
+			<mp>603.0</mp>
+			<cp>1396.736</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1805.56</hp>
+			<mp>624.3</mp>
+			<cp>1444.448</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1865.62</hp>
+			<mp>645.75</mp>
+			<cp>1492.496</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1926.1</hp>
+			<mp>667.35</mp>
+			<cp>1540.88</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1987.0</hp>
+			<mp>689.1</mp>
+			<cp>1589.6</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>2048.32</hp>
+			<mp>711.0</mp>
+			<cp>1638.656</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>2110.06</hp>
+			<mp>733.05</mp>
+			<cp>1688.048</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>2172.22</hp>
+			<mp>755.25</mp>
+			<cp>1737.776</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2234.8</hp>
+			<mp>777.6</mp>
+			<cp>1787.84</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2297.8</hp>
+			<mp>800.1</mp>
+			<cp>1838.24</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2361.22</hp>
+			<mp>822.75</mp>
+			<cp>1888.976</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2425.06</hp>
+			<mp>845.55</mp>
+			<cp>1940.048</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2489.32</hp>
+			<mp>868.5</mp>
+			<cp>1991.456</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2554.0</hp>
+			<mp>891.6</mp>
+			<cp>2043.2</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2619.1</hp>
+			<mp>914.85</mp>
+			<cp>2095.28</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2684.62</hp>
+			<mp>938.25</mp>
+			<cp>2147.696</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2750.56</hp>
+			<mp>961.8</mp>
+			<cp>2200.448</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2816.92</hp>
+			<mp>985.5</mp>
+			<cp>2253.536</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2883.7</hp>
+			<mp>1009.35</mp>
+			<cp>2306.96</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2950.9</hp>
+			<mp>1033.35</mp>
+			<cp>2360.72</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>3018.52</hp>
+			<mp>1057.5</mp>
+			<cp>2414.816</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>3086.56</hp>
+			<mp>1081.8</mp>
+			<cp>2469.248</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>3155.02</hp>
+			<mp>1106.25</mp>
+			<cp>2524.016</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>3223.9</hp>
+			<mp>1130.85</mp>
+			<cp>2579.12</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>3293.2</hp>
+			<mp>1155.6</mp>
+			<cp>2634.56</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>3362.92</hp>
+			<mp>1180.5</mp>
+			<cp>2690.336</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3433.06</hp>
+			<mp>1205.55</mp>
+			<cp>2746.448</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3503.62</hp>
+			<mp>1230.75</mp>
+			<cp>2802.896</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3574.6</hp>
+			<mp>1256.1</mp>
+			<cp>2859.68</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3646.0</hp>
+			<mp>1281.6</mp>
+			<cp>2916.8</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3717.82</hp>
+			<mp>1307.25</mp>
+			<cp>2974.256</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3790.06</hp>
+			<mp>1333.05</mp>
+			<cp>3032.048</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3862.72</hp>
+			<mp>1359.0</mp>
+			<cp>3090.176</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3935.8</hp>
+			<mp>1385.1</mp>
+			<cp>3148.64</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>4009.3</hp>
+			<mp>1411.35</mp>
+			<cp>3207.44</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>4083.22</hp>
+			<mp>1437.75</mp>
+			<cp>3266.576</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>4157.56</hp>
+			<mp>1464.3</mp>
+			<cp>3326.048</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>4232.32</hp>
+			<mp>1491.0</mp>
+			<cp>3385.856</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>4307.5</hp>
+			<mp>1517.85</mp>
+			<cp>3446.0</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>4383.1</hp>
+			<mp>1544.85</mp>
+			<cp>3506.48</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>4459.12</hp>
+			<mp>1572.0</mp>
+			<cp>3567.296</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4535.56</hp>
+			<mp>1599.3</mp>
+			<cp>3628.448</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4612.42</hp>
+			<mp>1626.75</mp>
+			<cp>3689.936</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4689.7</hp>
+			<mp>1654.35</mp>
+			<cp>3751.76</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4767.4</hp>
+			<mp>1682.1</mp>
+			<cp>3813.92</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4845.52</hp>
+			<mp>1710.0</mp>
+			<cp>3876.416</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4924.06</hp>
+			<mp>1738.05</mp>
+			<cp>3939.248</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>5003.02</hp>
+			<mp>1766.25</mp>
+			<cp>4002.416</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>5082.4</hp>
+			<mp>1794.6</mp>
+			<cp>4065.92</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>5162.2</hp>
+			<mp>1823.1</mp>
+			<cp>4129.77</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>5242.42</hp>
+			<mp>1851.75</mp>
+			<cp>4193.96</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>5323.06</hp>
+			<mp>1880.55</mp>
+			<cp>4258.49</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>5404.12</hp>
+			<mp>1909.5</mp>
+			<cp>4323.36</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>5485.6</hp>
+			<mp>1938.6</mp>
+			<cp>4388.56</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>5567.5</hp>
+			<mp>1967.85</mp>
+			<cp>4454.11</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>5649.82</hp>
+			<mp>1997.25</mp>
+			<cp>4519.856</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/baseStats/WindHunter.xml
+++ b/data/stats/chars/baseStats/WindHunter.xml
@@ -1,0 +1,923 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
+    <classId>210</classId>
+    <staticData>
+        <baseINT>20</baseINT>
+        <baseSTR>40</baseSTR>
+        <baseCON>40</baseCON>
+        <baseMEN>25</baseMEN>
+        <baseDEX>35</baseDEX>
+        <baseWIT>10</baseWIT>
+        <physicalAbnormalResist>10</physicalAbnormalResist>
+        <magicAbnormalResist>10</magicAbnormalResist>
+        <creationPoints>
+            <node x="102612" y="59473" z="-3773" />
+        </creationPoints>
+        <basePAtk>4</basePAtk>
+        <baseCritRate>4</baseCritRate>
+        <baseMCritRate>5</baseMCritRate>
+        <baseAtkType>FIST</baseAtkType>
+        <basePAtkSpd>300</basePAtkSpd>
+        <baseMAtkSpd>333</baseMAtkSpd>
+        <basePDef>
+            <chest>31</chest>
+            <legs>18</legs>
+            <head>12</head>
+            <feet>7</feet>
+            <gloves>8</gloves>
+            <underwear>3</underwear>
+            <cloak>1</cloak>
+        </basePDef>
+        <baseMAtk>6</baseMAtk>
+        <baseMDef>
+            <rear>9</rear>
+            <lear>9</lear>
+            <rfinger>5</rfinger>
+            <lfinger>5</lfinger>
+            <neck>13</neck>
+        </baseMDef>
+        <baseCanPenetrate>0</baseCanPenetrate>
+        <baseAtkRange>20</baseAtkRange>
+        <baseDamRange>
+            <verticalDirection>0</verticalDirection>
+            <horizontalDirection>0</horizontalDirection>
+            <distance>26</distance>
+            <width>120</width>
+        </baseDamRange>
+        <baseRndDam>10</baseRndDam>
+        <baseMoveSpd>
+            <walk>88</walk>
+            <run>141</run>
+            <slowSwim>50</slowSwim>
+            <fastSwim>50</fastSwim>
+        </baseMoveSpd>
+        <baseBreath>150</baseBreath>
+        <baseSafeFall>350</baseSafeFall>
+        <collisionMale>
+            <radius>6</radius>
+            <height>18.1</height>
+        </collisionMale>
+        <collisionFemale>
+            <radius>6.5</radius>
+            <height>19.2</height>
+        </collisionFemale>
+    </staticData>
+    <lvlUpgainData>
+        <level val="1">
+            <hp>80.0</hp>
+            <mp>30.0</mp>
+            <cp>40.0</cp>
+            <hpRegen>2.0</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2.0</cpRegen>
+        </level>
+        <level val="2">
+            <hp>97</hp>
+            <mp>36.5</mp>
+            <cp>48.5</cp>
+            <hpRegen>2.05</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2.0</cpRegen>
+        </level>
+        <level val="3">
+            <hp>114</hp>
+            <mp>44</mp>
+            <cp>57</cp>
+            <hpRegen>2.1</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2.0</cpRegen>
+        </level>
+        <level val="4">
+            <hp>131</hp>
+            <mp>52.5</mp>
+            <cp>65.5</cp>
+            <hpRegen>2.15</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2</cpRegen>
+        </level>
+        <level val="5">
+            <hp>148</hp>
+            <mp>62</mp>
+            <cp>74</cp>
+            <hpRegen>2.2</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2</cpRegen>
+        </level>
+        <level val="6">
+            <hp>165</hp>
+            <mp>72.5</mp>
+            <cp>82.5</cp>
+            <hpRegen>2.25</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2</cpRegen>
+        </level>
+        <level val="7">
+            <hp>182</hp>
+            <mp>84</mp>
+            <cp>91</cp>
+            <hpRegen>2.3</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2</cpRegen>
+        </level>
+        <level val="8">
+            <hp>199</hp>
+            <mp>96.5</mp>
+            <cp>99.5</cp>
+            <hpRegen>2.35</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2</cpRegen>
+        </level>
+        <level val="9">
+            <hp>216</hp>
+            <mp>110</mp>
+            <cp>108</cp>
+            <hpRegen>2.4</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2</cpRegen>
+        </level>
+        <level val="10">
+            <hp>233</hp>
+            <mp>124.5</mp>
+            <cp>116.5</cp>
+            <hpRegen>2.45</hpRegen>
+            <mpRegen>0.9</mpRegen>
+            <cpRegen>2</cpRegen>
+        </level>
+        <level val="11">
+            <hp>250</hp>
+            <mp>140</mp>
+            <cp>125</cp>
+            <hpRegen>2.55</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="12">
+            <hp>267</hp>
+            <mp>156.5</mp>
+            <cp>133.5</cp>
+            <hpRegen>2.65</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="13">
+            <hp>284</hp>
+            <mp>174</mp>
+            <cp>142</cp>
+            <hpRegen>2.75</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="14">
+            <hp>301</hp>
+            <mp>192.5</mp>
+            <cp>150.5</cp>
+            <hpRegen>2.85</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="15">
+            <hp>318</hp>
+            <mp>212</mp>
+            <cp>159</cp>
+            <hpRegen>2.95</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="16">
+            <hp>335</hp>
+            <mp>232.5</mp>
+            <cp>167.5</cp>
+            <hpRegen>3.05</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="17">
+            <hp>352</hp>
+            <mp>254</mp>
+            <cp>176</cp>
+            <hpRegen>3.15</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="18">
+            <hp>369</hp>
+            <mp>276.5</mp>
+            <cp>184.5</cp>
+            <hpRegen>3.25</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="19">
+            <hp>386</hp>
+            <mp>300</mp>
+            <cp>193</cp>
+            <hpRegen>3.35</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="20">
+            <hp>403</hp>
+            <mp>324.5</mp>
+            <cp>201.5</cp>
+            <hpRegen>3.45</hpRegen>
+            <mpRegen>1.2</mpRegen>
+            <cpRegen>2.5</cpRegen>
+        </level>
+        <level val="21">
+            <hp>420</hp>
+            <mp>350</mp>
+            <cp>210</cp>
+            <hpRegen>3.55</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="22">
+            <hp>437</hp>
+            <mp>376.5</mp>
+            <cp>218.5</cp>
+            <hpRegen>3.65</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="23">
+            <hp>454</hp>
+            <mp>404</mp>
+            <cp>227</cp>
+            <hpRegen>3.75</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="24">
+            <hp>471</hp>
+            <mp>432.5</mp>
+            <cp>235.5</cp>
+            <hpRegen>3.85</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="25">
+            <hp>488</hp>
+            <mp>462</mp>
+            <cp>244</cp>
+            <hpRegen>3.95</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="26">
+            <hp>505</hp>
+            <mp>492.5</mp>
+            <cp>252.5</cp>
+            <hpRegen>4.05</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="27">
+            <hp>522</hp>
+            <mp>524</mp>
+            <cp>261</cp>
+            <hpRegen>4.15</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="28">
+            <hp>539</hp>
+            <mp>556.5</mp>
+            <cp>269.5</cp>
+            <hpRegen>4.25</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="29">
+            <hp>556</hp>
+            <mp>590</mp>
+            <cp>278</cp>
+            <hpRegen>4.35</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="30">
+            <hp>573</hp>
+            <mp>624.5</mp>
+            <cp>286.5</cp>
+            <hpRegen>4.45</hpRegen>
+            <mpRegen>1.5</mpRegen>
+            <cpRegen>3.5</cpRegen>
+        </level>
+        <level val="31">
+            <hp>590</hp>
+            <mp>660</mp>
+            <cp>295</cp>
+            <hpRegen>4.55</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="32">
+            <hp>607</hp>
+            <mp>696.5</mp>
+            <cp>303.5</cp>
+            <hpRegen>4.65</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="33">
+            <hp>624</hp>
+            <mp>734</mp>
+            <cp>312</cp>
+            <hpRegen>4.75</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="34">
+            <hp>641</hp>
+            <mp>772.5</mp>
+            <cp>320.5</cp>
+            <hpRegen>4.85</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="35">
+            <hp>658</hp>
+            <mp>812</mp>
+            <cp>329</cp>
+            <hpRegen>4.95</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="36">
+            <hp>675</hp>
+            <mp>852.5</mp>
+            <cp>337.5</cp>
+            <hpRegen>5.05</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="37">
+            <hp>692</hp>
+            <mp>894</mp>
+            <cp>346</cp>
+            <hpRegen>5.15</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="38">
+            <hp>709</hp>
+            <mp>936.5</mp>
+            <cp>354.5</cp>
+            <hpRegen>5.25</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="39">
+            <hp>726</hp>
+            <mp>980</mp>
+            <cp>363</cp>
+            <hpRegen>5.35</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="40">
+            <hp>895</hp>
+            <mp>147.5</mp>
+            <cp>626</cp>
+            <hpRegen>5.45</hpRegen>
+            <mpRegen>1.8</mpRegen>
+            <cpRegen>4.5</cpRegen>
+        </level>
+        <level val="41">
+            <hp>943</hp>
+            <mp>196</mp>
+            <cp>660</cp>
+            <hpRegen>5.55</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="42">
+            <hp>991</hp>
+            <mp>244.5</mp>
+            <cp>694</cp>
+            <hpRegen>5.65</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="43">
+            <hp>1039</hp>
+            <mp>293</mp>
+            <cp>728</cp>
+            <hpRegen>5.75</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="44">
+            <hp>1087</hp>
+            <mp>341.5</mp>
+            <cp>762</cp>
+            <hpRegen>5.85</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="45">
+            <hp>1135</hp>
+            <mp>390</mp>
+            <cp>796</cp>
+            <hpRegen>5.95</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="46">
+            <hp>1183</hp>
+            <mp>438.5</mp>
+            <cp>830</cp>
+            <hpRegen>6.05</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="47">
+            <hp>1231</hp>
+            <mp>487</mp>
+            <cp>864</cp>
+            <hpRegen>6.15</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="48">
+            <hp>1279</hp>
+            <mp>535.5</mp>
+            <cp>898</cp>
+            <hpRegen>6.25</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="49">
+            <hp>1327</hp>
+            <mp>584</mp>
+            <cp>932</cp>
+            <hpRegen>6.35</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="50">
+            <hp>1375</hp>
+            <mp>632.5</mp>
+            <cp>966</cp>
+            <hpRegen>6.45</hpRegen>
+            <mpRegen>2.1</mpRegen>
+            <cpRegen>5.5</cpRegen>
+        </level>
+        <level val="51">
+            <hp>1423</hp>
+            <mp>681</mp>
+            <cp>1000</cp>
+            <hpRegen>6.55</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="52">
+            <hp>1471</hp>
+            <mp>729.5</mp>
+            <cp>1034</cp>
+            <hpRegen>6.65</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="53">
+            <hp>1519</hp>
+            <mp>778</mp>
+            <cp>1068</cp>
+            <hpRegen>6.75</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="54">
+            <hp>1567</hp>
+            <mp>826.5</mp>
+            <cp>1102</cp>
+            <hpRegen>6.85</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="55">
+            <hp>1615</hp>
+            <mp>875</mp>
+            <cp>1136</cp>
+            <hpRegen>6.95</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="56">
+            <hp>1663</hp>
+            <mp>923.5</mp>
+            <cp>1170</cp>
+            <hpRegen>7.05</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="57">
+            <hp>1711</hp>
+            <mp>972</mp>
+            <cp>1204</cp>
+            <hpRegen>7.15</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="58">
+            <hp>1759</hp>
+            <mp>1020.5</mp>
+            <cp>1238</cp>
+            <hpRegen>7.25</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="59">
+            <hp>1807</hp>
+            <mp>1069</mp>
+            <cp>1272</cp>
+            <hpRegen>7.35</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="60">
+            <hp>1855</hp>
+            <mp>1117.5</mp>
+            <cp>1306</cp>
+            <hpRegen>7.45</hpRegen>
+            <mpRegen>2.4</mpRegen>
+            <cpRegen>6.5</cpRegen>
+        </level>
+        <level val="61">
+            <hp>1903</hp>
+            <mp>1166</mp>
+            <cp>1340</cp>
+            <hpRegen>7.55</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="62">
+            <hp>1951</hp>
+            <mp>1214.5</mp>
+            <cp>1374</cp>
+            <hpRegen>7.65</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="63">
+            <hp>1999</hp>
+            <mp>1263</mp>
+            <cp>1408</cp>
+            <hpRegen>7.75</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="64">
+            <hp>2047</hp>
+            <mp>1311.5</mp>
+            <cp>1442</cp>
+            <hpRegen>7.85</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="65">
+            <hp>2095</hp>
+            <mp>1360</mp>
+            <cp>1476</cp>
+            <hpRegen>7.95</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="66">
+            <hp>2143</hp>
+            <mp>1408.5</mp>
+            <cp>1510</cp>
+            <hpRegen>8.05</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="67">
+            <hp>2191</hp>
+            <mp>1457</mp>
+            <cp>1544</cp>
+            <hpRegen>8.15</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="68">
+            <hp>2239</hp>
+            <mp>1505.5</mp>
+            <cp>1578</cp>
+            <hpRegen>8.25</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="69">
+            <hp>2287</hp>
+            <mp>1554</mp>
+            <cp>1612</cp>
+            <hpRegen>8.35</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="70">
+            <hp>2335</hp>
+            <mp>1602.5</mp>
+            <cp>1646</cp>
+            <hpRegen>8.45</hpRegen>
+            <mpRegen>2.7</mpRegen>
+            <cpRegen>7.5</cpRegen>
+        </level>
+        <level val="71">
+            <hp>2383</hp>
+            <mp>1651</mp>
+            <cp>1680</cp>
+            <hpRegen>8.55</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="72">
+            <hp>2431</hp>
+            <mp>1699.5</mp>
+            <cp>1714</cp>
+            <hpRegen>8.65</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="73">
+            <hp>2479</hp>
+            <mp>1748</mp>
+            <cp>1748</cp>
+            <hpRegen>8.75</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="74">
+            <hp>2527</hp>
+            <mp>1796.5</mp>
+            <cp>1782</cp>
+            <hpRegen>8.85</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="75">
+            <hp>2575</hp>
+            <mp>1845</mp>
+            <cp>1816</cp>
+            <hpRegen>8.95</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="76">
+            <hp>2879</hp>
+            <mp>988</mp>
+            <cp>2001</cp>
+            <hpRegen>9.05</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="77">
+            <hp>2920</hp>
+            <mp>1008.5</mp>
+            <cp>2044</cp>
+            <hpRegen>9.15</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="78">
+            <hp>2982</hp>
+            <mp>1030</mp>
+            <cp>2088</cp>
+            <hpRegen>9.25</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="79">
+            <hp>3065</hp>
+            <mp>1052.5</mp>
+            <cp>2133</cp>
+            <hpRegen>9.35</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="80">
+            <hp>3169</hp>
+            <mp>1076</mp>
+            <cp>2179</cp>
+            <hpRegen>9.45</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="81">
+            <hp>3294</hp>
+            <mp>1100.5</mp>
+            <cp>2226</cp>
+            <hpRegen>9.55</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="82">
+            <hp>3440</hp>
+            <mp>1126</mp>
+            <cp>2274</cp>
+            <hpRegen>9.65</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="83">
+            <hp>3607</hp>
+            <mp>1152.5</mp>
+            <cp>2323</cp>
+            <hpRegen>9.75</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="84">
+            <hp>3795</hp>
+            <mp>1180</mp>
+            <cp>2373</cp>
+            <hpRegen>9.85</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="85">
+            <hp>4004</hp>
+            <mp>1208.5</mp>
+            <cp>2424</cp>
+            <hpRegen>9.95</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="86">
+            <hp>4234</hp>
+            <mp>1238</mp>
+            <cp>2476</cp>
+            <hpRegen>10.05</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="87">
+            <hp>4485</hp>
+            <mp>1268.5</mp>
+            <cp>2529</cp>
+            <hpRegen>10.15</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="88">
+            <hp>4757</hp>
+            <mp>1300</mp>
+            <cp>2583</cp>
+            <hpRegen>10.25</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="89">
+            <hp>5050</hp>
+            <mp>1332.5</mp>
+            <cp>2638</cp>
+            <hpRegen>10.35</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="90">
+            <hp>5364</hp>
+            <mp>1366</mp>
+            <cp>2694</cp>
+            <hpRegen>10.45</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="91">
+            <hp>5699</hp>
+            <mp>1400.5</mp>
+            <cp>2751</cp>
+            <hpRegen>10.55</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="92">
+            <hp>6055</hp>
+            <mp>1436</mp>
+            <cp>2809</cp>
+            <hpRegen>10.65</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="93">
+            <hp>6432</hp>
+            <mp>1472.5</mp>
+            <cp>2868</cp>
+            <hpRegen>10.75</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="94">
+            <hp>6830</hp>
+            <mp>1510</mp>
+            <cp>2928</cp>
+            <hpRegen>10.85</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="95">
+            <hp>7249</hp>
+            <mp>1548.5</mp>
+            <cp>2989</cp>
+            <hpRegen>10.95</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="96">
+            <hp>7689</hp>
+            <mp>1588</mp>
+            <cp>3051</cp>
+            <hpRegen>11.05</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="97">
+            <hp>8150</hp>
+            <mp>1628.5</mp>
+            <cp>3114</cp>
+            <hpRegen>11.15</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="98">
+            <hp>8632</hp>
+            <mp>1670</mp>
+            <cp>3178</cp>
+            <hpRegen>11.25</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="99">
+            <hp>9135</hp>
+            <mp>1712.5</mp>
+            <cp>3243</cp>
+            <hpRegen>11.35</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="100">
+            <hp>9659</hp>
+            <mp>1756</mp>
+            <cp>3309</cp>
+            <hpRegen>11.45</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="101">
+            <hp>10204</hp>
+            <mp>1800.5</mp>
+            <cp>3376</cp>
+            <hpRegen>11.55</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="102">
+            <hp>10770</hp>
+            <mp>1846</mp>
+            <cp>3444</cp>
+            <hpRegen>11.65</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="103">
+            <hp>11357</hp>
+            <mp>1892.5</mp>
+            <cp>3513</cp>
+            <hpRegen>11.75</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="104">
+            <hp>11965</hp>
+            <mp>1940</mp>
+            <cp>3583</cp>
+            <hpRegen>11.85</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="105">
+            <hp>12594</hp>
+            <mp>1988.5</mp>
+            <cp>3654</cp>
+            <hpRegen>11.95</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="106">
+            <hp>13244</hp>
+            <mp>2038</mp>
+            <cp>3726</cp>
+            <hpRegen>12.05</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+        <level val="107">
+            <hp>13915</hp>
+            <mp>2088.5</mp>
+            <cp>3799</cp>
+            <hpRegen>12.15</hpRegen>
+            <mpRegen>3</mpRegen>
+            <cpRegen>8.5</cpRegen>
+        </level>
+    </lvlUpgainData>
+</list>

--- a/data/stats/chars/baseStats/WindRider.xml
+++ b/data/stats/chars/baseStats/WindRider.xml
@@ -1,800 +1,928 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/charTemplate.xsd">
-    <classId>101</classId>
-    <staticData>
-        <baseINT>23</baseINT>
-        <baseSTR>36</baseSTR>
-        <baseCON>36</baseCON>
-        <baseMEN>26</baseMEN>
-        <baseDEX>35</baseDEX>
-        <baseWIT>14</baseWIT>
-        <physicalAbnormalResist>10</physicalAbnormalResist>
-        <magicAbnormalResist>15</magicAbnormalResist>
-        <creationPoints>
-            <node x="46045" y="41251" z="-3440"/>
-            <node x="46117" y="41247" z="-3440"/>
-            <node x="46182" y="41198" z="-3440"/>
-            <node x="46115" y="41141" z="-3440"/>
-            <node x="46048" y="41141" z="-3440"/>
-            <node x="45978" y="41196" z="-3440"/>
-        </creationPoints>
-        <basePAtk>4</basePAtk>
-        <baseCritRate>4</baseCritRate>
-        <baseMCritRate>5</baseMCritRate>
-        <baseAtkType>FIST</baseAtkType>
-        <basePAtkSpd>300</basePAtkSpd>
-        <baseMAtkSpd>333</baseMAtkSpd>
-        <basePDef>
-            <chest>31</chest>
-            <legs>18</legs>
-            <head>12</head>
-            <feet>7</feet>
-            <gloves>8</gloves>
-            <underwear>3</underwear>
-            <cloak>1</cloak>
-        </basePDef>
-        <baseMAtk>6</baseMAtk>
-        <baseMDef>
-            <rear>9</rear>
-            <lear>9</lear>
-            <rfinger>5</rfinger>
-            <lfinger>5</lfinger>
-            <neck>13</neck>
-        </baseMDef>
-        <baseCanPenetrate>0</baseCanPenetrate>
-        <baseAtkRange>20</baseAtkRange>
-        <baseDamRange>
-            <verticalDirection>0</verticalDirection>
-            <horizontalDirection>0</horizontalDirection>
-            <distance>26</distance>
-            <width>120</width>
-        </baseDamRange>
-        <baseRndDam>10</baseRndDam>
-        <baseMoveSpd>
-            <walk>90</walk>
-            <run>143</run>
-            <slowSwim>50</slowSwim>
-            <fastSwim>50</fastSwim>
-        </baseMoveSpd>
-        <baseBreath>150</baseBreath>
-        <baseSafeFall>350</baseSafeFall>
-        <collisionMale>
-            <radius>7.5</radius>
-            <height>24</height>
-        </collisionMale>
-        <collisionFemale>
-            <radius>7.5</radius>
-            <height>23</height>
-        </collisionFemale>
-    </staticData>
-    <lvlUpgainData>
-        <level val="1">
-            <hp>89.0</hp>
-            <mp>30.0</mp>
-            <cp>48.95</cp>
-            <hpRegen>2.0</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="2">
-            <hp>101.74</hp>
-            <mp>35.46</mp>
-            <cp>55.957</cp>
-            <hpRegen>2.05</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="3">
-            <hp>114.62</hp>
-            <mp>40.98</mp>
-            <cp>63.041</cp>
-            <hpRegen>2.1</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="4">
-            <hp>127.64</hp>
-            <mp>46.56</mp>
-            <cp>70.202</cp>
-            <hpRegen>2.15</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="5">
-            <hp>140.8</hp>
-            <mp>52.2</mp>
-            <cp>77.44</cp>
-            <hpRegen>2.2</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="6">
-            <hp>154.1</hp>
-            <mp>57.9</mp>
-            <cp>84.755</cp>
-            <hpRegen>2.25</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="7">
-            <hp>167.54</hp>
-            <mp>63.66</mp>
-            <cp>92.147</cp>
-            <hpRegen>2.3</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="8">
-            <hp>181.12</hp>
-            <mp>69.48</mp>
-            <cp>99.616</cp>
-            <hpRegen>2.35</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="9">
-            <hp>194.84</hp>
-            <mp>75.36</mp>
-            <cp>107.162</cp>
-            <hpRegen>2.4</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="10">
-            <hp>208.7</hp>
-            <mp>81.3</mp>
-            <cp>114.785</cp>
-            <hpRegen>2.45</hpRegen>
-            <mpRegen>0.9</mpRegen>
-            <cpRegen>2.0</cpRegen>
-        </level>
-        <level val="11">
-            <hp>222.7</hp>
-            <mp>87.3</mp>
-            <cp>122.485</cp>
-            <hpRegen>2.5</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="12">
-            <hp>236.84</hp>
-            <mp>93.36</mp>
-            <cp>130.262</cp>
-            <hpRegen>2.6</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="13">
-            <hp>251.12</hp>
-            <mp>99.48</mp>
-            <cp>138.116</cp>
-            <hpRegen>2.7</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="14">
-            <hp>265.54</hp>
-            <mp>105.66</mp>
-            <cp>146.047</cp>
-            <hpRegen>2.8</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="15">
-            <hp>280.1</hp>
-            <mp>111.9</mp>
-            <cp>154.055</cp>
-            <hpRegen>2.9</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="16">
-            <hp>294.8</hp>
-            <mp>118.2</mp>
-            <cp>162.14</cp>
-            <hpRegen>3.0</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="17">
-            <hp>309.64</hp>
-            <mp>124.56</mp>
-            <cp>170.302</cp>
-            <hpRegen>3.1</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="18">
-            <hp>324.62</hp>
-            <mp>130.98</mp>
-            <cp>178.541</cp>
-            <hpRegen>3.2</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="19">
-            <hp>339.74</hp>
-            <mp>137.46</mp>
-            <cp>186.857</cp>
-            <hpRegen>3.3</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="20">
-            <hp>355.0</hp>
-            <mp>144.0</mp>
-            <cp>195.25</cp>
-            <hpRegen>3.4</hpRegen>
-            <mpRegen>1.2</mpRegen>
-            <cpRegen>2.5</cpRegen>
-        </level>
-        <level val="21">
-            <hp>385.8</hp>
-            <mp>153.9</mp>
-            <cp>212.19</cp>
-            <hpRegen>3.5</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="22">
-            <hp>416.88</hp>
-            <mp>163.89</mp>
-            <cp>229.284</cp>
-            <hpRegen>3.6</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="23">
-            <hp>448.24</hp>
-            <mp>173.97</mp>
-            <cp>246.532</cp>
-            <hpRegen>3.7</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="24">
-            <hp>479.88</hp>
-            <mp>184.14</mp>
-            <cp>263.934</cp>
-            <hpRegen>3.8</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="25">
-            <hp>511.8</hp>
-            <mp>194.4</mp>
-            <cp>281.49</cp>
-            <hpRegen>3.9</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="26">
-            <hp>544.0</hp>
-            <mp>204.75</mp>
-            <cp>299.2</cp>
-            <hpRegen>4.0</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="27">
-            <hp>576.48</hp>
-            <mp>215.19</mp>
-            <cp>317.064</cp>
-            <hpRegen>4.1</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="28">
-            <hp>609.24</hp>
-            <mp>225.72</mp>
-            <cp>335.082</cp>
-            <hpRegen>4.2</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="29">
-            <hp>642.28</hp>
-            <mp>236.34</mp>
-            <cp>353.254</cp>
-            <hpRegen>4.3</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="30">
-            <hp>675.6</hp>
-            <mp>247.05</mp>
-            <cp>371.58</cp>
-            <hpRegen>4.4</hpRegen>
-            <mpRegen>1.5</mpRegen>
-            <cpRegen>3.5</cpRegen>
-        </level>
-        <level val="31">
-            <hp>709.2</hp>
-            <mp>257.85</mp>
-            <cp>390.06</cp>
-            <hpRegen>4.5</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="32">
-            <hp>743.08</hp>
-            <mp>268.74</mp>
-            <cp>408.694</cp>
-            <hpRegen>4.6</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="33">
-            <hp>777.24</hp>
-            <mp>279.72</mp>
-            <cp>427.482</cp>
-            <hpRegen>4.7</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="34">
-            <hp>811.68</hp>
-            <mp>290.79</mp>
-            <cp>446.424</cp>
-            <hpRegen>4.8</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="35">
-            <hp>846.4</hp>
-            <mp>301.95</mp>
-            <cp>465.52</cp>
-            <hpRegen>4.9</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="36">
-            <hp>881.4</hp>
-            <mp>313.2</mp>
-            <cp>484.77</cp>
-            <hpRegen>5.0</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="37">
-            <hp>916.68</hp>
-            <mp>324.54</mp>
-            <cp>504.174</cp>
-            <hpRegen>5.1</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="38">
-            <hp>952.24</hp>
-            <mp>335.97</mp>
-            <cp>523.732</cp>
-            <hpRegen>5.2</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="39">
-            <hp>988.08</hp>
-            <mp>347.49</mp>
-            <cp>543.444</cp>
-            <hpRegen>5.3</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="40">
-            <hp>1024.2</hp>
-            <mp>359.1</mp>
-            <cp>563.31</cp>
-            <hpRegen>5.4</hpRegen>
-            <mpRegen>1.8</mpRegen>
-            <cpRegen>4.5</cpRegen>
-        </level>
-        <level val="41">
-            <hp>1071.0</hp>
-            <mp>378.6</mp>
-            <cp>589.05</cp>
-            <hpRegen>5.5</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="42">
-            <hp>1118.16</hp>
-            <mp>398.25</mp>
-            <cp>614.988</cp>
-            <hpRegen>5.6</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="43">
-            <hp>1165.68</hp>
-            <mp>418.05</mp>
-            <cp>641.124</cp>
-            <hpRegen>5.7</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="44">
-            <hp>1213.56</hp>
-            <mp>438.0</mp>
-            <cp>667.458</cp>
-            <hpRegen>5.8</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="45">
-            <hp>1261.8</hp>
-            <mp>458.1</mp>
-            <cp>693.99</cp>
-            <hpRegen>5.9</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="46">
-            <hp>1310.4</hp>
-            <mp>478.35</mp>
-            <cp>720.72</cp>
-            <hpRegen>6.0</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="47">
-            <hp>1359.36</hp>
-            <mp>498.75</mp>
-            <cp>747.648</cp>
-            <hpRegen>6.1</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="48">
-            <hp>1408.68</hp>
-            <mp>519.3</mp>
-            <cp>774.774</cp>
-            <hpRegen>6.2</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="49">
-            <hp>1458.36</hp>
-            <mp>540.0</mp>
-            <cp>802.098</cp>
-            <hpRegen>6.3</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="50">
-            <hp>1508.4</hp>
-            <mp>560.85</mp>
-            <cp>829.62</cp>
-            <hpRegen>6.4</hpRegen>
-            <mpRegen>2.1</mpRegen>
-            <cpRegen>5.5</cpRegen>
-        </level>
-        <level val="51">
-            <hp>1558.8</hp>
-            <mp>581.85</mp>
-            <cp>857.34</cp>
-            <hpRegen>6.5</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="52">
-            <hp>1609.56</hp>
-            <mp>603.0</mp>
-            <cp>885.258</cp>
-            <hpRegen>6.6</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="53">
-            <hp>1660.68</hp>
-            <mp>624.3</mp>
-            <cp>913.374</cp>
-            <hpRegen>6.7</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="54">
-            <hp>1712.16</hp>
-            <mp>645.75</mp>
-            <cp>941.688</cp>
-            <hpRegen>6.8</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="55">
-            <hp>1764.0</hp>
-            <mp>667.35</mp>
-            <cp>970.2</cp>
-            <hpRegen>6.9</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="56">
-            <hp>1816.2</hp>
-            <mp>689.1</mp>
-            <cp>998.91</cp>
-            <hpRegen>7.0</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="57">
-            <hp>1868.76</hp>
-            <mp>711.0</mp>
-            <cp>1027.818</cp>
-            <hpRegen>7.1</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="58">
-            <hp>1921.68</hp>
-            <mp>733.05</mp>
-            <cp>1056.924</cp>
-            <hpRegen>7.2</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="59">
-            <hp>1974.96</hp>
-            <mp>755.25</mp>
-            <cp>1086.228</cp>
-            <hpRegen>7.3</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="60">
-            <hp>2028.6</hp>
-            <mp>777.6</mp>
-            <cp>1115.73</cp>
-            <hpRegen>7.4</hpRegen>
-            <mpRegen>2.4</mpRegen>
-            <cpRegen>6.5</cpRegen>
-        </level>
-        <level val="61">
-            <hp>2082.6</hp>
-            <mp>800.1</mp>
-            <cp>1145.43</cp>
-            <hpRegen>7.5</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="62">
-            <hp>2136.96</hp>
-            <mp>822.75</mp>
-            <cp>1175.328</cp>
-            <hpRegen>7.6</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="63">
-            <hp>2191.68</hp>
-            <mp>845.55</mp>
-            <cp>1205.424</cp>
-            <hpRegen>7.7</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="64">
-            <hp>2246.76</hp>
-            <mp>868.5</mp>
-            <cp>1235.718</cp>
-            <hpRegen>7.8</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="65">
-            <hp>2302.2</hp>
-            <mp>891.6</mp>
-            <cp>1266.21</cp>
-            <hpRegen>7.9</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="66">
-            <hp>2358.0</hp>
-            <mp>914.85</mp>
-            <cp>1296.9</cp>
-            <hpRegen>8.0</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="67">
-            <hp>2414.16</hp>
-            <mp>938.25</mp>
-            <cp>1327.788</cp>
-            <hpRegen>8.1</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="68">
-            <hp>2470.68</hp>
-            <mp>961.8</mp>
-            <cp>1358.874</cp>
-            <hpRegen>8.2</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="69">
-            <hp>2527.56</hp>
-            <mp>985.5</mp>
-            <cp>1390.158</cp>
-            <hpRegen>8.3</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="70">
-            <hp>2584.8</hp>
-            <mp>1009.35</mp>
-            <cp>1421.64</cp>
-            <hpRegen>8.4</hpRegen>
-            <mpRegen>2.7</mpRegen>
-            <cpRegen>7.5</cpRegen>
-        </level>
-        <level val="71">
-            <hp>2642.4</hp>
-            <mp>1033.35</mp>
-            <cp>1453.32</cp>
-            <hpRegen>8.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="72">
-            <hp>2700.36</hp>
-            <mp>1057.5</mp>
-            <cp>1485.198</cp>
-            <hpRegen>8.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="73">
-            <hp>2758.68</hp>
-            <mp>1081.8</mp>
-            <cp>1517.274</cp>
-            <hpRegen>8.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="74">
-            <hp>2817.36</hp>
-            <mp>1106.25</mp>
-            <cp>1549.548</cp>
-            <hpRegen>8.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="75">
-            <hp>2876.4</hp>
-            <mp>1130.85</mp>
-            <cp>1582.02</cp>
-            <hpRegen>8.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="76">
-            <hp>2935.8</hp>
-            <mp>1155.6</mp>
-            <cp>1614.69</cp>
-            <hpRegen>9.0</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="77">
-            <hp>2995.56</hp>
-            <mp>1180.5</mp>
-            <cp>1647.558</cp>
-            <hpRegen>9.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="78">
-            <hp>3055.68</hp>
-            <mp>1205.55</mp>
-            <cp>1680.624</cp>
-            <hpRegen>9.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="79">
-            <hp>3116.16</hp>
-            <mp>1230.75</mp>
-            <cp>1713.888</cp>
-            <hpRegen>9.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="80">
-            <hp>3177.0</hp>
-            <mp>1256.1</mp>
-            <cp>1747.35</cp>
-            <hpRegen>9.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="81">
-            <hp>3238.2</hp>
-            <mp>1281.6</mp>
-            <cp>1781.01</cp>
-            <hpRegen>9.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="82">
-            <hp>3299.76</hp>
-            <mp>1307.25</mp>
-            <cp>1814.868</cp>
-            <hpRegen>9.6</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="83">
-            <hp>3361.68</hp>
-            <mp>1333.05</mp>
-            <cp>1848.924</cp>
-            <hpRegen>9.7</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="84">
-            <hp>3423.96</hp>
-            <mp>1359.0</mp>
-            <cp>1883.178</cp>
-            <hpRegen>9.8</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="85">
-            <hp>3486.6</hp>
-            <mp>1385.1</mp>
-            <cp>1917.63</cp>
-            <hpRegen>9.9</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="86">
-            <hp>3549.6</hp>
-            <mp>1411.35</mp>
-            <cp>1952.28</cp>
-            <hpRegen>10</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="87">
-            <hp>3612.96</hp>
-            <mp>1437.75</mp>
-            <cp>1987.128</cp>
-            <hpRegen>10.1</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="88">
-            <hp>3676.68</hp>
-            <mp>1464.3</mp>
-            <cp>2022.174</cp>
-            <hpRegen>10.2</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="89">
-            <hp>3740.76</hp>
-            <mp>1491.0</mp>
-            <cp>2057.418</cp>
-            <hpRegen>10.3</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="90">
-            <hp>3805.2</hp>
-            <mp>1517.85</mp>
-            <cp>2092.86</cp>
-            <hpRegen>10.4</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-        <level val="91">
-            <hp>3870.0</hp>
-            <mp>1544.85</mp>
-            <cp>2128.5</cp>
-            <hpRegen>10.5</hpRegen>
-            <mpRegen>3.0</mpRegen>
-            <cpRegen>8.5</cpRegen>
-        </level>
-    </lvlUpgainData>
+	<classId>101</classId>
+	<staticData>
+		<baseINT>23</baseINT>
+		<baseSTR>36</baseSTR>
+		<baseCON>36</baseCON>
+		<baseMEN>26</baseMEN>
+		<baseDEX>35</baseDEX>
+		<baseWIT>14</baseWIT>
+		<physicalAbnormalResist>10</physicalAbnormalResist>
+		<magicAbnormalResist>15</magicAbnormalResist>
+		<creationPoints>
+			<node x="46045" y="41251" z="-3440" />
+			<node x="46117" y="41247" z="-3440" />
+			<node x="46182" y="41198" z="-3440" />
+			<node x="46115" y="41141" z="-3440" />
+			<node x="46048" y="41141" z="-3440" />
+			<node x="45978" y="41196" z="-3440" />
+		</creationPoints>
+		<basePAtk>4</basePAtk>
+		<baseCritRate>4</baseCritRate>
+		<baseMCritRate>5</baseMCritRate>
+		<baseAtkType>FIST</baseAtkType>
+		<basePAtkSpd>300</basePAtkSpd>
+		<baseMAtkSpd>333</baseMAtkSpd>
+		<basePDef>
+			<chest>31</chest>
+			<legs>18</legs>
+			<head>12</head>
+			<feet>7</feet>
+			<gloves>8</gloves>
+			<underwear>3</underwear>
+			<cloak>1</cloak>
+		</basePDef>
+		<baseMAtk>6</baseMAtk>
+		<baseMDef>
+			<rear>9</rear>
+			<lear>9</lear>
+			<rfinger>5</rfinger>
+			<lfinger>5</lfinger>
+			<neck>13</neck>
+		</baseMDef>
+		<baseCanPenetrate>0</baseCanPenetrate>
+		<baseAtkRange>20</baseAtkRange>
+		<baseDamRange>
+			<verticalDirection>0</verticalDirection>
+			<horizontalDirection>0</horizontalDirection>
+			<distance>26</distance>
+			<width>120</width>
+		</baseDamRange>
+		<baseRndDam>10</baseRndDam>
+		<baseMoveSpd>
+			<walk>90</walk>
+			<run>143</run>
+			<slowSwim>50</slowSwim>
+			<fastSwim>50</fastSwim>
+		</baseMoveSpd>
+		<baseBreath>150</baseBreath>
+		<baseSafeFall>350</baseSafeFall>
+		<collisionMale>
+			<radius>7.5</radius>
+			<height>24</height>
+		</collisionMale>
+		<collisionFemale>
+			<radius>7.5</radius>
+			<height>23</height>
+		</collisionFemale>
+	</staticData>
+	<lvlUpgainData>
+		<level val="1">
+			<hp>89.0</hp>
+			<mp>30.0</mp>
+			<cp>48.95</cp>
+			<hpRegen>2.0</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="2">
+			<hp>101.74</hp>
+			<mp>35.46</mp>
+			<cp>55.957</cp>
+			<hpRegen>2.05</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="3">
+			<hp>114.62</hp>
+			<mp>40.98</mp>
+			<cp>63.041</cp>
+			<hpRegen>2.1</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="4">
+			<hp>127.64</hp>
+			<mp>46.56</mp>
+			<cp>70.202</cp>
+			<hpRegen>2.15</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="5">
+			<hp>140.8</hp>
+			<mp>52.2</mp>
+			<cp>77.44</cp>
+			<hpRegen>2.2</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="6">
+			<hp>154.1</hp>
+			<mp>57.9</mp>
+			<cp>84.755</cp>
+			<hpRegen>2.25</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="7">
+			<hp>167.54</hp>
+			<mp>63.66</mp>
+			<cp>92.147</cp>
+			<hpRegen>2.3</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="8">
+			<hp>181.12</hp>
+			<mp>69.48</mp>
+			<cp>99.616</cp>
+			<hpRegen>2.35</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="9">
+			<hp>194.84</hp>
+			<mp>75.36</mp>
+			<cp>107.162</cp>
+			<hpRegen>2.4</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="10">
+			<hp>208.7</hp>
+			<mp>81.3</mp>
+			<cp>114.785</cp>
+			<hpRegen>2.45</hpRegen>
+			<mpRegen>0.9</mpRegen>
+			<cpRegen>2.0</cpRegen>
+		</level>
+		<level val="11">
+			<hp>222.7</hp>
+			<mp>87.3</mp>
+			<cp>122.485</cp>
+			<hpRegen>2.5</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="12">
+			<hp>236.84</hp>
+			<mp>93.36</mp>
+			<cp>130.262</cp>
+			<hpRegen>2.6</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="13">
+			<hp>251.12</hp>
+			<mp>99.48</mp>
+			<cp>138.116</cp>
+			<hpRegen>2.7</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="14">
+			<hp>265.54</hp>
+			<mp>105.66</mp>
+			<cp>146.047</cp>
+			<hpRegen>2.8</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="15">
+			<hp>280.1</hp>
+			<mp>111.9</mp>
+			<cp>154.055</cp>
+			<hpRegen>2.9</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="16">
+			<hp>294.8</hp>
+			<mp>118.2</mp>
+			<cp>162.14</cp>
+			<hpRegen>3.0</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="17">
+			<hp>309.64</hp>
+			<mp>124.56</mp>
+			<cp>170.302</cp>
+			<hpRegen>3.1</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="18">
+			<hp>324.62</hp>
+			<mp>130.98</mp>
+			<cp>178.541</cp>
+			<hpRegen>3.2</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="19">
+			<hp>339.74</hp>
+			<mp>137.46</mp>
+			<cp>186.857</cp>
+			<hpRegen>3.3</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="20">
+			<hp>355.0</hp>
+			<mp>144.0</mp>
+			<cp>195.25</cp>
+			<hpRegen>3.4</hpRegen>
+			<mpRegen>1.2</mpRegen>
+			<cpRegen>2.5</cpRegen>
+		</level>
+		<level val="21">
+			<hp>385.8</hp>
+			<mp>153.9</mp>
+			<cp>212.19</cp>
+			<hpRegen>3.5</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="22">
+			<hp>416.88</hp>
+			<mp>163.89</mp>
+			<cp>229.284</cp>
+			<hpRegen>3.6</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="23">
+			<hp>448.24</hp>
+			<mp>173.97</mp>
+			<cp>246.532</cp>
+			<hpRegen>3.7</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="24">
+			<hp>479.88</hp>
+			<mp>184.14</mp>
+			<cp>263.934</cp>
+			<hpRegen>3.8</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="25">
+			<hp>511.8</hp>
+			<mp>194.4</mp>
+			<cp>281.49</cp>
+			<hpRegen>3.9</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="26">
+			<hp>544.0</hp>
+			<mp>204.75</mp>
+			<cp>299.2</cp>
+			<hpRegen>4.0</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="27">
+			<hp>576.48</hp>
+			<mp>215.19</mp>
+			<cp>317.064</cp>
+			<hpRegen>4.1</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="28">
+			<hp>609.24</hp>
+			<mp>225.72</mp>
+			<cp>335.082</cp>
+			<hpRegen>4.2</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="29">
+			<hp>642.28</hp>
+			<mp>236.34</mp>
+			<cp>353.254</cp>
+			<hpRegen>4.3</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="30">
+			<hp>675.6</hp>
+			<mp>247.05</mp>
+			<cp>371.58</cp>
+			<hpRegen>4.4</hpRegen>
+			<mpRegen>1.5</mpRegen>
+			<cpRegen>3.5</cpRegen>
+		</level>
+		<level val="31">
+			<hp>709.2</hp>
+			<mp>257.85</mp>
+			<cp>390.06</cp>
+			<hpRegen>4.5</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="32">
+			<hp>743.08</hp>
+			<mp>268.74</mp>
+			<cp>408.694</cp>
+			<hpRegen>4.6</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="33">
+			<hp>777.24</hp>
+			<mp>279.72</mp>
+			<cp>427.482</cp>
+			<hpRegen>4.7</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="34">
+			<hp>811.68</hp>
+			<mp>290.79</mp>
+			<cp>446.424</cp>
+			<hpRegen>4.8</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="35">
+			<hp>846.4</hp>
+			<mp>301.95</mp>
+			<cp>465.52</cp>
+			<hpRegen>4.9</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="36">
+			<hp>881.4</hp>
+			<mp>313.2</mp>
+			<cp>484.77</cp>
+			<hpRegen>5.0</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="37">
+			<hp>916.68</hp>
+			<mp>324.54</mp>
+			<cp>504.174</cp>
+			<hpRegen>5.1</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="38">
+			<hp>952.24</hp>
+			<mp>335.97</mp>
+			<cp>523.732</cp>
+			<hpRegen>5.2</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="39">
+			<hp>988.08</hp>
+			<mp>347.49</mp>
+			<cp>543.444</cp>
+			<hpRegen>5.3</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="40">
+			<hp>1024.2</hp>
+			<mp>359.1</mp>
+			<cp>563.31</cp>
+			<hpRegen>5.4</hpRegen>
+			<mpRegen>1.8</mpRegen>
+			<cpRegen>4.5</cpRegen>
+		</level>
+		<level val="41">
+			<hp>1071.0</hp>
+			<mp>378.6</mp>
+			<cp>589.05</cp>
+			<hpRegen>5.5</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="42">
+			<hp>1118.16</hp>
+			<mp>398.25</mp>
+			<cp>614.988</cp>
+			<hpRegen>5.6</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="43">
+			<hp>1165.68</hp>
+			<mp>418.05</mp>
+			<cp>641.124</cp>
+			<hpRegen>5.7</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="44">
+			<hp>1213.56</hp>
+			<mp>438.0</mp>
+			<cp>667.458</cp>
+			<hpRegen>5.8</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="45">
+			<hp>1261.8</hp>
+			<mp>458.1</mp>
+			<cp>693.99</cp>
+			<hpRegen>5.9</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="46">
+			<hp>1310.4</hp>
+			<mp>478.35</mp>
+			<cp>720.72</cp>
+			<hpRegen>6.0</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="47">
+			<hp>1359.36</hp>
+			<mp>498.75</mp>
+			<cp>747.648</cp>
+			<hpRegen>6.1</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="48">
+			<hp>1408.68</hp>
+			<mp>519.3</mp>
+			<cp>774.774</cp>
+			<hpRegen>6.2</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="49">
+			<hp>1458.36</hp>
+			<mp>540.0</mp>
+			<cp>802.098</cp>
+			<hpRegen>6.3</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="50">
+			<hp>1508.4</hp>
+			<mp>560.85</mp>
+			<cp>829.62</cp>
+			<hpRegen>6.4</hpRegen>
+			<mpRegen>2.1</mpRegen>
+			<cpRegen>5.5</cpRegen>
+		</level>
+		<level val="51">
+			<hp>1558.8</hp>
+			<mp>581.85</mp>
+			<cp>857.34</cp>
+			<hpRegen>6.5</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="52">
+			<hp>1609.56</hp>
+			<mp>603.0</mp>
+			<cp>885.258</cp>
+			<hpRegen>6.6</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="53">
+			<hp>1660.68</hp>
+			<mp>624.3</mp>
+			<cp>913.374</cp>
+			<hpRegen>6.7</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="54">
+			<hp>1712.16</hp>
+			<mp>645.75</mp>
+			<cp>941.688</cp>
+			<hpRegen>6.8</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="55">
+			<hp>1764.0</hp>
+			<mp>667.35</mp>
+			<cp>970.2</cp>
+			<hpRegen>6.9</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="56">
+			<hp>1816.2</hp>
+			<mp>689.1</mp>
+			<cp>998.91</cp>
+			<hpRegen>7.0</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="57">
+			<hp>1868.76</hp>
+			<mp>711.0</mp>
+			<cp>1027.818</cp>
+			<hpRegen>7.1</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="58">
+			<hp>1921.68</hp>
+			<mp>733.05</mp>
+			<cp>1056.924</cp>
+			<hpRegen>7.2</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="59">
+			<hp>1974.96</hp>
+			<mp>755.25</mp>
+			<cp>1086.228</cp>
+			<hpRegen>7.3</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="60">
+			<hp>2028.6</hp>
+			<mp>777.6</mp>
+			<cp>1115.73</cp>
+			<hpRegen>7.4</hpRegen>
+			<mpRegen>2.4</mpRegen>
+			<cpRegen>6.5</cpRegen>
+		</level>
+		<level val="61">
+			<hp>2082.6</hp>
+			<mp>800.1</mp>
+			<cp>1145.43</cp>
+			<hpRegen>7.5</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="62">
+			<hp>2136.96</hp>
+			<mp>822.75</mp>
+			<cp>1175.328</cp>
+			<hpRegen>7.6</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="63">
+			<hp>2191.68</hp>
+			<mp>845.55</mp>
+			<cp>1205.424</cp>
+			<hpRegen>7.7</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="64">
+			<hp>2246.76</hp>
+			<mp>868.5</mp>
+			<cp>1235.718</cp>
+			<hpRegen>7.8</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="65">
+			<hp>2302.2</hp>
+			<mp>891.6</mp>
+			<cp>1266.21</cp>
+			<hpRegen>7.9</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="66">
+			<hp>2358.0</hp>
+			<mp>914.85</mp>
+			<cp>1296.9</cp>
+			<hpRegen>8.0</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="67">
+			<hp>2414.16</hp>
+			<mp>938.25</mp>
+			<cp>1327.788</cp>
+			<hpRegen>8.1</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="68">
+			<hp>2470.68</hp>
+			<mp>961.8</mp>
+			<cp>1358.874</cp>
+			<hpRegen>8.2</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="69">
+			<hp>2527.56</hp>
+			<mp>985.5</mp>
+			<cp>1390.158</cp>
+			<hpRegen>8.3</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="70">
+			<hp>2584.8</hp>
+			<mp>1009.35</mp>
+			<cp>1421.64</cp>
+			<hpRegen>8.4</hpRegen>
+			<mpRegen>2.7</mpRegen>
+			<cpRegen>7.5</cpRegen>
+		</level>
+		<level val="71">
+			<hp>2642.4</hp>
+			<mp>1033.35</mp>
+			<cp>1453.32</cp>
+			<hpRegen>8.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="72">
+			<hp>2700.36</hp>
+			<mp>1057.5</mp>
+			<cp>1485.198</cp>
+			<hpRegen>8.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="73">
+			<hp>2758.68</hp>
+			<mp>1081.8</mp>
+			<cp>1517.274</cp>
+			<hpRegen>8.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="74">
+			<hp>2817.36</hp>
+			<mp>1106.25</mp>
+			<cp>1549.548</cp>
+			<hpRegen>8.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="75">
+			<hp>2876.4</hp>
+			<mp>1130.85</mp>
+			<cp>1582.02</cp>
+			<hpRegen>8.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="76">
+			<hp>2935.8</hp>
+			<mp>1155.6</mp>
+			<cp>1614.69</cp>
+			<hpRegen>9.0</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="77">
+			<hp>2995.56</hp>
+			<mp>1180.5</mp>
+			<cp>1647.558</cp>
+			<hpRegen>9.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="78">
+			<hp>3055.68</hp>
+			<mp>1205.55</mp>
+			<cp>1680.624</cp>
+			<hpRegen>9.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="79">
+			<hp>3116.16</hp>
+			<mp>1230.75</mp>
+			<cp>1713.888</cp>
+			<hpRegen>9.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="80">
+			<hp>3177.0</hp>
+			<mp>1256.1</mp>
+			<cp>1747.35</cp>
+			<hpRegen>9.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="81">
+			<hp>3238.2</hp>
+			<mp>1281.6</mp>
+			<cp>1781.01</cp>
+			<hpRegen>9.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="82">
+			<hp>3299.76</hp>
+			<mp>1307.25</mp>
+			<cp>1814.868</cp>
+			<hpRegen>9.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="83">
+			<hp>3361.68</hp>
+			<mp>1333.05</mp>
+			<cp>1848.924</cp>
+			<hpRegen>9.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="84">
+			<hp>3423.96</hp>
+			<mp>1359.0</mp>
+			<cp>1883.178</cp>
+			<hpRegen>9.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="85">
+			<hp>3486.6</hp>
+			<mp>1385.1</mp>
+			<cp>1917.63</cp>
+			<hpRegen>9.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="86">
+			<hp>3549.6</hp>
+			<mp>1411.35</mp>
+			<cp>1952.28</cp>
+			<hpRegen>10</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="87">
+			<hp>3612.96</hp>
+			<mp>1437.75</mp>
+			<cp>1987.128</cp>
+			<hpRegen>10.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="88">
+			<hp>3676.68</hp>
+			<mp>1464.3</mp>
+			<cp>2022.174</cp>
+			<hpRegen>10.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="89">
+			<hp>3740.76</hp>
+			<mp>1491.0</mp>
+			<cp>2057.418</cp>
+			<hpRegen>10.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="90">
+			<hp>3805.2</hp>
+			<mp>1517.85</mp>
+			<cp>2092.86</cp>
+			<hpRegen>10.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="91">
+			<hp>3870.0</hp>
+			<mp>1544.85</mp>
+			<cp>2128.5</cp>
+			<hpRegen>10.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="92">
+			<hp>3935.16</hp>
+			<mp>1572.0</mp>
+			<cp>2164.338</cp>
+			<hpRegen>10.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="93">
+			<hp>4000.68</hp>
+			<mp>1599.3</mp>
+			<cp>2200.374</cp>
+			<hpRegen>10.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="94">
+			<hp>4066.56</hp>
+			<mp>1626.75</mp>
+			<cp>2236.608</cp>
+			<hpRegen>10.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="95">
+			<hp>4132.8</hp>
+			<mp>1654.35</mp>
+			<cp>2273.04</cp>
+			<hpRegen>10.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="96">
+			<hp>4199.4</hp>
+			<mp>1682.1</mp>
+			<cp>2309.67</cp>
+			<hpRegen>11</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="97">
+			<hp>4266.36</hp>
+			<mp>1710.0</mp>
+			<cp>2346.498</cp>
+			<hpRegen>11.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="98">
+			<hp>4333.68</hp>
+			<mp>1738.05</mp>
+			<cp>2383.524</cp>
+			<hpRegen>11.2</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="99">
+			<hp>4401.36</hp>
+			<mp>1766.25</mp>
+			<cp>2420.748</cp>
+			<hpRegen>11.3</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="100">
+			<hp>4469.4</hp>
+			<mp>1794.6</mp>
+			<cp>2458.17</cp>
+			<hpRegen>11.4</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="101">
+			<hp>4537.8</hp>
+			<mp>1823.1</mp>
+			<cp>2495.8</cp>
+			<hpRegen>11.5</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="102">
+			<hp>4606.56</hp>
+			<mp>1851.75</mp>
+			<cp>2533.62</cp>
+			<hpRegen>11.6</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="103">
+			<hp>4675.68</hp>
+			<mp>1880.55</mp>
+			<cp>2571.64</cp>
+			<hpRegen>11.7</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="104">
+			<hp>4745.16</hp>
+			<mp>1909.5</mp>
+			<cp>2609.87</cp>
+			<hpRegen>11.8</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="105">
+			<hp>4815</hp>
+			<mp>1938.6</mp>
+			<cp>2648.29</cp>
+			<hpRegen>11.9</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="106">
+			<hp>4885.2</hp>
+			<mp>1967.85</mp>
+			<cp>2686.92</cp>
+			<hpRegen>12</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+		<level val="107">
+			<hp>4955.76</hp>
+			<mp>1997.25</mp>
+			<cp>2725.668</cp>
+			<hpRegen>12.1</hpRegen>
+			<mpRegen>3.0</mpRegen>
+			<cpRegen>8.5</cpRegen>
+		</level>
+	</lvlUpgainData>
 </list>

--- a/data/stats/chars/classList.xml
+++ b/data/stats/chars/classList.xml
@@ -1,76 +1,76 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../../xsd/classList.xsd">
     <!-- Start Classes -->
-	<class classId="0" name="Human Fighter"/>
-	<class classId="10" name="Human Mystic"/>
-	<class classId="18" name="Elven Fighter"/>
-	<class classId="25" name="Elven Mystic"/>
-	<class classId="31" name="Dark Fighter"/>
-	<class classId="38" name="Dark Mystic"/>
-	<class classId="44" name="Orc Fighter"/>
-	<class classId="49" name="Orc Mystic"/>
-	<class classId="53" name="Dwarf Fighter"/>
-	<class classId="192" name="Jin Kamael Soldier"/>
-	
-    <!-- 1-st Classes -->   
-    <class classId="1" name="Warrior" parentClassId="0"/>    
-    <class classId="4" name="Human Knight" parentClassId="0"/>    
-    <class classId="7" name="Rogue" parentClassId="0"/>       
-    <class classId="11" name="Human Wizard" parentClassId="10"/>    
-    <class classId="15" name="Cleric" parentClassId="10"/>        
+    <class classId="0" name="Human Fighter"/>
+    <class classId="10" name="Human Mystic"/>
+    <class classId="18" name="Elven Fighter"/>
+    <class classId="25" name="Elven Mystic"/>
+    <class classId="31" name="Dark Fighter"/>
+    <class classId="38" name="Dark Mystic"/>
+    <class classId="44" name="Orc Fighter"/>
+    <class classId="49" name="Orc Mystic"/>
+    <class classId="53" name="Dwarf Fighter"/>
+    <class classId="192" name="Jin Kamael Soldier"/>
+
+    <!-- 1-st Classes -->
+    <class classId="1" name="Warrior" parentClassId="0"/>
+    <class classId="4" name="Human Knight" parentClassId="0"/>
+    <class classId="7" name="Rogue" parentClassId="0"/>
+    <class classId="11" name="Human Wizard" parentClassId="10"/>
+    <class classId="15" name="Cleric" parentClassId="10"/>
     <class classId="19" name="Elven Knight" parentClassId="18"/>
-    <class classId="22" name="Elven Scout" parentClassId="18"/>        
+    <class classId="22" name="Elven Scout" parentClassId="18"/>
     <class classId="26" name="Elven Wizard" parentClassId="25"/>
-    <class classId="29" name="Elven Oracle" parentClassId="25"/>        
-    <class classId="32" name="Palus Knight" parentClassId="31"/>    
-    <class classId="35" name="Assassin" parentClassId="31"/>       
-    <class classId="39" name="Dark Wizard" parentClassId="38"/>    
-    <class classId="42" name="Shillien Oracle" parentClassId="38"/>    
-    <class classId="45" name="Orc Raider" parentClassId="44"/>    
-    <class classId="47" name="Monk" parentClassId="44"/>    
-    <class classId="50" name="Orc Shaman" parentClassId="49"/>        
+    <class classId="29" name="Elven Oracle" parentClassId="25"/>
+    <class classId="32" name="Palus Knight" parentClassId="31"/>
+    <class classId="35" name="Assassin" parentClassId="31"/>
+    <class classId="39" name="Dark Wizard" parentClassId="38"/>
+    <class classId="42" name="Shillien Oracle" parentClassId="38"/>
+    <class classId="45" name="Orc Raider" parentClassId="44"/>
+    <class classId="47" name="Monk" parentClassId="44"/>
+    <class classId="50" name="Orc Shaman" parentClassId="49"/>
     <class classId="54" name="Scavenger" parentClassId="53"/>
-    <class classId="56" name="Artisan" parentClassId="53"/>    
+    <class classId="56" name="Artisan" parentClassId="53"/>
     <class classId="125" name="Trooper" parentClassId="192"/>
-	<class classId="126" name="Warden" parentClassId="192"/>
-    <class classId="193" name="Soul Finder" parentClassId="192"/>   
-	
+    <class classId="126" name="Warden" parentClassId="192"/>
+    <class classId="193" name="Soul Finder" parentClassId="192"/>
+
     <!-- 2-st Classes -->
-	<class classId="2" name="Gladiator" parentClassId="1"/>
+    <class classId="2" name="Gladiator" parentClassId="1"/>
     <class classId="3" name="Warlord" parentClassId="1"/>
-	<class classId="5" name="Paladin" parentClassId="4"/>
+    <class classId="5" name="Paladin" parentClassId="4"/>
     <class classId="6" name="Dark Avenger" parentClassId="4"/>
-	<class classId="8" name="Treasure Hunter" parentClassId="7"/>
+    <class classId="8" name="Treasure Hunter" parentClassId="7"/>
     <class classId="9" name="Hawkeye" parentClassId="7"/>
-	<class classId="12" name="Sorcerer" parentClassId="11"/>
+    <class classId="12" name="Sorcerer" parentClassId="11"/>
     <class classId="13" name="Necromancer" parentClassId="11"/>
     <class classId="14" name="Warlock" parentClassId="11"/>
-	<class classId="16" name="Bishop" parentClassId="15"/>
+    <class classId="16" name="Bishop" parentClassId="15"/>
     <class classId="17" name="Prophet" parentClassId="15"/>
-	<class classId="20" name="Temple Knight" parentClassId="19"/>
+    <class classId="20" name="Temple Knight" parentClassId="19"/>
     <class classId="21" name="Sword Singer" parentClassId="19"/>
-	<class classId="23" name="Plains Walker" parentClassId="22"/>
+    <class classId="23" name="Plains Walker" parentClassId="22"/>
     <class classId="24" name="Silver Ranger" parentClassId="22"/>
-	<class classId="27" name="Spellsinger" parentClassId="26"/>
+    <class classId="27" name="Spellsinger" parentClassId="26"/>
     <class classId="28" name="Elemental Summoner" parentClassId="26"/>
-	<class classId="30" name="Elven Elder" parentClassId="29"/>
-	<class classId="33" name="Shillien Knight" parentClassId="32"/>
+    <class classId="30" name="Elven Elder" parentClassId="29"/>
+    <class classId="33" name="Shillien Knight" parentClassId="32"/>
     <class classId="34" name="Bladedancer" parentClassId="32"/>
-	<class classId="36" name="Abyss Walker" parentClassId="35"/>
+    <class classId="36" name="Abyss Walker" parentClassId="35"/>
     <class classId="37" name="Phantom Ranger" parentClassId="35"/>
-	<class classId="40" name="Spellhowler" parentClassId="39"/>
+    <class classId="40" name="Spellhowler" parentClassId="39"/>
     <class classId="41" name="Phantom Summoner" parentClassId="39"/>
-	<class classId="43" name="Shillien Elder" parentClassId="42"/>
-	<class classId="46" name="Destroyer" parentClassId="45"/>
-	<class classId="48" name="Tyrant" parentClassId="47"/>
-	<class classId="51" name="Overlord" parentClassId="50"/>
+    <class classId="43" name="Shillien Elder" parentClassId="42"/>
+    <class classId="46" name="Destroyer" parentClassId="45"/>
+    <class classId="48" name="Tyrant" parentClassId="47"/>
+    <class classId="51" name="Overlord" parentClassId="50"/>
     <class classId="52" name="Warcryer" parentClassId="50"/>
-	<class classId="55" name="Bounty Hunter" parentClassId="54"/>
-	<class classId="57" name="Warsmith" parentClassId="56"/>
-	<class classId="127" name="Beserker" parentClassId="125"/>
-	<class classId="130" name="Arbalester" parentClassId="126"/>
+    <class classId="55" name="Bounty Hunter" parentClassId="54"/>
+    <class classId="57" name="Warsmith" parentClassId="56"/>
+    <class classId="127" name="Beserker" parentClassId="125"/>
+    <class classId="130" name="Arbalester" parentClassId="126"/>
     <class classId="194" name="Soul Breaker" parentClassId="193"/>
-	
+
     <!-- 3-rd Classes -->
     <class classId="88" name="Duelist" parentClassId="2"/>
     <class classId="89" name="Dreadnought" parentClassId="3"/>
@@ -103,31 +103,34 @@
     <class classId="116" name="Doom Cryer" parentClassId="52"/>
     <class classId="117" name="Fortune Seeker" parentClassId="55"/>
     <class classId="118" name="Maestro" parentClassId="57"/>
-	<class classId="131" name="Doombringer" parentClassId="127"/>
-	<class classId="134" name="Trickster" parentClassId="130"/>
+    <class classId="131" name="Doombringer" parentClassId="127"/>
+    <class classId="134" name="Trickster" parentClassId="130"/>
     <class classId="195" name="Soul Hound" parentClassId="194"/>
+
     <!-- Death Knight - Human -->
-    <class classId="196" name="Death Pilgrim" />
-    <class classId="205" name="Death Blade" parentClassId="196" />
-    <class classId="202" name="Death Messenger" parentClassId="205" />
-    <class classId="199" name="Death Knight" parentClassId="202" />
+    <class classId="196" name="Death Walker" />
+    <class classId="197" name="Death Blader" parentClassId="196" />
+    <class classId="198" name="Undertaker" parentClassId="197" />
+    <class classId="199" name="Death Knight" parentClassId="198" />
+
     <!-- Death Knight - Elf -->
-    <class classId="200" name="Death Pilgrim" />
-    <class classId="197" name="Death Blade" parentClassId="200" />
-    <class classId="206" name="Death Messenger" parentClassId="197" />
-    <class classId="203" name="Death Knight" parentClassId="206" />
+    <class classId="200" name="Death Walker" />
+    <class classId="201" name="Death Blader" parentClassId="200" />
+    <class classId="202" name="Undertaker" parentClassId="201" />
+    <class classId="203" name="Death Knight" parentClassId="202" />
+
     <!-- Death Knight - Dark Elf -->
-    <class classId="204" name="Death Pilgrim" />
-    <class classId="201" name="Death Blade" parentClassId="204" />
-    <class classId="198" name="Death Messenger" parentClassId="201" />
-    <class classId="207" name="Death Knight" parentClassId="198" />
+    <class classId="204" name="Death Walker" />
+    <class classId="205" name="Death Blader" parentClassId="204" />
+    <class classId="206" name="Undertaker" parentClassId="205" />
+    <class classId="207" name="Death Knight" parentClassId="206" />
 
     <!-- Sylph -->
     <class classId="208" name="Sylph" />
     <class classId="209" name="Free Shooter" parentClassId="208" />
     <class classId="210" name="Free Hunter" parentClassId="209" />
     <class classId="211" name="Shooting Master" parentClassId="210" />
-	
+
     <!-- NPCs -->
     <class classId="119" name="World Trap"/>
     <class classId="120" name="Player Trap"/>

--- a/data/stats/ensoul-stones.xml
+++ b/data/stats/ensoul-stones.xml
@@ -1382,4 +1382,506 @@
     <stone id="91182" type="SPECIAL">
         <option id="1020" name="Lilith Power" desc="HP Recovery +15%, Attack +15%, Hit activates HP Recovery 900" skill-id="54035" skill-level="10"/>
     </stone>
+
+    <!-- Aden Soul Crystals -->
+    <!-- Aden Soul Crystal Health Up/Mana Up, P. Atk/M. Atk,, Atk/Casting Spd,  Speed,  P.Atk Crit Chance,  P.Skill/ M.Skill Critical Rate, P.Atk Critical Damage, P.Skill/M.Skill Critical Damage, Shock Atk, Silence Atk Lv. 1 -->
+    <stone id="95783">
+        <option id="1101" name="Health Up" desc="Max HP +4%" skill-id="82000" skill-level="1"/>
+        <option id="1151" name="Mana Up" desc="Max MP +4%" skill-id="82001" skill-level="1"/>
+        <option id="1201" name="Physical Attack" desc="Atk. Spd 3%" skill-id="82002" skill-level="1"/>
+        <option id="1251" name="Magical Attack" desc="M. Atk +50" skill-id="82003" skill-level="1"/>
+        <option id="1301" name="Physical Speed" desc="Atk Spd +3%" skill-id="82004" skill-level="1"/>
+        <option id="1351" name="Magical Speed" desc="Casting Spd +3%" skill-id="82005" skill-level="1"/>
+        <option id="1401" name="Moving Speed" desc="Speed +4" skill-id="82006" skill-level="1"/>
+        <option id="1451" name="Physical Attack Critical Chance" desc="P. Critical Rate +30" skill-id="82007" skill-level="1"/>
+        <option id="1501" name="Physical Skill Critical Chance" desc="P. Skill Critical Rate +1%" skill-id="82008" skill-level="1"/>
+        <option id="1551" name="Magical Skill Critical Chance" desc="M. Skill Critical Rate +3%" skill-id="82009" skill-level="1"/>
+        <option id="1601" name="Physical Attack Critical Damage" desc="P. Critical Damage +95" skill-id="82010" skill-level="1"/>
+        <option id="1651" name="Physical Skill Critical Damage" desc="P. Skill Critical Damage +0.5%" skill-id="82011" skill-level="1"/>
+        <option id="1701" name="Magical Skill Critical Damage" desc="M. Skill Critical Damage +0.5%" skill-id="82012" skill-level="1"/>
+        <option id="1751" name="Stuns the target for 3 seconds when attacking (Activation Chance: 3%)" desc="P. Atk +50" skill-id="82013" skill-level="1"/>
+        <option id="1801" name="Silence Attack" desc="Silences the target for 5 seconds when attacking (Activation Chance: 3%)" skill-id="82015" skill-level="1"/>
+    </stone>
+
+    <!-- Aden Soul Crystal Health Up/Mana Up, P. Atk/M. Atk,, Atk/Casting Spd,  Speed,  P.Atk Crit Chance,  P.Skill/ M.Skill Critical Rate, P.Atk Critical Damage, P.Skill/M.Skill Critical Damage, Shock Atk, Silence Atk Lv. 2 -->
+    <stone id="95784">
+        <option id="1102" name="Health Up" desc="Max HP +5%" skill-id="82000" skill-level="2"/>
+        <option id="1152" name="Mana Up" desc="Max MP +5%" skill-id="82001" skill-level="2"/>
+        <option id="1202" name="Physical Attack" desc="P. Atk +70" skill-id="82002" skill-level="2"/>
+        <option id="1252" name="Magical Attack" desc="M. Atk +70" skill-id="82003" skill-level="2"/>
+        <option id="1302" name="Physical Speed" desc="Atk. Spd +4%" skill-id="82004" skill-level="2"/>
+        <option id="1352" name="Magical Speed" desc="Casting Spd +4%" skill-id="82005" skill-level="2"/>
+        <option id="1402" name="Moving Speed" desc="Speed +4.5" skill-id="82006" skill-level="2"/>
+        <option id="1452" name="Physical Attack Critical Chance" desc="P. Critical Rate +35" skill-id="82007" skill-level="2"/>
+        <option id="1502" name="Physical Skill Critical Chance" desc="P. Skill Critical Rate +1.5%" skill-id="82008" skill-level="2"/>
+        <option id="1552" name="Magical Skill Critical Chance" desc="M. Skill Critical Rate +4%" skill-id="82009" skill-level="2"/>
+        <option id="1602" name="Physical Attack Critical Damage" desc="P. Critical Damage +115" skill-id="82010" skill-level="2"/>
+        <option id="1652" name="Physical Skill Critical Damage" desc="P. Skill Critical Damage +0.7%" skill-id="82011" skill-level="1"/>
+        <option id="1702" name="Magical Skill Critical Damage" desc="M. Skill Critical Damage +0.7%" skill-id="82012" skill-level="2"/>
+        <option id="1752" name="Shock Attack" desc="Stuns the target for 3 seconds when attacking (Activation Chance: 4%)" skill-id="82013" skill-level="2"/>
+        <option id="1802" name="Silence Attack" desc="Silences the target for 5 seconds when attacking (Activation Chance: 4%)" skill-id="82015" skill-level="2"/>
+    </stone>
+
+    <!-- Aden Soul Crystal Health Up/Mana Up, P. Atk/M. Atk,, Atk/Casting Spd,  Speed,  P.Atk Crit Chance,  P.Skill/ M.Skill Critical Rate, P.Atk Critical Damage, P.Skill/M.Skill Critical Damage, Shock Atk, Silence Atk Lv. 3 -->
+    <stone id="95785">
+        <option id="1103" name="Health Up" desc="Max HP +6%" skill-id="82000" skill-level="3"/>
+        <option id="1153" name="Mana Up" desc="Max MP +6%" skill-id="82001" skill-level="3"/>
+        <option id="1203" name="Physical Attack" desc="P. Atk +90" skill-id="82002" skill-level="3"/>
+        <option id="1253" name="Magical Attack" desc="M. Atk +90" skill-id="82003" skill-level="3"/>
+        <option id="1303" name="Physical Speed" desc="Atk. Spd 5%" skill-id="82004" skill-level="3"/>
+        <option id="1353" name="Magical Speed" desc="Casting Spd +5%" skill-id="82005" skill-level="3"/>
+        <option id="1403" name="Moving Speed" desc="Speed +5" skill-id="82006" skill-level="3"/>
+        <option id="1453" name="Physical Attack Critical Chance" desc="P. Critical Rate +40" skill-id="82007" skill-level="3"/>
+        <option id="1503" name="Physical Skill Critical Chance" desc="P. Skill Critical Rate +2%" skill-id="82008" skill-level="3"/>
+        <option id="1553" name="Magical Skill Critical Chance" desc="M. Skill Critical Rate +5%" skill-id="82009" skill-level="3"/>
+        <option id="1603" name="Physical Attack Critical Damage" desc="P. Critical Damage +135" skill-id="82010" skill-level="3"/>
+        <option id="1653" name="Physical Skill Critical Damage" desc="P. Skill Critical Damage +0.9%" skill-id="82011" skill-level="3"/>
+        <option id="1703" name="Magical Skill Critical Damage" desc="M. Skill Critical Damage +0.9%" skill-id="82012" skill-level="3"/>
+        <option id="1753" name="Shock Attack" desc="Stuns the target for 3 seconds when attacking (Activation Chance: 5%)" skill-id="82013" skill-level="3"/>
+        <option id="1803" name="Silence Attack" desc="Silences the target for 5 seconds when attacking (Activation Chance: 5%)" skill-id="82015" skill-level="3"/>
+    </stone>
+
+    <!-- Aden Soul Crystal Health Up/Mana Up, P. Atk/M. Atk,, Atk/Casting Spd,  Speed,  P.Atk Crit Chance,  P.Skill/ M.Skill Critical Rate, P.Atk Critical Damage, P.Skill/M.Skill Critical Damage, Shock Atk, Silence Atk Lv. 4 -->
+    <stone id="95786">
+        <option id="1104" name="Health Up" desc="Max HP +7%" skill-id="82000" skill-level="4"/>
+        <option id="1154" name="Mana Up" desc="Max MP +7%" skill-id="82001" skill-level="4"/>
+        <option id="1204" name="Physical Attack" desc="P. Atk +110" skill-id="82002" skill-level="4"/>
+        <option id="1254" name="Magical Attack" desc="M. Atk +110" skill-id="82003" skill-level="4"/>
+        <option id="1304" name="Physical Speed" desc="Atk. Spd 6%" skill-id="82004" skill-level="4"/>
+        <option id="1354" name="Magical Speed" desc="Casting Spd +6%" skill-id="82005" skill-level="4"/>
+        <option id="1404" name="Moving Speed" desc="Speed +5.5" skill-id="82006" skill-level="4"/>
+        <option id="1454" name="Physical Attack Critical Chance" desc="P. Critical Rate +45" skill-id="82007" skill-level="4"/>
+        <option id="1504" name="Physical Skill Critical Chance" desc="P. Skill Critical Rate +2.5%" skill-id="82008" skill-level="4"/>
+        <option id="1554" name="Magical Skill Critical Chance" desc="M. Skill Critical Rate +6%" skill-id="82009" skill-level="4"/>
+        <option id="1604" name="Physical Attack Critical Damage" desc="P. Critical Damage +155" skill-id="82010" skill-level="4"/>
+        <option id="1654" name="Physical Skill Critical Damage" desc="P. Skill Critical Damage +1.1%" skill-id="82011" skill-level="4"/>
+        <option id="1704" name="Magical Skill Critical Damage" desc="M. Skill Critical Damage +1.1%" skill-id="82012" skill-level="4"/>
+        <option id="1754" name="Shock Attack" desc="Stuns the target for 3 seconds when attacking (Activation Chance: 6%)" skill-id="82013" skill-level="4"/>
+        <option id="1804" name="Silence Attack" desc="P. Atk +50" skill-id="82015" skill-level="4"/>
+    </stone>
+
+    <!-- Aden Soul Crystal Health Up/Mana Up, P. Atk/M. Atk,, Atk/Casting Spd,  Speed,  P.Atk Crit Chance,  P.Skill/ M.Skill Critical Rate, P.Atk Critical Damage, P.Skill/M.Skill Critical Damage, Shock Atk, Silence Atk Lv. 5 -->
+    <stone id="95787">
+        <option id="1105" name="Health Up" desc="Max HP +8%" skill-id="82000" skill-level="5"/>
+        <option id="1155" name="Mana Up" desc="Max MP +8%" skill-id="82001" skill-level="5"/>
+        <option id="1205" name="Physical Attack" desc="P. Atk +130" skill-id="82002" skill-level="5"/>
+        <option id="1255" name="Magical Attack" desc="M. Atk +130" skill-id="82003" skill-level="5"/>
+        <option id="1305" name="Physical Speed" desc="Atk. Spd 7%" skill-id="82004" skill-level="5"/>
+        <option id="1355" name="Magical Speed" desc="Casting Spd +7%" skill-id="82005" skill-level="5"/>
+        <option id="1405" name="Moving Speed" desc="Speed +6" skill-id="82006" skill-level="5"/>
+        <option id="1455" name="Physical Attack Critical Chance" desc="P. Critical Rate +50" skill-id="82007" skill-level="5"/>
+        <option id="1505" name="Physical Skill Critical Chance" desc="P. Skill Critical Rate +3%" skill-id="82008" skill-level="5"/>
+        <option id="1555" name="Magical Skill Critical Chance" desc="M. Skill Critical Rate +6.5%" skill-id="82009" skill-level="5"/>
+        <option id="1605" name="Physical Attack Critical Damage" desc="P. Critical Damage +175" skill-id="82010" skill-level="5"/>
+        <option id="1655" name="Physical Skill Critical Damage" desc="P. Skill Critical Damage +1.3%" skill-id="82011" skill-level="5"/>
+        <option id="1705" name="Magical Skill Critical Damage" desc="M. Skill Critical Damage +1.3%" skill-id="82012" skill-level="5"/>
+        <option id="1755" name="Shock Attack" desc="Stuns the target for 3 seconds when attacking (Activation Chance: 7%)" skill-id="82013" skill-level="5"/>
+        <option id="1805" name="Silence Attack" desc="Silences the target for 5 seconds when attacking (Activation Chance: 7%)" skill-id="82015" skill-level="5"/>
+    </stone>
+
+    <!-- Aden Soul Crystal Health Up/Mana Up, P. Atk/M. Atk,, Atk/Casting Spd,  Speed,  P.Atk Crit Chance,  P.Skill/ M.Skill Critical Rate, P.Atk Critical Damage, P.Skill/M.Skill Critical Damage, Shock Atk, Silence Atk Lv. 6 -->
+    <stone id="95788">
+        <option id="1106" name="Health Up" desc="Max HP +9%" skill-id="82000" skill-level="6"/>
+        <option id="1156" name="Mana Up" desc="Max MP +9%" skill-id="82001" skill-level="6"/>
+        <option id="1206" name="Physical Attack" desc="P. Atk +170" skill-id="82002" skill-level="6"/>
+        <option id="1256" name="Magical Attack" desc="M. Atk +170" skill-id="82003" skill-level="6"/>
+        <option id="1306" name="Physical Speed" desc="Atk. Spd 8%" skill-id="82004" skill-level="6"/>
+        <option id="1356" name="Magical Speed" desc="Casting Spd +8%" skill-id="82005" skill-level="6"/>
+        <option id="1406" name="Moving Speed" desc="Speed +6.5" skill-id="82006" skill-level="6"/>
+        <option id="1456" name="Physical Attack Critical Chance" desc="P. Critical Rate +55" skill-id="82007" skill-level="6"/>
+        <option id="1506" name="Physical Skill Critical Chance" desc="P. Skill Critical Rate +3.5%" skill-id="82008" skill-level="6"/>
+        <option id="1556" name="Magical Skill Critical Chance" desc="M. Skill Critical Rate +8%" skill-id="82009" skill-level="6"/>
+        <option id="1606" name="Physical Attack Critical Damage" desc="P. Critical Damage +200" skill-id="82010" skill-level="6"/>
+        <option id="1656" name="Physical Skill Critical Damage" desc="P. Skill Critical Damage +1.5%" skill-id="82011" skill-level="6"/>
+        <option id="1706" name="Magical Skill Critical Damage" desc="M. Skill Critical Damage +1.5%" skill-id="82012" skill-level="6"/>
+        <option id="1756" name="Shock Attack" desc="Stuns the target for 3 seconds when attacking (Activation Chance: 9%)" skill-id="82013" skill-level="6"/>
+        <option id="1806" name="Silence Attack" desc="Silences the target for 5 seconds when attacking (Activation Chance: 9%)" skill-id="82015" skill-level="6"/>
+    </stone>
+
+    <!-- Aden Soul Crystal Health Up/Mana Up, P. Atk/M. Atk,, Atk/Casting Spd,  Speed,  P.Atk Crit Chance,  P.Skill/ M.Skill Critical Rate, P.Atk Critical Damage, P.Skill/M.Skill Critical Damage, Shock Atk, Silence Atk Lv. 7 -->
+    <stone id="95789">
+        <option id="1107" name="Health Up" desc="Max HP +10%" skill-id="82000" skill-level="7"/>
+        <option id="1157" name="Mana Up" desc="Max MP +10%" skill-id="82001" skill-level="7"/>
+        <option id="1207" name="Physical Attack" desc="P. Atk +200" skill-id="82002" skill-level="7"/>
+        <option id="1257" name="Magical Attack" desc="M. Atk +200" skill-id="82003" skill-level="7"/>
+        <option id="1307" name="Physical Speed" desc="Atk. Spd 9%" skill-id="82004" skill-level="7"/>
+        <option id="1357" name="Magical Speed" desc="Casting Spd +9%" skill-id="82005" skill-level="7"/>
+        <option id="1407" name="Moving Speed" desc="Speed +7" skill-id="82006" skill-level="7"/>
+        <option id="1457" name="Physical Attack Critical Chance" desc="P. Critical Rate +60" skill-id="82007" skill-level="7"/>
+        <option id="1507" name="Physical Skill Critical Chance" desc="P. Skill Critical Rate +4%" skill-id="82008" skill-level="7"/>
+        <option id="1557" name="Magical Skill Critical Chance" desc="M. Skill Critical Rate +9%" skill-id="82009" skill-level="7"/>
+        <option id="1607" name="Physical Attack Critical Damage" desc="P. Critical Damage +220" skill-id="82010" skill-level="7"/>
+        <option id="1657" name="Physical Skill Critical Damage" desc="P. Skill Critical Damage +1.7%" skill-id="82011" skill-level="7"/>
+        <option id="1707" name="Magical Skill Critical Damage" desc="M. Skill Critical Damage +1.7%" skill-id="82012" skill-level="7"/>
+        <option id="1757" name="Shock Attack" desc="Stuns the target for 3 seconds when attacking (Activation Chance: 10%)" skill-id="82013" skill-level="7"/>
+        <option id="1807" name="Silence Attack" desc="Silences the target for 5 seconds when attacking (Activation Chance: 10%)" skill-id="82015" skill-level="7"/>
+    </stone>
+
+    <!-- Aden Soul Crystal Health Up/Mana Up, P. Atk/M. Atk,, Atk/Casting Spd,  Speed,  P.Atk Crit Chance,  P.Skill/ M.Skill Critical Rate, P.Atk Critical Damage, P.Skill/M.Skill Critical Damage, Shock Atk, Silence Atk Lv. 8 -->
+    <stone id="95790">
+        <option id="1108" name="Health Up" desc="Max HP +12%" skill-id="82000" skill-level="8"/>
+        <option id="1158" name="Mana Up" desc="Max MP +12%" skill-id="82001" skill-level="8"/>
+        <option id="1208" name="Physical Attack" desc="P. Atk +230" skill-id="82002" skill-level="8"/>
+        <option id="1258" name="Magical Attack" desc="M. Atk +230" skill-id="82003" skill-level="8"/>
+        <option id="1308" name="Physical Speed" desc="Atk. Spd 10%" skill-id="82004" skill-level="8"/>
+        <option id="1358" name="Magical Speed" desc="Casting Spd +10%" skill-id="82005" skill-level="8"/>
+        <option id="1408" name="Moving Speed" desc="Speed +7.5" skill-id="82006" skill-level="8"/>
+        <option id="1458" name="Physical Attack Critical Chance" desc="P. Critical Rate +65" skill-id="82007" skill-level="8"/>
+        <option id="1508" name="Physical Skill Critical Chance" desc="P. Skill Critical Rate +4.5%" skill-id="82008" skill-level="8"/>
+        <option id="1558" name="Magical Skill Critical Chance" desc="M. Skill Critical Rate +10%" skill-id="82009" skill-level="8"/>
+        <option id="1608" name="Physical Attack Critical Damage" desc="P. Critical Damage +240" skill-id="82010" skill-level="8"/>
+        <option id="1658" name="Physical Skill Critical Damage" desc="P. Skill Critical Damage +1.9%" skill-id="82011" skill-level="8"/>
+        <option id="1708" name="Magical Skill Critical Damage" desc="PM. Skill Critical Damage +1.9%" skill-id="82012" skill-level="8"/>
+        <option id="1758" name="Shock Attack" desc="Stuns the target for 3 seconds when attacking (Activation Chance: 11%)" skill-id="82013" skill-level="8"/>
+        <option id="1808" name="Silence Attack" desc="P. Atk +50" skill-id="82015" skill-level="8"/>
+    </stone>
+
+    <!-- Aden Soul Crystal Health Up/Mana Up, P. Atk/M. Atk,, Atk/Casting Spd,  Speed,  P.Atk Crit Chance,  P.Skill/ M.Skill Critical Rate, P.Atk Critical Damage, P.Skill/M.Skill Critical Damage, Shock Atk, Silence Atk Lv. 9 -->
+    <stone id="95791">
+        <option id="1109" name="Health Up" desc="Max HP +14%" skill-id="82000" skill-level="9"/>
+        <option id="1159" name="Mana Up" desc="Max MP +14%" skill-id="82001" skill-level="9"/>
+        <option id="1209" name="Physical Attack" desc="P. Atk +260" skill-id="82002" skill-level="9"/>
+        <option id="1259" name="Magical Attack" desc="M. Atk +260" skill-id="82003" skill-level="9"/>
+        <option id="1309" name="Physical Speed" desc="Atk. Spd 11%" skill-id="82004" skill-level="9"/>
+        <option id="1359" name="Magical Speed" desc="Casting Spd +11%" skill-id="82005" skill-level="9"/>
+        <option id="1409" name="Moving Speed" desc="Speed +8" skill-id="82006" skill-level="9"/>
+        <option id="1459" name="Physical Attack Critical Chance" desc="P. Critical Rate +70" skill-id="82007" skill-level="9"/>
+        <option id="1509" name="Physical Skill Critical Chance" desc="P. Skill Critical Rate +5%" skill-id="82008" skill-level="9"/>
+        <option id="1559" name="Magical Skill Critical Chance" desc="M. Skill Critical Rate +11%" skill-id="82009" skill-level="9"/>
+        <option id="1609" name="Physical Attack Critical Damage" desc="P. Critical Damage +260" skill-id="82010" skill-level="9"/>
+        <option id="1659" name="Physical Skill Critical Damage" desc="P. Skill Critical Damage +2.1%" skill-id="82011" skill-level="9"/>
+        <option id="1709" name="Magical Skill Critical Damage" desc="PM. Skill Critical Damage +2.1%" skill-id="82012" skill-level="9"/>
+        <option id="1759" name="Shock Attack" desc="Stuns the target for 3 seconds when attacking (Activation Chance: 12%)" skill-id="82013" skill-level="9"/>
+        <option id="1709" name="Silence Attack" desc="Silences the target for 5 seconds when attacking (Activation Chance: 12%)" skill-id="82015" skill-level="9"/>
+    </stone>
+
+    <!-- Aden Soul Crystal Health Up/Mana Up, P. Atk/M. Atk,, Atk/Casting Spd,  Speed,  P.Atk Crit Chance,  P.Skill/ M.Skill Critical Rate, P.Atk Critical Damage, P.Skill/M.Skill Critical Damage, Shock Atk, Silence Atk Lv. 10 -->
+    <stone id="95792">
+        <option id="1110" name="Health Up" desc="Max HP +16%" skill-id="82000" skill-level="10"/>
+        <option id="1160" name="Mana Up" desc="Max MP +16%" skill-id="82001" skill-level="10"/>
+        <option id="1210" name="Physical Attack" desc="P. Atk +290" skill-id="82002" skill-level="10"/>
+        <option id="1260" name="Magical Attack" desc="M. Atk +290" skill-id="82003" skill-level="10"/>
+        <option id="1310" name="Physical Speed" desc="Atk. Spd 12%" skill-id="82004" skill-level="10"/>
+        <option id="1360" name="Magical Speed" desc="Casting Spd +12%" skill-id="82005" skill-level="10"/>
+        <option id="1410" name="Moving Speed" desc="Speed +8.5" skill-id="82006" skill-level="10"/>
+        <option id="1460" name="Physical Attack Critical Chance" desc="P. Critical Rate +75" skill-id="82007" skill-level="10"/>
+        <option id="1510" name="Physical Skill Critical Chance" desc="P. Skill Critical Rate +5.5%" skill-id="82008" skill-level="10"/>
+        <option id="1560" name="Magical Skill Critical Chance" desc="M. Skill Critical Rate +12%" skill-id="82009" skill-level="10"/>
+        <option id="1610" name="Physical Attack Critical Damage" desc="P. Critical Damage +280" skill-id="82010" skill-level="10"/>
+        <option id="1660" name="Physical Skill Critical Damage" desc="P. Skill Critical Damage +2.3%" skill-id="82011" skill-level="10"/>
+        <option id="1710" name="Magical Skill Critical Damage" desc="M. Skill Critical Damage +2.3%" skill-id="82012" skill-level="10"/>
+        <option id="1760" name="Shock Attack" desc="Stuns the target for 3 seconds when attacking (Activation Chance: 13%)" skill-id="82013" skill-level="10"/>
+        <option id="1810" name="Silence Attack" desc="Silences the target for 5 seconds when attacking (Activation Chance: 13%)" skill-id="82015" skill-level="10"/>
+    </stone>
+
+    <!-- Aden Soul Crystal Health Up/Mana Up, P. Atk/M. Atk,, Atk/Casting Spd,  Speed,  P.Atk Crit Chance,  P.Skill/ M.Skill Critical Rate, P.Atk Critical Damage, P.Skill/M.Skill Critical Damage, Shock Atk, Silence Atk Lv. 11 -->
+    <stone id="95793">
+        <option id="1111" name="Health Up" desc="Max HP +18%" skill-id="82000" skill-level="11"/>
+        <option id="1161" name="Mana Up" desc="Max MP +18%" skill-id="82001" skill-level="11"/>
+        <option id="1211" name="Physical Attack" desc="P. Atk +340" skill-id="82002" skill-level="11"/>
+        <option id="1261" name="Magical Attack" desc="M. Atk +340" skill-id="82003" skill-level="11"/>
+        <option id="1311" name="Physical Speed" desc="Atk. Spd 14%" skill-id="82004" skill-level="11"/>
+        <option id="1361" name="Magical Speed" desc="Casting Spd +14%" skill-id="82005" skill-level="11"/>
+        <option id="1411" name="Moving Speed" desc="Speed +9" skill-id="82006" skill-level="11"/>
+        <option id="1461" name="Physical Attack Critical Chance" desc="P. Critical Rate +80" skill-id="82007" skill-level="11"/>
+        <option id="1511" name="Physical Skill Critical Chance" desc="P. Skill Critical Rate +6%" skill-id="82008" skill-level="11"/>
+        <option id="1561" name="Magical Skill Critical Chance" desc="M. Skill Critical Rate +14%" skill-id="82009" skill-level="11"/>
+        <option id="1611" name="Physical Attack Critical Damage" desc="P. Critical Damage +300" skill-id="82010" skill-level="11"/>
+        <option id="1661" name="Physical Skill Critical Damage" desc="P. Skill Critical Damage +2.5%" skill-id="82011" skill-level="11"/>
+        <option id="1711" name="Magical Skill Critical Damage" desc="M. Skill Critical Damage +2.5%" skill-id="82012" skill-level="11"/>
+        <option id="1761" name="Shock Attack" desc="Stuns the target for 3 seconds when attacking (Activation Chance: 15%)" skill-id="82013" skill-level="11"/>
+        <option id="1611" name="Silence Attack" desc="Silences the target for 5 seconds when attacking (Activation Chance: 15%)" skill-id="82015" skill-level="11"/>
+    </stone>
+
+    <!-- Aden Soul Crystal Health Up/Mana Up, P. Atk/M. Atk,, Atk/Casting Spd,  Speed,  P.Atk Crit Chance,  P.Skill/ M.Skill Critical Rate, P.Atk Critical Damage, P.Skill/M.Skill Critical Damage, Shock Atk, Silence Atk Lv. 12 -->
+    <stone id="95794">
+        <option id="1112" name="Health Up" desc="Max HP +20%" skill-id="82000" skill-level="12"/>
+        <option id="1162" name="Mana Up" desc="Max MP +20%" skill-id="82001" skill-level="12"/>
+        <option id="1212" name="Physical Attack" desc="P. Atk +380" skill-id="82002" skill-level="12"/>
+        <option id="1262" name="Magical Attack" desc="M. Atk +380" skill-id="82003" skill-level="12"/>
+        <option id="1312" name="Physical Speed" desc="Atk. Spd +15%" skill-id="82004" skill-level="12"/>
+        <option id="1362" name="Magical Speed" desc="Casting Spd +15%" skill-id="82005" skill-level="12"/>
+        <option id="1412" name="Moving Speed" desc="Speed +9.5" skill-id="82006" skill-level="12"/>
+        <option id="1462" name="Physical Attack Critical Chance" desc="P. Critical Rate +85" skill-id="82007" skill-level="12"/>
+        <option id="1512" name="Physical Skill Critical Chance" desc="PP. Skill Critical Rate +6.5%" skill-id="82008" skill-level="12"/>
+        <option id="1552" name="Magical Skill Critical Chance" desc="M. Skill Critical Rate +15%" skill-id="82009" skill-level="12"/>
+        <option id="1612" name="Physical Attack Critical Damage" desc="P. Critical Damage +320" skill-id="82010" skill-level="12"/>
+        <option id="1662" name="Physical Skill Critical Damage" desc="P. Skill Critical Damage +2.7%" skill-id="82011" skill-level="12"/>
+        <option id="1712" name="Magical Skill Critical Damage" desc="M. Skill Critical Damage +2.7%" skill-id="82012" skill-level="12"/>
+        <option id="1762" name="Shock Attack" desc="Stuns the target for 3 seconds when attacking (Activation Chance: 16%)" skill-id="82013" skill-level="12"/>
+        <option id="1812" name="Silence Attack" desc="Silences the target for 5 seconds when attacking (Activation Chance: 16%)" skill-id="82015" skill-level="12"/>
+    </stone>
+
+    <!-- Aden Soul Crystal Health Up/Mana Up, P. Atk/M. Atk,, Atk/Casting Spd,  Speed,  P.Atk Crit Chance,  P.Skill/ M.Skill Critical Rate, P.Atk Critical Damage, P.Skill/M.Skill Critical Damage, Shock Atk, Silence Atk Lv. 13 -->
+    <stone id="95795">
+        <option id="1113" name="Health Up" desc="Max HP +22%" skill-id="82000" skill-level="13"/>
+        <option id="1163" name="Mana Up" desc="Max MP +22%" skill-id="82001" skill-level="13"/>
+        <option id="1213" name="Physical Attack" desc="P. Atk +420" skill-id="82002" skill-level="13"/>
+        <option id="1263" name="Magical Attack" desc="M. Atk +420" skill-id="82003" skill-level="13"/>
+        <option id="1313" name="Physical Speed" desc="Atk. Spd +16%" skill-id="82004" skill-level="13"/>
+        <option id="1363" name="Magical Speed" desc="Casting Spd +16%" skill-id="82005" skill-level="13"/>
+        <option id="1413" name="Moving Speed" desc="Speed +10" skill-id="82006" skill-level="13"/>
+        <option id="1463" name="Physical Attack Critical Chance" desc="P. Critical Rate +90" skill-id="82007" skill-level="13"/>
+        <option id="1513" name="Physical Skill Critical Chance" desc="P. Skill Critical Rate +7%" skill-id="82008" skill-level="13"/>
+        <option id="1553" name="Magical Skill Critical Chance" desc="M. Skill Critical Rate +16%" skill-id="82009" skill-level="13"/>
+        <option id="1613" name="Physical Attack Critical Damage" desc="P. Critical Damage +340" skill-id="82010" skill-level="13"/>
+        <option id="1663" name="Physical Skill Critical Damage" desc="P. Skill Critical Damage +2.9%" skill-id="82011" skill-level="13"/>
+        <option id="1713" name="Magical Skill Critical Damage" desc="M. Skill Critical Damage +2.9%" skill-id="82012" skill-level="13"/>
+        <option id="1763" name="Shock Attack" desc="Stuns the target for 3 seconds when attacking (Activation Chance: 17%)" skill-id="82013" skill-level="13"/>
+        <option id="1813" name="Silence Attack" desc="Silences the target for 5 seconds when attacking (Activation Chance: 17%)" skill-id="82015" skill-level="13"/>
+    </stone>
+
+    <!-- Aden Soul Crystal Health Up/Mana Up, P. Atk/M. Atk,, Atk/Casting Spd,  Speed,  P.Atk Crit Chance,  P.Skill/ M.Skill Critical Rate, P.Atk Critical Damage, P.Skill/M.Skill Critical Damage, Shock Atk, Silence Atk Lv. 14 -->
+    <stone id="95796">
+        <option id="1114" name="Health Up" desc="Max HP +25%" skill-id="82000" skill-level="14"/>
+        <option id="1164" name="Mana Up" desc="Max MP +25%" skill-id="82001" skill-level="14"/>
+        <option id="1214" name="Physical Attack" desc="P. Atk +460" skill-id="82002" skill-level="14"/>
+        <option id="1264" name="Magical Attack" desc="M. Atk +460" skill-id="82003" skill-level="14"/>
+        <option id="1314" name="Physical Speed" desc="Atk. Spd +17%" skill-id="82004" skill-level="14"/>
+        <option id="1364" name="Magical Speed" desc="Casting Spd +17%" skill-id="82005" skill-level="14"/>
+        <option id="1414" name="Moving Speed" desc="Speed +10.5" skill-id="82006" skill-level="14"/>
+        <option id="1464" name="Physical Attack Critical Chance" desc="P. Critical Rate +95" skill-id="82007" skill-level="14"/>
+        <option id="1514" name="Physical Skill Critical Chance" desc="P. Skill Critical Rate +7.5%" skill-id="82008" skill-level="14"/>
+        <option id="1554" name="Magical Skill Critical Chance" desc="M. Skill Critical Rate +17%" skill-id="82009" skill-level="14"/>
+        <option id="1614" name="Physical Attack Critical Damage" desc="P. Critical Damage +360" skill-id="82010" skill-level="14"/>
+        <option id="1664" name="Physical Skill Critical Damage" desc="P. Skill Critical Damage +3.1%" skill-id="82011" skill-level="14"/>
+        <option id="1714" name="Magical Skill Critical Damage" desc="PM. Skill Critical Damage +3.1%" skill-id="82012" skill-level="14"/>
+        <option id="1764" name="Shock Attack" desc="Stuns the target for 3 seconds when attacking (Activation Chance: 18%)" skill-id="82013" skill-level="14"/>
+        <option id="1813" name="Silence Attack" desc="Silences the target for 5 seconds when attacking (Activation Chance: 18%)" skill-id="82015" skill-level="14"/>
+    </stone>
+
+    <!-- Aden Soul Crystal Health Up/Mana Up, P. Atk/M. Atk,, Atk/Casting Spd,  Speed,  P.Atk Crit Chance,  P.Skill/ M.Skill Critical Rate, P.Atk Critical Damage, P.Skill/M.Skill Critical Damage, Shock Atk, Silence Atk Lv. 15 -->
+    <stone id="95797">
+        <option id="1115" name="Health Up" desc="Max HP +28%" skill-id="82000" skill-level="15"/>
+        <option id="1165" name="Mana Up" desc="Max MP +28%" skill-id="82001" skill-level="15"/>
+        <option id="1215" name="Physical Attack" desc="P. Atk +500" skill-id="82002" skill-level="15"/>
+        <option id="1265" name="Magical Attack" desc="M. Atk +500" skill-id="82003" skill-level="15"/>
+        <option id="1315" name="Physical Speed" desc="Atk. Spd +18%" skill-id="82004" skill-level="15"/>
+        <option id="1365" name="Magical Speed" desc="Casting Spd +18%" skill-id="82005" skill-level="15"/>
+        <option id="1415" name="Moving Speed" desc="Speed +11" skill-id="82006" skill-level="15"/>
+        <option id="1465" name="Physical Attack Critical Chance" desc="P. Critical Rate +100" skill-id="82007" skill-level="15"/>
+        <option id="1515" name="Physical Skill Critical Chance" desc="P. Skill Critical Rate +8%" skill-id="82008" skill-level="15"/>
+        <option id="1555" name="Magical Skill Critical Chance" desc="M. Skill Critical Rate +18%" skill-id="82009" skill-level="15"/>
+        <option id="1615" name="Physical Attack Critical Damage" desc="P. Critical Damage +380" skill-id="82010" skill-level="15"/>
+        <option id="1665" name="Physical Skill Critical Damage" desc="P. Skill Critical Damage +3.3%" skill-id="82011" skill-level="15"/>
+        <option id="1715" name="Magical Skill Critical Damage" desc="M. Skill Critical Damage +3.3%" skill-id="82012" skill-level="15"/>
+        <option id="1765" name="Shock Attack" desc="Stuns the target for 3 seconds when attacking (Activation Chance: 19%)" skill-id="82013" skill-level="15"/>
+        <option id="1815" name="Silence Attack" desc="Silences the target for 5 seconds when attacking (Activation Chance: 19%)" skill-id="82015" skill-level="15"/>
+    </stone>
+
+    <!-- Aden Soul Crystal Health Up/Mana Up, P. Atk/M. Atk,, Atk/Casting Spd,  Speed,  P.Atk Crit Chance,  P.Skill/ M.Skill Critical Rate, P.Atk Critical Damage, P.Skill/M.Skill Critical Damage, Shock Atk, Silence Atk Lv. 16 -->
+    <stone id="95798">
+        <option id="1116" name="Health Up" desc="Max HP +29%" skill-id="82000" skill-level="16"/>
+        <option id="1166" name="Mana Up" desc="Max MP +29%" skill-id="82001" skill-level="16"/>
+        <option id="1216" name="Physical Attack" desc="P. Atk +600" skill-id="82002" skill-level="16"/>
+        <option id="1266" name="Magical Attack" desc="M. Atk +600" skill-id="82003" skill-level="16"/>
+        <option id="1316" name="Physical Speed" desc="Atk. Spd +20%" skill-id="82004" skill-level="16"/>
+        <option id="1366" name="Magical Speed" desc="Casting Spd +20%" skill-id="82005" skill-level="16"/>
+        <option id="1416" name="Moving Speed" desc="Speed +11.2" skill-id="82006" skill-level="16"/>
+        <option id="1466" name="Physical Attack Critical Chance" desc="P. Critical Rate +110" skill-id="82007" skill-level="16"/>
+        <option id="1516" name="Physical Skill Critical Chance" desc="P. Skill Critical Rate +8.5%" skill-id="82008" skill-level="16"/>
+        <option id="1556" name="Magical Skill Critical Chance" desc="M. Skill Critical Rate +18.5%" skill-id="82009" skill-level="16"/>
+        <option id="1616" name="Physical Attack Critical Damage" desc="P. Critical Damage +400" skill-id="82010" skill-level="16"/>
+        <option id="1656" name="Physical Skill Critical Damage" desc="P. Skill Critical Damage +3.5%" skill-id="82011" skill-level="16"/>
+        <option id="1716" name="Magical Skill Critical Damage" desc="M. Skill Critical Damage +3.5%" skill-id="82012" skill-level="16"/>
+        <option id="1766" name="Shock Attack" desc="Stuns the target for 3 seconds when attacking (Activation Chance: 21%)" skill-id="82013" skill-level="16"/>
+        <option id="1816" name="Silence Attack" desc="Silences the target for 5 seconds when attacking (Activation Chance: 21%)" skill-id="82015" skill-level="16"/>
+    </stone>
+
+    <!-- Aden Soul Crystal Health Up/Mana Up, P. Atk/M. Atk,, Atk/Casting Spd,  Speed,  P.Atk Crit Chance,  P.Skill/ M.Skill Critical Rate, P.Atk Critical Damage, P.Skill/M.Skill Critical Damage, Shock Atk, Silence Atk Lv. 17 -->
+    <stone id="95799">
+        <option id="1117" name="Health Up" desc="Max HP +30%" skill-id="82000" skill-level="17"/>
+        <option id="1167" name="Mana Up" desc="Max MP +30%" skill-id="82001" skill-level="17"/>
+        <option id="1217" name="Physical Attack" desc="P. Atk +700" skill-id="82002" skill-level="17"/>
+        <option id="1267" name="Magical Attack" desc="M. Atk +700" skill-id="82003" skill-level="17"/>
+        <option id="1317" name="Physical Speed" desc="Atk. Spd +21%" skill-id="82004" skill-level="17"/>
+        <option id="1367" name="Magical Speed" desc="Casting Spd +21%" skill-id="82005" skill-level="17"/>
+        <option id="1417" name="Moving Speed" desc="Speed +11.4" skill-id="82006" skill-level="17"/>
+        <option id="1467" name="Physical Attack Critical Chance" desc="P. Critical Rate +120" skill-id="82007" skill-level="17"/>
+        <option id="1517" name="Physical Skill Critical Chance" desc="P. Skill Critical Rate +9%" skill-id="82008" skill-level="17"/>
+        <option id="1557" name="Magical Skill Critical Chance" desc="M. Skill Critical Rate +19%" skill-id="82009" skill-level="17"/>
+        <option id="1617" name="Physical Attack Critical Damage" desc="P. Critical Damage +420" skill-id="82010" skill-level="17"/>
+        <option id="1657" name="Physical Skill Critical Damage" desc="P. Skill Critical Damage +3.7%" skill-id="82011" skill-level="17"/>
+        <option id="1717" name="Magical Skill Critical Damage" desc="M. Skill Critical Damage +3.7%" skill-id="82012" skill-level="17"/>
+        <option id="1767" name="Shock Attack" desc="Stuns the target for 3 seconds when attacking (Activation Chance: 22%)" skill-id="82013" skill-level="17"/>
+        <option id="1817" name="Silence Attack" desc="Silences the target for 5 seconds when attacking (Activation Chance: 22%)" skill-id="82015" skill-level="17"/>
+    </stone>
+
+    <!-- Aden Soul Crystal Health Up/Mana Up, P. Atk/M. Atk,, Atk/Casting Spd,  Speed,  P.Atk Crit Chance,  P.Skill/ M.Skill Critical Rate, P.Atk Critical Damage, P.Skill/M.Skill Critical Damage, Shock Atk, Silence Atk Lv. 18 -->
+    <stone id="95800">
+        <option id="1118" name="Health Up" desc="Max HP +31%" skill-id="82000" skill-level="18"/>
+        <option id="1168" name="Mana Up" desc="Max MP +31%" skill-id="82001" skill-level="18"/>
+        <option id="1218" name="Physical Attack" desc="P. Atk +800" skill-id="82002" skill-level="18"/>
+        <option id="1268" name="Magical Attack" desc="M. Atk +800" skill-id="82003" skill-level="18"/>
+        <option id="1318" name="Physical Speed" desc="Atk. Spd +22%" skill-id="82004" skill-level="18"/>
+        <option id="1368" name="Magical Speed" desc="Casting Spd +22%" skill-id="82005" skill-level="18"/>
+        <option id="1418" name="Moving Speed" desc="Speed +11.6" skill-id="82006" skill-level="18"/>
+        <option id="1468" name="Physical Attack Critical Chance" desc="P. Critical Rate +130" skill-id="82007" skill-level="18"/>
+        <option id="1518" name="Physical Skill Critical Chance" desc="P. Skill Critical Rate +9.5%" skill-id="82008" skill-level="18"/>
+        <option id="1558" name="Magical Skill Critical Chance" desc="M. Skill Critical Rate +19.5%" skill-id="82009" skill-level="18"/>
+        <option id="1618" name="Physical Attack Critical Damage" desc="P. Critical Damage +440" skill-id="82010" skill-level="18"/>
+        <option id="1658" name="Physical Skill Critical Damage" desc="P. Skill Critical Damage +3.9%" skill-id="82011" skill-level="18"/>
+        <option id="1718" name="Magical Skill Critical Damage" desc="M. Skill Critical Damage +3.9%" skill-id="82012" skill-level="18"/>
+        <option id="1758" name="Shock Attack" desc="Stuns the target for 3 seconds when attacking (Activation Chance: 23%)" skill-id="82013" skill-level="18"/>
+        <option id="1718" name="Silence Attack" desc="Silences the target for 5 seconds when attacking (Activation Chance: 23%)" skill-id="82015" skill-level="18"/>
+    </stone>
+
+    <!-- Aden Soul Crystal Health Up/Mana Up, P. Atk/M. Atk,, Atk/Casting Spd,  Speed,  P.Atk Crit Chance,  P.Skill/ M.Skill Critical Rate, P.Atk Critical Damage, P.Skill/M.Skill Critical Damage, Shock Atk, Silence Atk Lv. 19 -->
+    <stone id="95801">
+        <option id="1119" name="Health Up" desc="Max HP +32%" skill-id="82000" skill-level="19"/>
+        <option id="1169" name="Mana Up" desc="Max MP +32%" skill-id="82001" skill-level="19"/>
+        <option id="1219" name="Physical Attack" desc="P. Atk +900" skill-id="82002" skill-level="19"/>
+        <option id="1269" name="Magical Attack" desc="M. Atk +900" skill-id="82003" skill-level="19"/>
+        <option id="1319" name="Physical Speed" desc="Atk. Spd +23%" skill-id="82004" skill-level="19"/>
+        <option id="1369" name="Magical Speed" desc="Casting Spd +23%" skill-id="82005" skill-level="19"/>
+        <option id="1419" name="Moving Speed" desc="Speed +11.8" skill-id="82006" skill-level="19"/>
+        <option id="1469" name="Physical Attack Critical Chance" desc="P. Critical Rate +140" skill-id="82007" skill-level="19"/>
+        <option id="1519" name="Physical Skill Critical Chance" desc="P. Skill Critical Rate +10%" skill-id="82008" skill-level="19"/>
+        <option id="1559" name="Magical Skill Critical Chance" desc="M. Skill Critical Rate +20%" skill-id="82009" skill-level="19"/>
+        <option id="1619" name="Physical Attack Critical Damage" desc="P. Critical Damage +460" skill-id="82010" skill-level="19"/>
+        <option id="1659" name="Physical Skill Critical Damage" desc="P. Skill Critical Damage +4.1%" skill-id="82011" skill-level="19"/>
+        <option id="1719" name="Magical Skill Critical Damage" desc="M. Skill Critical Damage +4.1%" skill-id="82012" skill-level="19"/>
+        <option id="1769" name="Shock Attack" desc="Stuns the target for 3 seconds when attacking (Activation Chance: 24%)" skill-id="82013" skill-level="19"/>
+        <option id="1819" name="Silence Attack" desc="Silences the target for 5 seconds when attacking (Activation Chance: 24%)" skill-id="82015" skill-level="19"/>
+    </stone>
+
+    <!-- Aden Soul Crystal Health Up/Mana Up, P. Atk/M. Atk,, Atk/Casting Spd,  Speed,  P.Atk Crit Chance,  P.Skill/ M.Skill Critical Rate, P.Atk Critical Damage, P.Skill/M.Skill Critical Damage, Shock Atk, Silence Atk Lv. 20 -->
+    <stone id="95802">
+        <option id="1120" name="Health Up" desc="Max HP +33%" skill-id="82000" skill-level="20"/>
+        <option id="1170" name="Mana Up" desc="Max MP +33%" skill-id="82001" skill-level="20"/>
+        <option id="1220" name="Physical Attack" desc="P. Atk +1000" skill-id="82002" skill-level="20"/>
+        <option id="1270" name="Magical Attack" desc="M. Atk +1000" skill-id="82003" skill-level="20"/>
+        <option id="1320" name="Physical Speed" desc="Atk. Spd 24%" skill-id="82004" skill-level="20"/>
+        <option id="1370" name="Magical Speed" desc="Casting Spd 24%" skill-id="82005" skill-level="20"/>
+        <option id="1420" name="Moving Speed" desc="Speed +12" skill-id="82006" skill-level="20"/>
+        <option id="1470" name="Physical Attack Critical Chance" desc="P. Critical Rate +150" skill-id="82007" skill-level="20"/>
+        <option id="1520" name="Physical Skill Critical Chance" desc="P. Skill Critical Rate +11%" skill-id="82008" skill-level="20"/>
+        <option id="1560" name="Magical Skill Critical Chance" desc="M. Skill Critical Rate +21%" skill-id="82009" skill-level="20"/>
+        <option id="1620" name="Physical Attack Critical Damage" desc="P. Critical Damage +500" skill-id="82010" skill-level="20"/>
+        <option id="1670" name="Physical Skill Critical Damage" desc="P. Skill Critical Damage +4.3%" skill-id="82011" skill-level="20"/>
+        <option id="1720" name="Magical Skill Critical Damage" desc="M. Skill Critical Damage +4.3%" skill-id="82012" skill-level="20"/>
+        <option id="1770" name="Shock Attack" desc="Stuns the target for 3 seconds when attacking (Activation Chance: 25%)" skill-id="82013" skill-level="20"/>
+        <option id="1820" name="Silence Attack" desc="Silences the target for 5 seconds when attacking (Activation Chance: 25%)" skill-id="82015" skill-level="20"/>
+    </stone>
+
+    <!-- Hardin's Soul Crystal -->
+    <!-- Hardin Soul Crystal Power Ability and Magic Ability  -->
+    <stone id="95803" type="SPECIAL">
+        <option id="1901" name="Magic Ability" desc="P. Atk. +1%, HP Recovery Bonus +1" skill-id="82017" skill-level="1"/>
+        <option id="1851" name="Power Ability" desc="P. Atk. +1%, HP Recovery Bonus +1" skill-id="82018" skill-level="1"/>
+    </stone>
+
+    <!-- Hardin Soul Crystal Power Ability and Magic Ability  -->
+    <stone id="95804" type="SPECIAL">
+        <option id="1902" name="Magic Ability" desc="M. Atk. +2% MP Recovery Bonus +2" skill-id="82017" skill-level="2"/>
+        <option id="1852" name="Power Ability" desc="P. Atk. +2%, HP Recovery Bonus +2" skill-id="82018" skill-level="2"/>
+    </stone>
+
+    <!-- Hardin Soul Crystal Power Ability and Magic Ability  -->
+    <stone id="95805" type="SPECIAL">
+        <option id="1903" name="Magic Ability" desc="M. Atk. +3% MP Recovery Bonus +3" skill-id="82017" skill-level="3"/>
+        <option id="1853" name="Power Ability" desc="P. Atk. +3%, HP Recovery Bonus +3" skill-id="82018" skill-level="3"/>
+    </stone>
+
+    <!-- Hardin Soul Crystal Power Ability and Magic Ability  -->
+    <stone id="95806" type="SPECIAL">
+        <option id="1904" name="Magic Ability" desc="M. Atk. +4% MP Recovery Bonus +4" skill-id="82017" skill-level="4"/>
+        <option id="1854" name="Power Ability" desc="P. Atk. +4%, HP Recovery Bonus +4" skill-id="82018" skill-level="4"/>
+    </stone>
+
+    <!-- Hardin Soul Crystal Power Ability and Magic Ability  -->
+    <stone id="95807" type="SPECIAL">
+        <option id="1905" name="Magic Ability" desc="M. Atk. +5% MP Recovery Bonus +5" skill-id="82017" skill-level="5"/>
+        <option id="1855" name="Power Ability" desc="P. Atk. +5%, HP Recovery Bonus +5" skill-id="82018" skill-level="5"/>
+    </stone>
+
+    <!-- Hardin Soul Crystal Power Ability and Magic Ability  -->
+    <stone id="95808" type="SPECIAL">
+        <option id="1906" name="Magic Ability" desc="M. Atk. +6% MP Recovery Bonus +6 Recovers 75 MP when hitting and using skills (Activation Chance: 30%)" skill-id="82017" skill-level="6"/>
+        <option id="1856" name="Power Ability" desc="P. Atk. +6%, HP Recovery Bonus +6, Recovers 100 HP when hitting and using skills, (Activation Chance: 30%)" skill-id="82018" skill-level="6"/>
+    </stone>
+
+    <!-- Hardin Soul Crystal Power Ability and Magic Ability  -->
+    <stone id="95809" type="SPECIAL">
+        <option id="1907" name="Magic Ability" desc="M. Atk. +7% MP Recovery Bonus +7 Recovers 150 MP when hitting and using skills (Activation Chance: 30%)" skill-id="82017" skill-level="7"/>
+        <option id="1857" name="Power Ability" desc="P. Atk. +7%, HP Recovery Bonus +7, Recovers 200 HP when hitting and using skills, (Activation Chance: 30%)" skill-id="82018" skill-level="7"/>
+    </stone>
+
+    <!-- Hardin Soul Crystal Power Ability and Magic Ability  -->
+    <stone id="95810" type="SPECIAL">
+        <option id="1908" name="Magic Ability" desc="M. Atk. +8% MP Recovery Bonus +8 Recovers 225 MP when hitting and using skills (Activation Chance: 30%)" skill-id="82017" skill-level="8"/>
+        <option id="1858" name="Power Ability" desc="P. Atk. +8%, HP Recovery Bonus +8, Recovers 300 HP when hitting and using skills, (Activation Chance: 30%)" skill-id="82018" skill-level="8"/>
+    </stone>
+
+    <!-- Hardin Soul Crystal Power Ability and Magic Ability  -->
+    <stone id="95811" type="SPECIAL">
+        <option id="1909" name="Magic Ability" desc="M. Atk. +11% MP Recovery Bonus +9 Recovers 300 MP when hitting and using skills (Activation Chance: 30%)" skill-id="82017" skill-level="9"/>
+        <option id="1869" name="Power Ability" desc="P. Atk. +11%, HP Recovery Bonus +9, Recovers 400 HP when hitting and using skills, (Activation Chance: 30%)" skill-id="82018" skill-level="9"/>
+    </stone>
+
+    <!-- Hardin Soul Crystal Power Ability and Magic Ability  -->
+    <stone id="95812" type="SPECIAL">
+        <option id="1910" name="Magic Ability" desc="M. Atk. +15% MP Recovery Bonus +10 Recovers 600 MP when hitting and using skills (Activation Chance: 30%)" skill-id="82017" skill-level="10"/>
+        <option id="1860" name="Power Ability" desc=". Atk. +15%, HP Recovery Bonus +10, Recovers 900 HP when hitting and using skills, (Activation Chance: 30%)" skill-id="82018" skill-level="10"/>
+    </stone>
+
+    <!-- Hardin Soul Crystal Power Ability and Magic Ability  -->
+    <stone id="95813" type="SPECIAL">
+        <option id="1911" name="Magic Ability" desc="M. Atk. +16% MP Recovery Bonus +11 MEN +1 Recovers 600 MP when hitting and using skills (Activation Chance: 30%)" skill-id="82017" skill-level="11"/>
+        <option id="1861" name="Power Ability" desc="P. Atk. +16%, HP Recovery Bonus +11, CON +1, Recovers 900 HP when hitting and using skills, (Activation Chance: 30%)" skill-id="82018" skill-level="11"/>
+    </stone>
+
+    <!-- Hardin Soul Crystal Power Ability and Magic Ability  -->
+    <stone id="95814" type="SPECIAL">
+        <option id="1912" name="Magic Ability" desc="M. Atk. +17% MP Recovery Bonus +12 MEN +1 Recovers 600 MP when hitting and using skills (Activation Chance: 30%)" skill-id="82017" skill-level="12"/>
+        <option id="1862" name="Power Ability" desc="P. Atk. +17%, HP Recovery Bonus +12, CON +1, Recovers 900 HP when hitting and using skills, (Activation Chance: 30%)" skill-id="82018" skill-level="12"/>
+    </stone>
+
+    <!-- Hardin Soul Crystal Power Ability and Magic Ability  -->
+    <stone id="95815" type="SPECIAL">
+        <option id="1913" name="Magic Ability" desc="PM. Atk. +18% MP Recovery Bonus +13 MEN +2 Recovers 600 MP when hitting and using skills (Activation Chance: 30%)" skill-id="82017" skill-level="13"/>
+        <option id="1863" name="Power Ability" desc="P. Atk. +18%, HP Recovery Bonus +13, CON +2, Recovers 900 HP when hitting and using skills, (Activation Chance: 30%)" skill-id="82018" skill-level="13"/>
+    </stone>
+
+    <!-- Hardin Soul Crystal Power Ability and Magic Ability  -->
+    <stone id="95816" type="SPECIAL">
+        <option id="1914" name="Magic Ability" desc="M. Atk. +19% MP Recovery Bonus +14 MEN +2 Recovers 600 MP when hitting and using skills (Activation Chance: 30%)" skill-id="82017" skill-level="14"/>
+        <option id="1864" name="Power Ability" desc="P. Atk. +19%, HP Recovery Bonus +14, CON +2, Recovers 900 HP when hitting and using skills, (Activation Chance: 30%)" skill-id="82018" skill-level="14"/>
+    </stone>
+
+    <!-- Hardin Soul Crystal Power Ability and Magic Ability  -->
+    <stone id="95817" type="SPECIAL">
+        <option id="1915" name="Magic Ability" desc="M. Atk. +20% MP Recovery Bonus +15 MEN +3 Recovers 600 MP when hitting and using skills (Activation Chance: 30%)" skill-id="82017" skill-level="15"/>
+        <option id="1865" name="Power Ability" desc="P. Atk. +20%, HP Recovery Bonus +15, CON +3, Recovers 900 HP when hitting and using skills, (Activation Chance: 30%)" skill-id="82018" skill-level="15"/>
+    </stone>
+
+    <!-- Hardin Soul Crystal Power Ability and Magic Ability  -->
+    <stone id="95818" type="SPECIAL">
+        <option id="1916" name="Magic Ability" desc="M. Atk. +20% M. Skill Power +1% MP Recovery Bonus +15 MEN +3 Recovers 600 MP when hitting and using skills (Activation Chance: 30%)" skill-id="82017" skill-level="16"/>
+        <option id="1866" name="Power Ability" desc="P. Atk. +20%, P. Skill Power +1%, HP Recovery Bonus +15, CON +3, Recovers 900 HP when hitting and using skills, (Activation Chance: 30%)" skill-id="82018" skill-level="16"/>
+    </stone>
+
+    <!-- Hardin Soul Crystal Power Ability and Magic Ability  -->
+    <stone id="95819" type="SPECIAL">
+        <option id="1917" name="Magic Ability" desc="PM. Atk. +20% M. Skill Power +2% MP Recovery Bonus +15 MEN +4 Recovers 600 MP when hitting and using skills (Activation Chance: 30%)" skill-id="82017" skill-level="17"/>
+        <option id="1867" name="Power Ability" desc="P. Atk. +20%, P. Skill Power +2%, HP Recovery Bonus +15, CON +4, Recovers 900 HP when hitting and using skills, (Activation Chance: 30%)" skill-id="82018" skill-level="17"/>
+    </stone>
+
+    <!-- Hardin Soul Crystal Power Ability and Magic Ability  -->
+    <stone id="95820" type="SPECIAL">
+        <option id="1918" name="Magic Ability" desc="M. Atk. +20% M. Skill Power +3% MP Recovery Bonus +15 MEN +4 Recovers 600 MP when hitting and using skills (Activation Chance: 30%)" skill-id="82017" skill-level="18"/>
+        <option id="1868" name="Power Ability" desc="P. Atk. +20%, P. Skill Power +3%, HP Recovery Bonus +15, CON +4, Recovers 900 HP when hitting and using skills, (Activation Chance: 30%)" skill-id="82018" skill-level="18"/>
+    </stone>
+
+    <!-- Hardin Soul Crystal Power Ability and Magic Ability  -->
+    <stone id="95821" type="SPECIAL">
+        <option id="1919" name="Magic Ability" desc="M. Atk. +20% M. Skill Power +4% MP Recovery Bonus +15 MEN +5 Recovers 600 MP when hitting and using skills (Activation Chance: 30%)" skill-id="82017" skill-level="19"/>
+        <option id="1869" name="Power Ability" desc="P. Atk. +20%, P. Skill Power +4%, HP Recovery Bonus +15, CON +5, Recovers 900 HP when hitting and using skills, (Activation Chance: 30%)" skill-id="82018" skill-level="19"/>
+    </stone>
+
+    <!-- Hardin Soul Crystal Power Ability and Magic Ability  -->
+    <stone id="95822" type="SPECIAL">
+        <option id="1920" name="Magic Ability" desc="M. Atk. +20% M. Skill Power +5% MP Recovery Bonus +15 MEN +5 Recovers 600 MP when hitting and using skills (Activation Chance: 30%)" skill-id="82017" skill-level="20"/>
+        <option id="1870" name="Power Ability" desc="P. Atk. +20%, P. Skill Power +5%, HP Recovery Bonus +15, CON +5, Recovers 900 HP when hitting and using skills, (Activation Chance: 30%)" skill-id="82018" skill-level="20"/>
+    </stone>
 </list>

--- a/data/stats/initialEquipment.xml
+++ b/data/stats/initialEquipment.xml
@@ -1,89 +1,126 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org ../xsd/initialEquipment.xsd">
+
     <!-- Human Fighter -->
     <equipment classId="0">
-        <item id="2369" count="1" equipped="true"/> <!-- Squire's Sword -->
-        <item id="10" count="1"/> <!-- Dagger -->
-        <item id="1146" count="1" equipped="true"/> <!-- Squire's Shirt -->
-        <item id="1147" count="1" equipped="true"/> <!-- Squire's Pants -->
-        <item id="10650" count="3"/> <!-- Newbie Scroll of Escape -->        
+        <item id="2369" count="1" equipped="true" /> <!-- Squire's Sword -->
+        <item id="95689" count="1" equipped="true" /> <!-- Young Knight Shield -->
+        <item id="10" count="1" /> <!-- Dagger -->
+        <item id="1146" count="1" equipped="true" /> <!-- Squire's Shirt -->
+        <item id="1147" count="1" equipped="true" /> <!-- Squire's Pants -->
+        <item id="10650" count="3" /> <!-- Newbie Scroll of Escape -->
     </equipment>
+
     <!-- Human Mystic -->
     <equipment classId="10">
-        <item id="6" count="1" equipped="true"/> <!-- Apprentice's Wand -->
-        <item id="425" count="1" equipped="true"/> <!-- Apprentice's Tunic -->
-        <item id="461" count="1" equipped="true"/> <!-- Apprentice's Stockings -->
-        <item id="10650" count="3"/> <!-- Newbie Scroll of Escape -->
+        <item id="6" count="1" equipped="true" /> <!-- Apprentice's Wand -->
+        <item id="425" count="1" equipped="true" /> <!-- Apprentice's Tunic -->
+        <item id="461" count="1" equipped="true" /> <!-- Apprentice's Stockings -->
+        <item id="10650" count="3" /> <!-- Newbie Scroll of Escape -->
     </equipment>
+
     <!-- Elven Fighter -->
     <equipment classId="18">
-        <item id="2369" count="1" equipped="true"/> <!-- Squire's Sword -->
-        <item id="10" count="1"/> <!-- Dagger -->
-        <item id="1146" count="1" equipped="true"/> <!-- Squire's Shirt -->
-        <item id="1147" count="1" equipped="true"/> <!-- Squire's Pants -->
-        <item id="10650" count="3"/> <!-- Newbie Scroll of Escape -->
+        <item id="2369" count="1" equipped="true" /> <!-- Squire's Sword -->
+        <item id="95689" count="1" equipped="true" /> <!-- Young Knight Shield -->
+        <item id="10" count="1" /> <!-- Dagger -->
+        <item id="1146" count="1" equipped="true" /> <!-- Squire's Shirt -->
+        <item id="1147" count="1" equipped="true" /> <!-- Squire's Pants -->
+        <item id="10650" count="3" /> <!-- Newbie Scroll of Escape -->
     </equipment>
+
     <!-- Elven Mystic -->
     <equipment classId="25">
-        <item id="6" count="1" equipped="true"/> <!-- Apprentice's Wand -->
-        <item id="425" count="1" equipped="true"/> <!-- Apprentice's Tunic -->
-        <item id="461" count="1" equipped="true"/> <!-- Apprentice's Stockings -->
-        <item id="10650" count="3"/> <!-- Newbie Scroll of Escape -->
+        <item id="6" count="1" equipped="true" /> <!-- Apprentice's Wand -->
+        <item id="425" count="1" equipped="true" /> <!-- Apprentice's Tunic -->
+        <item id="461" count="1" equipped="true" /> <!-- Apprentice's Stockings -->
+        <item id="10650" count="3" /> <!-- Newbie Scroll of Escape -->
+        <item id="93498" count="1" /> <!--Enchanted C-Grade Weapon Coupon -->
     </equipment>
+
     <!-- Dark Fighter -->
     <equipment classId="31">
-        <item id="2369" count="1" equipped="true"/> <!-- Squire's Sword -->
-        <item id="10" count="1"/> <!-- Dagger -->
-        <item id="1146" count="1" equipped="true"/> <!-- Squire's Shirt -->
-        <item id="1147" count="1" equipped="true"/> <!-- Squire's Pants -->
-        <item id="10650" count="3"/> <!-- Newbie Scroll of Escape -->
+        <item id="2369" count="1" equipped="true" /> <!-- Squire's Sword -->
+        <item id="95689" count="1" equipped="true" /> <!-- Young Knight Shield -->
+        <item id="10" count="1" /> <!-- Dagger -->
+        <item id="1146" count="1" equipped="true" /> <!-- Squire's Shirt -->
+        <item id="1147" count="1" equipped="true" /> <!-- Squire's Pants -->
+        <item id="10650" count="3" /> <!-- Newbie Scroll of Escape -->
     </equipment>
+
     <!-- Dark Mystic -->
     <equipment classId="38">
-        <item id="6" count="1" equipped="true"/> <!-- Apprentice's Wand -->
-        <item id="425" count="1" equipped="true"/> <!-- Apprentice's Tunic -->
-        <item id="461" count="1" equipped="true"/> <!-- Apprentice's Stockings -->
-        <item id="10650" count="3"/> <!-- Newbie Scroll of Escape -->
+        <item id="6" count="1" equipped="true" /> <!-- Apprentice's Wand -->
+        <item id="425" count="1" equipped="true" /> <!-- Apprentice's Tunic -->
+        <item id="461" count="1" equipped="true" /> <!-- Apprentice's Stockings -->
+        <item id="10650" count="3" /> <!-- Newbie Scroll of Escape -->
     </equipment>
+
     <!-- Orc Fighter -->
     <equipment classId="44">
-        <item id="2369" count="1"/> <!-- Squire's Sword -->
-        <item id="2368" count="1" equipped="true"/> <!-- Training Gloves -->
-        <item id="1146" count="1" equipped="true"/> <!-- Squire's Shirt -->
-        <item id="1147" count="1" equipped="true"/> <!-- Squire's Pants -->
-        <item id="10650" count="3"/> <!-- Newbie Scroll of Escape -->
+        <item id="981" count="1" /> <!-- Red Sunset Sword -->
+        <item id="2368" count="1" equipped="true" /> <!-- Training Gloves -->
+        <item id="1146" count="1" equipped="true" /> <!-- Squire's Shirt -->
+        <item id="1147" count="1" equipped="true" /> <!-- Squire's Pants -->
+        <item id="10650" count="3" /> <!-- Newbie Scroll of Escape -->
     </equipment>
+
     <!-- Orc Mystic -->
-    <!-- NOTE: This is orc_mage (orc_shaman is retail typo) -->
     <equipment classId="49">
-        <item id="2368" count="1" equipped="true"/> <!-- Training Gloves -->
-        <item id="425" count="1" equipped="true"/> <!-- Apprentice's Tunic -->
-        <item id="461" count="1" equipped="true"/> <!-- Apprentice's Stockings -->
-        <item id="10650" count="3"/> <!-- Newbie Scroll of Escape -->
+        <item id="2368" count="1" equipped="true" /> <!-- Training Gloves -->
+        <item id="425" count="1" equipped="true" /> <!-- Apprentice's Tunic -->
+        <item id="461" count="1" equipped="true" /> <!-- Apprentice's Stockings -->
+        <item id="10650" count="3" /> <!-- Newbie Scroll of Escape -->
     </equipment>
+
     <!-- Dwarf Fighter -->
     <equipment classId="53">
-        <item id="2370" count="1" equipped="true"/> <!-- Guild Member's Club -->
-        <item id="10" count="1"/> <!-- Dagger -->
-        <item id="1146" count="1" equipped="true"/> <!-- Squire's Shirt -->
-        <item id="1147" count="1" equipped="true"/> <!-- Squire's Pants -->
-        <item id="10650" count="3"/> <!-- Newbie Scroll of Escape -->
+        <item id="2370" count="1" equipped="true" /> <!-- Guild Member's Club -->
+        <item id="10" count="1" /> <!-- Dagger -->
+        <item id="1146" count="1" equipped="true" /> <!-- Squire's Shirt -->
+        <item id="1147" count="1" equipped="true" /> <!-- Squire's Pants -->
+        <item id="10650" count="3" /> <!-- Newbie Scroll of Escape -->
     </equipment>
+
     <!-- Jin Kamael Soldier -->
     <equipment classId="192">
-        <item id="91950" count="1" equipped="true"/> <!-- Novice Warrior's Ancient Sword -->
-        <item id="1146" count="1" equipped="true"/> <!-- Squire's Shirt -->
-        <item id="1147" count="1" equipped="true"/> <!-- Squire's Pants -->
-        <item id="91949" count="1"/> <!-- Novice Warrior's Rapier -->
-        <item id="10650" count="3"/> <!-- Newbie Scroll of Escape -->
+        <item id="91950" count="1" /> <!-- Novice Warrior's Ancient Sword -->
+        <item id="1146" count="1" equipped="true" /> <!-- Squire's Shirt -->
+        <item id="1147" count="1" equipped="true" /> <!-- Squire's Pants -->
+        <item id="91949" count="1" equipped="true" /> <!-- Novice Warrior's Rapier -->
+        <item id="10650" count="3" /> <!-- Newbie Scroll of Escape -->
     </equipment>
+
+    <!-- Human Death Knight -->
+    <equipment classId="196">
+        <item id="2369" count="1" equipped="true" /> <!-- Squire's Sword -->
+        <item id="1146" count="1" equipped="true" /> <!-- Squire's Shirt -->
+        <item id="1147" count="1" equipped="true" /> <!-- Squire's Pants -->
+        <item id="10650" count="3" /> <!-- Newbie Scroll of Escape -->
+    </equipment>
+
+    <!-- Elf Death Knight -->
+    <equipment classId="200">
+        <item id="2369" count="1" equipped="true" /> <!-- Squire's Sword -->
+        <item id="1146" count="1" equipped="true" /> <!-- Squire's Shirt -->
+        <item id="1147" count="1" equipped="true" /> <!-- Squire's Pants -->
+        <item id="10650" count="3" /> <!-- Newbie Scroll of Escape -->
+    </equipment>
+
+    <!-- Dark Elf Death Knight -->
+    <equipment classId="204">
+        <item id="2369" count="1" equipped="true" /> <!-- Squire's Sword -->
+        <item id="1146" count="1" equipped="true" /> <!-- Squire's Shirt -->
+        <item id="1147" count="1" equipped="true" /> <!-- Squire's Pants -->
+        <item id="10650" count="3" /> <!-- Newbie Scroll of Escape -->
+    </equipment>
+
     <!-- Sylph Gunner -->
     <equipment classId="208">
-        <item id="95410" count="1" equipped="true" /> <!-- Young Knight's Pistols -->
+        <item id="95410" count="1" equipped="true" /> <!-- Apprentice Knight's Shooter (Imprint) -->
         <item id="1146" count="1" equipped="true" /> <!-- Squire's Shirt -->
         <item id="1147" count="1" equipped="true" /> <!-- Squire's Pants -->
         <item id="94891" count="1" /> <!-- No-grade Elemental Orb -->
         <item id="10650" count="3" /> <!-- Newbie Scroll of Escape -->
-        <item id="91691" count="25" /> <!-- Maliss' MP Replenishing Potion (Event) -->
     </equipment>
 </list>

--- a/data/stats/npcs/22100-22199.xml
+++ b/data/stats/npcs/22100-22199.xml
@@ -1,50 +1,1876 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org npcs.xsd">
-    <npc element="EARTH" id="22100" level="85" name="Lord Ishka" type="Monster" title="Valley's Disciple">
-        <acquire attribute_exp="1530" exp="2768115" sp="83044"/>
-        <stats con="35" dex="22" int="32" men="15" str="35" wit="20">
-            <vitals hp="44350.854" hpRegen="10" mp="2770.2" mpRegen="5"/>
-            <attack physical="9482.07" magical="3981.53" random="10" critical="4" accuracy="4.75" attackSpeed="253" type="SWORD" range="40" distance="80" width="120"/>
-            <defence physical="1742.98" magical="1362.44" evasion="-18"/>
+    <npc id="22100" level="85" type="RaidBoss" name="Lord Ishka" title="Apostle of the Valley" element="EARTH">
+        <race>UNDEAD</race>
+        <sex>FEMALE</sex>
+        <equipment rhand="1472" />
+        <acquire exp="2768115" sp="83044" attribute_exp="1530" />
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="40504.6242774566" hpRegen="10.5" mp="2252.80528052805" mpRegen="3.6" />
             <speed>
-                <walk ground="100"/>
-                <run ground="190"/>
+                <walk ground="100" />
+                <run ground="190" />
             </speed>
-                <hitTime>450</hitTime>
-            <abnormalResist physical="230" magical="230"/>
+            <attack physical="1950.2231755595" magical="1331.5869440987" critical="4" attackSpeed="253" range="40" />
+            <defence physical="405.85106382979" magical="297.0297029703" />
         </stats>
-        <status attackable="true" undying="false"/>
-        <exCrtEffect>true</exCrtEffect>
-        <ai type="BALANCED" clanHelpRange="300"/>
+        <status attackable="false" />
+        <skillList>
+            <skill id="4085" level="1" /> <!-- Critical Damage -->
+            <skill id="4086" level="1" /> <!-- Critical Chance -->
+            <skill id="4408" level="12" /> <!-- HP Increase (4x) -->
+            <skill id="4410" level="15" /> <!-- Strong P. Atk. -->
+            <skill id="4411" level="14" /> <!-- Strong M. Atk. -->
+            <skill id="4412" level="19" /> <!-- Extremely Strong P. Def. -->
+            <skill id="4413" level="19" /> <!-- Extremely Strong M. Def. -->
+            <skill id="4416" level="1" /> <!-- Undead -->
+            <skill id="48047" level="1" /> <!-- Monster of Earth Element -->
+        </skillList>
         <collision>
-            <radius normal="22"/>
-            <height normal="67"/>
+            <radius normal="22" />
+            <height normal="67" />
         </collision>
-        <parameters>       
-            <skill name="RangeHold_a" id="4197" level="6"/>
+        <dropLists>
+            <drop>
+                <item id="91953" min="1" max="1" chance="1" /> <!-- Dragon Valley's Earring -->
+                <item id="57" min="4085" max="9532" chance="70" /> <!-- Adena -->
+                <item id="91034" min="1" max="1" chance="2.018" /> <!-- Earth Spirit Evolution Stone -->
+            </drop>
+        </dropLists>
+    </npc>
+    <npc id="22101" level="65" type="Monster" name="Guard Butcher" element="EARTH">
+        <race>UNDEAD</race>
+        <sex>FEMALE</sex>
+        <equipment rhand="134" lhand="6721" />
+        <acquire exp="5028" sp="375" attribute_exp="22" />
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="3401.15606936416" hpRegen="10.5" mp="966.336633663366" mpRegen="3.6" />
+            <speed>
+                <walk ground="39" />
+                <run ground="180" />
+            </speed>
+            <attack physical="367.275422872161" magical="80.8169973141629" critical="4.75" attackSpeed="253" range="40" />
+            <defence physical="163.636363636364" magical="87.008700870087" />
+        </stats>
+        <status attackable="false" />
+        <skillList>
+            <skill id="4071" level="5" /> <!-- Bow Resistance -->
+            <skill id="4416" level="1" /> <!-- Undead -->
+            <skill id="5620" level="2" /> <!-- Melee Attack Vulnerability -->
+            <skill id="48047" level="1" /> <!-- Monster of Earth Element -->
+        </skillList>
+        <collision>
+            <radius normal="7" />
+            <height normal="30" />
+        </collision>
+    </npc>
+    <npc id="22102" level="66" type="Monster" name="Guard of Honor" element="WIND">
+        <race>HUMANOID</race>
+        <sex>FEMALE</sex>
+        <equipment rhand="38448" />
+        <acquire exp="5262" sp="459" attribute_exp="23" />
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="3480.34682080925" hpRegen="10.5" mp="991.419141914192" mpRegen="3.6" />
+            <speed>
+                <walk ground="45" />
+                <run ground="180" />
+            </speed>
+            <attack physical="398.38350988785" magical="88.2228587418453" critical="4.75" attackSpeed="253" range="40" />
+            <defence physical="162.58064516129" magical="92.835089960609" />
+        </stats>
+        <status attackable="false" />
+        <skillList>
+            <skill id="4071" level="5" /> <!-- Bow Resistance -->
+            <skill id="4416" level="6" /> <!-- Humanoids -->
+            <skill id="5620" level="2" /> <!-- Melee Attack Vulnerability -->
+            <skill id="48046" level="1" /> <!-- Monster of Wind Element -->
+        </skillList>
+        <collision>
+            <radius normal="36" />
+            <height normal="44.25" />
+        </collision>
+    </npc>
+    <npc id="22103" level="72" type="Monster" name="Fierce Guard" element="WATER">
+        <race>ANIMAL</race>
+        <sex>FEMALE</sex>
+        <acquire exp="4935" sp="546" attribute_exp="34" />
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="2446.82080924855" hpRegen="10.5" mp="1146.53465346535" mpRegen="3.6" />
+            <speed>
+                <walk ground="51" />
+                <run ground="180" />
+            </speed>
+            <attack physical="424.97548218372" magical="97.8926873074313" critical="4.75" attackSpeed="253" range="40" />
+            <defence physical="183.229813664596" magical="95.115101572269" />
+        </stats>
+        <status attackable="false" />
+        <skillList>
+            <skill id="4071" level="5" /> <!-- Bow Resistance -->
+            <skill id="4416" level="4" /> <!-- Animals -->
+            <skill id="5620" level="3" /> <!-- Melee Attack Vulnerability -->
+            <skill id="48045" level="1" /> <!-- Monster of Water Element -->
+        </skillList>
+        <collision>
+            <radius normal="31.5" />
+            <height normal="44.7" />
+        </collision>
+    </npc>
+    <npc id="22104" level="85" type="Npc" name="Kellow" title="Ruler of Garden">
+        <!-- AUTO GENERATED NPC TODO: FIX IT -->
+        <race>ETC</race>
+        <sex>FEMALE</sex>
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="5736" hpRegen="10.5" mp="1708" mpRegen="3.6" />
+            <speed>
+                <walk ground="36" />
+                <run ground="200" />
+            </speed>
+            <attack physical="1950.2231755595" magical="1331.5869440987" critical="4" attackSpeed="253" range="40" />
+            <defence physical="405.85106382979" magical="297.0297029703" />
+        </stats>
+        <status attackable="false" />
+        <collision>
+            <radius normal="36" />
+            <height normal="42.6" />
+        </collision>
+    </npc>
+    <npc id="22105" level="85" type="Npc" name="Crokin Commander" title="Ruler of Garden">
+        <!-- AUTO GENERATED NPC TODO: FIX IT -->
+        <race>ETC</race>
+        <sex>FEMALE</sex>
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="7138" hpRegen="10.5" mp="2039" mpRegen="3.6" />
+            <speed>
+                <walk ground="50" />
+                <run ground="180" />
+            </speed>
+            <attack physical="1950.2231755595" magical="1331.5869440987" critical="4" attackSpeed="253" range="40" />
+            <defence physical="405.85106382979" magical="297.0297029703" />
+        </stats>
+        <status attackable="false" />
+        <collision>
+            <radius normal="58" />
+            <height normal="52.5" />
+        </collision>
+    </npc>
+    <npc id="22106" level="75" type="Monster" name="Ancient Guardian" element="EARTH">
+        <race>HUMANOID</race>
+        <sex>FEMALE</sex>
+        <acquire exp="5340" sp="942" attribute_exp="41" />
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="3094.21965317919" hpRegen="10.5" mp="1838.94389438944" mpRegen="3.6" />
+            <speed>
+                <walk ground="40" />
+                <run ground="180" />
+            </speed>
+            <attack physical="343.072556003544" magical="92.9903099408827" critical="4.75" attackSpeed="253" range="40" />
+            <defence physical="190.243902439024" magical="91.7652740883845" />
+        </stats>
+        <status attackable="false" />
+        <skillList>
+            <skill id="4071" level="2" /> <!-- Bow Resistance -->
+            <skill id="4416" level="6" /> <!-- Humanoids -->
+            <skill id="5620" level="3" /> <!-- Melee Attack Vulnerability -->
+            <skill id="48047" level="1" /> <!-- Monster of Earth Element -->
+        </skillList>
+        <collision>
+            <radius normal="28" />
+            <height normal="46.15" />
+        </collision>
+    </npc>
+    <npc id="22107" level="45" type="Monster" name="Rotting Tree">
+        <parameters>
+            <param name="MoveAroundSocial" value="100" />
+            <param name="MoveAroundSocial1" value="100" />
+            <param name="MoveAroundSocial2" value="100" />
+            <param name="SoulShot" value="200" />
+            <param name="SoulShotRate" value="5" />
+            <param name="SpiritShot" value="100" />
+            <param name="SpiritShotRate" value="10" />
+            <param name="LongRangeGuardRate" value="10" />
+            <skill name="DeBuff" id="4076" level="3" />
+        </parameters>
+        <race>PLANT</race>
+        <sex>MALE</sex>
+        <acquire exp="1633" sp="116" />
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="1697.39292364991" hpRegen="5.5" mp="558.177379983727" mpRegen="2.1" />
+            <attack physical="190.9530182" magical="143.43577" random="30" critical="4" accuracy="4.75" attackSpeed="253" type="SWORD" range="40" distance="80" width="120" />
+            <defence physical="186.047587" magical="123.76505" />
+            <speed>
+                <walk ground="55" />
+                <run ground="174" />
+            </speed>
+            <hitTime>480</hitTime>
+            <abnormalResist physical="10" magical="10" />
+        </stats>
+        <status undying="false" canBeSown="true" />
+        <skillList>
+            <skill id="4071" level="4" /> <!-- Bow Resistance -->
+            <skill id="4116" level="6" /> <!-- Magic Damage Resistance -->
+            <skill id="4274" level="1" /> <!-- Blunt Weapon Vulnerability -->
+            <skill id="4416" level="5" /> <!-- Plants -->
+            <skill id="48045" level="1" /> <!-- Monster of Water Element -->
+            <skill id="4275" level="2" /> <!-- Holy Attack Vulnerability -->
+            <skill id="4278" level="1" /> <!-- Dark Attack -->
+            <skill id="4076" level="3" /> <!-- Decrease Speed -->
+        </skillList>
+        <shots shotChance="30" spiritChance="30" />
+        <exCrtEffect>false</exCrtEffect>
+        <ai	aggroRange="1200" />
+        <collision>
+            <radius normal="35" grown="42" />
+            <height normal="80" grown="96" />
+        </collision>
+        <dropLists>
+            <drop>
+                <item id="92912" min="1" max="1" chance="100" /> <!-- Material: Plain Fabric -->
+            </drop>
+        </dropLists>
+    </npc>
+    <npc id="22108" level="45" type="Monster" name="Giant Fungus">
+        <race>PLANT</race>
+        <sex>FEMALE</sex>
+        <acquire exp="1785" sp="128" />
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="1139.88439306358" hpRegen="10.5" mp="496.369636963696" mpRegen="3.6" />
+            <speed>
+                <walk ground="70" />
+                <run ground="174" />
+            </speed>
+            <attack physical="179.237245942268" magical="48.4143461526226" critical="4.75" attackSpeed="253" range="40" />
+            <defence physical="136.567164179104" magical="64.5288409437959" />
+        </stats>
+        <status attackable="false" />
+        <skillList>
+            <skill id="4416" level="5" /> <!-- Plants -->
+        </skillList>
+        <collision>
+            <radius normal="15" />
+            <height normal="31.3" />
+        </collision>
+    </npc>
+    <npc id="22109" level="45" type="Monster" name="Dire Wyrm">
+        <parameters>
+            <param name="MoveAroundSocial" value="60" />
+            <param name="MoveAroundSocial1" value="60" />
+            <param name="MoveAroundSocial2" value="60" />
+            <param name="SoulShot" value="200" />
+            <param name="SoulShotRate" value="5" />
+            <param name="SpiritShot" value="100" />
+            <param name="SpiritShotRate" value="10" />
+            <param name="LongRangeGuardRate" value="10" />
+        </parameters>
+        <race>DRAGON</race>
+        <sex>MALE</sex>
+        <acquire exp="1555" sp="111" attribute_exp="4" />
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="1630.35381750466" hpRegen="5.5" mp="532.139951179821" mpRegen="2.1" />
+            <speed>
+                <walk ground="70" />
+                <run ground="174" />
+            </speed>
+            <hitTime>190</hitTime>
+            <attack physical="180.3144636" magical="135.44454" random="30" critical="4" accuracy="4.75" attackSpeed="253" type="SWORD" range="40" distance="80" width="120" />
+            <defence physical="181.373643" magical="120.65578" />
+        </stats>
+        <status undying="false" canBeSown="true" />
+        <skillList>
+            <skill id="4071" level="4" /> <!-- Bow Resistance -->
+            <skill id="4116" level="6" /> <!-- Magic Damage Resistance -->
+            <skill id="4416" level="10" /> <!-- Dragons -->
+            <skill id="48045" level="1" /> <!-- Monster of Water Element -->
+        </skillList>
+        <shots shotChance="30" spiritChance="30" />
+        <exCrtEffect>false</exCrtEffect>
+        <ai aggroRange="1500"/>
+        <collision>
+            <radius normal="29" />
+            <height normal="72" />
+        </collision>
+        <dropLists>
+            <drop>
+                <item id="92912" min="1" max="1" chance="100" /> <!-- Material: Plain Fabric -->
+            </drop>
+        </dropLists>
+    </npc>
+    <npc id="22110" level="55" type="Monster" name="Taik Orc Supply Officer">
+        <parameters>
+            <param name="MoveAroundSocial" value="90" />
+            <param name="MoveAroundSocial1" value="65" />
+            <param name="MoveAroundSocial2" value="90" />
+            <param name="SoulShot" value="100" />
+            <param name="SoulShotRate" value="10" />
+            <param name="SpiritShot" value="100" />
+            <param name="SpiritShotRate" value="5" />
+            <param name="LongRangeGuardRate" value="5" />
+            <skill name="PhysicalSpecial" id="4073" level="5" /> <!-- Stun -->
+        </parameters>
+        <race>HUMANOID</race>
+        <sex>MALE</sex>
+        <equipment rhand="75" /> <!-- rhand: Caliburs -->
+        <acquire exp="2919" sp="192" attribute_exp="11" />
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="3451.58286778399" hpRegen="6.5" mp="890.968266883645" mpRegen="2.4" />
+            <speed>
+                <walk ground="36" />
+                <run ground="174" />
+            </speed>
+            <hitTime>540</hitTime>
+            <attack physical="426.922562" magical="265.02979" random="30" critical="4" accuracy="4.75" attackSpeed="253" type="SWORD" range="40" distance="80" width="120" />
+            <defence physical="203.3056364" magical="163.64727" />
+        </stats>
+        <status undying="false" canBeSown="true" />
+        <skillList>
+            <skill id="4416" level="6" /> <!-- Humanoids -->
+            <skill id="5620" level="1" /> <!-- Melee Attack Vulnerability -->
+            <skill id="48044" level="1" /> <!-- Monster of Fire Element -->
+        </skillList>
+        <shots shotChance="30" spiritChance="30" />
+        <exCrtEffect>false</exCrtEffect>
+        <ai aggroRange="500" clanHelpRange="300" isAggressive="true">
+            <clanList>
+                <clan>ORC</clan>
+            </clanList>
+        </ai>
+        <collision>
+            <radius normal="12" grown="14" />
+            <height normal="24" grown="28.8" />
+        </collision>
+        <dropLists>
+            <drop>
+                <item id="92913" min="1" max="1" chance="100" /> <!-- Material: Unknown Metal -->
+            </drop>
+        </dropLists>
+    </npc>
+    <npc id="22111" level="55" type="Monster" name="Tortured Undead">
+        <parameters>
+            <param name="MoveAroundSocial" value="82" />
+            <param name="MoveAroundSocial1" value="82" />
+            <param name="MoveAroundSocial2" value="82" />
+            <param name="SoulShot" value="100" />
+            <param name="SoulShotRate" value="10" />
+            <param name="SpiritShot" value="100" />
+            <param name="SpiritShotRate" value="5" />
+            <param name="LongRangeGuardRate" value="5" />
+            <skill name="DeBuff" id="4098" level="6" />
         </parameters>
         <race>UNDEAD</race>
         <sex>MALE</sex>
-        <equipment rhand="1472"/> <!-- Dreadbane -->
-        <!--Lord Ishka-->
+        <acquire exp="2869" sp="355" attribute_exp="10" />
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="3242.08566108007" hpRegen="6.5" mp="834.011391375102" mpRegen="2.4" />
+            <attack physical="389.082012" magical="241.5387" random="30" critical="4" accuracy="4.75" attackSpeed="253" type="SWORD" range="40" distance="80" width="120" />
+            <defence physical="194.7120545" magical="156.73001" />
+            <speed>
+                <walk ground="15" />
+                <run ground="174" />
+            </speed>
+            <hitTime>430</hitTime>
+            <abnormalResist physical="10" magical="10" />
+        </stats>
+        <status undying="false" canBeSown="true" />
+        <skillList>
+            <skill id="4416" level="1" /> <!-- Undead -->
+            <skill id="5620" level="1" /> <!-- Melee Attack Vulnerability -->
+            <skill id="48044" level="1" /> <!-- Monster of Fire Element -->
+            <skill id="4275" level="2" /> <!-- Holy Attack Vulnerability -->
+            <skill id="4278" level="1" /> <!-- Dark Attack -->
+            <skill id="4098" level="6" /> <!-- Silence -->
+        </skillList>
+        <shots shotChance="30" spiritChance="30" />
+        <exCrtEffect>false</exCrtEffect>
+        <ai aggroRange="450" clanHelpRange="0" isAggressive="true">
+            <clanList>
+                <clan>ALL</clan>
+            </clanList>
+        </ai>
+        <collision>
+            <radius normal="30" grown="15.5" />
+            <height normal="40" grown="48.5" />
+        </collision>
         <dropLists>
             <drop>
-                <item id="57" min="4085" max="9532" chance="70" />
-                <item id="91034" min="1" max="1" chance="2" />
-                <item id="91953" min="1" max="2" chance="5" />
-                <item id="91967" min="1" max="5" chance="7" />
+                <item id="92913" min="1" max="1" chance="100" /> <!-- Material: Unknown Metal -->
             </drop>
         </dropLists>
-        <skillList><!--Нежить: Поднятые из могил с помощью Черной Магии, проклятия или злой волей, большинству этих существ недостает ума, так что они способны выполнять лишь простейшие действия. Тем не менее высшая нежить обладает обширными знаниями по сравнении с обычными смертными.-->
-            <skill id="4416" level="1"/><!--HP увеличены (4x):-->
-            <skill id="4408" level="12"/><!--Сильная Физ. Атк.:-->
-            <skill id="4410" level="15"/><!--Сильная Маг. Атк.:-->
-            <skill id="4411" level="14"/><!--Предельно Сильная Физ. Защ.:-->
-            <skill id="4412" level="19"/><!--Предельно Сильная Маг. Защ.:-->
-            <skill id="4413" level="19"/><!--Монстры Стихии Земли: Атаки огнем наносят дополнительный урон.-->
-            <skill id="48047" level="1"/><!--Критическая Мощность: Предоставляет возможность мощной физ. крит. атаки-->
-            <skill id="4085" level="1"/><!--Шанс Крит. Удара: Увеличивает шанс Физ. Крит. Атк.-->
-            <skill id="4086" level="1"/>
+    </npc>
+    <npc id="22112" level="55" type="Monster" name="Soul of Ruins">
+        <parameters>
+            <param name="MoveAroundSocial" value="0" />
+            <param name="MoveAroundSocial1" value="0" />
+            <param name="MoveAroundSocial2" value="0" />
+            <skill name="DDMagic" id="4002" level="5" /> <!-- NPC HP Drain -->
+            <param name="SoulShot" value="100" />
+            <param name="SoulShotRate" value="10" />
+            <param name="SpiritShot" value="100" />
+            <param name="SpiritShotRate" value="5" />
+            <param name="LongRangeGuardRate" value="5" />
+            <skill name="DDMagic" id="4002" level="5" /> <!-- NPC HP Drain -->
+        </parameters>
+        <race>UNDEAD</race>
+        <sex>MALE</sex>
+        <acquire exp="2982" sp="183" attribute_exp="10" />
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="3345.43761638734" hpRegen="6.5" mp="863.303498779496" mpRegen="2.4" />
+            <speed>
+                <walk ground="80" />
+                <run ground="174" />
+            </speed>
+            <hitTime>390</hitTime>
+            <attack physical="336.9900364" magical="253.13256" random="30" critical="4" accuracy="4.75" attackSpeed="253" type="SWORD" range="40" distance="80" width="120" />
+            <defence physical="240.785479" magical="160.17851" />
+        </stats>
+        <status undying="false" canBeSown="true" />
+        <skillList>
+            <skill id="4416" level="1" /> <!-- Undead -->
+            <skill id="5620" level="1" /> <!-- Melee Attack Vulnerability -->
+            <skill id="48044" level="1" /> <!-- Monster of Fire Element -->
+            <skill id="4275" level="2" /> <!-- Holy Attack Vulnerability -->
+            <skill id="4278" level="1" /> <!-- Dark Attack -->
         </skillList>
+        <shots shotChance="30" spiritChance="30" />
+        <exCrtEffect>false</exCrtEffect>
+        <ai aggroRange="350" clanHelpRange="300" isAggressive="true">
+            <clanList>
+                <clan>UNDEAD</clan>
+            </clanList>
+        </ai>
+        <collision>
+            <radius normal="8" />
+            <height normal="22" />
+        </collision>
+        <dropLists>
+            <drop>
+                <item id="92913" min="1" max="1" chance="100" /> <!-- Material: Unknown Metal -->
+            </drop>
+        </dropLists>
+    </npc>
+    <npc id="22113" level="65" type="Monster" name="Vanor Silenos Chieftain">
+        <parameters>
+            <param name="MoveAroundSocial" value="90" />
+            <param name="MoveAroundSocial1" value="60" />
+            <param name="MoveAroundSocial2" value="90" />
+            <param name="SoulShot" value="200" />
+            <param name="SoulShotRate" value="5" />
+            <param name="SpiritShot" value="100" />
+            <param name="SpiritShotRate" value="10" />
+            <param name="LongRangeGuardRate" value="10" />
+            <skill name="MagicHeal" id="4065" level="5" />
+        </parameters>
+        <race>HUMANOID</race>
+        <sex>MALE</sex>
+        <equipment rhand="75" /> <!-- Caliburs -->
+        <acquire exp="4862" sp="395" attribute_exp="22" />
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="5478.58472998138" hpRegen="7.5" mp="1191.21236777868" mpRegen="2.7" />
+            <attack physical="277.7718727" magical="208.6504" random="30" critical="4" accuracy="4.75" attackSpeed="253" type="SWORD" range="40" distance="80" width="120" />
+            <defence physical="220.262284" magical="146.5258" />
+            <speed>
+                <walk ground="27" />
+                <run ground="175" />
+            </speed>
+            <hitTime>390</hitTime>
+            <abnormalResist physical="10" magical="10" />
+        </stats>
+        <status undying="false" canBeSown="true" />
+        <skillList>
+            <skill id="4071" level="1" /> <!-- Bow Resistance -->
+            <skill id="4416" level="6" /> <!-- Humanoids -->
+            <skill id="5620" level="2" /> <!-- Melee Attack Vulnerability -->
+            <skill id="48046" level="1" /> <!-- Monster of Wind Element -->
+            <skill id="4065" level="5" /> <!-- NPC Heal -->
+        </skillList>
+        <shots shotChance="30" spiritChance="30" />
+        <exCrtEffect>false</exCrtEffect>
+        <sNpcPropHpRate>2</sNpcPropHpRate>
+        <ai aggroRange="500" clanHelpRange="400" isAggressive="true"/>
+        <collision>
+            <radius normal="13" />
+            <height normal="31.5" />
+        </collision>
+        <dropLists>
+            <drop>
+                <item id="92913" min="1" max="1" chance="100" /> <!-- Material: Unknown Metal -->
+            </drop>
+        </dropLists>
+    </npc>
+    <npc id="22114" level="65" type="Monster" name="Vanor">
+        <race>HUMANOID</race>
+        <sex>FEMALE</sex>
+        <acquire exp="5007" sp="459" attribute_exp="23" />
+        <equipment rhand="160" />
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="5606.14525139665" hpRegen="7.5" mp="1222.13181448332" mpRegen="2.7" />
+            <speed>
+                <walk ground="36" />
+                <run ground="175" />
+            </speed>
+            <attack physical="1950.2231755595" magical="1331.5869440987" critical="4" attackSpeed="253" range="40" />
+            <defence physical="405.85106382979" magical="297.0297029703" />
+        </stats>
+        <status attackable="false" />
+        <ai aggroRange="500" clanHelpRange="400" isAggressive="true"/>
+        <skillList>
+            <skill id="4071" level="1" /> <!-- Bow Resistance -->
+            <skill id="4085" level="1" /> <!-- Critical Damage -->
+            <skill id="4086" level="1" /> <!-- Critical Chance -->
+            <skill id="4416" level="6" /> <!-- Humanoids -->
+            <skill id="5620" level="3" /> <!-- Melee Attack Vulnerability -->
+            <skill id="48046" level="1" /> <!-- Monster of Wind Element -->
+        </skillList>
+        <collision>
+            <radius normal="15.6" />
+            <height normal="37.8" />
+        </collision>
+        <dropLists>
+            <drop>
+                <item id="92913" min="1" max="1" chance="100" /> <!-- Material: Unknown Metal -->
+            </drop>
+        </dropLists>
+    </npc>
+    <npc id="22115" level="65" type="Monster" name="Vanor Silenos Shaman">
+        <parameters>
+            <param name="MoveAroundSocial" value="100" />
+            <param name="MoveAroundSocial1" value="60" />
+            <param name="MoveAroundSocial2" value="100" />
+            <param name="SoulShot" value="200" />
+            <param name="SoulShotRate" value="5" />
+            <param name="SpiritShot" value="100" />
+            <param name="SpiritShotRate" value="10" />
+            <param name="LongRangeGuardRate" value="10" />
+            <skill name="W_LongRangeDDMagic" id="4155" level="4" />
+            <skill name="W_ShortRangeDDMagic" id="4160" level="4" />
+            <skill name="DeBuff" id="4076" level="3" />
+        </parameters>
+        <race>HUMANOID</race>
+        <sex>MALE</sex>
+        <equipment rhand="9" /> <!-- Cedar Staff -->
+        <acquire exp="4724" sp="208" attribute_exp="20" />
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="5350.09310986965" hpRegen="7.5" mp="1161.10659072417" mpRegen="2.7" />
+            <attack physical="319.490468" magical="198.33688" random="50" critical="1" accuracy="9" attackSpeed="253" type="BLUNT" range="40" distance="80" width="120" />
+            <defence physical="177.8754727" magical="143.17771" />
+            <speed>
+                <walk ground="29" />
+                <run ground="174" />
+            </speed>
+            <hitTime>220</hitTime>
+            <abnormalResist physical="10" magical="10" />
+        </stats>
+        <status undying="false" canBeSown="true" />
+        <skillList>
+            <skill id="4071" level="1" /> <!-- Bow Resistance -->
+            <skill id="4416" level="6" /> <!-- Humanoids -->
+            <skill id="5620" level="2" /> <!-- Melee Attack Vulnerability -->
+            <skill id="48046" level="1" /> <!-- Monster of Wind Element -->
+            <skill id="4076" level="3" /> <!-- Decrease Speed -->
+            <skill id="4155" level="4" /> <!-- NPC Twister - Magic -->
+            <skill id="4160" level="4" /> <!-- NPC Aura Burn - Magic -->
+        </skillList>
+        <shots shotChance="30" spiritChance="30" />
+        <exCrtEffect>false</exCrtEffect>
+        <ai aggroRange="500" clanHelpRange="350" isAggressive="true"/>
+        <collision>
+            <radius normal="13" />
+            <height normal="32" />
+        </collision>
+        <dropLists>
+            <drop>
+                <item id="92913" min="1" max="1" chance="100" /> <!-- Material: Unknown Metal -->
+            </drop>
+        </dropLists>
+    </npc>
+    <npc id="22116" level="75" type="Monster" name="Farcran">
+        <parameters>
+            <param name="MoveAroundSocial" value="60" />
+            <param name="MoveAroundSocial1" value="60" />
+            <param name="MoveAroundSocial2" value="60" />
+            <param name="SoulShot" value="200" />
+            <param name="SoulShotRate" value="5" />
+            <param name="SpiritShot" value="100" />
+            <param name="SpiritShotRate" value="10" />
+            <param name="LongRangeGuardRate" value="10" />
+            <skill name="PhysicalSpecial" id="4073" level="5" />
+        </parameters>
+        <race>ANIMAL</race>
+        <sex>MALE</sex>
+        <acquire exp="6575" sp="546" attribute_exp="34" />
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="7882.68156424581" hpRegen="8.5" mp="1413.344182262" mpRegen="3" />
+            <attack physical="353.71092" magical="241.5387" random="30" critical="4" accuracy="4.75" attackSpeed="253" type="SWORD" range="40" distance="80" width="120" />
+            <defence physical="214.18326" magical="156.73001" />
+            <speed>
+                <walk ground="37" />
+                <run ground="174" />
+            </speed>
+            <hitTime>450</hitTime>
+            <abnormalResist physical="10" magical="10" />
+        </stats>
+        <status undying="false" canBeSown="true" />
+        <skillList>
+            <skill id="4071" level="1" /> <!-- Bow Resistance -->
+            <skill id="4085" level="1" /> <!-- Critical Damage -->
+            <skill id="4086" level="1" /> <!-- Critical Chance -->
+            <skill id="4116" level="3" /> <!-- Magic Damage Resistance -->
+            <skill id="4416" level="4" /> <!-- Animals -->
+            <skill id="5620" level="3" /> <!-- Melee Attack Vulnerability -->
+            <skill id="48045" level="1" /> <!-- Monster of Water Element -->
+            <skill id="4073" level="5" /> <!-- Stun -->
+        </skillList>
+        <shots shotChance="30" spiritChance="30" />
+        <exCrtEffect>false</exCrtEffect>
+        <ai clanHelpRange="300" aggroRange="450" isAggressive="true" />
+        <collision>
+            <radius normal="19" />
+            <height normal="36" />
+        </collision>
+        <dropLists>
+            <drop>
+                <item id="92915" min="1" max="1" chance="100" /> <!-- Material: Bag of Low-grade Stuff -->
+            </drop>
+        </dropLists>
+    </npc>
+    <npc id="22117" level="75" type="Monster" name="Deprive">
+        <parameters>
+            <param name="MoveAroundSocial" value="40" />
+            <param name="MoveAroundSocial1" value="40" />
+            <param name="MoveAroundSocial2" value="40" />
+            <param name="SoulShot" value="200" />
+            <param name="SoulShotRate" value="5" />
+            <param name="SpiritShot" value="100" />
+            <param name="SpiritShotRate" value="10" />
+            <param name="LongRangeGuardRate" value="10" />
+            <skill name="DDMagic" id="4039" level="5" />
+        </parameters>
+        <race>ETC</race>
+        <sex>MALE</sex>
+        <acquire exp="6209" sp="248" attribute_exp="30" />
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="7584.72998137803" hpRegen="7.5" mp="1348.25061025224" mpRegen="2.7" />
+            <attack physical="336.103966" magical="208.6504" random="30" critical="4" accuracy="4.75" attackSpeed="253" type="SWORD" range="40" distance="80" width="120" />
+            <defence physical="182.0349455" magical="146.5258" />
+            <speed>
+                <walk ground="70" />
+                <run ground="174" />
+            </speed>
+            <hitTime>410</hitTime>
+            <abnormalResist physical="10" magical="10" />
+        </stats>
+        <status undying="false" canBeSown="true" />
+        <skillList>
+            <skill id="4071" level="1" /> <!-- Bow Resistance -->
+            <skill id="4116" level="2" /> <!-- Magic Damage Resistance -->
+            <skill id="4416" level="2" /> <!-- Magical Creatures -->
+            <skill id="5620" level="3" /> <!-- Melee Attack Vulnerability -->
+            <skill id="48045" level="1" /> <!-- Monster of Water Element -->
+            <skill id="4039" level="5" /> <!-- NPC MP Drain -->
+        </skillList>
+        <shots shotChance="30" spiritChance="30" />
+        <exCrtEffect>false</exCrtEffect>
+        <ai aggroRange="450" clanHelpRange="300" isAggressive="true" />
+        <collision>
+            <radius normal="15" />
+            <height normal="30" />
+        </collision>
+        <dropLists>
+            <drop>
+                <item id="92915" min="1" max="1" chance="100" /> <!-- Material: Bag of Low-grade Stuff -->
+            </drop>
+        </dropLists>
+    </npc>
+    <npc id="22118" level="75" type="Monster" name="Hatar Ratman Boss">
+        <parameters>
+            <param name="MoveAroundSocial" value="100" />
+            <param name="MoveAroundSocial1" value="100" />
+            <param name="MoveAroundSocial2" value="100" />
+            <param name="SoulShot" value="200" />
+            <param name="SoulShotRate" value="5" />
+            <param name="SpiritShot" value="100" />
+            <param name="SpiritShotRate" value="10" />
+            <param name="LongRangeGuardRate" value="10" />
+            <skill name="PhysicalSpecial" id="4067" level="4" />
+        </parameters>
+        <race>HUMANOID</race>
+        <sex>MALE</sex>
+        <equipment rhand="221" /> <!-- Assassin Knife -->
+        <acquire exp="5859" sp="234" attribute_exp="26" />
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="7279.32960893855" hpRegen="7.5" mp="1285.59804719284" mpRegen="2.7" />
+            <attack physical="241.3486688" magical="188.35412" random="10" critical="8" accuracy="0" attackSpeed="289" type="DAGGER" range="40" distance="80" width="120" />
+            <defence physical="191.12803" magical="139.8592" />
+            <speed>
+                <walk ground="80" />
+                <run ground="174" />
+            </speed>
+            <hitTime>610</hitTime>
+            <abnormalResist physical="10" magical="10" />
+        </stats>
+        <status undying="false" canBeSown="true" />
+        <skillList>
+            <skill id="4071" level="1" /> <!-- Bow Resistance -->
+            <skill id="4116" level="2" /> <!-- Magic Damage Resistance -->
+            <skill id="4416" level="6" /> <!-- Humanoids -->
+            <skill id="5620" level="3" /> <!-- Melee Attack Vulnerability -->
+            <skill id="48045" level="1" /> <!-- Monster of Water Element -->
+            <skill id="4067" level="4" /> <!-- NPC Mortal Blow -->
+        </skillList>
+        <shots shotChance="30" spiritChance="30" />
+        <exCrtEffect>false</exCrtEffect>
+        <ai clanHelpRange="300" aggroRange="450" isAggressive="true">
+            <clanList>
+                <clan>HATAR</clan>
+            </clanList>
+        </ai>
+        <collision>
+            <radius normal="14" />
+            <height normal="25" />
+        </collision>
+        <dropLists>
+            <drop>
+                <item id="92915" min="1" max="1" chance="100" /> <!-- Material: Bag of Low-grade Stuff -->
+            </drop>
+        </dropLists>
+    </npc>
+    <npc id="22119" level="85" type="Npc" name="Sly Hound Dog">
+        <!-- AUTO GENERATED NPC TODO: FIX IT -->
+        <race>ETC</race>
+        <sex>FEMALE</sex>
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="3646" hpRegen="10.5" mp="2512" mpRegen="3.6" />
+            <speed>
+                <walk ground="30" />
+                <run ground="185" />
+            </speed>
+            <attack physical="1950.2231755595" magical="1331.5869440987" critical="4" attackSpeed="253" range="40" />
+            <defence physical="405.85106382979" magical="297.0297029703" />
+        </stats>
+        <status attackable="false" />
+        <collision>
+            <radius normal="18" />
+            <height normal="25" />
+        </collision>
+    </npc>
+    <npc id="22120" level="85" type="Npc" name="Valley Buffalo">
+        <!-- AUTO GENERATED NPC TODO: FIX IT -->
+        <race>ETC</race>
+        <sex>FEMALE</sex>
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="3646" hpRegen="10.5" mp="2512" mpRegen="3.6" />
+            <speed>
+                <walk ground="20" />
+                <run ground="160" />
+            </speed>
+            <attack physical="1950.2231755595" magical="1331.5869440987" critical="4" attackSpeed="253" range="40" />
+            <defence physical="405.85106382979" magical="297.0297029703" />
+        </stats>
+        <status attackable="false" />
+        <collision>
+            <radius normal="22" />
+            <height normal="31" />
+        </collision>
+    </npc>
+    <npc id="22121" level="85" type="Npc" name="Eye of Pilgrim">
+        <!-- AUTO GENERATED NPC TODO: FIX IT -->
+        <race>ETC</race>
+        <sex>FEMALE</sex>
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="3646" hpRegen="10.5" mp="2512" mpRegen="3.6" />
+            <speed>
+                <walk ground="30" />
+                <run ground="165" />
+            </speed>
+            <attack physical="1950.2231755595" magical="1331.5869440987" critical="4" attackSpeed="253" range="40" />
+            <defence physical="405.85106382979" magical="297.0297029703" />
+        </stats>
+        <status attackable="false" />
+        <collision>
+            <radius normal="25" />
+            <height normal="63" />
+        </collision>
+    </npc>
+    <npc id="22122" level="45" type="Monster" name="Special Treasure Chest">
+        <race>ETC</race>
+        <sex>FEMALE</sex>
+        <acquire exp="26822" sp="7509" />
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="2279.76878612717" hpRegen="10.5" mp="496.369636963696" mpRegen="3.6" />
+            <speed>
+                <walk ground="30" />
+                <run ground="180" />
+            </speed>
+            <attack physical="179.237245942268" magical="48.4143461526226" critical="4.75" attackSpeed="253" range="40" />
+            <defence physical="136.567164179104" magical="64.5288409437959" />
+        </stats>
+        <status attackable="false" />
+        <ai aggroRange="1200"/>
+        <skillList>
+            <skill id="4416" level="2" /> <!-- Magical Creatures -->
+        </skillList>
+        <collision>
+            <radius normal="24" />
+            <height normal="19" />
+        </collision>
+        <dropLists>
+            <drop>
+                <item id="92912" min="1" max="1" chance="100" /> <!-- Material: Plain Fabric -->
+            </drop>
+        </dropLists>
+    </npc>
+    <npc id="22123" level="55" type="Monster" name="Special Treasure Chest">
+        <race>ETC</race>
+        <sex>FEMALE</sex>
+        <acquire exp="44577" sp="12479" />
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="3221.96531791908" hpRegen="10.5" mp="722.772277227723" mpRegen="3.6" />
+            <speed>
+                <walk ground="30" />
+                <run ground="180" />
+            </speed>
+            <attack physical="274.380199324603" magical="71.4860425312335" critical="4.75" attackSpeed="253" range="40" />
+            <defence physical="169.444444444444" magical="77.007700770077" />
+        </stats>
+        <status attackable="false" />
+        <ai aggroRange="500" clanHelpRange="400" isAggressive="true"/>
+        <skillList>
+            <skill id="4416" level="2" /> <!-- Magical Creatures -->
+        </skillList>
+        <collision>
+            <radius normal="24" />
+            <height normal="19" />
+        </collision>
+        <dropLists>
+            <drop>
+                <item id="92913" min="1" max="1" chance="100" /> <!-- Material: Unknown Metal -->
+            </drop>
+        </dropLists>
+    </npc>
+    <npc id="22124" level="65" type="Monster" name="Special Treasure Chest">
+        <race>ETC</race>
+        <sex>FEMALE</sex>
+        <acquire exp="65074" sp="18219" />
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="4224.85549132948" hpRegen="10.5" mp="966.336633663366" mpRegen="3.6" />
+            <speed>
+                <walk ground="30" />
+                <run ground="180" />
+            </speed>
+            <attack physical="367.275422872161" magical="80.8169973141629" critical="4.75" attackSpeed="253" range="40" />
+            <defence physical="163.636363636364" magical="87.008700870087" />
+        </stats>
+        <status attackable="false" />
+        <skillList>
+            <skill id="4416" level="2" /> <!-- Magical Creatures -->
+        </skillList>
+        <collision>
+            <radius normal="24" />
+            <height normal="19" />
+        </collision>
+        <dropLists>
+            <drop>
+                <item id="92914" min="1" max="1" chance="100" /> <!-- Material: Sack Shreds -->
+            </drop>
+        </dropLists>
+    </npc>
+    <npc id="22125" level="75" type="Monster" name="Special Treasure Chest">
+        <race>ETC</race>
+        <sex>FEMALE</sex>
+        <acquire exp="96773" sp="27090" />
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="5156.64739884393" hpRegen="10.5" mp="1225.74257425743" mpRegen="3.6" />
+            <speed>
+                <walk ground="30" />
+                <run ground="180" />
+            </speed>
+            <attack physical="343.072556003544" magical="92.9903099408827" critical="4.75" attackSpeed="253" range="40" />
+            <defence physical="190.243902439024" magical="91.7652740883845" />
+        </stats>
+        <status attackable="false" />
+        <ai aggroRange="500" clanHelpRange="400" isAggressive="true"/>
+        <skillList>
+            <skill id="4416" level="2" /> <!-- Magical Creatures -->
+        </skillList>
+        <collision>
+            <radius normal="24" />
+            <height normal="19" />
+        </collision>
+        <dropLists>
+            <drop>
+                <item id="92915" min="1" max="1" chance="100" /> <!-- Material: Bag of Low-grade Stuff -->
+            </drop>
+        </dropLists>
+    </npc>
+    <npc id="22126" level="85" type="Monster" name="Special Treasure Chest">
+        <race>ETC</race>
+        <sex>FEMALE</sex>
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="8446" hpRegen="10.5" mp="2355" mpRegen="3.6" />
+            <speed>
+                <walk ground="30" />
+                <run ground="180" />
+            </speed>
+            <attack physical="1950.2231755595" magical="1331.5869440987" critical="4" attackSpeed="253" range="40" />
+            <defence physical="405.85106382979" magical="297.0297029703" />
+        </stats>
+        <status attackable="false" />
+        <ai aggroRange="500" clanHelpRange="400" isAggressive="true"/>
+        <collision>
+            <radius normal="24" />
+            <height normal="19" />
+        </collision>
+    </npc>
+    <npc id="22127" level="73" type="Monster" name="Flame Warden" element="FIRE">
+        <race>UNDEAD</race>
+        <sex>FEMALE</sex>
+        <equipment rhand="70" />
+        <acquire exp="5070" sp="2054" attribute_exp="36" />
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="2491.32947976879" hpRegen="10.5" mp="1172.93729372937" mpRegen="3.6" />
+            <speed>
+                <walk ground="40" />
+                <run ground="175" />
+            </speed>
+            <attack physical="377.508717019466" magical="95.7472890089901" critical="4.75" attackSpeed="253" range="40" />
+            <defence physical="178.395061728395" magical="97.7875565334311" />
+        </stats>
+        <status attackable="false" />
+        <skillList>
+            <skill id="4071" level="5" /> <!-- Bow Resistance -->
+            <skill id="4416" level="1" /> <!-- Undead -->
+            <skill id="48044" level="1" /> <!-- Monster of Fire Element -->
+        </skillList>
+        <collision>
+            <radius normal="10" />
+            <height normal="25" />
+        </collision>
+    </npc>
+    <npc id="22128" level="55" type="Monster" name="Grave Warden" element="FIRE">
+        <race>UNDEAD</race>
+        <sex>FEMALE</sex>
+        <acquire exp="3241" sp="192" attribute_exp="11" />
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="2142.77456647399" hpRegen="10.5" mp="722.772277227723" mpRegen="3.6" />
+            <speed>
+                <walk ground="50" />
+                <run ground="175" />
+            </speed>
+            <attack physical="274.380199324603" magical="71.4860425312335" critical="4.75" attackSpeed="253" range="40" />
+            <defence physical="169.444444444444" magical="77.007700770077" />
+        </stats>
+        <status attackable="false" />
+        <skillList>
+            <skill id="4071" level="5" /> <!-- Bow Resistance -->
+            <skill id="4416" level="1" /> <!-- Undead -->
+            <skill id="5620" level="1" /> <!-- Melee Attack Vulnerability -->
+            <skill id="48044" level="1" /> <!-- Monster of Fire Element -->
+        </skillList>
+        <collision>
+            <radius normal="18" />
+            <height normal="30.6" />
+        </collision>
+    </npc>
+    <npc id="22129" level="85" type="Npc" name="Turek Orc Ranger">
+        <!-- AUTO GENERATED NPC TODO: FIX IT -->
+        <race>ETC</race>
+        <sex>FEMALE</sex>
+        <equipment rhand="2" />
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="3816" hpRegen="10.5" mp="2049" mpRegen="3.6" />
+            <speed>
+                <walk ground="45" />
+                <run ground="175" />
+            </speed>
+            <attack physical="1950.2231755595" magical="1331.5869440987" critical="4" attackSpeed="253" range="40" />
+            <defence physical="405.85106382979" magical="297.0297029703" />
+        </stats>
+        <status attackable="false" />
+        <collision>
+            <radius normal="15" />
+            <height normal="33" />
+        </collision>
+    </npc>
+    <npc id="22130" level="85" type="Npc" name="Turek Orc Skirmisher">
+        <!-- AUTO GENERATED NPC TODO: FIX IT -->
+        <race>ETC</race>
+        <sex>FEMALE</sex>
+        <equipment rhand="121" />
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="3875" hpRegen="10.5" mp="2093" mpRegen="3.6" />
+            <speed>
+                <walk ground="45" />
+                <run ground="175" />
+            </speed>
+            <attack physical="1950.2231755595" magical="1331.5869440987" critical="4" attackSpeed="253" range="40" />
+            <defence physical="405.85106382979" magical="297.0297029703" />
+        </stats>
+        <status attackable="false" />
+        <collision>
+            <radius normal="18" />
+            <height normal="34.5" />
+        </collision>
+    </npc>
+    <npc id="22131" level="85" type="Npc" name="Turek Orc Marksman">
+        <!-- AUTO GENERATED NPC TODO: FIX IT -->
+        <race>ETC</race>
+        <sex>FEMALE</sex>
+        <equipment rhand="14" />
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="3932" hpRegen="10.5" mp="2137" mpRegen="3.6" />
+            <speed>
+                <walk ground="45" />
+                <run ground="175" />
+            </speed>
+            <attack physical="1950.2231755595" magical="1331.5869440987" critical="4" attackSpeed="253" range="40" />
+            <defence physical="405.85106382979" magical="297.0297029703" />
+        </stats>
+        <status attackable="false" />
+        <collision>
+            <radius normal="21" />
+            <height normal="39" />
+        </collision>
+    </npc>
+    <npc id="22132" level="85" type="Npc" name="Turek Orc Captain">
+        <!-- AUTO GENERATED NPC TODO: FIX IT -->
+        <race>ETC</race>
+        <sex>FEMALE</sex>
+        <equipment rhand="127" />
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="4041" hpRegen="10.5" mp="2227" mpRegen="3.6" />
+            <speed>
+                <walk ground="45" />
+                <run ground="175" />
+            </speed>
+            <attack physical="1950.2231755595" magical="1331.5869440987" critical="4" attackSpeed="253" range="40" />
+            <defence physical="405.85106382979" magical="297.0297029703" />
+        </stats>
+        <status attackable="false" />
+        <collision>
+            <radius normal="15" />
+            <height normal="36" />
+        </collision>
+    </npc>
+    <npc id="22133" level="85" type="Npc" name="Turek Orc Elder">
+        <!-- AUTO GENERATED NPC TODO: FIX IT -->
+        <race>ETC</race>
+        <sex>FEMALE</sex>
+        <equipment rhand="7" />
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="3987" hpRegen="10.5" mp="2182" mpRegen="3.6" />
+            <speed>
+                <walk ground="45" />
+                <run ground="175" />
+            </speed>
+            <attack physical="1950.2231755595" magical="1331.5869440987" critical="4" attackSpeed="253" range="40" />
+            <defence physical="405.85106382979" magical="297.0297029703" />
+        </stats>
+        <status attackable="false" />
+        <collision>
+            <radius normal="13.5" />
+            <height normal="34.5" />
+        </collision>
+    </npc>
+    <npc id="22134" level="85" type="Npc" name="Turek Orc Commander" title="Hero of the Past">
+        <!-- AUTO GENERATED NPC TODO: FIX IT -->
+        <race>ETC</race>
+        <sex>FEMALE</sex>
+        <equipment rhand="75" />
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="4041" hpRegen="10.5" mp="2227" mpRegen="3.6" />
+            <speed>
+                <walk ground="36" />
+                <run ground="175" />
+            </speed>
+            <attack physical="1950.2231755595" magical="1331.5869440987" critical="4" attackSpeed="253" range="40" />
+            <defence physical="405.85106382979" magical="297.0297029703" />
+        </stats>
+        <status attackable="false" />
+        <collision>
+            <radius normal="18" />
+            <height normal="37.5" />
+        </collision>
+    </npc>
+    <npc id="22135" level="85" type="Monster" name="Turek Orc" element="FIRE">
+        <race>HUMANOID</race>
+        <sex>FEMALE</sex>
+        <acquire exp="207788" sp="11807" attribute_exp="765" />
+        <equipment rhand="2" /> <!-- Long Sword -->
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="10124.8554913295" hpRegen="10.5" mp="2252.80528052805" mpRegen="3.6" />
+            <speed>
+                <walk ground="80" />
+                <run ground="175" />
+            </speed>
+            <attack physical="3950.2231755595" magical="1331.5869440987" critical="4" attackSpeed="253" range="40" />
+            <defence physical="3405.85106382979" magical="1297.0297029703" />
+        </stats>
+        <status attackable="false" />
+        <skillList>
+            <skill id="4116" level="6" /> <!-- Magic Damage Resistance -->
+            <skill id="4416" level="6" /> <!-- Humanoids -->
+            <skill id="48044" level="1" /> <!-- Monster of Fire Element -->
+        </skillList>
+        <collision>
+            <radius normal="13.5" />
+            <height normal="33.75" />
+        </collision>
+        <dropLists>
+            <drop>
+                <item id="57" min="992" max="2314" chance="70" /> <!-- Adena -->
+                <item id="92479" min="1" max="1" chance="5.501" /> <!-- Metallograph -->
+                <item id="92999" min="1" max="1" chance="0.75" /> <!-- High-grade Resources -->
+                <item id="92912" min="1" max="1" chance="0.75" /> <!-- Material: Plain Fabric -->
+                <item id="92913" min="1" max="1" chance="0.3" /> <!-- Material: Unknown Metal -->
+                <item id="92995" min="1" max="1" chance="0.3" /> <!-- Thons -->
+                <item id="92914" min="1" max="1" chance="0.075" /> <!-- Material: Sack Shreds -->
+                <item id="92915" min="1" max="1" chance="0.075" /> <!-- Material: Bag of Low-grade Stuff -->
+                <item id="92916" min="1" max="1" chance="0.03" /> <!-- Material: Animal Spirit -->
+                <item id="92919" min="1" max="1" chance="0.003" /> <!-- Material: Blacksmith's High-grade Power -->
+            </drop>
+            <spoil>
+                <item id="92996" min="1" max="1" chance="56.01" /> <!-- Old Resources -->
+                <item id="92997" min="1" max="1" chance="11.28" /> <!-- Unknown Resources -->
+                <item id="92998" min="1" max="1" chance="5.674" /> <!-- Shining Resources -->
+                <item id="92999" min="1" max="1" chance="1.198" /> <!-- High-grade Resources -->
+                <item id="92995" min="1" max="1" chance="0.75" /> <!-- Thons -->
+            </spoil>
+        </dropLists>
+    </npc>
+    <npc id="22136" level="85" type="Monster" name="Turek Orc Footman" element="FIRE">
+        <race>HUMANOID</race>
+        <sex>FEMALE</sex>
+        <acquire exp="201682" sp="71424" attribute_exp="850" />
+        <equipment rhand="68" /> <!-- Falchion -->
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="10124.8554913295" hpRegen="10.5" mp="2252.80528052805" mpRegen="3.6" />
+            <speed>
+                <walk ground="80" />
+                <run ground="175" />
+            </speed>
+            <attack physical="1950.2231755595" magical="1331.5869440987" critical="4" attackSpeed="253" range="40" />
+            <defence physical="405.85106382979" magical="3297.0297029703" />
+        </stats>
+        <status attackable="false" />
+        <skillList>
+            <skill id="4116" level="6" /> <!-- Magic Damage Resistance -->
+            <skill id="4416" level="6" /> <!-- Humanoids -->
+            <skill id="48044" level="1" /> <!-- Monster of Fire Element -->
+        </skillList>
+        <collision>
+            <radius normal="15" />
+            <height normal="31.5" />
+        </collision>
+        <dropLists>
+            <drop>
+                <item id="57" min="1203" max="2807" chance="70" /> <!-- Adena -->
+                <item id="92912" min="1" max="1" chance="0.75" /> <!-- Material: Plain Fabric -->
+                <item id="92999" min="1" max="1" chance="0.75" /> <!-- High-grade Resources -->
+                <item id="92913" min="1" max="1" chance="0.3" /> <!-- Material: Unknown Metal -->
+                <item id="92914" min="1" max="1" chance="0.3" /> <!-- Material: Sack Shreds -->
+                <item id="92995" min="1" max="1" chance="0.3" /> <!-- Thons -->
+                <item id="92915" min="1" max="1" chance="0.075" /> <!-- Material: Bag of Low-grade Stuff -->
+                <item id="92916" min="1" max="1" chance="0.03" /> <!-- Material: Animal Spirit -->
+                <item id="92919" min="1" max="1" chance="0.003" /> <!-- Material: Blacksmith's High-grade Power -->
+            </drop>
+            <spoil>
+                <item id="92996" min="1" max="1" chance="66.83" /> <!-- Old Resources -->
+                <item id="92997" min="1" max="1" chance="13.86" /> <!-- Unknown Resources -->
+                <item id="92998" min="1" max="1" chance="6.856" /> <!-- Shining Resources -->
+                <item id="92999" min="1" max="1" chance="1.334" /> <!-- High-grade Resources -->
+                <item id="92995" min="1" max="1" chance="0.75" /> <!-- Thons -->
+            </spoil>
+        </dropLists>
+    </npc>
+    <npc id="22137" level="85" type="Monster" name="Turek Orc Marksman" element="FIRE">
+        <race>HUMANOID</race>
+        <sex>FEMALE</sex>
+        <acquire exp="207788" sp="71843" attribute_exp="935" />
+        <equipment rhand="14" /> <!-- Bow -->
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="10124.8554913295" hpRegen="10.5" mp="2252.80528052805" mpRegen="3.6" />
+            <speed>
+                <walk ground="45" />
+                <run ground="175" />
+            </speed>
+            <attack physical="3950.2231755595" magical="1331.5869440987" critical="4" attackSpeed="253" range="40" />
+            <defence physical="3405.85106382979" magical="1297.0297029703" />
+        </stats>
+        <status attackable="false" />
+        <skillList>
+            <skill id="4116" level="6" /> <!-- Magic Damage Resistance -->
+            <skill id="4416" level="6" /> <!-- Humanoids -->
+            <skill id="48044" level="1" /> <!-- Monster of Fire Element -->
+        </skillList>
+        <collision>
+            <radius normal="16.5" />
+            <height normal="33.75" />
+        </collision>
+        <dropLists>
+            <drop>
+                <item id="57" min="997" max="2327" chance="70" /> <!-- Adena -->
+                <item id="92912" min="1" max="1" chance="0.75" /> <!-- Material: Plain Fabric -->
+                <item id="92999" min="1" max="1" chance="0.75" /> <!-- High-grade Resources -->
+                <item id="92913" min="1" max="1" chance="0.3" /> <!-- Material: Unknown Metal -->
+                <item id="92914" min="1" max="1" chance="0.3" /> <!-- Material: Sack Shreds -->
+                <item id="92995" min="1" max="1" chance="0.3" /> <!-- Thons -->
+                <item id="92915" min="1" max="1" chance="0.075" /> <!-- Material: Bag of Low-grade Stuff -->
+                <item id="92916" min="1" max="1" chance="0.03" /> <!-- Material: Animal Spirit -->
+                <item id="92919" min="1" max="1" chance="0.003" /> <!-- Material: Blacksmith's High-grade Power -->
+            </drop>
+            <spoil>
+                <item id="92996" min="1" max="1" chance="56.21" /> <!-- Old Resources -->
+                <item id="92997" min="1" max="1" chance="11.21" /> <!-- Unknown Resources -->
+                <item id="92998" min="1" max="1" chance="5.677" /> <!-- Shining Resources -->
+                <item id="92999" min="1" max="1" chance="1.183" /> <!-- High-grade Resources -->
+                <item id="92995" min="1" max="1" chance="0.75" /> <!-- Thons -->
+            </spoil>
+        </dropLists>
+    </npc>
+    <npc id="22138" level="85" type="Monster" name="Turek Orc Warrior" element="FIRE">
+        <race>HUMANOID</race>
+        <sex>FEMALE</sex>
+        <acquire exp="209463" sp="17940" attribute_exp="1105" />
+        <equipment rhand="127" /> <!-- Crimson Sword -->
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="20249.710982659" hpRegen="10.5" mp="2252.80528052805" mpRegen="3.6" />
+            <speed>
+                <walk ground="80" />
+                <run ground="175" />
+            </speed>
+            <attack physical="3950.2231755595" magical="1331.5869440987" critical="4" attackSpeed="253" range="40" />
+            <defence physical="3405.85106382979" magical="1297.0297029703" />
+        </stats>
+        <status attackable="false" />
+        <skillList>
+            <skill id="4116" level="6" /> <!-- Magic Damage Resistance -->
+            <skill id="4416" level="6" /> <!-- Humanoids -->
+            <skill id="48044" level="1" /> <!-- Monster of Fire Element -->
+        </skillList>
+        <collision>
+            <radius normal="18" />
+            <height normal="37.5" />
+        </collision>
+        <dropLists>
+            <drop>
+                <item id="57" min="1350" max="3149" chance="70" /> <!-- Adena -->
+                <item id="92995" min="1" max="1" chance="0.3" /> <!-- Thons -->
+                <item id="92999" min="1" max="1" chance="0.3" /> <!-- High-grade Resources -->
+                <item id="92913" min="1" max="1" chance="0.3" /> <!-- Material: Unknown Metal -->
+                <item id="92912" min="1" max="1" chance="0.3" /> <!-- Material: Plain Fabric -->
+                <item id="92914" min="1" max="1" chance="0.075" /> <!-- Material: Sack Shreds -->
+                <item id="92915" min="1" max="1" chance="0.03" /> <!-- Material: Bag of Low-grade Stuff -->
+                <item id="92916" min="1" max="1" chance="0.03" /> <!-- Material: Animal Spirit -->
+                <item id="92988" min="1" max="1" chance="0.0075" /> <!-- Orcish Treasure -->
+                <item id="92919" min="1" max="1" chance="0.003" /> <!-- Material: Blacksmith's High-grade Power -->
+                <item id="92989" min="1" max="1" chance="0.0009" /> <!-- Orc King's Treasure -->
+            </drop>
+            <spoil>
+                <item id="92996" min="1" max="1" chance="76.62" /> <!-- Old Resources -->
+                <item id="92997" min="1" max="1" chance="14.78" /> <!-- Unknown Resources -->
+                <item id="92998" min="1" max="1" chance="7.646" /> <!-- Shining Resources -->
+                <item id="92999" min="1" max="1" chance="1.531" /> <!-- High-grade Resources -->
+                <item id="92995" min="1" max="1" chance="0.75" /> <!-- Thons -->
+            </spoil>
+        </dropLists>
+    </npc>
+    <npc id="22139" level="85" type="Monster" name="Turek Orc Shaman" element="FIRE">
+        <race>HUMANOID</race>
+        <sex>FEMALE</sex>
+        <acquire exp="207788" sp="21901" attribute_exp="1020" />
+        <equipment rhand="179" /> <!-- Mace of Prayer -->
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="10124.8554913295" hpRegen="10.5" mp="2252.80528052805" mpRegen="3.6" />
+            <speed>
+                <walk ground="50" />
+                <run ground="175" />
+            </speed>
+            <attack physical="3950.2231755595" magical="1331.5869440987" critical="4" attackSpeed="253" range="40" />
+            <defence physical="3405.85106382979" magical="1297.0297029703" />
+        </stats>
+        <status attackable="false" />
+        <skillList>
+            <skill id="4116" level="6" /> <!-- Magic Damage Resistance -->
+            <skill id="4416" level="6" /> <!-- Humanoids -->
+            <skill id="48044" level="1" /> <!-- Monster of Fire Element -->
+        </skillList>
+        <collision>
+            <radius normal="16.5" />
+            <height normal="25.5" />
+        </collision>
+        <dropLists>
+            <drop>
+                <item id="57" min="1003" max="2340" chance="70" /> <!-- Adena -->
+                <item id="92912" min="1" max="1" chance="0.75" /> <!-- Material: Plain Fabric -->
+                <item id="92999" min="1" max="1" chance="0.75" /> <!-- High-grade Resources -->
+                <item id="92913" min="1" max="1" chance="0.3" /> <!-- Material: Unknown Metal -->
+                <item id="92914" min="1" max="1" chance="0.3" /> <!-- Material: Sack Shreds -->
+                <item id="92995" min="1" max="1" chance="0.3" /> <!-- Thons -->
+                <item id="92915" min="1" max="1" chance="0.075" /> <!-- Material: Bag of Low-grade Stuff -->
+                <item id="92916" min="1" max="1" chance="0.03" /> <!-- Material: Animal Spirit -->
+                <item id="92919" min="1" max="1" chance="0.003" /> <!-- Material: Blacksmith's High-grade Power -->
+            </drop>
+            <spoil>
+                <item id="92996" min="1" max="1" chance="58.44" /> <!-- Old Resources -->
+                <item id="92997" min="1" max="1" chance="11.33" /> <!-- Unknown Resources -->
+                <item id="92998" min="1" max="1" chance="5.73" /> <!-- Shining Resources -->
+                <item id="92999" min="1" max="1" chance="1.207" /> <!-- High-grade Resources -->
+                <item id="92995" min="1" max="1" chance="0.75" /> <!-- Thons -->
+            </spoil>
+        </dropLists>
+    </npc>
+    <npc id="22140" level="85" type="Monster" name="Kerr" title="Hero" element="FIRE">
+        <race>HUMANOID</race>
+        <sex>FEMALE</sex>
+        <acquire exp="138918" sp="940" attribute_exp="1105" />
+        <equipment rhand="80" lhand="6919" /> <!-- Tallum Blade / Monster Only (Ketra Orc Shield) - Sealed -->
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="40499.4219653179" hpRegen="10.5" mp="2252.80528052805" mpRegen="3.6" />
+            <speed>
+                <walk ground="27" />
+                <run ground="175" />
+            </speed>
+            <attack physical="1950.2231755595" magical="1331.5869440987" critical="4" attackSpeed="253" range="40" />
+            <defence physical="405.85106382979" magical="297.0297029703" />
+        </stats>
+        <status attackable="false" />
+        <skillList>
+            <skill id="4116" level="6" /> <!-- Magic Damage Resistance -->
+            <skill id="4416" level="6" /> <!-- Humanoids -->
+            <skill id="48044" level="1" /> <!-- Monster of Fire Element -->
+        </skillList>
+        <collision>
+            <radius normal="18" />
+            <height normal="46.5" />
+        </collision>
+        <dropLists>
+            <drop>
+                <item id="57" min="5397" max="12594" chance="70" /> <!-- Adena -->
+                <item id="92999" min="1" max="1" chance="1.252" /> <!-- High-grade Resources -->
+                <item id="92912" min="1" max="1" chance="1.228" /> <!-- Material: Plain Fabric -->
+                <item id="92913" min="1" max="1" chance="0.75" /> <!-- Material: Unknown Metal -->
+                <item id="92995" min="1" max="1" chance="0.75" /> <!-- Thons -->
+                <item id="92914" min="1" max="1" chance="0.3" /> <!-- Material: Sack Shreds -->
+                <item id="92915" min="1" max="1" chance="0.3" /> <!-- Material: Bag of Low-grade Stuff -->
+                <item id="92916" min="1" max="1" chance="0.075" /> <!-- Material: Animal Spirit -->
+                <item id="92988" min="1" max="1" chance="0.03" /> <!-- Orcish Treasure -->
+                <item id="92919" min="1" max="1" chance="0.0075" /> <!-- Material: Blacksmith's High-grade Power -->
+                <item id="92989" min="1" max="1" chance="0.0009" /> <!-- Orc King's Treasure -->
+            </drop>
+            <spoil>
+                <item id="92996" min="1" max="7" chance="77.21" /> <!-- Old Resources -->
+                <item id="92997" min="1" max="1" chance="61.64" /> <!-- Unknown Resources -->
+                <item id="92998" min="1" max="1" chance="30.76" /> <!-- Shining Resources -->
+                <item id="92999" min="1" max="1" chance="6.196" /> <!-- High-grade Resources -->
+                <item id="92995" min="1" max="1" chance="3.08" /> <!-- Thons -->
+            </spoil>
+        </dropLists>
+    </npc>
+    <npc id="22141" level="85" type="Monster" name="Turek Orc Elite" element="FIRE">
+        <race>HUMANOID</race>
+        <sex>FEMALE</sex>
+        <acquire exp="202228" sp="10662" attribute_exp="1190" />
+        <equipment rhand="79" /> <!-- Damascus Sword -->
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="17911.5606936416" hpRegen="10.5" mp="2252.80528052805" mpRegen="3.6" />
+            <speed>
+                <walk ground="45" />
+                <run ground="175" />
+            </speed>
+            <attack physical="3950.2231755595" magical="1331.5869440987" critical="4" attackSpeed="253" range="40" />
+            <defence physical="3405.85106382979" magical="1297.0297029703" />
+        </stats>
+        <status attackable="false" />
+        <skillList>
+            <skill id="4116" level="6" /> <!-- Magic Damage Resistance -->
+            <skill id="4416" level="6" /> <!-- Humanoids -->
+            <skill id="48044" level="1" /> <!-- Monster of Fire Element -->
+        </skillList>
+        <collision>
+            <radius normal="14.4" />
+            <height normal="35.4" />
+        </collision>
+        <dropLists>
+            <drop>
+                <item id="57" min="1828" max="4265" chance="70" /> <!-- Adena -->
+                <item id="92912" min="1" max="1" chance="1.205" /> <!-- Material: Plain Fabric -->
+                <item id="92999" min="1" max="1" chance="1.186" /> <!-- High-grade Resources -->
+                <item id="92913" min="1" max="1" chance="0.75" /> <!-- Material: Unknown Metal -->
+                <item id="92995" min="1" max="1" chance="0.75" /> <!-- Thons -->
+                <item id="92914" min="1" max="1" chance="0.3" /> <!-- Material: Sack Shreds -->
+                <item id="92915" min="1" max="1" chance="0.3" /> <!-- Material: Bag of Low-grade Stuff -->
+                <item id="92916" min="1" max="1" chance="0.075" /> <!-- Material: Animal Spirit -->
+                <item id="92919" min="1" max="1" chance="0.0075" /> <!-- Material: Blacksmith's High-grade Power -->
+            </drop>
+            <spoil>
+                <item id="92996" min="1" max="3" chance="51.47" /> <!-- Old Resources -->
+                <item id="92997" min="1" max="1" chance="20.67" /> <!-- Unknown Resources -->
+                <item id="92998" min="1" max="1" chance="10.36" /> <!-- Shining Resources -->
+                <item id="92999" min="1" max="1" chance="2.14" /> <!-- High-grade Resources -->
+                <item id="92995" min="1" max="1" chance="1.005" /> <!-- Thons -->
+            </spoil>
+        </dropLists>
+    </npc>
+    <npc id="22142" level="85" type="Monster" name="Turek Orc Skirmisher" element="FIRE">
+        <race>HUMANOID</race>
+        <sex>FEMALE</sex>
+        <acquire exp="80313" sp="1792" attribute_exp="1275" />
+        <equipment rhand="79" lhand="6919" /> <!-- Damascus Sword / Monster Only (Ketra Orc Shield) - Sealed -->
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="17911.5606936416" hpRegen="10.5" mp="2252.80528052805" mpRegen="3.6" />
+            <speed>
+                <walk ground="36" />
+                <run ground="175" />
+            </speed>
+            <attack physical="3950.2231755595" magical="1331.5869440987" critical="4" attackSpeed="253" range="40" />
+            <defence physical="3405.85106382979" magical="1297.0297029703" />
+        </stats>
+        <status attackable="false" />
+        <skillList>
+            <skill id="4116" level="6" /> <!-- Magic Damage Resistance -->
+            <skill id="4416" level="6" /> <!-- Humanoids -->
+            <skill id="48044" level="1" /> <!-- Monster of Fire Element -->
+        </skillList>
+        <collision>
+            <radius normal="14.4" />
+            <height normal="29.4" />
+        </collision>
+        <dropLists>
+            <drop>
+                <item id="57" min="3289" max="7675" chance="70" /> <!-- Adena -->
+                <item id="92999" min="1" max="1" chance="2.085" /> <!-- High-grade Resources -->
+                <item id="92912" min="1" max="1" chance="2.016" /> <!-- Material: Plain Fabric -->
+                <item id="92995" min="1" max="1" chance="1.028" /> <!-- Thons -->
+                <item id="92913" min="1" max="1" chance="0.988" /> <!-- Material: Unknown Metal -->
+                <item id="92914" min="1" max="1" chance="0.3" /> <!-- Material: Sack Shreds -->
+                <item id="92915" min="1" max="1" chance="0.3" /> <!-- Material: Bag of Low-grade Stuff -->
+                <item id="92916" min="1" max="1" chance="0.3" /> <!-- Material: Animal Spirit -->
+                <item id="92919" min="1" max="1" chance="0.03" /> <!-- Material: Blacksmith's High-grade Power -->
+            </drop>
+            <spoil>
+                <item id="92996" min="1" max="3" chance="91.06" /> <!-- Old Resources -->
+                <item id="92997" min="1" max="1" chance="37.06" /> <!-- Unknown Resources -->
+                <item id="92998" min="1" max="1" chance="18.03" /> <!-- Shining Resources -->
+                <item id="92999" min="1" max="1" chance="3.761" /> <!-- High-grade Resources -->
+                <item id="92995" min="1" max="1" chance="1.813" /> <!-- Thons -->
+            </spoil>
+        </dropLists>
+    </npc>
+    <npc id="22143" level="85" type="Monster" name="Turek Orc Sniper" element="FIRE">
+        <race>HUMANOID</race>
+        <sex>FEMALE</sex>
+        <acquire exp="52228" sp="2782" attribute_exp="1360" />
+        <equipment rhand="288" /> <!-- Carnage Bow -->
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="17911.5606936416" hpRegen="10.5" mp="2252.80528052805" mpRegen="3.6" />
+            <speed>
+                <walk ground="45" />
+                <run ground="175" />
+            </speed>
+            <attack physical="3950.2231755595" magical="1331.5869440987" critical="4" attackSpeed="253" range="40" />
+            <defence physical="3405.85106382979" magical="1297.0297029703" />
+        </stats>
+        <status attackable="false" />
+        <skillList>
+            <skill id="4116" level="6" /> <!-- Magic Damage Resistance -->
+            <skill id="4416" level="6" /> <!-- Humanoids -->
+            <skill id="48044" level="1" /> <!-- Monster of Fire Element -->
+        </skillList>
+        <collision>
+            <radius normal="14.4" />
+            <height normal="33" />
+        </collision>
+        <dropLists>
+            <drop>
+                <item id="57" min="2445" max="5706" chance="70" /> <!-- Adena -->
+                <item id="92912" min="1" max="1" chance="1.563" /> <!-- Material: Plain Fabric -->
+                <item id="92999" min="1" max="1" chance="1.483" /> <!-- High-grade Resources -->
+                <item id="92913" min="1" max="1" chance="0.75" /> <!-- Material: Unknown Metal -->
+                <item id="92995" min="1" max="1" chance="0.75" /> <!-- Thons -->
+                <item id="92914" min="1" max="1" chance="0.3" /> <!-- Material: Sack Shreds -->
+                <item id="92915" min="1" max="1" chance="0.3" /> <!-- Material: Bag of Low-grade Stuff -->
+                <item id="92916" min="1" max="1" chance="0.075" /> <!-- Material: Animal Spirit -->
+                <item id="92919" min="1" max="1" chance="0.0075" /> <!-- Material: Blacksmith's High-grade Power -->
+            </drop>
+            <spoil>
+                <item id="92996" min="1" max="3" chance="70.25" /> <!-- Old Resources -->
+                <item id="92997" min="1" max="1" chance="27.3" /> <!-- Unknown Resources -->
+                <item id="92998" min="1" max="1" chance="13.92" /> <!-- Shining Resources -->
+                <item id="92999" min="1" max="1" chance="2.793" /> <!-- High-grade Resources -->
+                <item id="92995" min="1" max="1" chance="1.411" /> <!-- Thons -->
+            </spoil>
+        </dropLists>
+    </npc>
+    <npc id="22144" level="85" type="Monster" name="Turek Orc Prefect" element="FIRE">
+        <race>HUMANOID</race>
+        <sex>FEMALE</sex>
+        <acquire exp="171467" sp="3360" attribute_exp="1530" />
+        <equipment rhand="38425" /> <!-- Monster Only: Amden Blunt Weapon - Not Available - Not Available -->
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="35823.1213872832" hpRegen="10.5" mp="2252.80528052805" mpRegen="3.6" />
+            <speed>
+                <walk ground="48" />
+                <run ground="175" />
+            </speed>
+            <attack physical="3950.2231755595" magical="1331.5869440987" critical="4" attackSpeed="253" range="40" />
+            <defence physical="3405.85106382979" magical="1297.0297029703" />
+        </stats>
+        <status attackable="false" />
+        <skillList>
+            <skill id="4116" level="6" /> <!-- Magic Damage Resistance -->
+            <skill id="4416" level="6" /> <!-- Humanoids -->
+            <skill id="48044" level="1" /> <!-- Monster of Fire Element -->
+        </skillList>
+        <collision>
+            <radius normal="18" />
+            <height normal="40.2" />
+        </collision>
+        <dropLists>
+            <drop>
+                <item id="57" min="9499" max="22165" chance="70" /> <!-- Adena -->
+                <item id="92999" min="1" max="1" chance="2.441" /> <!-- High-grade Resources -->
+                <item id="92912" min="1" max="1" chance="2.358" /> <!-- Material: Plain Fabric -->
+                <item id="92995" min="1" max="1" chance="1.257" /> <!-- Thons -->
+                <item id="92913" min="1" max="1" chance="1.156" /> <!-- Material: Unknown Metal -->
+                <item id="92914" min="1" max="1" chance="0.3" /> <!-- Material: Sack Shreds -->
+                <item id="92915" min="1" max="1" chance="0.3" /> <!-- Material: Bag of Low-grade Stuff -->
+                <item id="92916" min="1" max="1" chance="0.3" /> <!-- Material: Animal Spirit -->
+                <item id="92919" min="1" max="1" chance="0.03" /> <!-- Material: Blacksmith's High-grade Power -->
+                <item id="92988" min="1" max="1" chance="0.03" /> <!-- Orcish Treasure -->
+                <item id="92989" min="1" max="1" chance="0.0009" /> <!-- Orc King's Treasure -->
+            </drop>
+            <spoil>
+                <item id="92996" min="1" max="11" chance="88.63" /> <!-- Old Resources -->
+                <item id="92998" min="1" max="1" chance="54.38" /> <!-- Shining Resources -->
+                <item id="92997" min="1" max="3" chance="53.69" /> <!-- Unknown Resources -->
+                <item id="92999" min="1" max="1" chance="10.45" /> <!-- High-grade Resources -->
+                <item id="92995" min="1" max="1" chance="5.382" /> <!-- Thons -->
+            </spoil>
+        </dropLists>
+    </npc>
+    <npc id="22145" level="85" type="Monster" name="Turek Orc Elder" element="FIRE">
+        <race>HUMANOID</race>
+        <sex>FEMALE</sex>
+        <acquire exp="253544" sp="23042" attribute_exp="1445" />
+        <equipment rhand="213" /> <!-- Branch of the Mother Tree -->
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="17911.5606936416" hpRegen="10.5" mp="2252.80528052805" mpRegen="3.6" />
+            <speed>
+                <walk ground="10" />
+                <run ground="175" />
+            </speed>
+            <attack physical="3950.2231755595" magical="1331.5869440987" critical="4" attackSpeed="253" range="40" />
+            <defence physical="3405.85106382979" magical="1297.0297029703" />
+        </stats>
+        <status attackable="false" />
+        <skillList>
+            <skill id="4116" level="6" /> <!-- Magic Damage Resistance -->
+            <skill id="4416" level="6" /> <!-- Humanoids -->
+            <skill id="48044" level="1" /> <!-- Monster of Fire Element -->
+        </skillList>
+        <collision>
+            <radius normal="12" />
+            <height normal="28.2" />
+        </collision>
+        <dropLists>
+            <drop>
+                <item id="80" min="1" max="1" chance="0.0009" /> <!-- Tallum Blade -->
+                <item id="7894" min="1" max="1" chance="0.0009" /> <!-- Spiritual Eye -->
+                <item id="7884" min="1" max="1" chance="0.0009" /> <!-- Infernal Master -->
+                <item id="5233" min="1" max="1" chance="0.0009" /> <!-- Keshanberk*Keshanberk -->
+                <item id="2504" min="1" max="1" chance="0.0009" /> <!-- Meteor Shower -->
+                <item id="288" min="1" max="1" chance="0.0009" /> <!-- Carnage Bow -->
+                <item id="269" min="1" max="1" chance="0.0009" /> <!-- Blood Tornado -->
+                <item id="235" min="1" max="1" chance="0.0009" /> <!-- Bloody Orchid -->
+                <item id="212" min="1" max="1" chance="0.0009" /> <!-- Dasparion's Staff -->
+                <item id="150" min="1" max="1" chance="0.0009" /> <!-- Elemental Sword -->
+                <item id="98" min="1" max="1" chance="0.0009" /> <!-- Halberd -->
+                <item id="7899" min="1" max="1" chance="0.0009" /> <!-- Destroyer Hammer -->
+                <item id="57" min="2726" max="6362" chance="70" /> <!-- Adena -->
+                <item id="92912" min="1" max="1" chance="0.75" /> <!-- Material: Plain Fabric -->
+                <item id="92999" min="1" max="1" chance="0.75" /> <!-- High-grade Resources -->
+                <item id="92913" min="1" max="1" chance="0.3" /> <!-- Material: Unknown Metal -->
+                <item id="92914" min="1" max="1" chance="0.3" /> <!-- Material: Sack Shreds -->
+                <item id="92995" min="1" max="1" chance="0.3" /> <!-- Thons -->
+                <item id="92915" min="1" max="1" chance="0.075" /> <!-- Material: Bag of Low-grade Stuff -->
+                <item id="92916" min="1" max="1" chance="0.03" /> <!-- Material: Animal Spirit -->
+                <item id="92919" min="1" max="1" chance="0.003" /> <!-- Material: Blacksmith's High-grade Power -->
+            </drop>
+            <spoil>
+                <item id="92996" min="1" max="3" chance="76.63" /> <!-- Old Resources -->
+                <item id="92997" min="1" max="1" chance="32.27" /> <!-- Unknown Resources -->
+                <item id="92998" min="1" max="1" chance="15.43" /> <!-- Shining Resources -->
+                <item id="92999" min="1" max="1" chance="3.082" /> <!-- High-grade Resources -->
+                <item id="92995" min="1" max="1" chance="1.593" /> <!-- Thons -->
+            </spoil>
+        </dropLists>
+    </npc>
+    <npc id="22146" level="85" type="Monster" name="Turek" title="High Prefect" element="FIRE">
+        <race>HUMANOID</race>
+        <sex>FEMALE</sex>
+        <acquire exp="274345" sp="3360" attribute_exp="1530" />
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="71646.2427745665" hpRegen="10.5" mp="2252.80528052805" mpRegen="3.6" />
+            <speed>
+                <walk ground="42" />
+                <run ground="175" />
+            </speed>
+            <attack physical="1950.2231755595" magical="1331.5869440987" critical="4" attackSpeed="253" range="40" />
+            <defence physical="405.85106382979" magical="297.0297029703" />
+        </stats>
+        <status attackable="false" />
+        <skillList>
+            <skill id="4116" level="6" /> <!-- Magic Damage Resistance -->
+            <skill id="4416" level="6" /> <!-- Humanoids -->
+            <skill id="48044" level="1" /> <!-- Monster of Fire Element -->
+        </skillList>
+        <collision>
+            <radius normal="15" />
+            <height normal="36.5" />
+        </collision>
+        <dropLists>
+            <drop>
+                <item id="57" min="27634" max="64478" chance="70" /> <!-- Adena -->
+                <item id="92912" min="1" max="1" chance="6.139" /> <!-- Material: Plain Fabric -->
+                <item id="92999" min="1" max="1" chance="6.072" /> <!-- High-grade Resources -->
+                <item id="92913" min="1" max="1" chance="3.111" /> <!-- Material: Unknown Metal -->
+                <item id="92995" min="1" max="1" chance="3.096" /> <!-- Thons -->
+                <item id="92914" min="1" max="1" chance="0.973" /> <!-- Material: Sack Shreds -->
+                <item id="92915" min="1" max="1" chance="0.75" /> <!-- Material: Bag of Low-grade Stuff -->
+                <item id="92916" min="1" max="1" chance="0.3" /> <!-- Material: Animal Spirit -->
+                <item id="92988" min="1" max="1" chance="0.3" /> <!-- Orcish Treasure -->
+                <item id="92919" min="1" max="1" chance="0.03" /> <!-- Material: Blacksmith's High-grade Power -->
+                <item id="92989" min="1" max="1" chance="0.003" /> <!-- Orc King's Treasure -->
+            </drop>
+            <spoil>
+                <item id="92996" min="1" max="33" chance="90.43" /> <!-- Old Resources -->
+                <item id="92998" min="1" max="3" chance="78.54" /> <!-- Shining Resources -->
+                <item id="92997" min="1" max="7" chance="77.53" /> <!-- Unknown Resources -->
+                <item id="92999" min="1" max="1" chance="30.52" /> <!-- High-grade Resources -->
+                <item id="92995" min="1" max="1" chance="15.97" /> <!-- Thons -->
+            </spoil>
+        </dropLists>
+    </npc>
+    <npc id="22147" level="80" type="Monster" name="Cave Maiden">
+        <race>BEAST</race>
+        <sex>FEMALE</sex>
+        <equipment rhand="68" />
+        <acquire exp="10471" sp="2932" />
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="7381.50289017341" hpRegen="10.5" mp="1811.22112211221" mpRegen="3.6" />
+            <speed>
+                <walk ground="70" />
+                <run ground="174" />
+            </speed>
+            <attack physical="467.58282488453" magical="118.638139627086" critical="4.75" attackSpeed="253" range="40" />
+            <defence physical="208.284023668639" magical="96.8617571816353" />
+        </stats>
+        <status attackable="false" />
+        <ai isAggressive="true" aggroRange="500" clanHelpRange="500"/>
+        <skillList>
+            <skill id="4416" level="3" /> <!-- Beasts -->
+        </skillList>
+        <collision>
+            <radius normal="25" />
+            <height normal="65" />
+        </collision>
+        <dropLists>
+            <drop>
+                <item id="92914" min="1" max="1" chance="100" /> <!-- Material: Sack Shreds -->
+            </drop>
+        </dropLists>
+    </npc>
+    <npc id="22148" level="80" type="Monster" name="Cave Keeper">
+        <race>BEAST</race>
+        <sex>FEMALE</sex>
+        <equipment rhand="223" />
+        <acquire exp="10471" sp="2932" />
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="7381.50289017341" hpRegen="10.5" mp="1811.22112211221" mpRegen="3.6" />
+            <speed>
+                <walk ground="70" />
+                <run ground="174" />
+            </speed>
+            <attack physical="467.58282488453" magical="118.638139627086" critical="4.75" attackSpeed="253" range="40" />
+            <defence physical="208.284023668639" magical="96.8617571816353" />
+        </stats>
+        <status attackable="false" />
+        <ai isAggressive="true" aggroRange="500" clanHelpRange="500"/>
+        <skillList>
+            <skill id="4416" level="3" /> <!-- Beasts -->
+        </skillList>
+        <collision>
+            <radius normal="17" />
+            <height normal="46" />
+        </collision>
+        <dropLists>
+            <drop>
+                <item id="92914" min="1" max="1" chance="100" /> <!-- Material: Sack Shreds -->
+            </drop>
+        </dropLists>
+    </npc>
+    <npc id="22149" level="80" type="Monster" name="Headless Knight">
+        <race>UNDEAD</race>
+        <sex>FEMALE</sex>
+        <equipment rhand="124" />
+        <acquire exp="10471" sp="2932" />
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="7381.50289017341" hpRegen="10.5" mp="1811.22112211221" mpRegen="3.6" />
+            <speed>
+                <walk ground="70" />
+                <run ground="174" />
+            </speed>
+            <attack physical="467.58282488453" magical="118.638139627086" critical="4.75" attackSpeed="253" range="40" />
+            <defence physical="208.284023668639" magical="96.8617571816353" />
+        </stats>
+        <status attackable="false" />
+        <ai isAggressive="true" aggroRange="500" clanHelpRange="500"/>
+        <skillList>
+            <skill id="4416" level="1" /> <!-- Undead -->
+        </skillList>
+        <collision>
+            <radius normal="21" />
+            <height normal="31" />
+        </collision>
+        <dropLists>
+            <drop>
+                <item id="92914" min="1" max="1" chance="100" /> <!-- Material: Sack Shreds -->
+            </drop>
+        </dropLists>
+    </npc>
+    <npc id="22150" level="80" type="Monster" name="Special Treasure Chest">
+        <race>ETC</race>
+        <sex>FEMALE</sex>
+        <acquire exp="125031" sp="35002" />
+        <stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+            <vitals hp="7381.50289017341" hpRegen="10.5" mp="1811.22112211221" mpRegen="3.6" />
+            <speed>
+                <walk ground="30" />
+                <run ground="180" />
+            </speed>
+            <attack physical="467.58282488453" magical="118.638139627086" critical="4.75" attackSpeed="253" range="40" />
+            <defence physical="208.284023668639" magical="96.8617571816353" />
+        </stats>
+        <status attackable="false" />
+        <ai isAggressive="true" aggroRange="500" clanHelpRange="500"/>
+        <skillList>
+            <skill id="4416" level="2" /> <!-- Magical Creatures -->
+        </skillList>
+        <collision>
+            <radius normal="24" />
+            <height normal="19" />
+        </collision>
+        <dropLists>
+            <drop>
+                <item id="92914" min="1" max="1" chance="100" /> <!-- Material: Sack Shreds -->
+            </drop>
+        </dropLists>
+    </npc>
+    <!-- Training Dummy -->
+    <npc id="22183" level="1" type="Monster" name="Training Dummy">
+        <race>ETC</race>
+        <sex>FEMALE</sex>
+        <stats str="79" int="34" dex="42" wit="66" con="75" men="12">
+            <vitals hp="34" hpRegen="2" mp="62" mpRegen="0.9" />
+            <attack physical="10.24492" magical="6.99595" critical="4" attackSpeed="253" range="40" type="SWORD" distance="80" width="120" random="10" accuracy="5" />
+            <defence physical="47.91652" magical="35.06323" />
+            <speed>
+                <walk ground="1" />
+                <run ground="1" />
+            </speed>
+            <abnormalResist physical="10" magical="10" />
+        </stats>
+        <status attackable="false" />
+        <collision>
+            <radius normal="9" />
+            <height normal="28.5" />
+        </collision>
+    </npc>
+    <npc id="22184" level="3" type="Monster" name="Skeleton Archer">
+        <race>UNDEAD</race>
+        <sex>FEMALE</sex>
+        <equipment rhand="15302" />
+        <acquire exp="76" sp="3" />
+        <stats str="79" int="34" dex="42" wit="66" con="75" men="12">
+            <vitals hp="59.9369085173502" hpRegen="2" mp="54.3390105433901" mpRegen="0.9" />
+            <speed>
+                <walk ground="50" />
+                <run ground="80" />
+            </speed>
+            <attack physical="1.0474747800303" magical="0.569393726771342" critical="4.75" attackSpeed="253" range="40" />
+            <defence physical="10.21739130434783" magical="4.51112067728512" />
+        </stats>
+        <skillList>
+            <skill id="4416" level="1" /> <!-- Undead -->
+        </skillList>
+        <collision>
+            <radius normal="7" />
+            <height normal="22" />
+        </collision>
+    </npc>
+    <npc id="22185" level="5" type="Monster" name="Skeleton Warrior">
+        <race>UNDEAD</race>
+        <sex>MALE</sex>
+        <acquire exp="91" sp="5" />
+        <stats str="79" int="34" dex="42" wit="66" con="75" men="12">
+            <vitals hp="83.9116719242902" hpRegen="2" mp="68.9375506893755" mpRegen="0.9" />
+            <speed>
+                <walk ground="50" />
+                <run ground="80" />
+            </speed>
+            <attack physical="1.18290932605713" magical="0.678746159252523" critical="4.75" attackSpeed="253" range="40" />
+            <defence physical="10.53191489361702" magical="4.5981321536409" />
+        </stats>
+        <skillList>
+            <skill id="4416" level="1" /> <!-- Undead -->
+        </skillList>
+        <collision>
+            <radius normal="15" />
+            <height normal="25" />
+        </collision>
+    </npc>
+    <npc id="22186" level="15" type="Monster" name="Skeleton Scout">
+        <race>UNDEAD</race>
+        <sex>MALE</sex>
+        <equipment rhand="15302" />
+        <acquire exp="236" sp="14" />
+        <stats str="79" int="34" dex="42" wit="66" con="75" men="12">
+            <vitals hp="259.305993690852" hpRegen="2.5" mp="149.229521492295" mpRegen="1.2" />
+            <speed>
+                <walk ground="45" />
+                <run ground="80" />
+            </speed>
+            <attack physical="2.77983691623425" magical="1.08599841832892" critical="4.75" attackSpeed="253" range="40" />
+            <defence physical="14.01923076923077" magical="6.36379791825336" />
+        </stats>
+        <status attackable="false" />
+        <skillList>
+            <skill id="4416" level="1" /> <!-- Undead -->
+        </skillList>
+        <collision>
+            <radius normal="13" />
+            <height normal="26" />
+        </collision>
+    </npc>
+    <npc id="22187" level="17" type="Monster" name="Skeleton Hunter">
+        <race>UNDEAD</race>
+        <sex>MALE</sex>
+        <equipment rhand="15302" />
+        <acquire exp="285" sp="15" />
+        <stats str="79" int="34" dex="42" wit="66" con="75" men="12">
+            <vitals hp="297.160883280757" hpRegen="2.5" mp="166.261151662611" mpRegen="1.2" />
+            <speed>
+                <walk ground="45" />
+                <run ground="80" />
+            </speed>
+            <attack physical="3.2868511965537" magical="1.2495433267306" critical="4.75" attackSpeed="253" range="40" />
+            <defence physical="14.35849056603774" magical="6.54941154492808" />
+        </stats>
+        <status attackable="false" />
+        <skillList>
+            <skill id="4416" level="1" /> <!-- Undead -->
+        </skillList>
+        <collision>
+            <radius normal="18" />
+            <height normal="27.5" />
+        </collision>
     </npc>
 </list>

--- a/data/stats/npcs/34100-34199.xml
+++ b/data/stats/npcs/34100-34199.xml
@@ -367,4 +367,245 @@
 			<height normal="12" />
 		</collision>
 	</npc>
+		<!-- Kate -->
+	<npc id="34120" level="85" type="Npc" name="Kate" title="Grand Master">
+		<race>ETC</race>
+		<sex>FEMALE</sex>
+		<stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+			<vitals hp="2578" hpRegen="10.5" mp="1345" mpRegen="3.6" />
+			<speed>
+				<walk ground="40" />
+				<run ground="120" />
+			</speed>
+			<attack physical="1950.2231755595" magical="1331.5869440987" critical="4" attackSpeed="253" range="40" />
+			<defence physical="405.85106382979" magical="297.0297029703" />
+		</stats>
+		<status attackable="false" />
+		<collision>
+			<radius normal="9" />
+			<height normal="22" />
+		</collision>
+	</npc>
+	<npc id="34121" level="85" type="Npc" name="Deekhin" title="Grand Master">
+		<race>ETC</race>
+		<sex>FEMALE</sex>
+		<stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+			<vitals hp="2578" hpRegen="10.5" mp="1345" mpRegen="3.6" />
+			<speed>
+				<walk ground="60" />
+				<run ground="120" />
+			</speed>
+			<attack physical="1950.2231755595" magical="1331.5869440987" critical="4" attackSpeed="253" range="40" />
+			<defence physical="405.85106382979" magical="297.0297029703" />
+		</stats>
+		<status attackable="false" />
+		<collision>
+			<radius normal="7.8" />
+			<height normal="17.285" />
+		</collision>
+	</npc>
+	<npc id="34122" level="85" type="Npc" name="Bunch" title="Grand Master">
+		<race>ETC</race>
+		<sex>FEMALE</sex>
+		<stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+			<vitals hp="2578" hpRegen="10.5" mp="1345" mpRegen="3.6" />
+			<speed>
+				<walk ground="36" />
+				<run ground="120" />
+			</speed>
+			<attack physical="1950.2231755595" magical="1331.5869440987" critical="4" attackSpeed="253" range="40" />
+			<defence physical="405.85106382979" magical="297.0297029703" />
+		</stats>
+		<status attackable="false" />
+		<collision>
+			<radius normal="12" />
+			<height normal="24.5" />
+		</collision>
+	</npc>
+	<npc id="34123" level="85" type="Npc" name="Ayan" title="Grand Master">
+		<race>ETC</race>
+		<sex>FEMALE</sex>
+		<stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+			<vitals hp="2578" hpRegen="10.5" mp="1345" mpRegen="3.6" />
+			<speed>
+				<walk ground="36" />
+				<run ground="120" />
+			</speed>
+			<attack physical="1950.2231755595" magical="1331.5869440987" critical="4" attackSpeed="253" range="40" />
+			<defence physical="405.85106382979" magical="297.0297029703" />
+		</stats>
+		<status attackable="false" />
+		<collision>
+			<radius normal="9" />
+			<height normal="23.5" />
+		</collision>
+	</npc>
+	<npc id="34124" level="85" type="Npc" name="Joon" title="Grand Master">
+		<race>ETC</race>
+		<sex>FEMALE</sex>
+		<stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+			<vitals hp="2578" hpRegen="10.5" mp="1345" mpRegen="3.6" />
+			<speed>
+				<walk ground="50" />
+				<run ground="120" />
+			</speed>
+			<attack physical="1950.2231755595" magical="1331.5869440987" critical="4" attackSpeed="253" range="40" />
+			<defence physical="405.85106382979" magical="297.0297029703" />
+		</stats>
+		<status attackable="false" />
+		<collision>
+			<radius normal="9.5" />
+			<height normal="23" />
+		</collision>
+	</npc>
+	<npc id="34125" level="85" type="Npc" name="Panji" title="Grand Master">
+		<race>ETC</race>
+		<sex>FEMALE</sex>
+		<stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+			<vitals hp="2578" hpRegen="10.5" mp="1345" mpRegen="3.6" />
+			<speed>
+				<walk ground="37" />
+				<run ground="120" />
+			</speed>
+			<attack physical="1950.2231755595" magical="1331.5869440987" critical="4" attackSpeed="253" range="40" />
+			<defence physical="405.85106382979" magical="297.0297029703" />
+		</stats>
+		<status attackable="false" />
+		<collision>
+			<radius normal="10" />
+			<height normal="23" />
+		</collision>
+	</npc>
+	<npc id="34126" level="85" type="Npc" name="Debbie" title="Grand Master">
+		<race>ETC</race>
+		<sex>FEMALE</sex>
+		<stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+			<vitals hp="2578" hpRegen="10.5" mp="1345" mpRegen="3.6" />
+			<speed>
+				<walk ground="50" />
+				<run ground="120" />
+			</speed>
+			<attack physical="1950.2231755595" magical="1331.5869440987" critical="4" attackSpeed="253" range="40" />
+			<defence physical="405.85106382979" magical="297.0297029703" />
+		</stats>
+		<status attackable="false" />
+		<collision>
+			<radius normal="10" />
+			<height normal="21.5" />
+		</collision>
+	</npc>
+	<npc id="34138" level="85" type="Folk" name="Kilemanja" title="Training Captain">
+		<race>DARK_ELF</race>
+		<sex>MALE</sex>
+		<stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+			<vitals hp="8446" hpRegen="10.5" mp="2355" mpRegen="3.6" />
+			<speed>
+				<walk ground="50" />
+				<run ground="1" />
+			</speed>
+			<attack physical="1950.2231755595" magical="1331.5869440987" critical="4" attackSpeed="253" range="40" />
+			<defence physical="405.85106382979" magical="297.0297029703" />
+		</stats>
+		<status attackable="false" />
+		<collision>
+			<radius normal="8" />
+			<height normal="23.5" />
+		</collision>
+	</npc>
+	<npc id="34139" level="85" type="Merchant" name="Mattehoren" title="Quartermaster">
+		<race>HUMAN</race>
+		<sex>MALE</sex>
+		<stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+			<vitals hp="8446" hpRegen="10.5" mp="2355" mpRegen="3.6" />
+			<speed>
+				<walk ground="50" />
+				<run ground="1" />
+			</speed>
+			<attack physical="1950.2231755595" magical="1331.5869440987" critical="4" attackSpeed="253" range="40" />
+			<defence physical="405.85106382979" magical="297.0297029703" />
+		</stats>
+		<status attackable="false" />
+		<collision>
+			<radius normal="8" />
+			<height normal="23.5" />
+		</collision>
+	</npc>
+	<npc id="34140" level="85" type="Teleporter" name="Marillia" title="Track Gatekeeper">
+		<race>HUMAN</race>
+		<sex>FEMALE</sex>
+		<stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+			<vitals hp="8446" hpRegen="10.5" mp="2355" mpRegen="3.6" />
+			<speed>
+				<walk ground="50" />
+				<run ground="1" />
+			</speed>
+			<attack physical="1950.2231755595" magical="1331.5869440987" critical="4" attackSpeed="253" range="40" />
+			<defence physical="405.85106382979" magical="297.0297029703" />
+		</stats>
+		<status attackable="false" />
+		<collision>
+			<radius normal="8" />
+			<height normal="25" />
+		</collision>
+	</npc>
+	<npc id="34141" level="85" type="Warehouse" name="Lucia" title="Warehouse Keeper">
+		<race>DWARF</race>
+		<sex>FEMALE</sex>
+		<stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+			<vitals hp="8446" hpRegen="10.5" mp="2355" mpRegen="3.6" />
+			<speed>
+				<walk ground="50" />
+				<run ground="1" />
+			</speed>
+			<attack physical="1950.2231755595" magical="1331.5869440987" critical="4" attackSpeed="253" range="40" />
+			<defence physical="405.85106382979" magical="297.0297029703" />
+		</stats>
+		<status attackable="false" />
+		<collision>
+			<radius normal="7" />
+			<height normal="18" />
+		</collision>
+	</npc>
+	<npc id="34149" level="80" type="Guard" name="Erest" title="Guard">
+		<race>DARK_ELF</race>
+		<sex>MALE</sex>
+		<equipment rhand="132" />
+		<stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+			<vitals hp="49042" hpRegen="8.5" mp="23550" mpRegen="3" />
+			<attack physical="1988.15672" magical="611" random="10" critical="8" accuracy="0" attackSpeed="227" reuseDelay="1500" type="BOW" range="1100" distance="10" width="0" />
+			<defence physical="341.38" magical="249.8" />
+			<speed>
+				<walk ground="50" />
+				<run ground="160" />
+			</speed>
+			<abnormalResist physical="10" magical="10" />
+		</stats>
+		<status attackable="false" talkable="false" />
+		<ai aggroRange="450" clanHelpRange="300" isAggressive="true" />
+		<collision>
+			<radius normal="8" />
+			<height normal="23.5" />
+		</collision>
+	</npc>
+	<npc id="34150" level="80" type="Guard" name="Altaid" title="Guard">
+		<race>HUMAN</race>
+		<sex>MALE</sex>
+		<equipment rhand="132" />
+		<stats str="40" int="21" dex="30" wit="20" con="43" men="10">
+			<vitals hp="49042" hpRegen="8.5" mp="23550" mpRegen="3" />
+			<attack physical="1988.15672" magical="611" random="10" critical="8" accuracy="0" attackSpeed="227" reuseDelay="1500" type="BOW" range="1100" distance="10" width="0" />
+			<defence physical="341.38" magical="249.8" />
+			<speed>
+				<walk ground="50" />
+				<run ground="160" />
+			</speed>
+			<abnormalResist physical="10" magical="10" />
+		</stats>
+		<status attackable="false" talkable="false" />
+		<ai aggroRange="450" clanHelpRange="300" isAggressive="true" />
+		<collision>
+			<radius normal="8" />
+			<height normal="23.5" />
+		</collision>
+	</npc>
 </list>

--- a/data/teleports.xml
+++ b/data/teleports.xml
@@ -1,5 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
-
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns="http://l2j.org" xsi:schemaLocation="http://l2j.org xsd/teleports.xsd" >
 
     <teleport id="2" price="22500"> <!-- Execution Grounds -->
@@ -222,15 +221,15 @@
         <location x="162205" y="27090" z="-3712"/>
     </teleport>
 
-    <teleport id="108" price="11200"> <!-- Orc Village -->
+    <teleport id="131" price="11200"> <!-- Orc Village -->
         <location x="-45158" y="-112583" z="-240"/>
     </teleport>
 
-    <teleport id="131" price="3900"> <!-- Cave of Trials -->
+    <teleport id="133" price="3900"> <!-- Cave of Trials -->
         <location x="9340" y="-112509" z="-2536"/>
     </teleport>
 
-    <teleport id="133" price="3900"> <!-- Frozen Waterfalls -->
+    <teleport id="134" price="3900"> <!-- Frozen Waterfalls -->
         <location x="8652" y="-139941" z="-1144"/>
     </teleport>
 

--- a/data/xsd/ensoul-stones.xsd
+++ b/data/xsd/ensoul-stones.xsd
@@ -25,7 +25,7 @@
 
 	<xs:complexType name="EnsoulStone">
 		<xs:sequence>
-			<xs:element name="option" type="EnsoulOption" maxOccurs="2"/>
+			<xs:element name="option" type="EnsoulOption" maxOccurs="21"/>
 		</xs:sequence>
 		<xs:attribute type="xs:int" name="id" use="required" />
 		<xs:attribute type="EnsoulType" name="type" default="COMMON" />


### PR DESCRIPTION
Update to Death Knight Zone with NPC/Spawns with removal of Execution Ground mobs, Update to Sylph Zone with NPC/Spawns and removal of Enchanted Valley mobs. Numerous changes to item's, changes to enchantment.xml, combinationitems.xml, enchantitemoptions.xml, max level can be set to 106, total of exp for 107 levels. Newest Aden Update requires minimum of top levle 99. Added L2Coin event, where dev's can set their own L2 Coin drops per level/level range. This includes amount, chance.